### PR TITLE
Fix crash on ipc.isConnected() with None path

### DIFF
--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -1,0 +1,12 @@
+from web3 import Web3
+from web3.providers.ipc import (
+    IPCProvider,
+)
+
+
+def test_ipc_no_path():
+    """
+    IPCProvider.isConnected() returns False when no path is supplied
+    """
+    ipc = IPCProvider(None)
+    assert ipc.isConnected() is False

--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -1,4 +1,3 @@
-from web3 import Web3
 from web3.providers.ipc import (
     IPCProvider,
 )

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -35,6 +35,9 @@ class PersistantSocket(object):
         self.ipc_path = ipc_path
 
     def __enter__(self):
+        if not self.ipc_path:
+            raise FileNotFoundError("cannot connect to IPC socket at path: %r" % self.ipc_path)
+
         if not self.sock:
             self.sock = get_ipc_socket(self.ipc_path)
         return self.sock
@@ -137,9 +140,6 @@ class IPCProvider(JSONBaseProvider):
 
     def make_request(self, method, params):
         request = self.encode_rpc_request(method, params)
-
-        if not self.ipc_path:
-            raise FileNotFoundError("cannot connect to IPC socket at path: %r" % self.ipc_path)
 
         with self._lock, self._socket as sock:
             sock.sendall(request)

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -138,6 +138,9 @@ class IPCProvider(JSONBaseProvider):
     def make_request(self, method, params):
         request = self.encode_rpc_request(method, params)
 
+        if not self.ipc_path:
+            raise FileNotFoundError("cannot connect to IPC socket at path: %r" % self.ipc_path)
+
         with self._lock, self._socket as sock:
             sock.sendall(request)
             raw_response = b""


### PR DESCRIPTION
### What was wrong?

Fixes #437 

### How was it fixed?

raise a `FileNotFoundError` instead of TypeError when trying to open an IPC path of None.

#### Cute Animal Picture

![Cute animal picture](http://www.awesomelycute.com/gallery/2015/05/tiny-horses-25.jpg)