### PR TITLE
Lru issue 409

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "eth-keyfile>=0.4.0",
         "eth-keys>=0.1.0-beta.3",
         "eth-utils>=0.7.1",
-        "lru-dict=1.1.6",
+        "lru-dict>=1.1.6",
         "pysha3>=0.3",
         "requests>=2.12.4",
         "rlp>=0.4.7",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "eth-keyfile>=0.4.0",
         "eth-keys>=0.1.0-beta.3",
         "eth-utils>=0.7.1",
-        "pylru>=1.0.9",
+        "lru-dict=1.1.6",
         "pysha3>=0.3",
         "requests>=2.12.4",
         "rlp>=0.4.7",

--- a/web3/utils/request.py
+++ b/web3/utils/request.py
@@ -1,10 +1,10 @@
-import pylru
+import lru
 import requests
 
 from web3.utils.caching import generate_cache_key
 
 
-_session_cache = pylru.lrucache(8)
+_session_cache = lru.LRU(8)
 
 
 def _get_session(*args, **kwargs):


### PR DESCRIPTION
### What was wrong?

This PR is for issue https://github.com/ethereum/web3.py/issues/409

I tried to implement functools.lru_cache but this would occur: `TypeError: unhashable type: 'dict'` on the wrapped generating_cache_key function.

### How was it fixed?

Changed requirement from pylru to lru-dict

#### Cute Animal Picture

![Cute animal picture](https://i.imgur.com/LEvnTfq.jpg)
