### PR TITLE
bumpversion and release in one-liner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,12 @@ linux-docs: build-docs
 	xdg-open docs/_build/html/index.html
 
 release: clean
+	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
+	git config commit.gpgSign true
+	bumpversion $(bump)
+	git push && git push --tags
 	python setup.py sdist bdist_wheel upload
+	git config commit.gpgSign "$CURRENT_SIGN_SETTING"
 
 dist: clean
 	python setup.py sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -179,9 +179,7 @@ apt install pandoc
 To release a new version:
 
 ```sh
-bumpversion $$VERSION_PART_TO_BUMP$$
-git push && git push --tags
-make release
+make release bump=$$VERSION_PART_TO_BUMP$$
 ```
 
 #### How to bumpversion
@@ -189,10 +187,10 @@ make release
 The version format for this repo is `{major}.{minor}.{patch}` for stable, and
 `{major}.{minor}.{patch}-{stage}.{devnum}` for unstable (`stage` can be alpha or beta).
 
-To issue the next version in line, use bumpversion and specify which part to bump,
-like `bumpversion minor` or `bumpversion devnum`.
+To issue the next version in line, specify which part to bump,
+like `make release bump=minor` or `make release bump=devnum`.
 
-If you are in a beta version, `bumpversion stage` will switch to a stable.
+If you are in a beta version, `make release bump=stage` will switch to a stable.
 
 To issue an unstable version when the current version is stable, specify the
-new version explicitly, like `bumpversion --new-version 4.0.0-alpha.1 devnum`
+new version explicitly, like `make release bump="--new-version 4.0.0-alpha.1 devnum"`


### PR DESCRIPTION
### What was wrong?

I'm too lazy to type or remember three lines for releasing new versions.

### How was it fixed?

Pushed all the version bump and release logic into the makefile

*Sorry I didn't come up with this before you copied it everywhere @pipermerriam X)*

#### Cute Animal Picture

![Cute animal picture](https://img.buzzfeed.com/buzzfeed-static/static/enhanced/web05/2011/9/3/15/enhanced-buzz-20818-1315077541-4.jpg)