### PR TITLE
Add support for sendRawTransaction in EthereumTesterProvider

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "requests>=2.12.4",
         "rlp>=0.4.7",
         "toolz>=0.8.2",
-        "eth-tester~=0.1.0b5",
+        "eth-tester~=0.1.0b6",
     ],
     setup_requires=['setuptools-markdown'],
     extras_require={

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -179,10 +179,6 @@ def not_implemented(method, exc_type=NotImplementedError):
 
 class TestEthereumTesterEthModule(EthModuleTest):
     test_eth_sign = not_implemented(EthModuleTest.test_eth_sign, ValueError)
-    test_eth_sendRawTransaction = not_implemented(
-        EthModuleTest.test_eth_sendRawTransaction,
-        ValueError,
-    )
 
     def test_eth_getTransactionReceipt_unmined(self, eth_tester, web3, unlocked_account):
         eth_tester.disable_auto_mine_transactions()

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands=
 deps =
     -r{toxinidir}/requirements-dev.txt
     gevent: -r{toxinidir}/requirements-gevent.txt
-    ethtester: ethereum-tester>=0.1.0-alpha.6
+    ethtester: eth-tester>=0.1.0b6
 setenv =
     gevent: THREADING_BACKEND=gevent
 passenv =

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -208,7 +208,7 @@ API_ENDPOINTS = {
         'getCode': call_eth_tester('get_code'),
         'sign': not_implemented,
         'sendTransaction': call_eth_tester('send_transaction'),
-        'sendRawTransaction': not_implemented,
+        'sendRawTransaction': call_eth_tester('send_raw_transaction'),
         'call': call_eth_tester('call'),  # TODO: untested
         'estimateGas': call_eth_tester('estimate_gas'),  # TODO: untested
         'getBlockByHash': null_if_block_not_found(call_eth_tester('get_block_by_hash')),

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -232,17 +232,9 @@ class EthModuleTest(object):
     )
     def test_eth_sendRawTransaction(self,
                                     web3,
-                                    unlocked_account,
                                     raw_transaction,
+                                    funded_account_for_raw_txn,
                                     expected_hash):
-        txn_params = {
-            'from': unlocked_account,
-            'to': "0x39EEed73fb1D3855E90Cbd42f348b3D7b340aAA6",
-            'value': (21000 * 100000000000 + 1),  # tx.gas * tx.gasprice + tx.value
-            'gas': 21000,
-            'gas_price': web3.eth.gasPrice,
-        }
-        txn_hash = web3.eth.sendTransaction(txn_params)
         txn_hash = web3.eth.sendRawTransaction(raw_transaction)
         assert txn_hash == web3.toBytes(hexstr=expected_hash)
 

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -230,16 +230,19 @@ class EthModuleTest(object):
             ),
         ]
     )
-    def test_eth_sendRawTransaction(self, web3, raw_transaction, expected_hash):
-        sender_in_case_1 = "0x39EEed73fb1D3855E90Cbd42f348b3D7b340aAA6"
-        fund_txn_params = {
-            'from': web3.eth.coinbase,
-            'to': sender_in_case_1,
-            'value': (21000 * 100000000000 + 1),
+    def test_eth_sendRawTransaction(self,
+                                    web3,
+                                    unlocked_account,
+                                    raw_transaction,
+                                    expected_hash):
+        txn_params = {
+            'from': unlocked_account,
+            'to': "0x39EEed73fb1D3855E90Cbd42f348b3D7b340aAA6",
+            'value': (21000 * 100000000000 + 1),  # tx.gas * tx.gasprice + tx.value
             'gas': 21000,
-            'gas_price': 1,
+            'gas_price': web3.eth.gasPrice,
         }
-        web3.eth.sendTransaction(fund_txn_params)
+        txn_hash = web3.eth.sendTransaction(txn_params)
         txn_hash = web3.eth.sendRawTransaction(raw_transaction)
         assert txn_hash == web3.toBytes(hexstr=expected_hash)
 

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -217,6 +217,7 @@ class EthModuleTest(object):
         'raw_transaction, expected_hash',
         [
             (
+                # address 0x39EEed73fb1D3855E90Cbd42f348b3D7b340aAA6
                 '0xf8648085174876e8008252089439eeed73fb1d3855e90cbd42f348b3d7b340aaa601801ba0ec1295f00936acd0c2cb90ab2cdaacb8bf5e11b3d9957833595aca9ceedb7aada05dfc8937baec0e26029057abd3a1ef8c505dca2cdc07ffacb046d090d2bea06a',  # noqa: E501
                 '0x1f80f8ab5f12a45be218f76404bda64d37270a6f4f86ededd0eb599f80548c13',
             ),
@@ -230,6 +231,15 @@ class EthModuleTest(object):
         ]
     )
     def test_eth_sendRawTransaction(self, web3, raw_transaction, expected_hash):
+        sender_in_case_1 = "0x39EEed73fb1D3855E90Cbd42f348b3D7b340aAA6"
+        fund_txn_params = {
+            'from': web3.eth.coinbase,
+            'to': sender_in_case_1,
+            'value': (21000 * 100000000000 + 1),
+            'gas': 21000,
+            'gas_price': 1,
+        }
+        web3.eth.sendTransaction(fund_txn_params)
         txn_hash = web3.eth.sendRawTransaction(raw_transaction)
         assert txn_hash == web3.toBytes(hexstr=expected_hash)
 


### PR DESCRIPTION
### What was wrong?
Recently `sendRawTransaction` is supported by `EthereumTester`, and therefore we can support it in `web3.providers.eth_tester.EthereumTesterProvider`

### How was it fixed?
1. Modify the config in `web3/providers/eth_tester/main.py`
2. Modify the version of `eth-tester` in the deps in `setup.py` to the latest one
3. Enable the according test
4. Fix the problem that the original `test_eth_sendRawTransaction` would fail because the sender of the raw transaction doesn't have enough funds in the case1.


#### Cute Animal Picture

![Cute animal picture](https://scontent-tpe1-1.xx.fbcdn.net/v/t31.0-8/21457553_747661088761628_4791922427176943536_o.jpg?oh=6e8094b56451bac9851439557da0577e&oe=5AC2B33C)
