### PR TITLE
Error on bytes[] input to contract

### DIFF
--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -192,6 +192,8 @@ zpad_bytes = pad_bytes(b'\0')
 def to_bytes(primitive=None, hexstr=None, text=None):
     assert_one_val(primitive, hexstr=hexstr, text=text)
 
+    if isinstance(primitive, list):
+        return primitive
     if is_boolean(primitive):
         return b'\x01' if primitive else b'\x00'
     elif isinstance(primitive, bytes):

--- a/web3/utils/normalizers.py
+++ b/web3/utils/normalizers.py
@@ -97,6 +97,8 @@ def abi_string_to_hex(abi_type, data):
 @implicitly_identity
 def hexstrs_to_bytes(abi_type, data):
     base, sub, arrlist = process_type(abi_type)
+    if arrlist:
+        data = [d.data for d in data]
     if base in {'string', 'bytes'} and not arrlist:
         return abi_type, hexstr_if_str(to_bytes, data)
 


### PR DESCRIPTION
### What was wrong?
Passing an array of bytes to a contract method fails. This is a valid argument in Solidity but something along the way web3.py fails. For example, given a valid contract like this:

```
pragma solidity ^0.4.14;
contract Test {
    function tester(bytes32[2] _bytes) public {}
}
```

Calling in Python throws a TypeError:
```
# Some imports
from web3.contract import ConciseContract
from web3 import Web3, HTTPProvider
from eth_utils import keccak
import json

# Connect to the blockchain
web3 = Web3(HTTPProvider('http://localhost:8545'))

# Get the address and ABI of the contract
address = '0xC2B29DB38d5F83681940422ee36f06021EA5d3A9'
abi = json.loads('[{"constant": false, "inputs": [{"name": "_bytes", "type": "bytes32[2]"}], "name": "tester", "outputs": [], "payable": false, "stateMutability": "nonpayable", "type": "function"}]')

# Create a contract object
contract = web3.eth.contract(
    address, 
    abi=abi,
    ContractFactoryClass=ConciseContract,
)

# Create an array of bytes32
bytes32array = [keccak('1'), keccak('2')]

contract.tester(bytes32array)
>> ~/Envs/teahupoo-jupyter/lib/python3.6/site-packages/web3-4.0.0b2-py3.6.egg/web3/utils/encoding.py in to_bytes(primitive, hexstr, text)
>>     201     elif text is not None:
>>     202         return text.encode('utf-8')
>> --> 203     raise TypeError("expected an int in first arg, or keyword of hexstr or text")
>>     204 
>>     205 
>> 
>> TypeError: expected an int in first arg, or keyword of hexstr or text
```
it appears that some functions upstream of here were not expecting arrays of bytes data.


### How was it fixed?
Simple fix adding some checks to see if the data is a list to bypass this error. I do not really understand most of the methods I edited so please make sure I haven't fixed this in the wrong spot!


#### Cute Animal Picture

![Cute animal picture](http://purrfectcatbreeds.com/wp-content/uploads/2016/06/cat-halloween-costumes.jpg)
