### PR TITLE
 enable block filter test, and bugfix BlockFilter

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -68,16 +68,16 @@ def wait_for_miner_start():
 
 @pytest.fixture()
 def wait_for_block():
-    def _wait_for_block(web3, block_number=1, timeout=60 * 10):
+    def _wait_for_block(web3, block_number=1, timeout=None):
+        if not timeout:
+            timeout = (block_number - web3.eth.blockNumber) * 3
         poll_delay_counter = PollDelayCounter()
         with Timeout(timeout) as timeout:
             while True:
                 if web3.eth.blockNumber >= block_number:
                     break
-                if is_all_testrpc_providers(web3.providers):
-                    web3.manager.request_blocking("evm_mine", [])
-                time.sleep(poll_delay_counter())
-                timeout.check()
+                web3.manager.request_blocking("evm_mine", [])
+                timeout.sleep(poll_delay_counter())
     return _wait_for_block
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ addopts= -v --showlocals --durations 10
 python_paths= .
 
 [pytest-watch]
-runner= py.test --failed-first --maxfail=1 --no-success-flaky-report
+runner= py.test --failed-first --maxfail=1 --no-success-flaky-report --fulltrace

--- a/tests/core/filtering/test_filter_against_latest_blocks.py
+++ b/tests/core/filtering/test_filter_against_latest_blocks.py
@@ -1,54 +1,28 @@
-from flaky import flaky
-
+from web3.providers.eth_tester import EthereumTesterProvider
 from web3.utils.threads import (
     Timeout,
 )
 
 
-@flaky(max_runs=3)
 def test_sync_filter_against_latest_blocks(web3, sleep_interval, wait_for_block, skip_if_testrpc):
-    skip_if_testrpc(web3)
+    if EthereumTesterProvider not in map(type, web3.providers):
+        web3.providers = EthereumTesterProvider()
 
-    seen_blocks = []
     txn_filter = web3.eth.filter("latest")
 
     current_block = web3.eth.blockNumber
 
     wait_for_block(web3, current_block + 3)
 
+    found_block_hashes = []
     with Timeout(5) as timeout:
-        while len(txn_filter.get_new_entries()) < 2:
+        while len(found_block_hashes) < 3:
+            found_block_hashes.extend(txn_filter.get_new_entries())
             timeout.sleep(sleep_interval())
 
-    expected_block_hashes = [
-        web3.eth.getBlock(n)['hash'] for n in range(current_block + 1, current_block + 3)
-    ]
-    assert len(txn_filter.get_new_entries()) >= 2
-
-    assert set(expected_block_hashes).issubset(seen_blocks)
-
-
-@flaky(max_runs=3)
-def test_async_filter_against_latest_blocks(web3, sleep_interval, wait_for_block, skip_if_testrpc):
-    skip_if_testrpc(web3)
-
-    seen_blocks = []
-    txn_filter = web3.eth.filter("latest")
-    txn_filter.watch(seen_blocks.append)
-
-    current_block = web3.eth.blockNumber
-
-    wait_for_block(web3, current_block + 3)
-
-    with Timeout(5) as timeout:
-        while len(seen_blocks) < 2:
-            timeout.sleep(sleep_interval())
-
-    txn_filter.stop_watching(3)
+    assert len(found_block_hashes) == 3
 
     expected_block_hashes = [
-        web3.eth.getBlock(n)['hash'] for n in range(current_block + 1, current_block + 3)
+        web3.eth.getBlock(n + 1).hash for n in range(current_block, current_block + 3)
     ]
-    assert len(seen_blocks) >= 2
-
-    assert set(expected_block_hashes).issubset(seen_blocks)
+    assert found_block_hashes == expected_block_hashes

--- a/tests/core/filtering/test_filter_against_latest_blocks.py
+++ b/tests/core/filtering/test_filter_against_latest_blocks.py
@@ -4,7 +4,7 @@ from web3.utils.threads import (
 )
 
 
-def test_sync_filter_against_latest_blocks(web3, sleep_interval, wait_for_block, skip_if_testrpc):
+def test_sync_filter_against_latest_blocks(web3, sleep_interval, wait_for_block):
     if EthereumTesterProvider not in map(type, web3.providers):
         web3.providers = EthereumTesterProvider()
 

--- a/tests/core/web3-module/test_providers.py
+++ b/tests/core/web3-module/test_providers.py
@@ -4,7 +4,7 @@ from web3.providers.eth_tester import EthereumTesterProvider
 def test_set_providers(web3):
     providers = [EthereumTesterProvider()]
 
-    web3.setProviders(providers)
+    web3.providers = providers
 
     assert web3.providers == providers
 
@@ -12,6 +12,6 @@ def test_set_providers(web3):
 def test_set_providers_single(web3):
     providers = [EthereumTesterProvider()]
 
-    web3.setProviders(providers[0])
+    web3.providers = providers[0]
 
     assert web3.providers == providers

--- a/tests/core/web3-module/test_providers.py
+++ b/tests/core/web3-module/test_providers.py
@@ -1,0 +1,17 @@
+from web3.providers.eth_tester import EthereumTesterProvider
+
+
+def test_set_providers(web3):
+    providers = [EthereumTesterProvider()]
+
+    web3.setProviders(providers)
+
+    assert web3.providers == providers
+
+
+def test_set_providers_single(web3):
+    providers = [EthereumTesterProvider()]
+
+    web3.setProviders(providers[0])
+
+    assert web3.providers == providers

--- a/web3/main.py
+++ b/web3/main.py
@@ -121,7 +121,7 @@ class Web3(object):
         return self.manager.providers
 
     def setProviders(self, providers):
-        self.manager.setProvider(providers)
+        self.manager.providers = providers
 
     @staticmethod
     @apply_to_return_value(HexBytes)

--- a/web3/main.py
+++ b/web3/main.py
@@ -120,7 +120,8 @@ class Web3(object):
     def providers(self):
         return self.manager.providers
 
-    def setProviders(self, providers):
+    @providers.setter
+    def providers(self, providers):
         self.manager.providers = providers
 
     @staticmethod

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -243,7 +243,7 @@ filter_params_formatter = apply_formatters_to_dict(FILTER_PARAMS_FORMATTERS)
 
 filter_result_formatter = apply_one_of_formatters((
     (apply_formatter_to_array(log_entry_formatter), is_array_of_dicts),
-    (apply_formatter_to_array(to_ascii_if_bytes), is_array_of_strings),
+    (apply_formatter_to_array(to_hexbytes(32)), is_array_of_strings),
 ))
 
 

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -23,6 +23,7 @@ from web3.utils.formatters import (
     apply_formatter_if,
 )
 
+from eth_tester import EthereumTester
 from eth_tester.exceptions import (
     BlockNotFound,
     FilterNotFound,
@@ -350,8 +351,11 @@ class EthereumTesterProvider(BaseProvider):
     ethereum_tester = None
     api_endpoints = None
 
-    def __init__(self, ethereum_tester, api_endpoints=API_ENDPOINTS):
-        self.ethereum_tester = ethereum_tester
+    def __init__(self, ethereum_tester=None, api_endpoints=API_ENDPOINTS):
+        if ethereum_tester is None:
+            self.ethereum_tester = EthereumTester()
+        else:
+            self.ethereum_tester = ethereum_tester
         self.api_endpoints = api_endpoints
 
     def make_request(self, method, params):

--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -108,7 +108,7 @@ class Filter:
 
     def _format_log_entries(self, log_entries=None):
         if log_entries is None:
-            log_entries = []
+            return []
 
         formatted_log_entries = [
             self.format_entry(log_entry) for log_entry in log_entries


### PR DESCRIPTION
### What was wrong?

BlockFilter (ie~ `eth.filter('latest')`) was broken.

### How was it fixed?

Depends on #489 

- removed 'skip' in the block test
- set up EthereumTester to work with `wait_for_block()`
- bugfix `BlockFilter` (move several required functions from `LogFilter` up to superclass `Filter`)

#### Cute Animal Picture

![Cute animal picture](http://3.bp.blogspot.com/-80l752uThao/VBIHJpBApYI/AAAAAAAABQ8/y57ARsMPaX8/s1600/Funny%2BTibetan%2BMastiff%2BPuppy%2BPicture.jpg)