### PR TITLE
Caching middlewares

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -164,3 +164,51 @@ Stalecheck
     If the latest block in the blockchain is older than 2 days in this example, then the
     middleware will raise a ``StaleBlockchain`` exception on every call except
     ``web3.eth.getBlock()``.
+
+
+Cache
+~~~~~~~~~~~
+
+All of the caching middlewares accept these common arguments.
+
+* ``cache_class`` must be a callable which returns an object which implements the dictionary API.
+* ``rpc_whitelist`` must be an iterable, preferably a set, of the RPC methods that may be cached.
+* ``should_cache_fn`` must be a callable with the signature ``fn(method, params, response)`` which returns whether the response should be cached.
+
+
+.. py:method:: web3.middleware.construct_simple_cache_middleware(cache_class, rpc_whitelist, should_cache_fn)
+
+    Constructs a middleware which will cache the return values for any RPC
+    method in the ``rpc_whitelist``.
+
+    A ready to use version of this middleware can be found at
+    ``web3.middlewares.simple_cache_middleware``.
+
+
+.. py:method:: web3.middleware.construct_time_based_cache_middleware(cache_class, cache_expire_seconds, rpc_whitelist, should_cache_fn)
+
+    Constructs a middleware which will cache the return values for any RPC
+    method in the ``rpc_whitelist`` for an amount of time defined by
+    ``cache_expire_seconds``.
+
+    * ``cache_expire_seconds`` should be the number of seconds a value may
+      remain in the cache before being evicted.
+
+    A ready to use version of this middleware can be found at
+    ``web3.middlewares.time_based_cache_middleware``.
+
+
+.. py:method:: web3.middleware.construct_latest_block_based_cache_middleware(cache_class, average_block_time_sample_size, default_average_block_time, rpc_whitelist, should_cache_fn)
+
+    Constructs a middleware which will cache the return values for any RPC
+    method in the ``rpc_whitelist`` for an amount of time defined by
+    ``cache_expire_seconds``.
+
+    * ``average_block_time_sample_size`` The number of blocks which should be
+      sampled to determine the average block time.
+    * ``default_average_block_time`` The initial average block time value to
+      use for cases where there is not enough chain history to determine the
+      average block time.
+
+    A ready to use version of this middleware can be found at
+    ``web3.middlewares.latest_block_based_cache_middleware``.

--- a/tests/core/middleware/test_latest_block_based_cache_middleware.py
+++ b/tests/core/middleware/test_latest_block_based_cache_middleware.py
@@ -21,12 +21,13 @@ def _time_travel_to_now(web3):
 def test_latest_block_based_cache_middleware_pulls_from_cache(web3):
     current_block_hash = web3.eth.getBlock('latest')['hash']
 
-    cache = {
-        generate_cache_key((current_block_hash, 'fake_endpoint', [1])): 'value-a',
-    }
+    def cache_class():
+        return {
+            generate_cache_key((current_block_hash, 'fake_endpoint', [1])): 'value-a',
+        }
 
     middleware = construct_latest_block_based_cache_middleware(
-        cache=cache,
+        cache_class=cache_class,
         rpc_whitelist={'fake_endpoint'},
     )(None, web3)
 
@@ -39,14 +40,8 @@ def test_latest_block_based_cache_middleware_populates_cache(web3):
             'result': str(uuid.uuid4()),
         }
 
-    current_block_hash = web3.eth.getBlock('latest')['hash']
-
-    cache = {
-        generate_cache_key((current_block_hash, 'fake_endpoint', [1])): 'value-a',
-    }
-
     middleware = construct_latest_block_based_cache_middleware(
-        cache=cache,
+        cache_class=dict,
         rpc_whitelist={'fake_endpoint'},
     )(make_request, web3)
 
@@ -70,7 +65,7 @@ def test_latest_block_cache_middleware_does_not_cache_bad_responses(web3, respon
         return assoc(response, 'id', str(uuid.uuid4()))
 
     middleware = construct_latest_block_based_cache_middleware(
-        cache={},
+        cache_class=dict,
         rpc_whitelist={'fake_endpoint'},
     )(make_request, web3)
 
@@ -93,7 +88,7 @@ def test_latest_block_based_cache_middleware_caches_latest_block(web3):
         }
 
     middleware = construct_latest_block_based_cache_middleware(
-        cache={},
+        cache_class=dict,
         average_block_time_sample_size=10,
         default_average_block_time=10,
         rpc_whitelist={'fake_endpoint'},

--- a/tests/core/middleware/test_latest_block_based_cache_middleware.py
+++ b/tests/core/middleware/test_latest_block_based_cache_middleware.py
@@ -1,0 +1,113 @@
+import time
+import uuid
+
+import pytest
+
+from cytoolz import assoc
+
+from web3.middleware.cache import (  # noqa: F401
+    construct_latest_block_based_cache_middleware,
+)
+from web3.utils.caching import (
+    generate_cache_key,
+)
+
+
+@pytest.fixture(autouse=True)
+def _time_travel_to_now(web3):
+    web3.testing.timeTravel(int(time.time()))
+
+
+def test_latest_block_based_cache_middleware_pulls_from_cache(web3):
+    current_block_hash = web3.eth.getBlock('latest')['hash']
+
+    cache = {
+        generate_cache_key((current_block_hash, 'fake_endpoint', [1])): 'value-a',
+    }
+
+    middleware = construct_latest_block_based_cache_middleware(
+        cache=cache,
+        rpc_whitelist={'fake_endpoint'},
+    )(None, web3)
+
+    assert middleware('fake_endpoint', [1]) == 'value-a'
+
+
+def test_latest_block_based_cache_middleware_populates_cache(web3):
+    def make_request(method, params):
+        return {
+            'result': str(uuid.uuid4()),
+        }
+
+    current_block_hash = web3.eth.getBlock('latest')['hash']
+
+    cache = {
+        generate_cache_key((current_block_hash, 'fake_endpoint', [1])): 'value-a',
+    }
+
+    middleware = construct_latest_block_based_cache_middleware(
+        cache=cache,
+        rpc_whitelist={'fake_endpoint'},
+    )(make_request, web3)
+
+    response = middleware('fake_endpoint', [])
+    assert 'result' in response
+
+    assert middleware('fake_endpoint', []) == response
+    assert not middleware('fake_endpoint', [1]) == response
+
+
+@pytest.mark.parametrize(
+    'response',
+    (
+        {},
+        {'result': None},
+        {'error': 'some error message'},
+    )
+)
+def test_latest_block_cache_middleware_does_not_cache_bad_responses(web3, response):
+    def make_request(method, params):
+        return assoc(response, 'id', str(uuid.uuid4()))
+
+    middleware = construct_latest_block_based_cache_middleware(
+        cache={},
+        rpc_whitelist={'fake_endpoint'},
+    )(make_request, web3)
+
+    response_a = middleware('fake_endpoint', [])
+    assert 'id' in response_a
+
+    response_b = middleware('fake_endpoint', [])
+    assert 'id' in response_b
+
+    assert not response_a['id'] == response_b['id']
+
+
+def test_latest_block_based_cache_middleware_caches_latest_block(web3):
+    for _ in range(2):
+        web3.testing.mine()
+
+    def make_request(method, params):
+        return {
+            'result': str(uuid.uuid4()),
+        }
+
+    middleware = construct_latest_block_based_cache_middleware(
+        cache={},
+        average_block_time_sample_size=10,
+        default_average_block_time=10,
+        rpc_whitelist={'fake_endpoint'},
+    )(make_request, web3)
+
+    # prime the internal latest block cache.
+    middleware('fake_endpoint', [])
+
+    response = middleware('fake_endpoint', [])
+    assert 'result' in response
+
+    assert middleware('fake_endpoint', []) == response
+
+    web3.testing.mine()
+
+    if not middleware('fake_endpoint', []) == response:
+        assert False, "Cache unexpectedly busted"

--- a/tests/core/middleware/test_simple_cache_middleware.py
+++ b/tests/core/middleware/test_simple_cache_middleware.py
@@ -1,0 +1,89 @@
+import uuid
+
+from cytoolz import assoc
+
+import pytest
+
+from web3.middleware.cache import (  # noqa: F401
+    construct_simple_cache_middleware,
+)
+from web3.utils.caching import (
+    generate_cache_key,
+)
+
+
+def test_simple_cache_middleware_pulls_from_cache():
+    cache = {
+        generate_cache_key(('fake_endpoint', [1])): 'value-a',
+    }
+
+    middleware = construct_simple_cache_middleware(
+        cache=cache,
+        rpc_whitelist={'fake_endpoint'},
+    )(None, None)
+
+    assert middleware('fake_endpoint', [1]) == 'value-a'
+
+
+def test_simple_cache_middleware_populates_cache():
+    def make_request(method, params):
+        return {
+            'result': str(uuid.uuid4()),
+        }
+
+    middleware = construct_simple_cache_middleware(
+        cache={},
+        rpc_whitelist={'fake_endpoint'},
+    )(make_request, None)
+
+    response = middleware('fake_endpoint', [])
+    assert 'result' in response
+
+    assert middleware('fake_endpoint', []) == response
+    assert not middleware('fake_endpoint', [1]) == response
+
+
+@pytest.mark.parametrize(
+    'response',
+    (
+        {},
+        {'result': None},
+        {'error': 'some error message'},
+    )
+)
+def test_simple_cache_middleware_does_not_cache_bad_responses(response):
+    def make_request(method, params):
+        return assoc(response, 'id', str(uuid.uuid4()))
+
+    middleware = construct_simple_cache_middleware(
+        cache={},
+        rpc_whitelist={'fake_endpoint'},
+    )(make_request, None)
+
+    response_a = middleware('fake_endpoint', [])
+    assert 'id' in response_a
+
+    response_b = middleware('fake_endpoint', [])
+    assert 'id' in response_b
+
+    assert not response_a['id'] == response_b['id']
+
+
+def test_simple_cache_middleware_does_not_endpoints_not_in_whitelist():
+    def make_request(method, params):
+        return {
+            'result': str(uuid.uuid4())
+        }
+
+    middleware = construct_simple_cache_middleware(
+        cache={},
+        rpc_whitelist={'fake_endpoint'},
+    )(make_request, None)
+
+    response_a = middleware('not_whitelisted', [])
+    assert 'result' in response_a
+
+    response_b = middleware('not_whitelisted', [])
+    assert 'result' in response_b
+
+    assert not response_a['result'] == response_b['result']

--- a/tests/core/middleware/test_simple_cache_middleware.py
+++ b/tests/core/middleware/test_simple_cache_middleware.py
@@ -13,12 +13,13 @@ from web3.utils.caching import (
 
 
 def test_simple_cache_middleware_pulls_from_cache():
-    cache = {
-        generate_cache_key(('fake_endpoint', [1])): 'value-a',
-    }
+    def cache_class():
+        return {
+            generate_cache_key(('fake_endpoint', [1])): 'value-a',
+        }
 
     middleware = construct_simple_cache_middleware(
-        cache=cache,
+        cache_class=cache_class,
         rpc_whitelist={'fake_endpoint'},
     )(None, None)
 
@@ -32,7 +33,7 @@ def test_simple_cache_middleware_populates_cache():
         }
 
     middleware = construct_simple_cache_middleware(
-        cache={},
+        cache_class=dict,
         rpc_whitelist={'fake_endpoint'},
     )(make_request, None)
 
@@ -56,7 +57,7 @@ def test_simple_cache_middleware_does_not_cache_bad_responses(response):
         return assoc(response, 'id', str(uuid.uuid4()))
 
     middleware = construct_simple_cache_middleware(
-        cache={},
+        cache_class=dict,
         rpc_whitelist={'fake_endpoint'},
     )(make_request, None)
 
@@ -76,7 +77,7 @@ def test_simple_cache_middleware_does_not_endpoints_not_in_whitelist():
         }
 
     middleware = construct_simple_cache_middleware(
-        cache={},
+        cache_class=dict,
         rpc_whitelist={'fake_endpoint'},
     )(make_request, None)
 

--- a/tests/core/middleware/test_time_based_cache_middleware.py
+++ b/tests/core/middleware/test_time_based_cache_middleware.py
@@ -1,0 +1,123 @@
+import time
+import uuid
+
+from cytoolz import assoc
+
+import pytest
+
+from web3.middleware.cache import (  # noqa: F401
+    construct_time_based_cache_middleware,
+)
+from web3.utils.caching import (
+    generate_cache_key,
+)
+
+
+def test_time_based_cache_middleware_pulls_from_cache():
+    cache = {
+        generate_cache_key(('fake_endpoint', [1])): (
+            time.time(),
+            'value-a',
+        ),
+    }
+
+    middleware = construct_time_based_cache_middleware(
+        cache=cache,
+        cache_expire_seconds=10,
+        rpc_whitelist={'fake_endpoint'},
+    )(None, None)
+
+    assert middleware('fake_endpoint', [1]) == 'value-a'
+
+
+def test_time_based_cache_middleware_populates_cache():
+    def make_request(method, params):
+        return {
+            'result': str(uuid.uuid4()),
+        }
+
+    middleware = construct_time_based_cache_middleware(
+        cache={},
+        cache_expire_seconds=10,
+        rpc_whitelist={'fake_endpoint'},
+    )(make_request, None)
+
+    response = middleware('fake_endpoint', [])
+    assert 'result' in response
+
+    assert middleware('fake_endpoint', []) == response
+    assert not middleware('fake_endpoint', [1]) == response
+
+
+def test_time_based_cache_middleware_expires_old_values():
+    def make_request(method, params):
+        return {
+            'result': str(uuid.uuid4())
+        }
+
+    cache = {
+        generate_cache_key(('fake_endpoint', [1])): (
+            time.time() - 10,
+            'value-a',
+        ),
+    }
+
+    middleware = construct_time_based_cache_middleware(
+        cache=cache,
+        cache_expire_seconds=10,
+        rpc_whitelist={'fake_endpoint'},
+    )(make_request, None)
+
+    response = middleware('fake_endpoint', [1])
+    assert not response == 'value-a'
+    assert 'result' in response
+
+    assert middleware('fake_endpoint', [1]) == response
+
+
+@pytest.mark.parametrize(
+    'response',
+    (
+        {},
+        {'result': None},
+        {'error': 'some error message'},
+    )
+)
+def test_time_based_cache_middleware_does_not_cache_bad_responses(response):
+    def make_request(method, params):
+        return assoc(response, 'id', str(uuid.uuid4()))
+
+    middleware = construct_time_based_cache_middleware(
+        cache={},
+        cache_expire_seconds=10,
+        rpc_whitelist={'fake_endpoint'},
+    )(make_request, None)
+
+    response_a = middleware('fake_endpoint', [])
+    assert 'id' in response_a
+
+    response_b = middleware('fake_endpoint', [])
+    assert 'id' in response_b
+
+    assert not response_a['id'] == response_b['id']
+
+
+def test_time_based_cache_middleware_does_not_endpoints_not_in_whitelist():
+    def make_request(method, params):
+        return {
+            'result': str(uuid.uuid4())
+        }
+
+    middleware = construct_time_based_cache_middleware(
+        cache={},
+        cache_expire_seconds=10,
+        rpc_whitelist={'fake_endpoint'},
+    )(make_request, None)
+
+    response_a = middleware('not_whitelisted', [])
+    assert 'result' in response_a
+
+    response_b = middleware('not_whitelisted', [])
+    assert 'result' in response_b
+
+    assert not response_a['result'] == response_b['result']

--- a/tests/core/middleware/test_time_based_cache_middleware.py
+++ b/tests/core/middleware/test_time_based_cache_middleware.py
@@ -14,15 +14,16 @@ from web3.utils.caching import (
 
 
 def test_time_based_cache_middleware_pulls_from_cache():
-    cache = {
-        generate_cache_key(('fake_endpoint', [1])): (
-            time.time(),
-            'value-a',
-        ),
-    }
+    def cache_class():
+        return {
+            generate_cache_key(('fake_endpoint', [1])): (
+                time.time(),
+                'value-a',
+            ),
+        }
 
     middleware = construct_time_based_cache_middleware(
-        cache=cache,
+        cache_class=cache_class,
         cache_expire_seconds=10,
         rpc_whitelist={'fake_endpoint'},
     )(None, None)
@@ -37,7 +38,7 @@ def test_time_based_cache_middleware_populates_cache():
         }
 
     middleware = construct_time_based_cache_middleware(
-        cache={},
+        cache_class=dict,
         cache_expire_seconds=10,
         rpc_whitelist={'fake_endpoint'},
     )(make_request, None)
@@ -55,15 +56,16 @@ def test_time_based_cache_middleware_expires_old_values():
             'result': str(uuid.uuid4())
         }
 
-    cache = {
-        generate_cache_key(('fake_endpoint', [1])): (
-            time.time() - 10,
-            'value-a',
-        ),
-    }
+    def cache_class():
+        return {
+            generate_cache_key(('fake_endpoint', [1])): (
+                time.time() - 10,
+                'value-a',
+            ),
+        }
 
     middleware = construct_time_based_cache_middleware(
-        cache=cache,
+        cache_class=cache_class,
         cache_expire_seconds=10,
         rpc_whitelist={'fake_endpoint'},
     )(make_request, None)
@@ -88,7 +90,7 @@ def test_time_based_cache_middleware_does_not_cache_bad_responses(response):
         return assoc(response, 'id', str(uuid.uuid4()))
 
     middleware = construct_time_based_cache_middleware(
-        cache={},
+        cache_class=dict,
         cache_expire_seconds=10,
         rpc_whitelist={'fake_endpoint'},
     )(make_request, None)
@@ -109,7 +111,7 @@ def test_time_based_cache_middleware_does_not_endpoints_not_in_whitelist():
         }
 
     middleware = construct_time_based_cache_middleware(
-        cache={},
+        cache_class=dict,
         cache_expire_seconds=10,
         rpc_whitelist={'fake_endpoint'},
     )(make_request, None)

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -3,11 +3,28 @@ import functools
 from .abi import (  # noqa: F401
     abi_middleware,
 )
-from .formatting import (  # noqa: F401
-    construct_formatting_middleware,
+from .attrdict import (  # noqa: F401
+    attrdict_middleware,
+)
+from .cache import (  # noqa: F401
+    construct_simple_cache_middleware,
+    construct_time_based_cache_middleware,
+    construct_block_number_based_cache_middleware,
+    simple_cache_middleware,
+    time_based_cache_middleware,
+    block_number_cache_middleware,
 )
 from .exception_handling import (  # noqa: F401
     construct_exception_handler_middleware,
+)
+from .fixture import (  # noqa: F401
+    construct_fixture_middleware,
+)
+from .formatting import (  # noqa: F401
+    construct_formatting_middleware,
+)
+from .gas_price_strategy import (  # noqa: F401
+    gas_price_strategy_middleware,
 )
 from .names import (  # noqa: F401
     name_to_address_middleware,
@@ -17,15 +34,6 @@ from .pythonic import (  # noqa: F401
 )
 from .stalecheck import (  # noqa: F401
     make_stalecheck_middleware,
-)
-from .attrdict import (  # noqa: F401
-    attrdict_middleware,
-)
-from .gas_price_strategy import (  # noqa: F401
-    gas_price_strategy_middleware,
-)
-from .fixture import (  # noqa: F401
-    construct_fixture_middleware,
 )
 
 

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -12,7 +12,7 @@ from .cache import (  # noqa: F401
     construct_latest_block_based_cache_middleware,
     simple_cache_middleware,
     time_based_cache_middleware,
-    latest_block_cache_middleware,
+    latest_block_based_cache_middleware,
 )
 from .exception_handling import (  # noqa: F401
     construct_exception_handler_middleware,

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -9,10 +9,10 @@ from .attrdict import (  # noqa: F401
 from .cache import (  # noqa: F401
     construct_simple_cache_middleware,
     construct_time_based_cache_middleware,
-    construct_block_number_based_cache_middleware,
+    construct_latest_block_based_cache_middleware,
     simple_cache_middleware,
     time_based_cache_middleware,
-    block_number_cache_middleware,
+    latest_block_cache_middleware,
 )
 from .exception_handling import (  # noqa: F401
     construct_exception_handler_middleware,

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -73,6 +73,14 @@ def should_cache(method, params, response):
 def construct_simple_cache_middleware(cache,
                                       rpc_whitelist=SIMPLE_CACHE_RPC_WHITELIST,
                                       should_cache_fn=should_cache):
+    """
+    Constructs a middleware which caches responses based on the request
+    ``method`` and ``params``
+
+    :param cache: Any dictionary-like object
+    :param rpc_whitelist: A set of RPC methods which may have their responses cached.
+    :param should_cache_fn: A callable which accepts ``method`` ``params`` and ``response`` and returns a boolean as to whether the response should be cached.
+    """
     def simple_cache_middleware(make_request, web3):
         def middleware(method, params):
             if method in rpc_whitelist:
@@ -148,6 +156,15 @@ def construct_time_based_cache_middleware(cache,
                                           cache_expire_seconds=15,
                                           rpc_whitelist=TIME_BASED_CACHE_RPC_WHITELIST,
                                           should_cache_fn=should_cache):
+    """
+    Constructs a middleware which caches responses based on the request
+    ``method`` and ``params`` for a maximum amount of time as specified
+
+    :param cache: Any dictionary-like object
+    :param cache_expire_seconds: The number of seconds an item may be cached before it should expire.
+    :param rpc_whitelist: A set of RPC methods which may have their responses cached.
+    :param should_cache_fn: A callable which accepts ``method`` ``params`` and ``response`` and returns a boolean as to whether the response should be cached.
+    """
     def simple_cache_middleware(make_request, web3):
         def middleware(method, params):
             if method in rpc_whitelist:
@@ -257,7 +274,21 @@ def construct_block_number_based_cache_middleware(cache,
                                                   average_block_time_sample_size=240,
                                                   default_average_block_time=15,
                                                   should_cache_fn=should_cache_by_block_number):
+    """
+    Constructs a middleware which caches responses based on the request
+    ``method``, ``params``, and the current latest block hash.
 
+    :param cache: Any dictionary-like object
+    :param cache_expire_seconds: The number of seconds an item may be cached before it should expire.
+    :param rpc_whitelist: A set of RPC methods which may have their responses cached.
+    :param should_cache_fn: A callable which accepts ``method`` ``params`` and ``response`` and returns a boolean as to whether the response should be cached.
+
+    .. note::
+        This middleware avoids re-fetching the current latest block for each
+        request by tracking the current average block time and only requesting
+        a new block when the last seen latest block is older than the average
+        block time.
+    """
     def block_number_based_cache_middleware(make_request, web3):
         block_info = {}
 

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -365,7 +365,7 @@ def construct_latest_block_based_cache_middleware(cache_class,
     return latest_block_based_cache_middleware
 
 
-latest_block_cache_middleware = construct_latest_block_based_cache_middleware(
+latest_block_based_cache_middleware = construct_latest_block_based_cache_middleware(
     cache_class=functools.partial(lru.LRU, 256),
     rpc_whitelist=BLOCK_NUMBER_RPC_WHITELIST,
 )

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -1,0 +1,328 @@
+import time
+
+import lru
+
+from web3.utils.caching import (
+    generate_cache_key,
+)
+
+
+SIMPLE_CACHE_RPC_WHITELIST = {
+    'web3_clientVersion',
+    'web3_sha3',
+    'net_version',
+    # 'net_peerCount',
+    # 'net_listening',
+    'eth_protocolVersion',
+    # 'eth_syncing',
+    # 'eth_coinbase',
+    # 'eth_mining',
+    # 'eth_hashrate',
+    # 'eth_gasPrice',
+    # 'eth_accounts',
+    # 'eth_blockNumber',
+    # 'eth_getBalance',
+    # 'eth_getStorageAt',
+    # 'eth_getTransactionCount',
+    'eth_getBlockTransactionCountByHash',
+    # 'eth_getBlockTransactionCountByNumber',
+    'eth_getUncleCountByBlockHash',
+    # 'eth_getUncleCountByBlockNumber',
+    # 'eth_getCode',
+    # 'eth_sign',
+    # 'eth_sendTransaction',
+    # 'eth_sendRawTransaction',
+    # 'eth_call',
+    # 'eth_estimateGas',
+    'eth_getBlockByHash',
+    # 'eth_getBlockByNumber',
+    'eth_getTransactionByHash',
+    'eth_getTransactionByBlockHashAndIndex',
+    # 'eth_getTransactionByBlockNumberAndIndex',
+    # 'eth_getTransactionReceipt',
+    'eth_getUncleByBlockHashAndIndex',
+    # 'eth_getUncleByBlockNumberAndIndex',
+    # 'eth_getCompilers',
+    # 'eth_compileLLL',
+    # 'eth_compileSolidity',
+    # 'eth_compileSerpent',
+    # 'eth_newFilter',
+    # 'eth_newBlockFilter',
+    # 'eth_newPendingTransactionFilter',
+    # 'eth_uninstallFilter',
+    # 'eth_getFilterChanges',
+    # 'eth_getFilterLogs',
+    # 'eth_getLogs',
+    # 'eth_getWork',
+    # 'eth_submitWork',
+    # 'eth_submitHashrate',
+}
+
+
+def should_cache(method, params, response):
+    if 'error' in response:
+        return False
+    elif 'result' not in response:
+        return False
+
+    if response['result'] is None:
+        return False
+    return True
+
+
+def construct_simple_cache_middleware(cache,
+                                      rpc_whitelist=SIMPLE_CACHE_RPC_WHITELIST,
+                                      should_cache_fn=should_cache):
+    def simple_cache_middleware(make_request, web3):
+        def middleware(method, params):
+            if method in rpc_whitelist:
+                cache_key = generate_cache_key((method, params))
+                if cache_key not in cache:
+                    response = make_request(method, params)
+                    if should_cache_fn(method, params, response):
+                        cache[cache_key] = response
+                    return response
+                return cache[cache_key]
+            else:
+                return make_request(method, params)
+        return middleware
+    return simple_cache_middleware
+
+
+simple_cache_middleware = construct_simple_cache_middleware(cache=lru.LRU(256))
+
+
+TIME_BASED_CACHE_RPC_WHITELIST = {
+    # 'web3_clientVersion',
+    # 'web3_sha3',
+    # 'net_version',
+    # 'net_peerCount',
+    # 'net_listening',
+    # 'eth_protocolVersion',
+    # 'eth_syncing',
+    'eth_coinbase',
+    # 'eth_mining',
+    # 'eth_hashrate',
+    # 'eth_gasPrice',
+    'eth_accounts',
+    # 'eth_blockNumber',
+    # 'eth_getBalance',
+    # 'eth_getStorageAt',
+    # 'eth_getTransactionCount',
+    # 'eth_getBlockTransactionCountByHash',
+    # 'eth_getBlockTransactionCountByNumber',
+    # 'eth_getUncleCountByBlockHash',
+    # 'eth_getUncleCountByBlockNumber',
+    # 'eth_getCode',
+    # 'eth_sign',
+    # 'eth_sendTransaction',
+    # 'eth_sendRawTransaction',
+    # 'eth_call',
+    # 'eth_estimateGas',
+    # 'eth_getBlockByHash',
+    # 'eth_getBlockByNumber',
+    # 'eth_getTransactionByHash',
+    # 'eth_getTransactionByBlockHashAndIndex',
+    # 'eth_getTransactionByBlockNumberAndIndex',
+    # 'eth_getTransactionReceipt',
+    # 'eth_getUncleByBlockHashAndIndex',
+    # 'eth_getUncleByBlockNumberAndIndex',
+    # 'eth_getCompilers',
+    # 'eth_compileLLL',
+    # 'eth_compileSolidity',
+    # 'eth_compileSerpent',
+    # 'eth_newFilter',
+    # 'eth_newBlockFilter',
+    # 'eth_newPendingTransactionFilter',
+    # 'eth_uninstallFilter',
+    # 'eth_getFilterChanges',
+    # 'eth_getFilterLogs',
+    # 'eth_getLogs',
+    # 'eth_getWork',
+    # 'eth_submitWork',
+    # 'eth_submitHashrate',
+}
+
+
+def construct_time_based_cache_middleware(cache,
+                                          cache_expire_seconds=15,
+                                          rpc_whitelist=TIME_BASED_CACHE_RPC_WHITELIST,
+                                          should_cache_fn=should_cache):
+    def simple_cache_middleware(make_request, web3):
+        def middleware(method, params):
+            if method in rpc_whitelist:
+                cache_key = generate_cache_key((method, params))
+                if cache_key in cache:
+                    # check that the cached response is not expired.
+                    cached_at, cached_response = cache[cache_key]
+                    cached_for = time.time() - cached_at
+
+                    if cached_for <= cache_expire_seconds:
+                        return cached_response
+                    else:
+                        del cache[cache_key]
+
+                # cache either missed or expired so make the request.
+                response = make_request(method, params)
+
+                if should_cache_fn(response):
+                    cache[cache_key] = (time.time(), response)
+
+                return response
+            else:
+                return make_request(method, params)
+        return middleware
+    return simple_cache_middleware
+
+
+time_based_cache_middleware = construct_time_based_cache_middleware(
+    cache=lru.LRU(256),
+)
+
+
+BLOCK_NUMBER_RPC_WHITELIST = {
+    # 'web3_clientVersion',
+    # 'web3_sha3',
+    # 'net_version',
+    # 'net_peerCount',
+    # 'net_listening',
+    # 'eth_protocolVersion',
+    # 'eth_syncing',
+    # 'eth_coinbase',
+    # 'eth_mining',
+    # 'eth_hashrate',
+    'eth_gasPrice',
+    # 'eth_accounts',
+    'eth_blockNumber',
+    'eth_getBalance',
+    'eth_getStorageAt',
+    'eth_getTransactionCount',
+    # 'eth_getBlockTransactionCountByHash',
+    'eth_getBlockTransactionCountByNumber',
+    # 'eth_getUncleCountByBlockHash',
+    'eth_getUncleCountByBlockNumber',
+    'eth_getCode',
+    # 'eth_sign',
+    # 'eth_sendTransaction',
+    # 'eth_sendRawTransaction',
+    'eth_call',
+    'eth_estimateGas',
+    # 'eth_getBlockByHash',
+    'eth_getBlockByNumber',
+    # 'eth_getTransactionByHash',
+    # 'eth_getTransactionByBlockHashAndIndex',
+    'eth_getTransactionByBlockNumberAndIndex',
+    'eth_getTransactionReceipt',
+    # 'eth_getUncleByBlockHashAndIndex',
+    'eth_getUncleByBlockNumberAndIndex',
+    # 'eth_getCompilers',
+    # 'eth_compileLLL',
+    # 'eth_compileSolidity',
+    # 'eth_compileSerpent',
+    # 'eth_newFilter',
+    # 'eth_newBlockFilter',
+    # 'eth_newPendingTransactionFilter',
+    # 'eth_uninstallFilter',
+    # 'eth_getFilterChanges',
+    # 'eth_getFilterLogs',
+    'eth_getLogs',
+    # 'eth_getWork',
+    # 'eth_submitWork',
+    # 'eth_submitHashrate',
+}
+
+
+AVG_BLOCK_TIME_KEY = 'avg_block_time'
+AVG_BLOCK_SAMPLE_SIZE_KEY = 'avg_block_sample_size'
+AVG_BLOCK_TIME_UPDATED_AT_KEY = 'avg_block_time_updated_at'
+
+
+def should_cache_by_block_number(method, params, response):
+    if method == 'eth_getBlockByNumber':
+        if params == ['latest'] or params == ['pending']:
+            return False
+
+    if 'error' in response:
+        return False
+    elif 'result' not in response:
+        return False
+
+    if response['result'] is None:
+        return False
+    return True
+
+
+def construct_block_number_based_cache_middleware(cache,
+                                                  rpc_whitelist=BLOCK_NUMBER_RPC_WHITELIST,
+                                                  average_block_time_sample_size=240,
+                                                  default_average_block_time=15,
+                                                  should_cache_fn=should_cache_by_block_number):
+
+    def block_number_based_cache_middleware(make_request, web3):
+        block_info = {}
+
+        def _update_block_info_cache(web3):
+            avg_block_time = block_info.get(AVG_BLOCK_TIME_KEY, default_average_block_time)
+            avg_block_sample_size = block_info.get(AVG_BLOCK_SAMPLE_SIZE_KEY, 0)
+            avg_block_time_updated_at = block_info.get(AVG_BLOCK_TIME_UPDATED_AT_KEY, 0)
+
+            # compute age as counted by number of blocks since the avg_block_time
+            if avg_block_time == 0:
+                avg_block_time_age_in_blocks = avg_block_sample_size
+            else:
+                avg_block_time_age_in_blocks = (
+                    (time.time() - avg_block_time_updated_at) / avg_block_time
+                )
+
+            if avg_block_time_age_in_blocks >= avg_block_sample_size:
+                # If the length of time since the average block time as
+                # measured by blocks is greater than or equal to the number of
+                # blocks sampled then we need to recompute the average block
+                # time.
+                latest_block = web3.eth.getBlock('latest')
+                ancestor_block_number = max(
+                    0,
+                    latest_block['number'] - average_block_time_sample_size,
+                )
+                ancestor_block = web3.eth.getBlock(ancestor_block_number)
+                sample_size = latest_block['number'] - ancestor_block_number
+
+                block_info[AVG_BLOCK_SAMPLE_SIZE_KEY] = sample_size
+                block_info[AVG_BLOCK_TIME_KEY] = (
+                    (latest_block['timestamp'] - ancestor_block['timestamp']) / sample_size
+                )
+                block_info[AVG_BLOCK_TIME_UPDATED_AT_KEY] = time.time()
+
+            if 'latest_block' in block_info:
+                latest_block = block_info['latest_block']
+                time_since_latest_block = time.time() - latest_block['timestamp']
+
+                # latest block is too old so update cache
+                if time_since_latest_block > avg_block_time:
+                    block_info['latest_block'] = web3.eth.getBlock('latest')
+            else:
+                # latest block has not been fetched so we fetch it.
+                block_info['latest_block'] = web3.eth.getBlock('latest')
+
+        def middleware(method, params):
+            if method in rpc_whitelist:
+                _update_block_info_cache()
+                latest_block_hash = block_info['latest_block']['hash']
+                cache_key = generate_cache_key((latest_block_hash, method, params))
+                if cache_key in cache:
+                    return cache[cache_key]
+
+                response = make_request(method, params)
+                if should_cache_fn(method, params, response):
+                    cache[cache_key] = response
+                return response
+            else:
+                return make_request(method, params)
+        return middleware
+    return block_number_based_cache_middleware
+
+
+block_number_cache_middleware = construct_block_number_based_cache_middleware(
+    cache=lru.LRU(256),
+    rpc_whitelist=BLOCK_NUMBER_RPC_WHITELIST,
+)


### PR DESCRIPTION
### What was wrong?

Many RPC requests can be cached reliably using various caching strategies.

### How was it fixed?

Implemented three new middleware factories.

- `construct_simple_cache_middleware`: *dumb* caching which returns any values which are present in the cache.  Works well for methods like `eth_protocolVersion` and `web3_clientVersion`.  Anything which should *always* have the same response given the same input parameters.
- `construct_time_based_cache_middleware`: caches certain responses for a specified amount of time.  Good for things that *may* change but are not expected to change often such as `eth_accounts` and `eth_coinbase`.
- `construct_block_number_based_cache_middleware`: caching for which all values are keyed by the current latest block number as well.  Works well for endpoints like `eth_call` or `eth_getBalance` which only change at block boundaries.

All middlewares intelligently refuse to cache `null` responses, error responses, and responses without a `'result'` key in the returned JSON.  This prevents things like.

- caching a `null` response for a transaction/block/receipt hash which isn't yet known by the node.
- caching error responses
- caching weird responses

TODO:

- [x] documentation
- [x] tests

#### Cute Animal Picture

![englishspringerspanielunderthechair](https://user-images.githubusercontent.com/824194/34625392-bf88209c-f215-11e7-8391-8cc199e6bc0f.jpg)

