### PR TITLE
bump eth-tester version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "requests>=2.12.4",
         "rlp>=0.4.7",
         "toolz>=0.8.2",
-        "eth-tester~=0.1.0b2",
+        "eth-tester~=0.1.0b4",
     ],
     setup_requires=['setuptools-markdown'],
     extras_require={


### PR DESCRIPTION
### What was wrong?

Upstream bugfixes for eth-tester to work with evolving py-evm API

### How was it fixed?

Updated things.

#### Cute Animal Picture

![32664292259756e95aad1b9986f22437](https://user-images.githubusercontent.com/824194/33567241-ca8b2c54-d8df-11e7-8d12-395b55e463ad.jpg)
