### PR TITLE
adding contract address to concise contract

### DIFF
--- a/web3/contract.py
+++ b/web3/contract.py
@@ -676,6 +676,7 @@ class ConciseContract(object):
     def __init__(self, classic_contract):
         classic_contract._return_data_normalizers += CONCISE_NORMALIZERS
         self._classic_contract = classic_contract
+        self.address = self._classic_contract.address
 
     @classmethod
     def factory(cls, *args, **kwargs):


### PR DESCRIPTION
### What was wrong?
I love the ConciseContract class but its annoying to have to call `concise_contract._classic_contract.address` to get the address. This commit allows it to be directly callable with `concise_contract.address`


### How was it fixed?
Added `address` as an attribute to the ConciseContract object when its instantiated.


#### Cute Animal Picture

![Cute animal picture](https://images-na.ssl-images-amazon.com/images/I/81k9qoZQzQL._SY355_.jpg)
