### PR TITLE
Human friendly ABI input parameter error

### DIFF
--- a/tests/contracts/test_bad_abi.py
+++ b/tests/contracts/test_bad_abi.py
@@ -1,0 +1,13 @@
+import pytest
+
+from web3.exceptions import ArgumentEncodeError
+
+
+def test_bad_constructor_input_encoding(StringContract):
+    """Deploying a contract with bad ABI signature should give a friendly exception."""
+
+    with pytest.raises(ArgumentEncodeError):
+        # web3.exceptions.ArgumentEncodeError: Cannot encode 1. argument of
+        StringContract.deploy(args=[None])
+
+

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -46,7 +46,6 @@ from web3.utils.abi import (
     function_abi_to_4byte_selector,
     merge_args_and_kwargs,
     normalize_return_type,
-    check_if_arguments_can_be_encoded,
     check_if_arguments_can_be_encoded_verbose
 )
 from web3.utils.decorators import (

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -47,6 +47,7 @@ from web3.utils.abi import (
     merge_args_and_kwargs,
     normalize_return_type,
     check_if_arguments_can_be_encoded,
+    check_if_arguments_can_be_encoded_verbose
 )
 from web3.utils.decorators import (
     combomethod,
@@ -582,13 +583,7 @@ class Contract(object):
     def _encode_abi(cls, abi, arguments, data=None):
         argument_types = get_abi_input_types(abi)
 
-        if not check_if_arguments_can_be_encoded(abi, arguments, {}):
-            raise TypeError(
-                "One or more arguments could not be encoded to the necessary "
-                "ABI type.  Expected types are: {0}".format(
-                    ', '.join(argument_types),
-                )
-            )
+        check_if_arguments_can_be_encoded_verbose(abi, arguments, {})
 
         try:
             encoded_arguments = encode_abi(

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -25,6 +25,10 @@ class InvalidResponseException(Exception):
         Exception.__init__(self, message)
 
 
+class ArgumentEncodeError(TypeError):
+    """ABI could not encode arguments going into smart contract function signature."""
+
+
 class BadFunctionCallOutput(Exception):
     """We failed to decode ABI output.
 

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -186,7 +186,7 @@ def check_if_arguments_can_be_encoded_verbose(function_abi, args, kwargs):
     for idx, arg in enumerate(arguments):
         _type = types[idx]
         if not is_encodable(_type, arg):
-            msg = "Cannot encode {}. argument of the function, expected type: {}, inbound value {}, full signature is ".format(idx, _type, arg, function_abi)
+            msg = "Cannot encode {}. argument of the function, expected type: {}, inbound value {}, full signature is {}".format(idx+1, _type, arg, function_abi)
             raise ArgumentEncodeError(msg)
 
 

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -173,20 +173,23 @@ def check_if_arguments_can_be_encoded_verbose(function_abi, args, kwargs):
     try:
         arguments = merge_args_and_kwargs(function_abi, args, kwargs)
     except TypeError as e:
-        msg = "Could not merge args and kwargs: {} {} {}".format(function_abi, args ,kwargs)
+        msg = "Could not merge args and kwargs: {} {} {}".format(function_abi, args, kwargs)
         raise_from(ArgumentEncodeError(msg, e))
 
     expected = len(function_abi['inputs'])
     actual = len(arguments)
     if expected != actual:
-        msg = "Wrong number of arguments. Expected {}, got {} for {}".format(expected, actual, function_abi)
+        msg = "Wrong number of arguments. Expected {}, got {} for {}" \
+            .format(expected, actual, function_abi)
         raise ArgumentEncodeError(msg)
 
     types = get_abi_input_types(function_abi)
     for idx, arg in enumerate(arguments):
         _type = types[idx]
         if not is_encodable(_type, arg):
-            msg = "Cannot encode {}. argument of the function, expected type: {}, inbound value {}, full signature is {}".format(idx+1, _type, arg, function_abi)
+            msg = "Cannot encode {}. argument of the function " + \
+                "expected type: {}, inbound value {}, full signature is {}" \
+                .format(idx+1, _type, arg, function_abi)
             raise ArgumentEncodeError(msg)
 
 


### PR DESCRIPTION
### What was wrong?

It was hard to figure out why the contract call input parameter encoding failed, esp. with all type coercion going on.

Now you get:

    web3.exceptions.ArgumentEncodeError: Cannot encode 1. argument of the function, expected type: b'string', inbound value None, full signature is {'inputs': [{'name': b'_value', 'type': b'string'}], 'type': b'constructor'

### How was it fixed?

Added a new TypeError exception subclass that comes with a human friendly error message.

For backwards compatibility, I kept old `check_if_arguments_can_be_encoded` function around, as there might be subtle differences in the behavior. However this function can be marked to be deprecated in the future release.

#### Cute Animal Picture

```
   /\     /\
  {  `---'  }
  {  O   O  }
  ~~>  V  <~~
   \  \|/  /
    `-----'__
    /     \  `^\_
   {       }\ |\_\_   W
   |  \_/  |/ /  \_\_( )
    \__/  /(_E     \__/
      (  /
       MM
```

