### PR TITLE
Re-raise formatting errors with field name

### DIFF
--- a/tests/core/utilities/test_formatters.py
+++ b/tests/core/utilities/test_formatters.py
@@ -2,6 +2,7 @@
 import pytest
 
 from web3.utils.formatters import (
+    apply_formatters_to_dict,
     map_collection,
     recursive_map,
 )
@@ -39,3 +40,12 @@ def test_recursive_collection_cycle():
     data.append(data)
     with pytest.raises(ValueError):
         recursive_map(square_int, data)
+
+
+def test_format_dict_error():
+    with pytest.raises(ValueError) as exc_info:
+        apply_formatters_to_dict(
+            {'myfield': int},
+            {'myfield': 'a'},
+        )
+    assert 'myfield' in str(exc_info.value)

--- a/web3/utils/formatters.py
+++ b/web3/utils/formatters.py
@@ -67,7 +67,10 @@ def apply_formatter_if(condition, formatter, value):
 def apply_formatters_to_dict(formatters, value):
     for key, item in value.items():
         if key in formatters:
-            yield key, formatters[key](item)
+            try:
+                yield key, formatters[key](item)
+            except (TypeError, ValueError) as exc:
+                raise type(exc)("Could not format value %r as field %r" % (item, key)) from exc
         else:
             yield key, item
 


### PR DESCRIPTION
### What was wrong?

Very difficult to debug which formatter is failing when applied to a dict.

### How was it fixed?

Re-raise the formatting exception with the field name.

Closes #459 

#### Cute Animal Picture

![Cute animal picture](http://1.bp.blogspot.com/_N_mOB63qPaE/TPqDpMSoi0I/AAAAAAAARLU/myhdmOG5TbY/s1600/Polar-Bear-Cute-Photo.jpg)