### PR TITLE
ens: use new w3 auto-import

### DIFF
--- a/ens/utils.py
+++ b/ens/utils.py
@@ -47,14 +47,22 @@ def ensure_hex(data):
     return data
 
 
-def init_web3(providers=None):
-    from web3 import HTTPProvider, IPCProvider, Web3
+def init_web3(providers=tuple()):
+    from web3 import Web3
+
+    if not providers:
+        from web3.auto import w3
+        if w3:
+            return customize_web3(w3)
+
+    w3 = Web3(providers, ens=None)
+    return customize_web3(w3)
+
+
+def customize_web3(w3):
     from web3.contract import ConciseContract
     from web3.middleware import make_stalecheck_middleware
 
-    if not providers:
-        providers = [IPCProvider(), HTTPProvider('http://localhost:8545')]
-    w3 = Web3(providers, ens=None)
     w3.middleware_stack.remove('name_to_address')
     w3.middleware_stack.add(
         make_stalecheck_middleware(ACCEPTABLE_STALE_HOURS * 3600),

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -26,6 +26,8 @@ from ens.constants import (
     REVERSE_REGISTRAR_DOMAIN,
 )
 
+default = object()
+
 
 def Web3():
     from web3 import Web3
@@ -47,15 +49,14 @@ def ensure_hex(data):
     return data
 
 
-def init_web3(providers=tuple()):
+def init_web3(providers=default):
     from web3 import Web3
 
-    if not providers:
-        from web3.auto import w3
-        if w3:
-            return customize_web3(w3)
+    if providers is default:
+        w3 = Web3(ens=None)
+    else:
+        w3 = Web3(providers, ens=None)
 
-    w3 = Web3(providers, ens=None)
     return customize_web3(w3)
 
 


### PR DESCRIPTION
### What was wrong?

The `ens` module had a watered down version of the automatic web3 import mechanism.

### How was it fixed?

Abandoned it in favor of the new `from web3.auto import w3`

Blocking on #487 

#### Cute Animal Picture

![Cute animal picture](https://static.boredpanda.com/blog/wp-content/uploads/2015/02/e3c5531554e60a12bfc0b9ffb67cf5ec__605.jpg)
