### PR TITLE
Deprecate usage of eth-testrpc

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -130,34 +130,32 @@ EthereumTesterProvider
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning:: Experimental:  This provider is experimental and should be used with caution.
+    However, it is the presumed replacement to :class:`~web3.providers.tester.EthereumTesterProvider`
+    and is being actively developed and supported.
 
-.. py:class:: EthereumTesterProvider(eth_tester)
+.. py:class:: EthereumTesterProvider(eth_tester=None)
 
-    This provider integrates with the ``ethereum-tester`` library.  The
+    This provider integrates with the ``eth-tester`` library.  The
     ``eth_tester`` constructor argument should be an instance of the
-    ``eth_tester.EthereumTester`` class provided by the ``ethereum-tester``
-    library.  See the ``ethereum-tester`` library documentation for
+    :class:`~eth_tester.EthereumTester` class provided by the ``eth-tester``
+    library.  See the ``eth-tester`` library documentation for
     instructions on how to use the library.
 
     .. code-block:: python
 
         >>> from web3 import Web3
         >>> from web3.providers.eth_tester import EthereumTesterProvider
-        >>> from eth_tester import EthereumTester
-        >>> eth_tester = EthereumTester()
-        >>> web3 = Web3(EthereumTesterProvider(eth_tester))
+        >>> w3 = Web3(EthereumTesterProvider())
 
-
-
-.. py:currentmodule:: web3.providers.tester
 
 
 EthereumTesterProvider (legacy)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. warning:: Pending Deprecation:  This provider is being deprecated soon in favor of the newly created ethereum-tester library.
+.. warning:: Deprecated:  This provider is deprecated in favor of
+    :class:`~web3.providers.eth_tester.EthereumTesterProvider` and the newly created eth-tester.
 
-.. py:class:: EthereumTesterProvider():
+.. py:class:: web3.providers.tester.EthereumTesterProvider()
 
     This provider can be used for testing.  It uses an ephemeral blockchain
     backed by the ``ethereum.tester`` module.
@@ -166,9 +164,10 @@ EthereumTesterProvider (legacy)
 TestRPCProvider
 ~~~~~~~~~~~~~~~
 
-.. warning:: Pending Deprecation:  This provider is being deprecated soon in favor of the newly created ethereum-tester library.
+.. warning:: Deprecated:  This provider is deprecated in favor of
+    :class:`~web3.providers.eth_tester.EthereumTesterProvider` and the newly created eth-tester.
 
-.. py:class:: TestRPCProvider():
+.. py:class:: TestRPCProvider()
 
     This provider can be used for testing.  It uses an ephemeral blockchain
     backed by the ``ethereum.tester`` module.  This provider will be slower

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -29,13 +29,6 @@ Web3.py can be installed using ``pip`` as follows.
 
    $ pip install web3
 
-Or to install with support for the ``TestRPCProvider`` and
-``EthereumTesterProvider`` you can use this install command.
-
-.. code-block:: shell
-
-   $ pip install web3[tester]
-
 
 Installation from source can be done from the root of the project with the
 following command.

--- a/web3/providers/tester.py
+++ b/web3/providers/tester.py
@@ -17,6 +17,9 @@ from web3.middleware import (
     construct_exception_handler_middleware,
 )
 
+from web3.utils.decorators import (
+    deprecated_for,
+)
 from web3.utils.formatters import (
     hex_to_integer,
     apply_formatter_if,
@@ -103,6 +106,7 @@ class EthereumTesterProvider(BaseProvider):
         ethereum_tester_personal_remapper_middleware,
     ]
 
+    @deprecated_for("web3.providers.eth_tester.EthereumTesterProvider")
     def __init__(self,
                  *args,
                  **kwargs):
@@ -134,6 +138,7 @@ class EthereumTesterProvider(BaseProvider):
 class TestRPCProvider(HTTPProvider):
     middlewares = [ethtestrpc_middleware, ethtestrpc_exception_middleware]
 
+    @deprecated_for("web3.providers.eth_tester.EthereumTesterProvider")
     def __init__(self, host="127.0.0.1", port=8545, *args, **kwargs):
         if not is_testrpc_available():
             raise Exception("`TestRPCProvider` requires the `eth-testrpc` package to be installed")


### PR DESCRIPTION
### What was wrong?

#505 - deprecate eth-testrpc

### How was it fixed?

added deprecation warnings, and removed eth-testrpc from quickstart

#### Cute Animal Picture

![Cute animal picture](https://i.ytimg.com/vi/QL6Ws4i07is/hqdefault.jpg)
