### PR TITLE
Fix ABI encoding of arrays of strings and bytes

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ flaky>=3.3.0
 flake8==3.4.1
 hypothesis>=3.31.2
 py-geth==1.10.2
-pytest>=3.2.1
+pytest==3.2.5
 pytest-mock==1.*
 pytest-pythonpath>=0.3
 pytest-watch==4.*

--- a/tests/core/contracts/test_contract_method_abi_encoding.py
+++ b/tests/core/contracts/test_contract_method_abi_encoding.py
@@ -5,6 +5,7 @@ import pytest
 ABI_A = json.loads('[{"constant":false,"inputs":[],"name":"a","outputs":[],"type":"function"}]')
 ABI_B = json.loads('[{"constant":false,"inputs":[{"name":"","type":"uint256"}],"name":"a","outputs":[],"type":"function"}]')  # noqa: E501
 ABI_C = json.loads('[{"constant":false,"inputs":[],"name":"a","outputs":[],"type":"function"},{"constant":false,"inputs":[{"name":"","type":"bytes32"}],"name":"a","outputs":[],"type":"function"},{"constant":false,"inputs":[{"name":"","type":"uint256"}],"name":"a","outputs":[],"type":"function"}]')  # noqa: E501
+ABI_D = json.loads('[{ "constant": false, "inputs": [ { "name": "b", "type": "bytes32[]" } ], "name": "byte_array", "outputs": [], "payable": false, "type": "function" }]')  # noqa: E501
 
 
 @pytest.mark.parametrize(
@@ -59,4 +60,26 @@ ABI_C = json.loads('[{"constant":false,"inputs":[],"name":"a","outputs":[],"type
 def test_contract_abi_encoding(web3, abi, method, arguments, data, expected):
     contract = web3.eth.contract(abi=abi)
     actual = contract.encodeABI(method, arguments, data=data)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'abi,method,kwargs,expected',
+    (
+        (
+            ABI_D,
+            'byte_array',
+            {
+                'b': [
+                    '0x5595c210956e7721f9b692e702708556aa9aabb14ea163e96afa56ffbe9fa809',
+                    '0x6f8d2fa18448afbfe4f82143c384484ad09a0271f3a3c0eb9f629e703f883125',
+                ],
+            },
+            '0xf166d6f8000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000025595c210956e7721f9b692e702708556aa9aabb14ea163e96afa56ffbe9fa8096f8d2fa18448afbfe4f82143c384484ad09a0271f3a3c0eb9f629e703f883125',  # noqa: E501
+        ),
+    ),
+)
+def test_contract_abi_encoding_kwargs(web3, abi, method, kwargs, expected):
+    contract = web3.eth.contract(abi=abi)
+    actual = contract.encodeABI(method, kwargs=kwargs)
     assert actual == expected

--- a/web3/utils/normalizers.py
+++ b/web3/utils/normalizers.py
@@ -97,7 +97,7 @@ def abi_string_to_hex(abi_type, data):
 @implicitly_identity
 def hexstrs_to_bytes(abi_type, data):
     base, sub, arrlist = process_type(abi_type)
-    if base in {'string', 'bytes'}:
+    if base in {'string', 'bytes'} and not arrlist:
         return abi_type, hexstr_if_str(to_bytes, data)
 
 


### PR DESCRIPTION
### What was wrong?

Only in v4: `contract.encodeABI` fails to encode a byte-array with:

> `TypeError: expected an int in first arg, or keyword of hexstr or text`

It was trying to convert an array of hex strings into bytes all at once.

This conversion to bytes only happens in contract ABI encoding, because `encode_abi` expects byte arguments, and the other places that do this encoding (like middleware before sending to a client) expect hex-encoded arguments.

### How was it fixed?

Check that conversion from hex to bytes only happens at the basic type level, not the array level.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/d2/9b/61/d29b61c81bf5dea37046199b93a135f1.jpg)
