### PR TITLE
bump eth-tester version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "pysha3>=1.0.0,<2.0.0",
         "requests>=2.12.4,<3.0.0",
         "rlp>=0.4.7,<1.0.0",
-        "eth-tester>=0.1.0b10,<0.2.0",
+        "eth-tester>=0.1.0b11,<0.2.0",
     ],
     setup_requires=['setuptools-markdown'],
     extras_require={


### PR DESCRIPTION
### What was wrong?

Upstream fixes to `eth-tester` (from upstream changes to `py-evm`)

### How was it fixed?

Bumped to latest `eth-tester`

#### Cute Animal Picture


![cute-animals-sleeping-stuffed-toys-7](https://user-images.githubusercontent.com/824194/34684612-f4962712-f462-11e7-9107-893c0f4a3a4f.jpg)

