### PR TITLE
Update README.md with package requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ If you would like to hack on web3.py, set up your dev environment with:
 sudo apt-get install libssl-dev
 # ^ This is for Debian-like systems. TODO: Add more platforms
 
+sudo pacman -Sy libsecp256k1
+# ^ This is for ArchLinux system
+
 git clone git@github.com:ethereum/web3.py.git
 cd web3.py
 virtualenv venv


### PR DESCRIPTION
### What was wrong?

This is an issue with Arch Linux systems and I just wanted to share my solution.

When executing `pip install -r requirements-dev.txt` it would error out install the secp256k1 package. (populus is also affected by this). Here is there error of just that pip package: [https://pastebin.com/c98Bpsw2](https://pastebin.com/c98Bpsw2)

[Here](https://www.archlinux.org/packages/community/x86_64/libsecp256k1/) is the package page.

### How was it fixed?

I installed the `libsecp256k1` and that fixed the installation issue.

#### Cute Animal Picture

![Cute animal picture](https://i.imgur.com/LEvnTfq.jpg)
