### PR TITLE
IPCProvider: reattempt on broken pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,7 @@ output/*/index.html
 # Sphinx
 docs/_build
 docs/modules.rst
-docs/web3.rst
-docs/web3.providers.rst
-docs/web3.utils.rst
+docs/web3.*
 
 # Blockchain
 chains


### PR DESCRIPTION
### What was wrong?

Because the IPC connection is now kept open persistently, restarting the node causes an error on the next ipc call. 

### How was it fixed?

Automatically catch and retry on a BrokenPipeError.

#### Cute Animal Picture

![Cute animal picture](http://38.media.tumblr.com/5faf634d2dfdc83f29b80c4b6e6f8687/tumblr_nbar4sZqHO1s9rrcgo1_250.jpg)