### PR TITLE
w3.setProviders(providers) => w3.providers = providers

### DIFF
--- a/tests/core/web3-module/test_providers.py
+++ b/tests/core/web3-module/test_providers.py
@@ -4,7 +4,7 @@ from web3.providers.eth_tester import EthereumTesterProvider
 def test_set_providers(web3):
     providers = [EthereumTesterProvider()]
 
-    web3.setProviders(providers)
+    web3.providers = providers
 
     assert web3.providers == providers
 
@@ -12,6 +12,6 @@ def test_set_providers(web3):
 def test_set_providers_single(web3):
     providers = [EthereumTesterProvider()]
 
-    web3.setProviders(providers[0])
+    web3.providers = providers[0]
 
     assert web3.providers == providers

--- a/tests/core/web3-module/test_providers.py
+++ b/tests/core/web3-module/test_providers.py
@@ -1,0 +1,17 @@
+from web3.providers.eth_tester import EthereumTesterProvider
+
+
+def test_set_providers(web3):
+    providers = [EthereumTesterProvider()]
+
+    web3.setProviders(providers)
+
+    assert web3.providers == providers
+
+
+def test_set_providers_single(web3):
+    providers = [EthereumTesterProvider()]
+
+    web3.setProviders(providers[0])
+
+    assert web3.providers == providers

--- a/web3/main.py
+++ b/web3/main.py
@@ -121,7 +121,7 @@ class Web3(object):
         return self.manager.providers
 
     def setProviders(self, providers):
-        self.manager.setProvider(providers)
+        self.manager.providers = providers
 
     @staticmethod
     @apply_to_return_value(HexBytes)

--- a/web3/main.py
+++ b/web3/main.py
@@ -120,7 +120,8 @@ class Web3(object):
     def providers(self):
         return self.manager.providers
 
-    def setProviders(self, providers):
+    @providers.setter
+    def providers(self, providers):
         self.manager.providers = providers
 
     @staticmethod

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -23,6 +23,7 @@ from web3.utils.formatters import (
     apply_formatter_if,
 )
 
+from eth_tester import EthereumTester
 from eth_tester.exceptions import (
     BlockNotFound,
     FilterNotFound,
@@ -350,8 +351,11 @@ class EthereumTesterProvider(BaseProvider):
     ethereum_tester = None
     api_endpoints = None
 
-    def __init__(self, ethereum_tester, api_endpoints=API_ENDPOINTS):
-        self.ethereum_tester = ethereum_tester
+    def __init__(self, ethereum_tester=None, api_endpoints=API_ENDPOINTS):
+        if ethereum_tester is None:
+            self.ethereum_tester = EthereumTester()
+        else:
+            self.ethereum_tester = ethereum_tester
         self.api_endpoints = api_endpoints
 
     def make_request(self, method, params):


### PR DESCRIPTION
### What was wrong?

`w3.setProviders()` fails hard...

### How was it fixed?

- Added a test for this feature
- Bugfix the broken call to `manager.setProviders()`
- Updated the API to be more in line with the manager API: `w3.providers = [Provider()]` or `w3.providers = Provider()`
- Default `EthereumTesterProvider()` to use `EthereumTester()` when an eth_tester instance is not provided

#### Cute Animal Picture

![Cute animal picture](http://i.dailymail.co.uk/i/pix/2013/03/09/article-2290757-18889264000005DC-88_306x423.jpg)