### PR TITLE
New contract method execution option: generating the transaction dictionary

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -172,6 +172,34 @@ Each Contract Factory exposes the following methods.
         >>> my_contract.estimateGas().multiply7(3)
         42650
 
+.. py:method:: Contract.prepareTransaction(transaction).myMethod(*args, **kwargs)
+
+    Prepare a transaction dictionary based on the contract function call specified. 
+
+    This method behaves the same as the :py:method::`Contract.transact` method,
+    with transaction details being passed into the first portion of the
+    function call, and function arguments being passed into the second portion.
+
+    .. note::
+        If ``web3.eth.defaultAccount`` is not set, this method will need another way
+        of finding the nonce. Therefore one of ``from`` or ``nonce`` has 
+        to be provided in the second portion of the function call 
+        ``myMethod(*args, **kwargs)``.
+
+    Returns a transaction dictionary. This dictionary may be used for offline 
+    transaction signing using :meth:`~web3.eth.account.Account.signTransaction`.
+
+    .. code-block:: python
+
+        >>> math_contract.prepareTransaction({'gasPrice': 21000000000}).increment(5)
+        {
+            'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',
+            'value': 0, 
+            'gas': 43242, 
+            'gasPrice': 21000000000, 
+            'nonce': 1, 
+            'chainId': 1
+        }
 
 Events
 ------

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -172,7 +172,7 @@ Each Contract Factory exposes the following methods.
         >>> my_contract.estimateGas().multiply7(3)
         42650
 
-.. py:method:: Contract.prepareTransaction(transaction).myMethod(*args, **kwargs)
+.. py:method:: Contract.buildTransaction(transaction).myMethod(*args, **kwargs)
 
     Prepare a transaction dictionary based on the contract function call specified. 
 
@@ -191,7 +191,7 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >>> math_contract.prepareTransaction({'gasPrice': 21000000000}).increment(5)
+        >>> math_contract.buildTransaction({'gasPrice': 21000000000}).increment(5)
         {
             'to': '0x6Bc272FCFcf89C14cebFC57B8f1543F5137F97dE',
             'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -174,20 +174,33 @@ Each Contract Factory exposes the following methods.
 
 .. py:method:: Contract.buildTransaction(transaction).myMethod(*args, **kwargs)
 
-    Prepare a transaction dictionary based on the contract function call specified. 
+    Builds a transaction dictionary based on the contract function call specified. 
 
     This method behaves the same as the :py:method::`Contract.transact` method,
     with transaction details being passed into the first portion of the
     function call, and function arguments being passed into the second portion.
 
     .. note::
-        If ``web3.eth.defaultAccount`` is not set, this method will need another way
-        of finding the nonce. Therefore one of ``from`` or ``nonce`` has 
-        to be provided in the second portion of the function call 
-        ``myMethod(*args, **kwargs)``.
+        `nonce` is not returned as part of the transaction dictionary unless it is 
+        specified in the first portion of the function call:
 
-    Returns a transaction dictionary. This dictionary may be used for offline 
-    transaction signing using :meth:`~web3.eth.account.Account.signTransaction`.
+        .. code-block:: python
+
+            >>> math_contract.buildTransaction({'nonce': 10}).increment(5)
+
+        You may use :meth:`~web3.eth.Eth.getTransactionCount` to get the current nonce
+        for an account. Therefore a shortcut for producing a transaction dictionary with 
+        nonce included looks like:
+
+        .. code-block:: python
+
+            >>> math_contract.buildTransaction({'nonce': web3.eth.getTransactionCount('0xF5...')}).increment(5)
+
+    Returns a transaction dictionary. This transaction dictionary can then be sent using 
+    :meth:`~web3.eth.Eth.sendTransaction`. 
+    
+    Additionally, the dictionary may be used for offline transaction signing using 
+    :meth:`~web3.eth.account.Account.signTransaction`.
 
     .. code-block:: python
 
@@ -198,7 +211,6 @@ Each Contract Factory exposes the following methods.
             'value': 0, 
             'gas': 43242, 
             'gasPrice': 21000000000, 
-            'nonce': 1, 
             'chainId': 1
         }
 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -193,6 +193,7 @@ Each Contract Factory exposes the following methods.
 
         >>> math_contract.prepareTransaction({'gasPrice': 21000000000}).increment(5)
         {
+            'to': '0x6Bc272FCFcf89C14cebFC57B8f1543F5137F97dE',
             'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',
             'value': 0, 
             'gas': 43242, 

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -299,6 +299,9 @@ The following methods are available on the ``Web3.eth.account`` namespace.
     and the hex-encoded transaction suitable for broadcast using
     :meth:`~web3.eth.Eth.sendRawTransaction`.
 
+    The transaction dict for executing contract methods may be created using 
+    :meth:`~web3.contract.Contract.prepareTransaction`.
+
     :param dict transaction_dict: the transaction with keys:
       nonce, chainId, to, data, value, gas, and gasPrice.
     :param private_key: the private key to sign the data with

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -300,7 +300,7 @@ The following methods are available on the ``Web3.eth.account`` namespace.
     :meth:`~web3.eth.Eth.sendRawTransaction`.
 
     The transaction dict for executing contract methods may be created using 
-    :meth:`~web3.contract.Contract.prepareTransaction`.
+    :meth:`~web3.contract.Contract.buildTransaction`.
 
     :param dict transaction_dict: the transaction with keys:
       nonce, chainId, to, data, value, gas, and gasPrice.

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -108,11 +108,11 @@ def test_build_transaction_with_contract_to_address_supplied_errors(web3, math_c
     ]
 )
 def test_build_transaction_with_contract_with_arguments(web3, skip_if_testrpc, math_contract,
-                                                          transaction_args,
-                                                          method_args,
-                                                          method_kwargs,
-                                                          expected,
-                                                          skip_testrpc):
+                                                        transaction_args,
+                                                        method_args,
+                                                        method_kwargs,
+                                                        expected,
+                                                        skip_testrpc):
     if skip_testrpc:
         skip_if_testrpc(web3)
 

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -15,8 +15,8 @@ def math_contract(web3, MathContract):
     return _math_contract
 
 
-def test_prepare_transaction_with_contract_no_arguments(web3, math_contract):
-    txn = math_contract.prepareTransaction().increment()
+def test_build_transaction_with_contract_no_arguments(web3, math_contract):
+    txn = math_contract.buildTransaction().increment()
     assert txn == {
         'to': math_contract.address,
         'data': '0xd09de08a',
@@ -27,8 +27,8 @@ def test_prepare_transaction_with_contract_no_arguments(web3, math_contract):
     }
 
 
-def test_prepare_transaction_with_contract_class_method(web3, MathContract, math_contract):
-    txn = MathContract.prepareTransaction({'to': math_contract.address}).increment()
+def test_build_transaction_with_contract_class_method(web3, MathContract, math_contract):
+    txn = MathContract.buildTransaction({'to': math_contract.address}).increment()
     assert txn == {
         'to': math_contract.address,
         'data': '0xd09de08a',
@@ -39,8 +39,8 @@ def test_prepare_transaction_with_contract_class_method(web3, MathContract, math
     }
 
 
-def test_prepare_transaction_with_contract_default_account_is_set(web3, math_contract):
-    txn = math_contract.prepareTransaction().increment()
+def test_build_transaction_with_contract_default_account_is_set(web3, math_contract):
+    txn = math_contract.buildTransaction().increment()
     assert txn == {
         'to': math_contract.address,
         'data': '0xd09de08a',
@@ -51,16 +51,16 @@ def test_prepare_transaction_with_contract_default_account_is_set(web3, math_con
     }
 
 
-def test_prepare_transaction_with_contract_data_supplied_errors(web3, math_contract):
+def test_build_transaction_with_contract_data_supplied_errors(web3, math_contract):
     with pytest.raises(ValueError):
-        math_contract.prepareTransaction({
+        math_contract.buildTransaction({
             'data': '0x000'
         }).increment()
 
 
-def test_prepare_transaction_with_contract_to_address_supplied_errors(web3, math_contract):
+def test_build_transaction_with_contract_to_address_supplied_errors(web3, math_contract):
     with pytest.raises(ValueError):
-        math_contract.prepareTransaction({
+        math_contract.buildTransaction({
             'to': '0xb2930B35844a230f00E51431aCAe96Fe543a0347'
         }).increment()
 
@@ -107,7 +107,7 @@ def test_prepare_transaction_with_contract_to_address_supplied_errors(web3, math
         'With Value',
     ]
 )
-def test_prepare_transaction_with_contract_with_arguments(web3, skip_if_testrpc, math_contract,
+def test_build_transaction_with_contract_with_arguments(web3, skip_if_testrpc, math_contract,
                                                           transaction_args,
                                                           method_args,
                                                           method_kwargs,
@@ -116,7 +116,7 @@ def test_prepare_transaction_with_contract_with_arguments(web3, skip_if_testrpc,
     if skip_testrpc:
         skip_if_testrpc(web3)
 
-    txn = math_contract.prepareTransaction(transaction_args).increment(
+    txn = math_contract.buildTransaction(transaction_args).increment(
         *method_args, **method_kwargs
     )
     expected['to'] = math_contract.address

--- a/tests/core/contracts/test_contract_prepareTransaction.py
+++ b/tests/core/contracts/test_contract_prepareTransaction.py
@@ -28,6 +28,21 @@ def test_prepare_transaction_with_contract_no_arguments(web3, math_contract):
     }
 
 
+def test_prepare_transaction_with_contract_class_method(web3, MathContract, math_contract):
+    txn = MathContract.prepareTransaction({
+        'from': web3.eth.coinbase, 'to': math_contract.address
+    }).increment()
+    assert txn == {
+        'to': math_contract.address,
+        'data': '0xd09de08a',
+        'value': 0,
+        'gas': 43120,
+        'gasPrice': 1,
+        'nonce': 1,
+        'chainId': 1
+    }
+
+
 def test_prepare_transaction_with_contract_default_account_is_set(web3, math_contract):
     web3.eth.defaultAccount = web3.eth.coinbase
     txn = math_contract.prepareTransaction().increment()

--- a/tests/core/contracts/test_contract_prepareTransaction.py
+++ b/tests/core/contracts/test_contract_prepareTransaction.py
@@ -2,17 +2,6 @@
 
 import pytest
 
-from eth_utils import (
-    force_bytes,
-)
-
-from web3.utils.empty import (
-    empty,
-)
-from web3.utils.transactions import (
-    wait_for_transaction_receipt,
-)
-
 # Ignore warning in pyethereum 1.6 - will go away with the upgrade
 pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
 
@@ -36,11 +25,17 @@ def test_prepare_transacting_with_contract_no_arguments(web3, math_contract):
 @pytest.mark.parametrize(
     'transaction_args,method_args,method_kwargs,expected',
     (
-        ({}, (5,), {}, {'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005'}),
+        ({},
+         (5,),
+         {},
+         {'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005'}),
     ),
 )
-def test_prepare_transacting_with_contract_with_arguments(web3, math_contract, transaction_args, method_args, method_kwargs, expected):
-    txn = math_contract.prepareTransaction(transaction_args).increment(*method_args, **method_kwargs)
+def test_prepare_transacting_with_contract_with_arguments(web3, math_contract, transaction_args,
+                                                          method_args, method_kwargs, expected):
+    txn = math_contract.prepareTransaction(transaction_args).increment(
+        *method_args, **method_kwargs
+    )
     expected['to'] = math_contract.address
     assert txn is not None
     assert txn == expected

--- a/tests/core/contracts/test_contract_prepareTransaction.py
+++ b/tests/core/contracts/test_contract_prepareTransaction.py
@@ -16,35 +16,6 @@ def math_contract(web3, MathContract):
 
 
 def test_prepare_transaction_with_contract_no_arguments(web3, math_contract):
-    txn = math_contract.prepareTransaction({'from': web3.eth.coinbase}).increment()
-    assert txn == {
-        'to': math_contract.address,
-        'data': '0xd09de08a',
-        'value': 0,
-        'gas': 43120,
-        'gasPrice': 1,
-        'nonce': 1,
-        'chainId': 1
-    }
-
-
-def test_prepare_transaction_with_contract_class_method(web3, MathContract, math_contract):
-    txn = MathContract.prepareTransaction({
-        'from': web3.eth.coinbase, 'to': math_contract.address
-    }).increment()
-    assert txn == {
-        'to': math_contract.address,
-        'data': '0xd09de08a',
-        'value': 0,
-        'gas': 43120,
-        'gasPrice': 1,
-        'nonce': 1,
-        'chainId': 1
-    }
-
-
-def test_prepare_transaction_with_contract_default_account_is_set(web3, math_contract):
-    web3.eth.defaultAccount = web3.eth.coinbase
     txn = math_contract.prepareTransaction().increment()
     assert txn == {
         'to': math_contract.address,
@@ -52,14 +23,32 @@ def test_prepare_transaction_with_contract_default_account_is_set(web3, math_con
         'value': 0,
         'gas': 43120,
         'gasPrice': 1,
-        'nonce': 1,
         'chainId': 1
     }
 
 
-def test_prepare_transaction_with_contract_no_default_account_no_nonce_errors(web3, math_contract):
-    with pytest.raises(ValueError):
-        math_contract.prepareTransaction().increment()
+def test_prepare_transaction_with_contract_class_method(web3, MathContract, math_contract):
+    txn = MathContract.prepareTransaction({'to': math_contract.address}).increment()
+    assert txn == {
+        'to': math_contract.address,
+        'data': '0xd09de08a',
+        'value': 0,
+        'gas': 43120,
+        'gasPrice': 1,
+        'chainId': 1
+    }
+
+
+def test_prepare_transaction_with_contract_default_account_is_set(web3, math_contract):
+    txn = math_contract.prepareTransaction().increment()
+    assert txn == {
+        'to': math_contract.address,
+        'data': '0xd09de08a',
+        'value': 0,
+        'gas': 43120,
+        'gasPrice': 1,
+        'chainId': 1
+    }
 
 
 def test_prepare_transaction_with_contract_data_supplied_errors(web3, math_contract):
@@ -82,19 +71,19 @@ def test_prepare_transaction_with_contract_to_address_supplied_errors(web3, math
         (
             {}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gas': 43242, 'gasPrice': 1, 'nonce': 1, 'chainId': 1
+                'value': 0, 'gas': 43242, 'gasPrice': 1, 'chainId': 1
             }, False
         ),
         (
             {'gas': 800000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gas': 800000, 'gasPrice': 1, 'nonce': 1, 'chainId': 1
+                'value': 0, 'gas': 800000, 'gasPrice': 1, 'chainId': 1
             }, False
         ),
         (
             {'gasPrice': 21000000000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gas': 43242, 'gasPrice': 21000000000, 'nonce': 1, 'chainId': 1
+                'value': 0, 'gas': 43242, 'gasPrice': 21000000000, 'chainId': 1
             }, False
         ),
         (
@@ -106,7 +95,7 @@ def test_prepare_transaction_with_contract_to_address_supplied_errors(web3, math
         (
             {'value': 20000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 20000, 'gas': 43242, 'gasPrice': 1, 'nonce': 1, 'chainId': 1
+                'value': 20000, 'gas': 43242, 'gasPrice': 1, 'chainId': 1
             }, False
         ),
     ),
@@ -127,7 +116,6 @@ def test_prepare_transaction_with_contract_with_arguments(web3, skip_if_testrpc,
     if skip_testrpc:
         skip_if_testrpc(web3)
 
-    transaction_args['from'] = web3.eth.coinbase
     txn = math_contract.prepareTransaction(transaction_args).increment(
         *method_args, **method_kwargs
     )

--- a/tests/core/contracts/test_contract_prepareTransaction.py
+++ b/tests/core/contracts/test_contract_prepareTransaction.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from eth_utils import (
+    force_bytes,
+)
+
+from web3.utils.empty import (
+    empty,
+)
+from web3.utils.transactions import (
+    wait_for_transaction_receipt,
+)
+
+# Ignore warning in pyethereum 1.6 - will go away with the upgrade
+pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
+
+
+@pytest.fixture()
+def math_contract(web3, MathContract):
+    deploy_txn = MathContract.deploy()
+    deploy_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    assert deploy_receipt is not None
+    _math_contract = MathContract(address=deploy_receipt['contractAddress'])
+    return _math_contract
+
+
+def test_prepare_transacting_with_contract_no_arguments(web3, math_contract):
+    txn = math_contract.prepareTransaction().increment()
+    assert txn is not None
+    assert txn['to'] == math_contract.address
+    assert txn['data'] == '0xd09de08a'
+
+
+@pytest.mark.parametrize(
+    'transaction_args,method_args,method_kwargs,expected',
+    (
+        ({}, (5,), {}, {'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005'}),
+    ),
+)
+def test_prepare_transacting_with_contract_with_arguments(web3, math_contract, transaction_args, method_args, method_kwargs, expected):
+    txn = math_contract.prepareTransaction(transaction_args).increment(*method_args, **method_kwargs)
+    expected['to'] = math_contract.address
+    assert txn is not None
+    assert txn == expected

--- a/tests/core/contracts/test_contract_prepareTransaction.py
+++ b/tests/core/contracts/test_contract_prepareTransaction.py
@@ -62,50 +62,56 @@ def test_prepare_transaction_with_contract_to_address_supplied_errors(web3, math
 
 
 @pytest.mark.parametrize(
-    'transaction_args,method_args,method_kwargs,expected',
+    'transaction_args,method_args,method_kwargs,expected,skip_testrpc',
     (
         (
             {}, (5,), {}, {
-                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa
+                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
                 'value': 0, 'gas': 43242, 'gasPrice': 1, 'nonce': 1, 'chainId': 1
-            }
+            }, False
         ),
         (
             {'gas': 800000}, (5,), {}, {
-                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa
+                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
                 'value': 0, 'gas': 800000, 'gasPrice': 1, 'nonce': 1, 'chainId': 1
-            }
+            }, False
         ),
         (
             {'gasPrice': 21000000000}, (5,), {}, {
-                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa
+                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
                 'value': 0, 'gas': 43242, 'gasPrice': 21000000000, 'nonce': 1, 'chainId': 1
-            }
+            }, False
         ),
-        # (
-        #     {'nonce': 7}, (5,), {}, {
-        #         'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa
-        #         'value': 0, 'gas': 43242, 'gasPrice': 1, 'nonce': 7, 'chainId': 1
-        #     }
-        # ),
+        (
+            {'nonce': 7}, (5,), {}, {
+                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
+                'value': 0, 'gas': 43242, 'gasPrice': 1, 'nonce': 7, 'chainId': 1
+            }, True
+        ),
         (
             {'value': 20000}, (5,), {}, {
-                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa
+                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
                 'value': 20000, 'gas': 43242, 'gasPrice': 1, 'nonce': 1, 'chainId': 1
-            }
+            }, False
         ),
     ),
     ids=[
         'Standard',
         'Explicit Gas',
         'Explicit Gas Price',
-        # 'Explicit Nonce',  # eth-testrpc sendTransaction breaks when nonce is set
-        #  https://github.com/pipermerriam/eth-testrpc/issues/98
+        'Explicit Nonce',
         'With Value',
     ]
 )
-def test_prepare_transaction_with_contract_with_arguments(web3, math_contract, transaction_args,
-                                                          method_args, method_kwargs, expected):
+def test_prepare_transaction_with_contract_with_arguments(web3, skip_if_testrpc, math_contract,
+                                                          transaction_args,
+                                                          method_args,
+                                                          method_kwargs,
+                                                          expected,
+                                                          skip_testrpc):
+    if skip_testrpc:
+        skip_if_testrpc(web3)
+
     transaction_args['from'] = web3.eth.coinbase
     txn = math_contract.prepareTransaction(transaction_args).increment(
         *method_args, **method_kwargs

--- a/tests/core/contracts/test_contract_prepareTransaction.py
+++ b/tests/core/contracts/test_contract_prepareTransaction.py
@@ -16,7 +16,7 @@ def math_contract(web3, MathContract):
 
 
 def test_prepare_transacting_with_contract_no_arguments(web3, math_contract):
-    txn = math_contract.prepareTransaction().increment()
+    txn = math_contract.prepareTransaction({'from': web3.eth.coinbase}).increment()
     assert txn is not None
     assert txn['to'] == math_contract.address
     assert txn['data'] == '0xd09de08a'
@@ -25,14 +25,24 @@ def test_prepare_transacting_with_contract_no_arguments(web3, math_contract):
 @pytest.mark.parametrize(
     'transaction_args,method_args,method_kwargs,expected',
     (
-        ({},
-         (5,),
-         {},
-         {'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005'}),
+        (
+            {},
+            (5,),
+            {},
+            {
+                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa
+                'value': 0,
+                'gas': 43242,
+                'gasPrice': 1,
+                'nonce': 1,
+                'chainId': 1
+            }
+        ),
     ),
 )
 def test_prepare_transacting_with_contract_with_arguments(web3, math_contract, transaction_args,
                                                           method_args, method_kwargs, expected):
+    transaction_args['from'] = web3.eth.coinbase
     txn = math_contract.prepareTransaction(transaction_args).increment(
         *method_args, **method_kwargs
     )

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -489,30 +489,30 @@ class Contract(object):
         return Transactor()
 
     @combomethod
-    def prepareTransaction(self, transaction=None):
+    def buildTransaction(self, transaction=None):
         """
-        Prepare a dict for a transaction without sending
+        Build the transaction dictionary without sending
         """
         if transaction is None:
-            prepared_transaction = {}
+            built_transaction = {}
         else:
-            prepared_transaction = dict(**transaction)
+            built_transaction = dict(**transaction)
 
-        if 'data' in prepared_transaction:
-            raise ValueError("Cannot set data in call prepareTransaction")
+        if 'data' in built_transaction:
+            raise ValueError("Cannot set data in call buildTransaction")
 
-        if isinstance(self, type) and 'to' not in prepared_transaction:
+        if isinstance(self, type) and 'to' not in built_transaction:
             raise ValueError(
-                "When using `Contract.prepareTransaction` from a contract factory "
+                "When using `Contract.buildTransaction` from a contract factory "
                 "you must provide a `to` address with the transaction"
             )
-        if not isinstance(self, type) and 'to' in prepared_transaction:
-            raise ValueError("Cannot set to in call prepareTransaction")
+        if not isinstance(self, type) and 'to' in built_transaction:
+            raise ValueError("Cannot set to in call buildTransaction")
 
         if self.address:
-            prepared_transaction.setdefault('to', self.address)
+            built_transaction.setdefault('to', self.address)
 
-        if 'to' not in prepared_transaction:
+        if 'to' not in built_transaction:
             raise ValueError(
                 "Please ensure that this contract instance has an address."
             )
@@ -522,10 +522,10 @@ class Contract(object):
         class Caller(object):
             def __getattr__(self, function_name):
                 callable_fn = functools.partial(
-                    prepare_transaction_for_function,
+                    build_transaction_for_function,
                     contract,
                     function_name,
-                    prepared_transaction,
+                    built_transaction,
                 )
                 return callable_fn
 
@@ -745,7 +745,7 @@ CONCISE_NORMALIZERS = (
 
 
 class ConciseMethod:
-    ALLOWED_MODIFIERS = set(['call', 'estimateGas', 'transact', 'prepareTransaction'])
+    ALLOWED_MODIFIERS = set(['call', 'estimateGas', 'transact', 'buildTransaction'])
 
     def __init__(self, contract, function):
         self.__contract = contract
@@ -868,14 +868,14 @@ def estimate_gas_for_function(contract=None,
     return gas_estimate
 
 
-def prepare_transaction_for_function(contract=None,
-                                     function_name=None,
-                                     transaction=None,
-                                     *args,
-                                     **kwargs):
-    """Prepares a dictionary with the fields required to make the given transaction
+def build_transaction_for_function(contract=None,
+                                   function_name=None,
+                                   transaction=None,
+                                   *args,
+                                   **kwargs):
+    """Builds a dictionary with the fields required to make the given transaction
 
-    Don't call this directly, instead use :meth:`Contract.prepareTransaction`
+    Don't call this directly, instead use :meth:`Contract.buildTransaction`
     on your contract instance.
     """
     prepared_transaction = contract._prepare_transaction(

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -498,6 +498,9 @@ class Contract(object):
         else:
             prepared_transaction = dict(**transaction)
 
+        if self.web3.eth.defaultAccount is not empty:
+            prepared_transaction.setdefault('from', self.web3.eth.defaultAccount)
+
         if 'data' in prepared_transaction:
             raise ValueError("Cannot set data in call prepareTransaction")
         if 'to' in prepared_transaction:
@@ -888,6 +891,6 @@ def prepare_transaction_for_function(contract=None,
     )
 
     prepared_transaction = fill_transaction_defaults(contract.web3, prepared_transaction)
-    prepared_transaction.pop('from')  # from is not a valid transaction part
+    prepared_transaction.pop('from')  # from is not a valid transaction part and used only for retreiving nonce
 
     return prepared_transaction

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -503,8 +503,15 @@ class Contract(object):
 
         if 'data' in prepared_transaction:
             raise ValueError("Cannot set data in call prepareTransaction")
-        if 'to' in prepared_transaction:
+
+        if isinstance(self, type) and 'to' not in prepared_transaction:
+            raise ValueError(
+                "When using `Contract.prepareTransaction` from a contract factory "
+                "you must provide a `to` address with the transaction"
+            )
+        if not isinstance(self, type) and 'to' in prepared_transaction:
             raise ValueError("Cannot set to in call prepareTransaction")
+
         if 'from' not in prepared_transaction and 'nonce' not in prepared_transaction:
             raise ValueError("Either 'from' or 'nonce' must be set in call prepareTransaction")
 
@@ -512,15 +519,9 @@ class Contract(object):
             prepared_transaction.setdefault('to', self.address)
 
         if 'to' not in prepared_transaction:
-            if isinstance(self, type):
-                raise ValueError(
-                    "When using `Contract.prepareTransaction` from a contract factory "
-                    "you must provide a `to` address with the transaction"
-                )
-            else:
-                raise ValueError(
-                    "Please ensure that this contract instance has an address."
-                )
+            raise ValueError(
+                "Please ensure that this contract instance has an address."
+            )
 
         contract = self
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -498,9 +498,6 @@ class Contract(object):
         else:
             prepared_transaction = dict(**transaction)
 
-        if self.web3.eth.defaultAccount is not empty:
-            prepared_transaction.setdefault('from', self.web3.eth.defaultAccount)
-
         if 'data' in prepared_transaction:
             raise ValueError("Cannot set data in call prepareTransaction")
 
@@ -511,9 +508,6 @@ class Contract(object):
             )
         if not isinstance(self, type) and 'to' in prepared_transaction:
             raise ValueError("Cannot set to in call prepareTransaction")
-
-        if 'from' not in prepared_transaction and 'nonce' not in prepared_transaction:
-            raise ValueError("Either 'from' or 'nonce' must be set in call prepareTransaction")
 
         if self.address:
             prepared_transaction.setdefault('to', self.address)
@@ -892,7 +886,5 @@ def prepare_transaction_for_function(contract=None,
     )
 
     prepared_transaction = fill_transaction_defaults(contract.web3, prepared_transaction)
-    # from is not a valid transaction part and used only for retreiving nonce
-    prepared_transaction.pop('from')
 
     return prepared_transaction

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -891,6 +891,7 @@ def prepare_transaction_for_function(contract=None,
     )
 
     prepared_transaction = fill_transaction_defaults(contract.web3, prepared_transaction)
-    prepared_transaction.pop('from')  # from is not a valid transaction part and used only for retreiving nonce
+    # from is not a valid transaction part and used only for retreiving nonce
+    prepared_transaction.pop('from')
 
     return prepared_transaction

--- a/web3/utils/transactions.py
+++ b/web3/utils/transactions.py
@@ -63,7 +63,6 @@ TRANSACTION_DEFAULTS = {
     'data': b'',
     'gas': lambda web3, tx: web3.eth.estimateGas(tx),
     'gasPrice': lambda web3, tx: web3.eth.gasPrice,
-    'nonce': lambda web3, tx: web3.eth.getTransactionCount(tx['from']),
     'chainId': lambda web3, tx: int(web3.net.version),
 }
 

--- a/web3/utils/transactions.py
+++ b/web3/utils/transactions.py
@@ -59,10 +59,12 @@ def encode_transaction(unsigned_transaction, vrs):
 
 
 TRANSACTION_DEFAULTS = {
-    'gasPrice': lambda web3: web3.eth.gasPrice,
     'value': 0,
     'data': b'',
-    'chainId': lambda web3: int(web3.net.version),
+    'gas': lambda web3, tx: web3.eth.estimateGas(tx),
+    'gasPrice': lambda web3, tx: web3.eth.gasPrice,
+    'nonce': lambda web3, tx: web3.eth.getTransactionCount(tx['from']),
+    'chainId': lambda web3, tx: int(web3.net.version),
 }
 
 TRANSACTION_FORMATTERS = {
@@ -97,7 +99,7 @@ def fill_transaction_defaults(web3, transaction):
         if key not in transaction:
             if callable(default_getter):
                 if web3 is not None:
-                    default_val = default_getter(web3)
+                    default_val = default_getter(web3, transaction)
                 else:
                     raise ValueError("You must specify %s in the transaction" % key)
             else:


### PR DESCRIPTION
### What was wrong?

There is no convenient way to prepare a contract transaction for offline signing.

### How was it fixed?

Add a method to the contract api `prepareTransaction` to return a dictionary for easy transaction signing.

### Tasks

- [x] choose naming
- [x] implement new API
- [x] document in docs/
- [x] reference this method in signTransaction docs docs/web3.eth.account.rst

#### Cute Animal Picture
![Mandatory fluff ball](https://i.pinimg.com/originals/9b/49/7e/9b497ece12df1a9ff742485f67c4276c.jpg)

Fixes #430