### PR TITLE
Fix merge_and_kwargs for kwargs and contract constructors.

### DIFF
--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -143,6 +143,7 @@ def check_if_arguments_can_be_encoded(function_abi, args, kwargs):
     )
 
 
+
 @coerce_args_to_text
 def merge_args_and_kwargs(function_abi, args, kwargs):
     if len(args) + len(kwargs) != len(function_abi['inputs']):
@@ -157,25 +158,25 @@ def merge_args_and_kwargs(function_abi, args, kwargs):
         return args
 
     args_as_kwargs = {
-        arg_abi['name']: arg
+        arg_abi.get('name', ''): arg
         for arg_abi, arg in zip(function_abi['inputs'], args)
     }
     duplicate_keys = set(args_as_kwargs).intersection(kwargs.keys())
     if duplicate_keys:
         raise TypeError(
             "{fn_name}() got multiple values for argument(s) '{dups}'".format(
-                fn_name=function_abi['name'],
+                fn_name=function_abi.get('name', ''),
                 dups=', '.join(duplicate_keys),
             )
         )
 
-    sorted_arg_names = [arg_abi['name'] for arg_abi in function_abi['inputs']]
+    sorted_arg_names = [arg_abi.get('name', '') for arg_abi in function_abi['inputs']]
 
     unknown_kwargs = {key for key in kwargs.keys() if key not in sorted_arg_names}
     if unknown_kwargs:
         raise TypeError(
             "{fn_name}() got unexpected keyword argument(s) '{dups}'".format(
-                fn_name=function_abi['name'],
+                fn_name=function_abi.get('name', ''),
                 dups=', '.join(unknown_kwargs),
             )
         )


### PR DESCRIPTION
### What was wrong?

Passing (invalid) kwargs to contract constructor was not handled properly.

### How was it fixed?

Constructor does not have `abi["name"]`. Default to empty string in this case.

#### Cute Animal Picture

```
              (__)                   (__)
              [##]                   (@o)
       /-------\/             /-------\/              /-------  (__)
      / |     ||             / |     ||              / |     || (oo)
     *  ||----||            *  ||----||             *  ||----|---\/
        ^^    ^^               ^^    ^^                ^^    ^
  This cow belonged      This cow lived with      This cow belonged to
   to Flash Gordon       the Little Rascals       the Headless Horseman
```
