### PR TITLE
update fixture middleware to accept callables

### DIFF
--- a/tests/core/middleware/test_fixture_middleware.py
+++ b/tests/core/middleware/test_fixture_middleware.py
@@ -4,8 +4,8 @@ from web3 import Web3
 from web3.providers.base import BaseProvider
 from web3.middleware import (
     construct_fixture_middleware,
-    construct_result_middleware,
-    construct_error_middleware,
+    construct_result_generator_middleware,
+    construct_error_generator_middleware,
 )
 
 
@@ -51,7 +51,7 @@ def test_result_middleware(w3, method, expected):
     def _callback(method, params):
         return params[0]
 
-    w3.middleware_stack.add(construct_result_middleware({
+    w3.middleware_stack.add(construct_result_generator_middleware({
         'test_endpoint': _callback,
     }))
 
@@ -74,7 +74,7 @@ def test_error_middleware(w3, method, expected):
     def _callback(method, params):
         return params[0]
 
-    w3.middleware_stack.add(construct_error_middleware({
+    w3.middleware_stack.add(construct_error_generator_middleware({
         'test_endpoint': _callback,
     }))
 

--- a/tests/core/middleware/test_fixture_middleware.py
+++ b/tests/core/middleware/test_fixture_middleware.py
@@ -9,8 +9,13 @@ from web3.middleware import (
 )
 
 
+def _fixture_callback(method, params):
+    return {'result': bool(params)}
+
+
 FIXTURES = {
-    'eth_protocolVersion': 'test-protocol',
+    'eth_protocolVersion': {'result': 'test-protocol'},
+    'test_endpoint': _fixture_callback,
 }
 
 
@@ -23,6 +28,8 @@ def _make_request(method, params):
     (
         ('eth_mining', [], 'default'),
         ('eth_protocolVersion', [], 'test-protocol'),
+        ('test_endpoint', [], False),
+        ('test_endpoint', [1], True),
     )
 )
 def test_fixture_middleware(method, params, expected):

--- a/tests/core/middleware/test_fixture_middleware.py
+++ b/tests/core/middleware/test_fixture_middleware.py
@@ -1,41 +1,87 @@
 import pytest
 
-from eth_utils import (
-    is_dict,
-)
-
+from web3 import Web3
+from web3.providers.base import BaseProvider
 from web3.middleware import (
     construct_fixture_middleware,
+    construct_result_middleware,
+    construct_error_middleware,
 )
 
 
-def _fixture_callback(method, params):
-    return {'result': bool(params)}
+class DummyProvider(BaseProvider):
+    def make_request(self, method, params):
+        raise NotImplementedError("Cannot make request for {0}:{1}".format(
+            method,
+            params,
+        ))
 
 
-FIXTURES = {
-    'eth_protocolVersion': {'result': 'test-protocol'},
-    'test_endpoint': _fixture_callback,
-}
-
-
-def _make_request(method, params):
-    return {'result': 'default'}
+@pytest.fixture
+def w3():
+    return Web3(providers=[DummyProvider()], middlewares=[])
 
 
 @pytest.mark.parametrize(
-    'method,params,expected',
+    'method,expected',
     (
-        ('eth_mining', [], 'default'),
-        ('eth_protocolVersion', [], 'test-protocol'),
-        ('test_endpoint', [], False),
-        ('test_endpoint', [1], True),
+        ('test_endpoint', 'value-a'),
+        ('not_implemented', NotImplementedError),
     )
 )
-def test_fixture_middleware(method, params, expected):
-    middleware = construct_fixture_middleware(FIXTURES)(_make_request, None)
+def test_fixture_middleware(w3, method, expected):
+    w3.middleware_stack.add(construct_fixture_middleware({'test_endpoint': 'value-a'}))
 
-    actual = middleware(method, params)
-    assert is_dict(actual)
-    assert 'result' in actual
-    assert actual['result'] == expected
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            w3.manager.request_blocking(method, [])
+    else:
+        actual = w3.manager.request_blocking(method, [])
+        assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'method,expected',
+    (
+        ('test_endpoint', 'value-a'),
+        ('not_implemented', NotImplementedError),
+    )
+)
+def test_result_middleware(w3, method, expected):
+    def _callback(method, params):
+        return params[0]
+
+    w3.middleware_stack.add(construct_result_middleware({
+        'test_endpoint': _callback,
+    }))
+
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            w3.manager.request_blocking(method, [expected])
+    else:
+        actual = w3.manager.request_blocking(method, [expected])
+        assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'method,expected',
+    (
+        ('test_endpoint', 'value-a'),
+        ('not_implemented', NotImplementedError),
+    )
+)
+def test_error_middleware(w3, method, expected):
+    def _callback(method, params):
+        return params[0]
+
+    w3.middleware_stack.add(construct_error_middleware({
+        'test_endpoint': _callback,
+    }))
+
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            w3.manager.request_blocking(method, [expected])
+    else:
+        with pytest.raises(ValueError) as err:
+            w3.manager.request_blocking(method, [expected])
+        assert expected in str(err)

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -19,8 +19,8 @@ from .exception_handling import (  # noqa: F401
 )
 from .fixture import (  # noqa: F401
     construct_fixture_middleware,
-    construct_result_middleware,
-    construct_error_middleware,
+    construct_result_generator_middleware,
+    construct_error_generator_middleware,
 )
 from .formatting import (  # noqa: F401
     construct_formatting_middleware,

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -19,6 +19,8 @@ from .exception_handling import (  # noqa: F401
 )
 from .fixture import (  # noqa: F401
     construct_fixture_middleware,
+    construct_result_middleware,
+    construct_error_middleware,
 )
 from .formatting import (  # noqa: F401
     construct_formatting_middleware,

--- a/web3/middleware/fixture.py
+++ b/web3/middleware/fixture.py
@@ -14,37 +14,37 @@ def construct_fixture_middleware(fixtures):
     return fixture_middleware
 
 
-def construct_result_middleware(result_callbacks):
+def construct_result_generator_middleware(result_generators):
     """
     Constructs a middleware which intercepts requests for any method found in
-    the provided mapping of endpoints to callbacks, returning whatever response
-    the callback generates.  Callbacks must be functions with the signature
-    `fn(method, params)`.
+    the provided mapping of endpoints to generator functions, returning
+    whatever response the generator function returns.  Callbacks must be
+    functions with the signature `fn(method, params)`.
     """
-    def result_callback_middleware(make_request, web3):
+    def result_generator_middleware(make_request, web3):
         def middleware(method, params):
-            if method in result_callbacks:
-                result = result_callbacks[method](method, params)
+            if method in result_generators:
+                result = result_generators[method](method, params)
                 return {'result': result}
             else:
                 return make_request(method, params)
         return middleware
-    return result_callback_middleware
+    return result_generator_middleware
 
 
-def construct_error_middleware(error_callbacks):
+def construct_error_generator_middleware(error_generators):
     """
     Constructs a middleware which intercepts requests for any method found in
-    the provided mapping of endpoints to callbacks, returning whatever response
-    the callback generates.  Callbacks must be functions with the signature
-    `fn(method, params)`.
+    the provided mapping of endpoints to generator functions, returning
+    whatever error message the generator function returns.  Callbacks must be
+    functions with the signature `fn(method, params)`.
     """
-    def error_callback_middleware(make_request, web3):
+    def error_generator_middleware(make_request, web3):
         def middleware(method, params):
-            if method in error_callbacks:
-                error_msg = error_callbacks[method](method, params)
+            if method in error_generators:
+                error_msg = error_generators[method](method, params)
                 return {'error': error_msg}
             else:
                 return make_request(method, params)
         return middleware
-    return error_callback_middleware
+    return error_generator_middleware

--- a/web3/middleware/fixture.py
+++ b/web3/middleware/fixture.py
@@ -6,9 +6,11 @@ def construct_fixture_middleware(fixtures):
     def fixture_middleware(make_request, web3):
         def middleware(method, params):
             if method in fixtures:
-                return {
-                    'result': fixtures[method],
-                }
+                response = fixtures[method]
+                if callable(response):
+                    return response(method, params)
+                else:
+                    return response
             else:
                 return make_request(method, params)
         return middleware

--- a/web3/middleware/fixture.py
+++ b/web3/middleware/fixture.py
@@ -6,12 +6,45 @@ def construct_fixture_middleware(fixtures):
     def fixture_middleware(make_request, web3):
         def middleware(method, params):
             if method in fixtures:
-                response = fixtures[method]
-                if callable(response):
-                    return response(method, params)
-                else:
-                    return response
+                result = fixtures[method]
+                return {'result': result}
             else:
                 return make_request(method, params)
         return middleware
     return fixture_middleware
+
+
+def construct_result_middleware(result_callbacks):
+    """
+    Constructs a middleware which intercepts requests for any method found in
+    the provided mapping of endpoints to callbacks, returning whatever response
+    the callback generates.  Callbacks must be functions with the signature
+    `fn(method, params)`.
+    """
+    def result_callback_middleware(make_request, web3):
+        def middleware(method, params):
+            if method in result_callbacks:
+                result = result_callbacks[method](method, params)
+                return {'result': result}
+            else:
+                return make_request(method, params)
+        return middleware
+    return result_callback_middleware
+
+
+def construct_error_middleware(error_callbacks):
+    """
+    Constructs a middleware which intercepts requests for any method found in
+    the provided mapping of endpoints to callbacks, returning whatever response
+    the callback generates.  Callbacks must be functions with the signature
+    `fn(method, params)`.
+    """
+    def error_callback_middleware(make_request, web3):
+        def middleware(method, params):
+            if method in error_callbacks:
+                error_msg = error_callbacks[method](method, params)
+                return {'error': error_msg}
+            else:
+                return make_request(method, params)
+        return middleware
+    return error_callback_middleware

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -239,15 +239,15 @@ ethereum_tester_middleware = construct_formatting_middleware(
 
 ethereum_tester_fixture_middleware = construct_fixture_middleware({
     # Eth
-    'eth_protocolVersion': {'result': '63'},
-    'eth_hashrate': {'result': 0},
-    'eth_gasPrice': {'result': 1},
-    'eth_syncing': {'result': False},
-    'eth_mining': {'result': False},
+    'eth_protocolVersion': '63',
+    'eth_hashrate': 0,
+    'eth_gasPrice': 1,
+    'eth_syncing': False,
+    'eth_mining': False,
     # Net
-    'net_version': {'result': '1'},
-    'net_listening': {'result': False},
-    'net_peerCount': {'result': 0},
+    'net_version': '1',
+    'net_listening': False,
+    'net_peerCount': 0,
 })
 
 

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -239,15 +239,15 @@ ethereum_tester_middleware = construct_formatting_middleware(
 
 ethereum_tester_fixture_middleware = construct_fixture_middleware({
     # Eth
-    'eth_protocolVersion': '63',
-    'eth_hashrate': 0,
-    'eth_gasPrice': 1,
-    'eth_syncing': False,
-    'eth_mining': False,
+    'eth_protocolVersion': {'result': '63'},
+    'eth_hashrate': {'result': 0},
+    'eth_gasPrice': {'result': 1},
+    'eth_syncing': {'result': False},
+    'eth_mining': {'result': False},
     # Net
-    'net_version': '1',
-    'net_listening': False,
-    'net_peerCount': 0,
+    'net_version': {'result': '1'},
+    'net_listening': {'result': False},
+    'net_peerCount': {'result': 0},
 })
 
 


### PR DESCRIPTION
### What was wrong?

A more expressive fixture middleware makes for easier testing.

### How was it fixed?

Allowed callbacks in the fixture middleware.

#### Cute Animal Picture

![article-2204915-15129347000005dc-919_964x628](https://user-images.githubusercontent.com/824194/34635897-683d8cee-f253-11e7-9232-b35649f29472.jpg)

