### PR TITLE
Piper/fix recursion error in caching middleware

### DIFF
--- a/tests/core/middleware/test_latest_block_based_cache_middleware.py
+++ b/tests/core/middleware/test_latest_block_based_cache_middleware.py
@@ -1,11 +1,20 @@
+import codecs
+import itertools
 import time
 import uuid
 
 import pytest
 
-from cytoolz import assoc
+from eth_utils import (
+    is_integer,
+    to_tuple,
+)
 
-from web3.middleware.cache import (  # noqa: F401
+from web3 import Web3
+from web3.providers.base import BaseProvider
+from web3.middleware import (  # noqa: F401
+    construct_result_generator_middleware,
+    construct_error_generator_middleware,
     construct_latest_block_based_cache_middleware,
 )
 from web3.utils.caching import (
@@ -13,96 +22,218 @@ from web3.utils.caching import (
 )
 
 
-@pytest.fixture(autouse=True)
-def _time_travel_to_now(web3):
-    web3.testing.timeTravel(int(time.time()))
+@pytest.fixture
+def w3_base():
+    return Web3(providers=[BaseProvider()], middlewares=[])
 
 
-def test_latest_block_based_cache_middleware_pulls_from_cache(web3):
-    current_block_hash = web3.eth.getBlock('latest')['hash']
+def _mk_block(n, timestamp):
+    return {
+        'hash': codecs.decode(str(n).zfill(32), 'hex'),
+        'number': n,
+        'timestamp': timestamp,
+    }
+
+
+@to_tuple
+def generate_block_history(num_mined_blocks=5, block_time=1):
+    genesis = _mk_block(0, time.time())
+    yield genesis
+    for block_number in range(1, num_mined_blocks + 1):
+        yield _mk_block(
+            block_number,
+            genesis['timestamp'] + 2 * block_number,
+        )
+
+
+@pytest.fixture
+def construct_block_data_middleware():
+    def _construct_block_data_middleware(num_blocks):
+        blocks = generate_block_history(num_blocks)
+        _block_info = {
+            'blocks': blocks,
+            'head_block_number': blocks[0]['number']
+        }
+
+        def _evm_mine(method, params, block_info=_block_info):
+            num_blocks = params[0]
+            head_block_number = block_info['head_block_number']
+            if head_block_number + num_blocks >= len(block_info['blocks']):
+                raise ValueError("no more blocks to mine")
+
+            block_info['head_block_number'] += num_blocks
+
+        def _get_block_by_number(method, params, block_info=_block_info):
+            block_id = params[0]
+            blocks = block_info['blocks']
+            head_block_number = block_info['head_block_number']
+
+            if block_id == 'latest':
+                return blocks[head_block_number]
+            elif block_id == 'pending':
+                if head_block_number + 1 >= len(blocks):
+                    raise ValueError("no pending block")
+                return blocks[head_block_number + 1]
+            elif block_id == 'earliest':
+                return blocks[0]
+            elif is_integer(block_id):
+                if block_id <= head_block_number:
+                    return blocks[block_id]
+                else:
+                    return None
+            else:
+                raise TypeError('Invalid type for block_id')
+
+        def _get_block_by_hash(method, params, block_info=_block_info):
+            block_hash = params[0]
+            blocks = block_info['blocks']
+            head_block_number = block_info['head_block_number']
+
+            blocks_by_hash = {
+                block['hash']: block
+                for block
+                in blocks
+            }
+            try:
+                block = blocks_by_hash[block_hash]
+                if block['number'] <= head_block_number:
+                    return block
+                else:
+                    return None
+            except KeyError:
+                return None
+
+        return construct_result_generator_middleware({
+            'eth_getBlockByNumber': _get_block_by_number,
+            'eth_getBlockByHash': _get_block_by_hash,
+            'evm_mine': _evm_mine,
+        })
+    return _construct_block_data_middleware
+
+
+@pytest.fixture
+def block_data_middleware(construct_block_data_middleware):
+    return construct_block_data_middleware(5)
+
+
+@pytest.fixture
+def result_generator_middleware():
+    return construct_result_generator_middleware({
+        'fake_endpoint': lambda *_: str(uuid.uuid4()),
+        'not_whitelisted': lambda *_: str(uuid.uuid4()),
+    })
+
+
+@pytest.fixture
+def latest_block_based_cache_middleware():
+    return construct_latest_block_based_cache_middleware(
+        cache_class=dict,
+        average_block_time_sample_size=1,
+        default_average_block_time=0.1,
+        rpc_whitelist={'fake_endpoint'},
+    )
+
+
+@pytest.fixture
+def w3(w3_base,
+       result_generator_middleware,
+       block_data_middleware,
+       latest_block_based_cache_middleware):
+    w3_base.middleware_stack.add(block_data_middleware)
+    w3_base.middleware_stack.add(result_generator_middleware)
+    w3_base.middleware_stack.add(latest_block_based_cache_middleware)
+    return w3_base
+
+
+def test_latest_block_based_cache_middleware_pulls_from_cache(w3_base,
+                                                              block_data_middleware,
+                                                              result_generator_middleware):
+    w3 = w3_base
+    w3.middleware_stack.add(block_data_middleware)
+    w3.middleware_stack.add(result_generator_middleware)
+
+    current_block_hash = w3.eth.getBlock('latest')['hash']
 
     def cache_class():
         return {
-            generate_cache_key((current_block_hash, 'fake_endpoint', [1])): 'value-a',
+            generate_cache_key(
+                (current_block_hash, 'fake_endpoint', [1])
+            ): {'result': 'value-a'},
         }
 
-    middleware = construct_latest_block_based_cache_middleware(
+    w3.middleware_stack.add(construct_latest_block_based_cache_middleware(
         cache_class=cache_class,
         rpc_whitelist={'fake_endpoint'},
-    )(None, web3)
+    ))
 
-    assert middleware('fake_endpoint', [1]) == 'value-a'
-
-
-def test_latest_block_based_cache_middleware_populates_cache(web3):
-    def make_request(method, params):
-        return {
-            'result': str(uuid.uuid4()),
-        }
-
-    middleware = construct_latest_block_based_cache_middleware(
-        cache_class=dict,
-        rpc_whitelist={'fake_endpoint'},
-    )(make_request, web3)
-
-    response = middleware('fake_endpoint', [])
-    assert 'result' in response
-
-    assert middleware('fake_endpoint', []) == response
-    assert not middleware('fake_endpoint', [1]) == response
+    assert w3.manager.request_blocking('fake_endpoint', [1]) == 'value-a'
 
 
-@pytest.mark.parametrize(
-    'response',
-    (
-        {},
-        {'result': None},
-        {'error': 'some error message'},
-    )
-)
-def test_latest_block_cache_middleware_does_not_cache_bad_responses(web3, response):
-    def make_request(method, params):
-        return assoc(response, 'id', str(uuid.uuid4()))
+def test_latest_block_based_cache_middleware_populates_cache(w3):
+    result = w3.manager.request_blocking('fake_endpoint', [])
 
-    middleware = construct_latest_block_based_cache_middleware(
-        cache_class=dict,
-        rpc_whitelist={'fake_endpoint'},
-    )(make_request, web3)
-
-    response_a = middleware('fake_endpoint', [])
-    assert 'id' in response_a
-
-    response_b = middleware('fake_endpoint', [])
-    assert 'id' in response_b
-
-    assert not response_a['id'] == response_b['id']
+    assert w3.manager.request_blocking('fake_endpoint', []) == result
+    assert not w3.manager.request_blocking('fake_endpoint', [1]) == result
 
 
-def test_latest_block_based_cache_middleware_caches_latest_block(web3):
-    for _ in range(2):
-        web3.testing.mine()
+def test_latest_block_based_cache_middleware_busts_cache(w3, mocker):
+    result = w3.manager.request_blocking('fake_endpoint', [])
 
-    def make_request(method, params):
-        return {
-            'result': str(uuid.uuid4()),
-        }
+    assert w3.manager.request_blocking('fake_endpoint', []) == result
+    w3.testing.mine()
 
-    middleware = construct_latest_block_based_cache_middleware(
-        cache_class=dict,
-        average_block_time_sample_size=10,
-        default_average_block_time=10,
-        rpc_whitelist={'fake_endpoint'},
-    )(make_request, web3)
+    # should still be cached for at least 1 second.  This also verifies that
+    # the middleware caches the latest block based on the block time.
+    assert w3.manager.request_blocking('fake_endpoint', []) == result
 
-    # prime the internal latest block cache.
-    middleware('fake_endpoint', [])
+    mocker.patch('time.time', return_value=time.time() + 5)
 
-    response = middleware('fake_endpoint', [])
-    assert 'result' in response
+    assert not w3.manager.request_blocking('fake_endpoint', []) == result
 
-    assert middleware('fake_endpoint', []) == response
 
-    web3.testing.mine()
+def test_latest_block_cache_middleware_does_not_cache_bad_responses(w3_base,
+                                                                    block_data_middleware,
+                                                                    latest_block_based_cache_middleware):
+    counter = itertools.count()
+    w3 = w3_base
 
-    if not middleware('fake_endpoint', []) == response:
-        assert False, "Cache unexpectedly busted"
+    def result_cb(method, params):
+        next(counter)
+        return None
+
+    w3 = w3_base
+    w3.middleware_stack.add(block_data_middleware)
+    w3.middleware_stack.add(construct_result_generator_middleware({
+        'fake_endpoint': result_cb,
+    }))
+    w3.middleware_stack.add(latest_block_based_cache_middleware)
+
+    w3.manager.request_blocking('fake_endpoint', [])
+    w3.manager.request_blocking('fake_endpoint', [])
+
+    assert next(counter) == 2
+
+
+def test_latest_block_cache_middleware_does_not_cache_error_response(w3_base,
+                                                                     block_data_middleware,
+                                                                     latest_block_based_cache_middleware):
+    counter = itertools.count()
+    w3 = w3_base
+
+    def error_cb(method, params):
+        next(counter)
+        return "the error message"
+
+    w3 = w3_base
+    w3.middleware_stack.add(block_data_middleware)
+    w3.middleware_stack.add(construct_error_generator_middleware({
+        'fake_endpoint': error_cb,
+    }))
+    w3.middleware_stack.add(latest_block_based_cache_middleware)
+
+    with pytest.raises(ValueError):
+        w3.manager.request_blocking('fake_endpoint', [])
+    with pytest.raises(ValueError):
+        w3.manager.request_blocking('fake_endpoint', [])
+
+    assert next(counter) == 2

--- a/tests/core/middleware/test_latest_block_based_cache_middleware.py
+++ b/tests/core/middleware/test_latest_block_based_cache_middleware.py
@@ -145,9 +145,10 @@ def w3(w3_base,
     return w3_base
 
 
-def test_latest_block_based_cache_middleware_pulls_from_cache(w3_base,
-                                                              block_data_middleware,
-                                                              result_generator_middleware):
+def test_latest_block_based_cache_middleware_pulls_from_cache(
+        w3_base,
+        block_data_middleware,
+        result_generator_middleware):
     w3 = w3_base
     w3.middleware_stack.add(block_data_middleware)
     w3.middleware_stack.add(result_generator_middleware)
@@ -173,7 +174,7 @@ def test_latest_block_based_cache_middleware_populates_cache(w3):
     result = w3.manager.request_blocking('fake_endpoint', [])
 
     assert w3.manager.request_blocking('fake_endpoint', []) == result
-    assert not w3.manager.request_blocking('fake_endpoint', [1]) == result
+    assert w3.manager.request_blocking('fake_endpoint', [1]) != result
 
 
 def test_latest_block_based_cache_middleware_busts_cache(w3, mocker):
@@ -188,12 +189,13 @@ def test_latest_block_based_cache_middleware_busts_cache(w3, mocker):
 
     mocker.patch('time.time', return_value=time.time() + 5)
 
-    assert not w3.manager.request_blocking('fake_endpoint', []) == result
+    assert w3.manager.request_blocking('fake_endpoint', []) != result
 
 
-def test_latest_block_cache_middleware_does_not_cache_bad_responses(w3_base,
-                                                                    block_data_middleware,
-                                                                    latest_block_based_cache_middleware):
+def test_latest_block_cache_middleware_does_not_cache_bad_responses(
+        w3_base,
+        block_data_middleware,
+        latest_block_based_cache_middleware):
     counter = itertools.count()
     w3 = w3_base
 
@@ -214,9 +216,10 @@ def test_latest_block_cache_middleware_does_not_cache_bad_responses(w3_base,
     assert next(counter) == 2
 
 
-def test_latest_block_cache_middleware_does_not_cache_error_response(w3_base,
-                                                                     block_data_middleware,
-                                                                     latest_block_based_cache_middleware):
+def test_latest_block_cache_middleware_does_not_cache_error_response(
+        w3_base,
+        block_data_middleware,
+        latest_block_based_cache_middleware):
     counter = itertools.count()
     w3 = w3_base
 
@@ -224,7 +227,6 @@ def test_latest_block_cache_middleware_does_not_cache_error_response(w3_base,
         next(counter)
         return "the error message"
 
-    w3 = w3_base
     w3.middleware_stack.add(block_data_middleware)
     w3.middleware_stack.add(construct_error_generator_middleware({
         'fake_endpoint': error_cb,

--- a/tests/core/middleware/test_simple_cache_middleware.py
+++ b/tests/core/middleware/test_simple_cache_middleware.py
@@ -57,7 +57,7 @@ def test_simple_cache_middleware_populates_cache(w3):
     result = w3.manager.request_blocking('fake_endpoint', [])
 
     assert w3.manager.request_blocking('fake_endpoint', []) == result
-    assert not w3.manager.request_blocking('fake_endpoint', [1]) == result
+    assert w3.manager.request_blocking('fake_endpoint', [1]) != result
 
 
 def test_simple_cache_middleware_does_not_cache_none_responses(w3_base):
@@ -102,7 +102,7 @@ def test_simple_cache_middleware_does_not_cache_error_responses(w3_base):
     assert str(err_a) != str(err_b)
 
 
-def test_simple_cache_middleware_does_not_endpoints_not_in_whitelist(w3):
+def test_simple_cache_middleware_does_not_cache_endpoints_not_in_whitelist(w3):
     w3.middleware_stack.add(construct_simple_cache_middleware(
         cache_class=dict,
         rpc_whitelist={'fake_endpoint'},
@@ -111,4 +111,4 @@ def test_simple_cache_middleware_does_not_endpoints_not_in_whitelist(w3):
     result_a = w3.manager.request_blocking('not_whitelisted', [])
     result_b = w3.manager.request_blocking('not_whitelisted', [])
 
-    assert not result_a == result_b
+    assert result_a != result_b

--- a/tests/core/middleware/test_time_based_cache_middleware.py
+++ b/tests/core/middleware/test_time_based_cache_middleware.py
@@ -1,80 +1,98 @@
+import itertools
 import time
 import uuid
 
-from cytoolz import assoc
-
 import pytest
 
-from web3.middleware.cache import (  # noqa: F401
+from web3 import Web3
+from web3.providers.base import BaseProvider
+from web3.middleware import (  # noqa: F401
     construct_time_based_cache_middleware,
+    construct_result_generator_middleware,
+    construct_error_generator_middleware,
 )
 from web3.utils.caching import (
     generate_cache_key,
 )
 
 
-def test_time_based_cache_middleware_pulls_from_cache():
+@pytest.fixture
+def w3_base():
+    return Web3(providers=[BaseProvider()], middlewares=[])
+
+
+@pytest.fixture
+def result_generator_middleware():
+    return construct_result_generator_middleware({
+        'fake_endpoint': lambda *_: str(uuid.uuid4()),
+        'not_whitelisted': lambda *_: str(uuid.uuid4()),
+    })
+
+
+@pytest.fixture
+def time_cache_middleware():
+    return construct_time_based_cache_middleware(
+        cache_class=dict,
+        cache_expire_seconds=10,
+        rpc_whitelist={'fake_endpoint'},
+    )
+
+
+@pytest.fixture
+def w3(w3_base, result_generator_middleware, time_cache_middleware):
+    w3_base.middleware_stack.add(result_generator_middleware)
+    w3_base.middleware_stack.add(time_cache_middleware)
+    return w3_base
+
+
+def test_time_based_cache_middleware_pulls_from_cache(w3_base):
+    w3 = w3_base
+
     def cache_class():
         return {
             generate_cache_key(('fake_endpoint', [1])): (
                 time.time(),
-                'value-a',
+                {'result': 'value-a'},
             ),
         }
 
-    middleware = construct_time_based_cache_middleware(
+    w3.middleware_stack.add(construct_time_based_cache_middleware(
         cache_class=cache_class,
         cache_expire_seconds=10,
         rpc_whitelist={'fake_endpoint'},
-    )(None, None)
+    ))
 
-    assert middleware('fake_endpoint', [1]) == 'value-a'
-
-
-def test_time_based_cache_middleware_populates_cache():
-    def make_request(method, params):
-        return {
-            'result': str(uuid.uuid4()),
-        }
-
-    middleware = construct_time_based_cache_middleware(
-        cache_class=dict,
-        cache_expire_seconds=10,
-        rpc_whitelist={'fake_endpoint'},
-    )(make_request, None)
-
-    response = middleware('fake_endpoint', [])
-    assert 'result' in response
-
-    assert middleware('fake_endpoint', []) == response
-    assert not middleware('fake_endpoint', [1]) == response
+    assert w3.manager.request_blocking('fake_endpoint', [1]) == 'value-a'
 
 
-def test_time_based_cache_middleware_expires_old_values():
-    def make_request(method, params):
-        return {
-            'result': str(uuid.uuid4())
-        }
+def test_time_based_cache_middleware_populates_cache(w3):
+    result = w3.manager.request_blocking('fake_endpoint', [])
+
+    assert w3.manager.request_blocking('fake_endpoint', []) == result
+    assert not w3.manager.request_blocking('fake_endpoint', [1]) == result
+
+
+def test_time_based_cache_middleware_expires_old_values(w3_base, result_generator_middleware):
+    w3 = w3_base
+    w3.middleware_stack.add(result_generator_middleware)
 
     def cache_class():
         return {
             generate_cache_key(('fake_endpoint', [1])): (
                 time.time() - 10,
-                'value-a',
+                {'result': 'value-a'},
             ),
         }
 
-    middleware = construct_time_based_cache_middleware(
+    w3.middleware_stack.add(construct_time_based_cache_middleware(
         cache_class=cache_class,
         cache_expire_seconds=10,
         rpc_whitelist={'fake_endpoint'},
-    )(make_request, None)
+    ))
 
-    response = middleware('fake_endpoint', [1])
-    assert not response == 'value-a'
-    assert 'result' in response
-
-    assert middleware('fake_endpoint', [1]) == response
+    result = w3.manager.request_blocking('fake_endpoint', [1])
+    assert not result == 'value-a'
+    assert w3.manager.request_blocking('fake_endpoint', [1]) == result
 
 
 @pytest.mark.parametrize(
@@ -82,44 +100,51 @@ def test_time_based_cache_middleware_expires_old_values():
     (
         {},
         {'result': None},
-        {'error': 'some error message'},
     )
 )
-def test_time_based_cache_middleware_does_not_cache_bad_responses(response):
-    def make_request(method, params):
-        return assoc(response, 'id', str(uuid.uuid4()))
+def test_time_based_cache_middleware_does_not_cache_bad_responses(w3_base,
+                                                                  response,
+                                                                  time_cache_middleware):
+    w3 = w3_base
+    counter = itertools.count()
 
-    middleware = construct_time_based_cache_middleware(
-        cache_class=dict,
-        cache_expire_seconds=10,
-        rpc_whitelist={'fake_endpoint'},
-    )(make_request, None)
+    def mk_result(method, params):
+        next(counter)
+        return None
 
-    response_a = middleware('fake_endpoint', [])
-    assert 'id' in response_a
+    w3.middleware_stack.add(construct_result_generator_middleware({'fake_endpoint': mk_result}))
+    w3.middleware_stack.add(time_cache_middleware)
 
-    response_b = middleware('fake_endpoint', [])
-    assert 'id' in response_b
+    w3.manager.request_blocking('fake_endpoint', [])
+    w3.manager.request_blocking('fake_endpoint', [])
 
-    assert not response_a['id'] == response_b['id']
+    assert next(counter) == 2
 
 
-def test_time_based_cache_middleware_does_not_endpoints_not_in_whitelist():
-    def make_request(method, params):
-        return {
-            'result': str(uuid.uuid4())
-        }
+def test_time_based_cache_middleware_does_not_cache_error_response(w3_base,
+                                                                   time_cache_middleware):
+    w3 = w3_base
+    counter = itertools.count()
 
-    middleware = construct_time_based_cache_middleware(
-        cache_class=dict,
-        cache_expire_seconds=10,
-        rpc_whitelist={'fake_endpoint'},
-    )(make_request, None)
+    def mk_error(method, params):
+        return "error-number-{0}".format(next(counter))
 
-    response_a = middleware('not_whitelisted', [])
-    assert 'result' in response_a
+    w3.middleware_stack.add(construct_error_generator_middleware({
+        'fake_endpoint': mk_error,
+    }))
+    w3.middleware_stack.add(time_cache_middleware)
 
-    response_b = middleware('not_whitelisted', [])
-    assert 'result' in response_b
+    with pytest.raises(ValueError) as err:
+        w3.manager.request_blocking('fake_endpoint', [])
+    assert 'error-number-0' in str(err)
 
-    assert not response_a['result'] == response_b['result']
+    with pytest.raises(ValueError) as err:
+        w3.manager.request_blocking('fake_endpoint', [])
+    assert 'error-number-1' in str(err)
+
+
+def test_time_based_cache_middleware_does_not_endpoints_not_in_whitelist(w3):
+    result_a = w3.manager.request_blocking('not_whitelisted', [])
+    result_b = w3.manager.request_blocking('not_whitelisted', [])
+
+    assert not result_a == result_b

--- a/tests/core/middleware/test_time_based_cache_middleware.py
+++ b/tests/core/middleware/test_time_based_cache_middleware.py
@@ -69,7 +69,7 @@ def test_time_based_cache_middleware_populates_cache(w3):
     result = w3.manager.request_blocking('fake_endpoint', [])
 
     assert w3.manager.request_blocking('fake_endpoint', []) == result
-    assert not w3.manager.request_blocking('fake_endpoint', [1]) == result
+    assert w3.manager.request_blocking('fake_endpoint', [1]) != result
 
 
 def test_time_based_cache_middleware_expires_old_values(w3_base, result_generator_middleware):
@@ -91,7 +91,7 @@ def test_time_based_cache_middleware_expires_old_values(w3_base, result_generato
     ))
 
     result = w3.manager.request_blocking('fake_endpoint', [1])
-    assert not result == 'value-a'
+    assert result != 'value-a'
     assert w3.manager.request_blocking('fake_endpoint', [1]) == result
 
 
@@ -102,9 +102,10 @@ def test_time_based_cache_middleware_expires_old_values(w3_base, result_generato
         {'result': None},
     )
 )
-def test_time_based_cache_middleware_does_not_cache_bad_responses(w3_base,
-                                                                  response,
-                                                                  time_cache_middleware):
+def test_time_based_cache_middleware_does_not_cache_bad_responses(
+        w3_base,
+        response,
+        time_cache_middleware):
     w3 = w3_base
     counter = itertools.count()
 
@@ -121,8 +122,9 @@ def test_time_based_cache_middleware_does_not_cache_bad_responses(w3_base,
     assert next(counter) == 2
 
 
-def test_time_based_cache_middleware_does_not_cache_error_response(w3_base,
-                                                                   time_cache_middleware):
+def test_time_based_cache_middleware_does_not_cache_error_response(
+        w3_base,
+        time_cache_middleware):
     w3 = w3_base
     counter = itertools.count()
 
@@ -143,8 +145,8 @@ def test_time_based_cache_middleware_does_not_cache_error_response(w3_base,
     assert 'error-number-1' in str(err)
 
 
-def test_time_based_cache_middleware_does_not_endpoints_not_in_whitelist(w3):
+def test_time_based_cache_middleware_does_not_cache_endpoints_not_in_whitelist(w3):
     result_a = w3.manager.request_blocking('not_whitelisted', [])
     result_b = w3.manager.request_blocking('not_whitelisted', [])
 
-    assert not result_a == result_b
+    assert result_a != result_b

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -10,9 +10,9 @@ from .cache import (  # noqa: F401
     construct_simple_cache_middleware,
     construct_time_based_cache_middleware,
     construct_latest_block_based_cache_middleware,
-    simple_cache_middleware,
-    time_based_cache_middleware,
-    latest_block_based_cache_middleware,
+    _simple_cache_middleware as simple_cache_middleware,
+    _time_based_cache_middleware as time_based_cache_middleware,
+    _latest_block_based_cache_middleware as latest_block_based_cache_middleware,
 )
 from .exception_handling import (  # noqa: F401
     construct_exception_handler_middleware,

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -271,7 +271,7 @@ AVG_BLOCK_TIME_UPDATED_AT_KEY = 'avg_block_time_updated_at'
 def _is_latest_or_pending_block_request(method, params):
     if method != 'eth_getBlockByNumber':
         return False
-    elif params == ['latest'] or params == ['pending']:
+    elif params == ['latest']:
         return True
     return False
 

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -60,21 +60,21 @@ SIMPLE_CACHE_RPC_WHITELIST = {
 }
 
 
-def _should_cache(method, params, response=None):
-    if response is not None:
-        if 'error' in response:
-            return False
-        elif 'result' not in response:
-            return False
+def _should_cache(method, params, response):
+    if 'error' in response:
+        return False
+    elif 'result' not in response:
+        return False
 
-        if response['result'] is None:
-            return False
+    if response['result'] is None:
+        return False
     return True
 
 
-def construct_simple_cache_middleware(cache_class,
-                                      rpc_whitelist=SIMPLE_CACHE_RPC_WHITELIST,
-                                      should_cache_fn=_should_cache):
+def construct_simple_cache_middleware(
+        cache_class,
+        rpc_whitelist=SIMPLE_CACHE_RPC_WHITELIST,
+        should_cache_fn=_should_cache):
     """
     Constructs a middleware which caches responses based on the request
     ``method`` and ``params``
@@ -89,7 +89,7 @@ def construct_simple_cache_middleware(cache_class,
         cache = cache_class()
 
         def middleware(method, params):
-            if method in rpc_whitelist and should_cache_fn(method, params):
+            if method in rpc_whitelist:
                 cache_key = generate_cache_key((method, params))
                 if cache_key not in cache:
                     response = make_request(method, params)
@@ -103,7 +103,7 @@ def construct_simple_cache_middleware(cache_class,
     return simple_cache_middleware
 
 
-simple_cache_middleware = construct_simple_cache_middleware(
+_simple_cache_middleware = construct_simple_cache_middleware(
     cache_class=functools.partial(lru.LRU, 256),
 )
 
@@ -160,10 +160,11 @@ TIME_BASED_CACHE_RPC_WHITELIST = {
 }
 
 
-def construct_time_based_cache_middleware(cache_class,
-                                          cache_expire_seconds=15,
-                                          rpc_whitelist=TIME_BASED_CACHE_RPC_WHITELIST,
-                                          should_cache_fn=_should_cache):
+def construct_time_based_cache_middleware(
+        cache_class,
+        cache_expire_seconds=15,
+        rpc_whitelist=TIME_BASED_CACHE_RPC_WHITELIST,
+        should_cache_fn=_should_cache):
     """
     Constructs a middleware which caches responses based on the request
     ``method`` and ``params`` for a maximum amount of time as specified
@@ -176,11 +177,11 @@ def construct_time_based_cache_middleware(cache_class,
         ``response`` and returns a boolean as to whether the response should be
         cached.
     """
-    def simple_cache_middleware(make_request, web3):
+    def time_based_cache_middleware(make_request, web3):
         cache = cache_class()
 
         def middleware(method, params):
-            if method in rpc_whitelist and should_cache_fn(method, params):
+            if method in rpc_whitelist:
                 cache_key = generate_cache_key((method, params))
                 if cache_key in cache:
                     # check that the cached response is not expired.
@@ -202,10 +203,10 @@ def construct_time_based_cache_middleware(cache_class,
             else:
                 return make_request(method, params)
         return middleware
-    return simple_cache_middleware
+    return time_based_cache_middleware
 
 
-time_based_cache_middleware = construct_time_based_cache_middleware(
+_time_based_cache_middleware = construct_time_based_cache_middleware(
     cache_class=functools.partial(lru.LRU, 256),
 )
 
@@ -267,19 +268,20 @@ AVG_BLOCK_SAMPLE_SIZE_KEY = 'avg_block_sample_size'
 AVG_BLOCK_TIME_UPDATED_AT_KEY = 'avg_block_time_updated_at'
 
 
-def _should_cache_by_latest_block(method, params, response=None):
-    if method == 'eth_getBlockByNumber':
-        if params == ['latest'] or params == ['pending']:
-            return False
+def _is_latest_or_pending_block_request(method, params):
+    if method != 'eth_getBlockByNumber':
+        return False
+    elif params == ['latest'] or params == ['pending']:
+        return True
+    return False
 
-    return _should_cache(method, params, response)
 
-
-def construct_latest_block_based_cache_middleware(cache_class,
-                                                  rpc_whitelist=BLOCK_NUMBER_RPC_WHITELIST,
-                                                  average_block_time_sample_size=240,
-                                                  default_average_block_time=15,
-                                                  should_cache_fn=_should_cache_by_latest_block):
+def construct_latest_block_based_cache_middleware(
+        cache_class,
+        rpc_whitelist=BLOCK_NUMBER_RPC_WHITELIST,
+        average_block_time_sample_size=240,
+        default_average_block_time=15,
+        should_cache_fn=_should_cache):
     """
     Constructs a middleware which caches responses based on the request
     ``method``, ``params``, and the current latest block hash.
@@ -349,7 +351,11 @@ def construct_latest_block_based_cache_middleware(cache_class,
                 block_info['latest_block'] = web3.eth.getBlock('latest')
 
         def middleware(method, params):
-            if method in rpc_whitelist and should_cache_fn(method, params):
+            should_try_cache = (
+                method in rpc_whitelist and
+                not _is_latest_or_pending_block_request(method, params)
+            )
+            if should_try_cache:
                 _update_block_info_cache()
                 latest_block_hash = block_info['latest_block']['hash']
                 cache_key = generate_cache_key((latest_block_hash, method, params))
@@ -366,7 +372,7 @@ def construct_latest_block_based_cache_middleware(cache_class,
     return latest_block_based_cache_middleware
 
 
-latest_block_based_cache_middleware = construct_latest_block_based_cache_middleware(
+_latest_block_based_cache_middleware = construct_latest_block_based_cache_middleware(
     cache_class=functools.partial(lru.LRU, 256),
     rpc_whitelist=BLOCK_NUMBER_RPC_WHITELIST,
 )

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -268,7 +268,7 @@ AVG_BLOCK_SAMPLE_SIZE_KEY = 'avg_block_sample_size'
 AVG_BLOCK_TIME_UPDATED_AT_KEY = 'avg_block_time_updated_at'
 
 
-def _is_latest_or_pending_block_request(method, params):
+def _is_latest_block_number_request(method, params):
     if method != 'eth_getBlockByNumber':
         return False
     elif params == ['latest']:
@@ -353,7 +353,7 @@ def construct_latest_block_based_cache_middleware(
         def middleware(method, params):
             should_try_cache = (
                 method in rpc_whitelist and
-                not _is_latest_or_pending_block_request(method, params)
+                not _is_latest_block_number_request(method, params)
             )
             if should_try_cache:
                 _update_block_info_cache()


### PR DESCRIPTION
Based on #536 which is likely to change in structure.

### What was wrong?

Caching middleware is broken.  It causes infinite recursion

### How was it fixed?

Each of the middlewares now do a pre-check using the `should_cache_fn` prior to fetching a response, and then again with the response to see if it should be cached.  All tests now use *legit* web3 instances and requests that are passed through the middleware stack just as they would be normally.

#### Cute Animal Picture

![hqdefault](https://user-images.githubusercontent.com/824194/34890047-aa415988-f78d-11e7-8266-0a95fb27ee70.jpg)
