### PR TITLE
Configuration for bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,21 @@
+[bumpversion]
+current_version = 4.0.0-beta.1
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)-(?P<stage>[^.]*)\.(?P<devnum>\d+)
+serialize =
+  {major}.{minor}.{patch}-{stage}.{devnum}
+  {major}.{minor}.{patch}
+
+[bumpversion:part:stage]
+optional_value = stable
+values =
+  alpha
+  beta
+  stable
+
+[bumpversion:part:devnum]
+
+[bumpversion:file:setup.py]
+search=    version='{current_version}',
+replace=    version='{new_version}',

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,13 +2,14 @@
 current_version = 4.0.0-beta.1
 commit = True
 tag = True
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)-(?P<stage>[^.]*)\.(?P<devnum>\d+)
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
 serialize =
   {major}.{minor}.{patch}-{stage}.{devnum}
   {major}.{minor}.{patch}
 
 [bumpversion:part:stage]
 optional_value = stable
+first_value = stable
 values =
   alpha
   beta

--- a/README.md
+++ b/README.md
@@ -176,4 +176,23 @@ For Debian-like systems:
 apt install pandoc
 ```
 
-*TODO* other release instructions
+To release a new version:
+
+```sh
+bumpversion $$VERSION_PART_TO_BUMP$$
+git push && git push --tags
+make release
+```
+
+#### How to bumpversion
+
+The version format for this repo is `{major}.{minor}.{patch}` for stable, and
+`{major}.{minor}.{patch}-{stage}.{devnum}` for unstable (`stage` can be alpha or beta).
+
+To issue the next version in line, use bumpversion and specify which part to bump,
+like `bumpversion minor` or `bumpversion devnum`.
+
+If you are in a beta version, `bumpversion stage` will switch to a stable.
+
+To issue an unstable version when the current version is stable, specify the
+new version explicitly, like `bumpversion --new-version 4.0.0-alpha.1 devnum`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+bumpversion
 eth-testrpc>=1.3.3
 ethereum>=1.6.1,<2.0
 flaky>=3.3.0

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ if sys.platform == 'win32':
 
 setup(
     name='web3',
+    # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version='4.0.0-beta.1',
     description="""Web3.py""",
     long_description_markdown_filename='README.md',


### PR DESCRIPTION
### What was wrong?

Version bumping is done manually

### How was it fixed?

Set up bumpversion so that it can be bumped with a one-liner, like `bumpversion patch`

See docs added to README

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/736x/40/58/0c/40580ce0cc67452e97d84051612989dc--fluffy-puppies-little-puppies.jpg)