### PR TITLE
Implicit contract

### DIFF
--- a/tests/core/contracts/test_implicit_contract.py
+++ b/tests/core/contracts/test_implicit_contract.py
@@ -61,7 +61,7 @@ def test_implicitcontract_call_default(math_contract, get_transaction_count):
 def test_implicitcontract_transact_default(math_contract, get_transaction_count):
     # Use to verify correct operation later on
     start_count = math_contract.counter()
-    assert is_integer(start_count) # Verify correct type
+    assert is_integer(start_count)  # Verify correct type
     # When a function is called that defaults to transact
     blocknum, starting_txns = get_transaction_count("pending")
     math_contract.increment()
@@ -87,7 +87,7 @@ def test_implicitcontract_call_override(math_contract, get_transaction_count):
 def test_implicitcontract_transact_override(math_contract, get_transaction_count):
     # Use to verify correct operation later on
     start_count = math_contract.counter()
-    assert is_integer(start_count) # Verify correct type
+    assert is_integer(start_count)  # Verify correct type
     # When a function is called with call override that defaults to transact
     blocknum, starting_txns = get_transaction_count("pending")
     math_contract.increment(call={})

--- a/tests/core/contracts/test_implicit_contract.py
+++ b/tests/core/contracts/test_implicit_contract.py
@@ -1,0 +1,89 @@
+import pytest
+
+from web3.contract import (
+    ImplicitContract,
+)
+
+
+@pytest.fixture()
+def math_contract(web3, MATH_ABI, MATH_CODE, MATH_RUNTIME):
+    # Deploy math contract
+    # NOTE Must use non-specialized contract factory or else deploy() doesn't work
+    MathContract = web3.eth.contract(
+        abi=MATH_ABI,
+        bytecode=MATH_CODE,
+        bytecode_runtime=MATH_RUNTIME,
+    )
+    tx_hash = MathContract.deploy()
+    tx_receipt = web3.eth.getTransactionReceipt(tx_hash)
+    math_address = tx_receipt['contractAddress']
+    # Return interactive contract instance at deployed address
+    # TODO Does parent class not implement 'deploy()' for a reason?
+    MathContract = web3.eth.contract(
+        abi=MATH_ABI,
+        bytecode=MATH_CODE,
+        bytecode_runtime=MATH_RUNTIME,
+        ContractFactoryClass=ImplicitContract,
+    )
+    return MathContract(math_address)
+
+
+@pytest.fixture()
+def get_transaction_count(web3):
+    def get_transaction_count(blocknum_or_label):
+        block = web3.eth.getBlock(blocknum_or_label)
+        # Return the blocknum if we requested this via labels
+        # so we can directly query the block next time (using the same API call)
+        # Either way, return the number of transactions in the given block
+        if blocknum_or_label in ["pending", "latest", "earliest"]:
+            return block.number, len(block.transactions)
+        else:
+            return len(block.transactions)
+    return get_transaction_count
+
+
+def test_implicitcontract_internals(math_contract):
+    # counter() is constant, so it calls by default
+    assert math_contract.counter.call_by_default
+    # return13() does not since it is not constant
+    assert not math_contract.return13.call_by_default
+
+
+def test_implicitcontract_call_default(math_contract, get_transaction_count):
+    blocknum, starting_txns = get_transaction_count("pending")
+    # When a function is called that defaults to call
+    # (Verify something was returned)
+    assert math_contract.counter() is not None
+    # Check that a call was made and not a transact
+    # (Auto-mining is enabled, so query by block number)
+    assert get_transaction_count(blocknum) == starting_txns
+
+
+def test_implicitcontract_transact_default(math_contract, get_transaction_count):
+    blocknum, starting_txns = get_transaction_count("pending")
+    # When a function is called that defaults to transact
+    # (Verify something was returned)
+    assert math_contract.return13() is not None
+    # Check that a transaction was made and not a call
+    # (Auto-mining is enabled, so query by block number)
+    assert get_transaction_count(blocknum) == starting_txns + 1
+
+
+def test_implicitcontract_call_override(math_contract, get_transaction_count):
+    blocknum, starting_txns = get_transaction_count("pending")
+    # When a function is called with transact override that defaults to call
+    # (Verify something was returned)
+    assert math_contract.counter(transact={}) is not None
+    # Check that a transaction was made and not a call
+    # (Auto-mining is enabled, so query by block number)
+    assert get_transaction_count(blocknum) == starting_txns + 1
+
+
+def test_implicitcontract_transact_override(math_contract, get_transaction_count):
+    blocknum, starting_txns = get_transaction_count("pending")
+    # When a function is called with call override that defaults to transact
+    # (Verify something was returned)
+    assert math_contract.return13(call={}) is not None
+    # Check that a call was made and not a transact
+    # (Auto-mining is enabled, so query by block number)
+    assert get_transaction_count(blocknum) == starting_txns

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -698,7 +698,7 @@ CONCISE_NORMALIZERS = (
 )
 
 
-class ConciseMethod(object):
+class ConciseMethod:
     ALLOWED_MODIFIERS = set(['call', 'estimateGas', 'transact', 'buildTransaction'])
 
     def __init__(self, function, normalizers=None):

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -746,8 +746,8 @@ class ImplicitContract(ConciseContract):
 class ImplicitMethod(ConciseMethod):
     def __call_by_default(self, args):
         # If function is constant in ABI, then call by default, else transact
-        function_abi = find_matching_fn_abi(self._function.contract_abi, 
-                                            fn_name=self._function.method_name, 
+        function_abi = find_matching_fn_abi(self._function.contract_abi,
+                                            fn_name=self._function.method_name,
                                             args=args)
         return function_abi['constant'] if 'constant' in function_abi.keys() else False
 


### PR DESCRIPTION
### What was wrong?
Wanted a contract type that could magically figure out (from the ABI) when a method should be a call by default, or a transaction by default

### How was it fixed?
I added a subclass of `ConciseContract` that checked the ABI whether or not the method was `constant`/`pure` ('constant': True in ABI), and passed that info to a subclass of `ConciseMethod`. If it was determined to make a transaction by default, the transaction is made using the defaultAccount and zero value.

#### Cute Animal Picture
![Cute animal picture](http://www.lifenews.com/wp-content/uploads/2014/12/orangutan.jpg)