### PR TITLE
Fix from pull request #470 didn't work

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -36,7 +36,11 @@ Or to install with support for the ``TestRPCProvider`` and
 
    $ pip install web3[tester]
 
-
+Installing Web3.py on Windows using ``pip`` can be done as follows.
+.. code-block:: shell
+   
+   $ pip install['win']
+   
 Installation from source can be done from the root of the project with the
 following command.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -39,7 +39,7 @@ Or to install with support for the ``TestRPCProvider`` and
 Installing Web3.py on Windows using ``pip`` can be done as follows.
 .. code-block:: shell
    
-   $ pip install['win']
+   $ pip install web3['win']
    
 Installation from source can be done from the root of the project with the
 following command.

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     extras_require={
         'tester': ["eth-testrpc>=1.3.3"],
-        'platform_system=="Windows"': [
-            'pypiwin32'
-        ],
+        'win': ['pypiwin32'],
     },
     py_modules=['web3', 'ens'],
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     extras_require={
         'tester': ["eth-testrpc>=1.3.3"],
-        'win': ['pypiwin32'],
+        'win': ["pypiwin32"],
     },
     py_modules=['web3', 'ens'],
     license="MIT",


### PR DESCRIPTION
### What was wrong?
After submitting #470, I thought I would be able to use web3.py without having to manually install `pypiwin32`. However, this was not the case. The suggestion from the stackoverflow post in #470 didn't work. 

### How was it fixed?
I looked up the [documentation](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies) for pip and there are 2 options:
..* Add an optional key, so that if the user is on Windows, install web3.py like `pip install web3['win']`
..* Add an extra value to the install requires list

The second option is what was implemented before #470. Thus, I decided to do the first option. Also, I think the first option is better because in the future, there might be more windows specific dependencies. To add any new dependencies, it simply requires adding the module to the list and the user installs as usual.

I also added how to install web3 if on a windows machine to the `Quickstart` documentation page.

#### Cute Animal Picture

![Cute animal picture](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-31.jpg)
