### PR TITLE
bump eth-tester to v0.1.0-beta.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "requests>=2.12.4",
         "rlp>=0.4.7",
         "toolz>=0.8.2",
-        "eth-tester~=0.1.0b4",
+        "eth-tester~=0.1.0b5",
     ],
     setup_requires=['setuptools-markdown'],
     extras_require={


### PR DESCRIPTION
### What was wrong?

Upstream bugfix in `eth-tester`

### How was it fixed?

Bumped the version in `setup.py`

#### Cute Animal Picture

![b250d313cfb3402824fddad5a4bc6d2e](https://user-images.githubusercontent.com/824194/33729252-45e50c88-db3a-11e7-9068-00142848e7ba.jpg)
