### PR TITLE
Block id contract call

### DIFF
--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -1,13 +1,9 @@
 import pytest
 
-<<<<<<< HEAD
 from hexbytes import (
     HexBytes,
 )
 
-=======
-from unittest.mock import patch
->>>>>>> Added ability to query a specific block when using the contract.functions.methodName.call() method. Blocks can be queried by 'latest', 'earliest', block number (indexed from back and front of chain) and block hash.
 from web3.exceptions import (
     BadFunctionCallOutput,
     InvalidAddress,
@@ -366,48 +362,6 @@ def test_call_undeployed_contract(undeployed_math_contract, call):
     assert expected_undeployed_call_error_message in str(exception_info.value)
 
 
-<<<<<<< HEAD
 def test_call_fallback_function(fallback_function_contract):
     result = fallback_function_contract.fallback.call()
     assert result == []
-=======
-def test_throws_error_if_block_out_of_range(web3, math_contract):
-    web3.providers[0].make_request(method='evm_mine', params=[20])
-    with pytest.raises(BlockNumberOutofRange):
-        math_contract.functions.counter().call(block_identifier=50)
-
-    with pytest.raises(BlockNumberOutofRange):
-        math_contract.functions.counter().call(block_identifier=-50)
-
-
-@patch('web3.eth.Eth.call', return_value='0x' + '0' * 64)
-def test_accepts_earliest_and_latest_block_id(eth_call_mock, web3, math_contract, call_transaction):
-    web3.providers[0].make_request(method='evm_mine', params=[20])
-    math_contract.functions.counter().call(block_identifier='earliest')
-    eth_call_mock.assert_called_with(call_transaction, block_identifier='earliest')
-
-    math_contract.functions.counter().call(block_identifier='latest')
-    eth_call_mock.assert_called_with(call_transaction, block_identifier='latest')
-
-
-@patch('web3.eth.Eth.call', return_value='0xeth_call_mock, ' + '0' * 64)
-def test_accepts_block_hash_as_identifier(eth_call_mock, web3, math_contract, call_transaction):
-    blocks = web3.providers[0].make_request(method='evm_mine', params=[15])
-    print(blocks)
-    math_contract.functions.counter().call(block_identifier=blocks['result'][5])
-    eth_call_mock.assert_called_with(call_transaction, block_identifier=7)
-
-
-@patch('web3.eth.Eth.call', return_value='0x' + '0' * 64)
-def test_neg_block_number_indexes_from_end(eth_call_mock, web3, math_contract, call_transaction):
-    web3.providers[0].make_request(method='evm_mine', params=[15])
-    math_contract.functions.counter().call(block_identifier=-6)
-    eth_call_mock.assert_called_with(call_transaction, block_identifier=11)
-
-
-@patch('web3.eth.Eth.call', return_value='0x' + '0' * 64)
-def test_returns_data_from_specified_block(eth_call_mock, web3, math_contract, call_transaction):
-    web3.providers[0].make_request(method='evm_mine', params=[20])
-    math_contract.functions.counter().call(block_identifier=14)
-    eth_call_mock.assert_called_with(call_transaction, block_identifier=14)
->>>>>>> Added ability to query a specific block when using the contract.functions.methodName.call() method. Blocks can be queried by 'latest', 'earliest', block number (indexed from back and front of chain) and block hash.

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -1,12 +1,17 @@
 import pytest
 
+<<<<<<< HEAD
 from hexbytes import (
     HexBytes,
 )
 
+=======
+from unittest.mock import patch
+>>>>>>> Added ability to query a specific block when using the contract.functions.methodName.call() method. Blocks can be queried by 'latest', 'earliest', block number (indexed from back and front of chain) and block hash.
 from web3.exceptions import (
     BadFunctionCallOutput,
     InvalidAddress,
+    BlockNumberOutofRange
 )
 from web3.utils.ens import (
     contract_ens_addresses,
@@ -61,6 +66,14 @@ def address_contract(web3, WithConstructorAddressArgumentsContract):
 @pytest.fixture(params=[b'\x04\x06', '0x0406', '0406'])
 def bytes_contract(web3, BytesContract, request):
     return deploy(web3, BytesContract, args=[request.param])
+
+
+@pytest.fixture()
+def call_transaction():
+    return {
+        'data': '0x61bc221a',
+        'to': '0xc305c901078781C232A2a521C2aF7980f8385ee9'
+    }
 
 
 @pytest.fixture(params=[
@@ -353,6 +366,48 @@ def test_call_undeployed_contract(undeployed_math_contract, call):
     assert expected_undeployed_call_error_message in str(exception_info.value)
 
 
+<<<<<<< HEAD
 def test_call_fallback_function(fallback_function_contract):
     result = fallback_function_contract.fallback.call()
     assert result == []
+=======
+def test_throws_error_if_block_out_of_range(web3, math_contract):
+    web3.providers[0].make_request(method='evm_mine', params=[20])
+    with pytest.raises(BlockNumberOutofRange):
+        math_contract.functions.counter().call(block_identifier=50)
+
+    with pytest.raises(BlockNumberOutofRange):
+        math_contract.functions.counter().call(block_identifier=-50)
+
+
+@patch('web3.eth.Eth.call', return_value='0x' + '0' * 64)
+def test_accepts_earliest_and_latest_block_id(eth_call_mock, web3, math_contract, call_transaction):
+    web3.providers[0].make_request(method='evm_mine', params=[20])
+    math_contract.functions.counter().call(block_identifier='earliest')
+    eth_call_mock.assert_called_with(call_transaction, block_identifier='earliest')
+
+    math_contract.functions.counter().call(block_identifier='latest')
+    eth_call_mock.assert_called_with(call_transaction, block_identifier='latest')
+
+
+@patch('web3.eth.Eth.call', return_value='0xeth_call_mock, ' + '0' * 64)
+def test_accepts_block_hash_as_identifier(eth_call_mock, web3, math_contract, call_transaction):
+    blocks = web3.providers[0].make_request(method='evm_mine', params=[15])
+    print(blocks)
+    math_contract.functions.counter().call(block_identifier=blocks['result'][5])
+    eth_call_mock.assert_called_with(call_transaction, block_identifier=7)
+
+
+@patch('web3.eth.Eth.call', return_value='0x' + '0' * 64)
+def test_neg_block_number_indexes_from_end(eth_call_mock, web3, math_contract, call_transaction):
+    web3.providers[0].make_request(method='evm_mine', params=[15])
+    math_contract.functions.counter().call(block_identifier=-6)
+    eth_call_mock.assert_called_with(call_transaction, block_identifier=11)
+
+
+@patch('web3.eth.Eth.call', return_value='0x' + '0' * 64)
+def test_returns_data_from_specified_block(eth_call_mock, web3, math_contract, call_transaction):
+    web3.providers[0].make_request(method='evm_mine', params=[20])
+    math_contract.functions.counter().call(block_identifier=14)
+    eth_call_mock.assert_called_with(call_transaction, block_identifier=14)
+>>>>>>> Added ability to query a specific block when using the contract.functions.methodName.call() method. Blocks can be queried by 'latest', 'earliest', block number (indexed from back and front of chain) and block hash.

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -365,3 +365,61 @@ def test_call_undeployed_contract(undeployed_math_contract, call):
 def test_call_fallback_function(fallback_function_contract):
     result = fallback_function_contract.fallback.call()
     assert result == []
+
+
+def test_throws_error_if_block_out_of_range(web3, math_contract):
+    web3.providers[0].make_request(method='evm_mine', params=[20])
+    with pytest.raises(BlockNumberOutofRange):
+        math_contract.functions.counter().call(block_identifier=50)
+
+    with pytest.raises(BlockNumberOutofRange):
+        math_contract.functions.counter().call(block_identifier=-50)
+
+
+def test_accepts_latest_block(web3, math_contract):
+    web3.providers[0].make_request(method='evm_mine', params=[5])
+    math_contract.functions.increment().transact()
+
+    late = math_contract.functions.counter().call(block_identifier='latest')
+    pend = math_contract.functions.counter().call(block_identifier='pending')
+
+    assert late == 1
+    assert pend == 1
+
+
+def test_accepts_block_hash_as_identifier(web3, math_contract):
+    blocks = web3.providers[0].make_request(method='evm_mine', params=[5])
+    math_contract.functions.increment().transact()
+    more_blocks = web3.providers[0].make_request(method='evm_mine', params=[5])
+
+    old = math_contract.functions.counter().call(block_identifier=blocks['result'][2])
+    new = math_contract.functions.counter().call(block_identifier=more_blocks['result'][2])
+
+    assert old == 0
+    assert new == 1
+
+
+def test_neg_block_indexes_from_the_end(web3, math_contract):
+    web3.providers[0].make_request(method='evm_mine', params=[5])
+    math_contract.functions.increment().transact()
+    math_contract.functions.increment().transact()
+    web3.providers[0].make_request(method='evm_mine', params=[5])
+
+    output1 = math_contract.functions.counter().call(block_identifier=-7)
+    output2 = math_contract.functions.counter().call(block_identifier=-6)
+
+    assert output1 == 1
+    assert output2 == 2
+
+
+def test_returns_data_from_specified_block(web3, math_contract):
+    web3.providers[0].make_request(method='evm_mine', params=[5])
+    math_contract.functions.increment().transact()
+    math_contract.functions.increment().transact()
+    web3.providers[0].make_request(method='evm_mine', params=[5])
+
+    output1 = math_contract.functions.counter().call(block_identifier=7)
+    output2 = math_contract.functions.counter().call(block_identifier=8)
+
+    assert output1 == 1
+    assert output2 == 2

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1041,10 +1041,7 @@ def call_contract_function(abi,
     else:
         return_data = web3.eth.call(call_transaction, block_identifier=block_id)
 
-<<<<<<< HEAD
     function_abi = find_matching_fn_abi(abi, function_identifier, args, kwargs)
-    function_abi = find_matching_fn_abi(abi, function_name, args, kwargs)
->>>>>>> Added ability to query a specific block when using the contract.functions.methodName.call() method. Blocks can be queried by 'latest', 'earliest', block number (indexed from back and front of chain) and block hash.
 
     output_types = get_abi_output_types(function_abi)
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -25,7 +25,9 @@ from toolz.functoolz import (
 
 from web3.exceptions import (
     BadFunctionCallOutput,
-    BlockNumberOutofRange
+    FallbackNotFound,
+    MismatchedABI,
+    BlockNumberOutofRange,
 )
 from web3.utils.abi import (
     fallback_func_abi_exists,
@@ -72,6 +74,10 @@ from web3.utils.normalizers import (
 )
 from web3.utils.transactions import (
     fill_transaction_defaults,
+)
+
+from web3.utils.blocks import (
+    is_hex_encoded_block_hash,
 )
 
 DEPRECATED_SIGNATURE_MESSAGE = (
@@ -1089,7 +1095,7 @@ def parse_block_identifier(web3, block_identifier):
             return block_identifier
         else:
             return last_block + block_identifier + 1
-    elif block_identifier in ['latest', 'earliest']:
+    elif block_identifier in ['latest', 'earliest', 'pending']:
         return block_identifier
     elif isinstance(block_identifier, bytes) or is_hex_encoded_block_hash(block_identifier):
         return web3.eth.getBlock(block_identifier).number

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -238,7 +238,6 @@ class Eth(Module):
         # TODO: move to middleware
         if block_identifier is None:
             block_identifier = self.defaultBlock
-
         return self.web3.manager.request_blocking(
             "eth_call",
             [transaction, block_identifier],

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -11,6 +11,13 @@ class BadFunctionCallOutput(Exception):
     pass
 
 
+class BlockNumberOutofRange(Exception):
+    '''
+    block_identifier passed does not match known block.
+    '''
+    pass
+
+
 class CannotHandleRequest(Exception):
     """
     Raised by a provider to signal that it cannot handle an RPC request and

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -14,6 +14,7 @@ from cytoolz.functoolz import (
     partial,
 )
 from eth_utils import (
+    combine_argument_formatters,
     encode_hex,
     is_address,
     is_bytes,
@@ -258,7 +259,10 @@ pythonic_middleware = construct_formatting_middleware(
         'eth_getUncleCountByBlockNumber': apply_formatter_at_index(block_number_formatter, 0),
         'eth_newFilter': apply_formatter_at_index(filter_params_formatter, 0),
         'eth_getLogs': apply_formatter_at_index(filter_params_formatter, 0),
-        'eth_call': apply_formatter_at_index(transaction_param_formatter, 0),
+        'eth_call': combine_argument_formatters(
+            transaction_param_formatter,
+            block_number_formatter,
+        ),
         'eth_estimateGas': apply_formatter_at_index(transaction_param_formatter, 0),
         'eth_sendTransaction': apply_formatter_at_index(transaction_param_formatter, 0),
         # personal

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -188,6 +188,7 @@ ethereum_tester_middleware = construct_formatting_middleware(
         ),
         'eth_call': apply_formatters_to_args(
             transaction_params_transformer,
+            apply_formatter_if(is_not_named_block, to_integer_if_hex),
         ),
         'eth_uninstallFilter': apply_formatters_to_args(hex_to_integer),
         # EVM

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -533,6 +533,15 @@ class EthModuleTest:
         result = web3.eth.getLogs(filter_params)
         assert_contains_log(result)
 
+    def test_eth_call_old_contract_state(self, web3, math_contract, unlocked_account):
+        math_contract.functions.increment().transact()
+
+        call_result_old = math_contract.functions.counter().call(block_identifier=6)
+        call_result = math_contract.functions.counter().call(block_identifier='latest')
+
+        assert call_result_old == 0
+        assert call_result == 1
+
     def test_eth_uninstallFilter(self, web3):
         filter = web3.eth.filter({})
         assert is_string(filter.filter_id)


### PR DESCRIPTION
### What was wrong?
Users could not directly specify a block to query contract state from when using the contract.functions.methodName.call() API. 


### How was it fixed?
A `block_identifier` parameter is now passed to the call method that allows users to query a specific block based on predefined blocks (`latest`, `earliest`), block number indexed from front or back of chain, and block hash.

Note: The tests for this feature feel partially incomplete because the eth-tester package does not allow one to query past contract state (outlined here ethereum/eth-tester#47). Instead the web3.eth.call method is assumed to be working as expected regarding querying past blocks (probably a safe assumption) and is mocked out.


#### Cute Animal Picture

![Cute animal picture](https://21786-presscdn-pagely.netdna-ssl.com/wp-content/uploads/2014/10/red-panda-445px.jpg)
