### PR TITLE
warning cleanup

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -173,7 +173,7 @@ Each Contract Factory exposes the following methods.
         >>> my_contract.estimateGas().multiply7(3)
         42650
 
-.. py:method:: Contract.buildTransaction(transaction).myMethod(*args, **kwargs)
+.. py:method:: Contract.functions.myMethod(*args, **kwargs).buildTransaction(transaction)
 
     Builds a transaction dictionary based on the contract function call specified. 
 
@@ -187,7 +187,7 @@ Each Contract Factory exposes the following methods.
 
         .. code-block:: python
 
-            >>> math_contract.buildTransaction({'nonce': 10}).increment(5)
+            >>> math_contract.functions.increment(5).buildTransaction({'nonce': 10})
 
         You may use :meth:`~web3.eth.Eth.getTransactionCount` to get the current nonce
         for an account. Therefore a shortcut for producing a transaction dictionary with 
@@ -195,7 +195,7 @@ Each Contract Factory exposes the following methods.
 
         .. code-block:: python
 
-            >>> math_contract.buildTransaction({'nonce': web3.eth.getTransactionCount('0xF5...')}).increment(5)
+            >>> math_contract.functions.increment(5).buildTransaction({'nonce': web3.eth.getTransactionCount('0xF5...')})
 
     Returns a transaction dictionary. This transaction dictionary can then be sent using 
     :meth:`~web3.eth.Eth.sendTransaction`. 
@@ -205,7 +205,7 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >>> math_contract.buildTransaction({'gasPrice': 21000000000}).increment(5)
+        >>> math_contract.functions.increment(5).buildTransaction({'gasPrice': 21000000000})
         {
             'to': '0x6Bc272FCFcf89C14cebFC57B8f1543F5137F97dE',
             'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -46,7 +46,7 @@ example in :class:`ConciseContract` for specifying an alternate factory.
 
         >>>  # which is equivalent to this transaction in the classic contract:
 
-        >>> contract.transact({'from': eth.accounts[1], 'gas': 100000, ...}).withdraw(amount)
+        >>> contract.functions.withdraw(amount).transact({'from': eth.accounts[1], 'gas': 100000, ...})
 
 
 Properties
@@ -104,7 +104,7 @@ Each Contract Factory exposes the following methods.
 
     Returns the transaction hash for the deploy transaction.
 
-.. py:method:: Contract.transact(transaction).myMethod(*args, **kwargs)
+.. py:method:: Contract.functions.myMethod(*args, **kwargs).transact(transaction)
 
     Execute the specified function by sending a new public transaction.  
 
@@ -131,7 +131,7 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >>> token_contract.transact().transfer(web3.eth.accounts[1], 12345)
+        >>> token_contract.functions.transfer(web3.eth.accounts[1], 12345).transact()
         "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd"
 
 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -35,7 +35,7 @@ example in :class:`ConciseContract` for specifying an alternate factory.
 
 
     This variation invokes all methods as a call, so if the classic contract had a method like
-    ``contract.call().owner()``, you could call it with ``concise.owner()`` instead.
+    ``contract.functions.owner().call()``, you could call it with ``concise.owner()`` instead.
 
     For access to send a transaction or estimate gas, you can add a keyword argument like so:
 
@@ -135,7 +135,7 @@ Each Contract Factory exposes the following methods.
         "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd"
 
 
-.. py:method:: Contract.call(transaction).myMethod(*args, **kwargs)
+.. py:method:: Contract.functions.myMethod(*args, **kwargs).call(transaction)
 
     Call a contract function, executing the transaction locally using the
     ``eth_call`` API.  This will not create a new public transaction.
@@ -148,11 +148,11 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >>> my_contract.call().multiply7(3)
+        >>> my_contract.functions.multiply7(3).call()
         21
-        >>> token_contract.call({'from': web3.eth.coinbase}).myBalance()
+        >>> token_contract.functions.myBalance().call({'from': web3.eth.coinbase})
         12345  # the token balance for `web3.eth.coinbase`
-        >>> token_contract.call({'from': web3.eth.accounts[1]}).myBalance()
+        >>> token_contract.functions.myBalance().call({'from': web3.eth.accounts[1]})
         54321  # the token balance for the account `web3.eth.accounts[1]`
 
 

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -55,7 +55,7 @@ def test_build_transaction_with_gas_price_strategy_set(web3, math_contract):
     def my_gas_price_strategy(web3, transaction_params):
         return 5
     web3.eth.setGasPriceStrategy(my_gas_price_strategy)
-    txn = math_contract.buildTransaction().increment()
+    txn = math_contract.functions.increment().buildTransaction()
     assert txn == {
         'to': math_contract.address,
         'data': '0xd09de08a',

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -146,7 +146,7 @@ def test_call_read_string_variable(string_contract):
 
 
 def test_call_get_bytes32_array(arrays_contract):
-    result = arrays_contract.call().getBytes32Value()
+    result = arrays_contract.functions.getBytes32Value().call()
     # expected_bytes32_array = [keccak('0'), keccak('1')]
     expected_bytes32_array = [
         b'\x04HR\xb2\xa6p\xad\xe5@~x\xfb(c\xc5\x1d\xe9\xfc\xb9eB\xa0q\x86\xfe:\xed\xa6\xbb\x8a\x11m',  # noqa: E501
@@ -156,7 +156,7 @@ def test_call_get_bytes32_array(arrays_contract):
 
 
 def test_call_get_bytes32_const_array(arrays_contract):
-    result = arrays_contract.call().getBytes32ConstValue()
+    result = arrays_contract.functions.getBytes32ConstValue().call()
     # expected_bytes32_array = [keccak('A'), keccak('B')]
     expected_bytes32_array = [
         b'\x03x?\xac.\xfe\xd8\xfb\xc9\xadD>Y.\xe3\x0ea\xd6_G\x11@\xc1\x0c\xa1U\xe97\xb45\xb7`',
@@ -166,13 +166,13 @@ def test_call_get_bytes32_const_array(arrays_contract):
 
 
 def test_call_get_byte_array(arrays_contract):
-    result = arrays_contract.call().getByteValue()
+    result = arrays_contract.functions.getByteValue().call()
     expected_byte_arr = [b'\xff', b'\xff', b'\xff', b'\xff']
     assert result == expected_byte_arr
 
 
 def test_call_get_byte_const_array(arrays_contract):
-    result = arrays_contract.call().getByteConstValue()
+    result = arrays_contract.functions.getByteConstValue().call()
     expected_byte_arr = [b'\x00', b'\x01']
     assert result == expected_byte_arr
 

--- a/tests/core/contracts/test_contract_init.py
+++ b/tests/core/contracts/test_contract_init.py
@@ -30,7 +30,7 @@ def test_contract_with_name_address(MathContract, math_addr):
         mc = MathContract(address='thedao.eth')
         caller = mc.web3.eth.coinbase
         assert mc.address == 'thedao.eth'
-        assert mc.call({'from': caller}).return13() == 13
+        assert mc.functions.return13().call({'from': caller}) == 13
 
 
 def test_contract_with_name_address_from_eth_contract(
@@ -50,7 +50,7 @@ def test_contract_with_name_address_from_eth_contract(
 
         caller = mc.web3.eth.coinbase
         assert mc.address == 'thedao.eth'
-        assert mc.call({'from': caller}).return13() == 13
+        assert mc.functions.return13().call({'from': caller}) == 13
 
 
 def test_contract_with_name_address_changing(MathContract, math_addr):
@@ -64,13 +64,13 @@ def test_contract_with_name_address_changing(MathContract, math_addr):
     # what happen when name returns no address at all
     with contract_ens_addresses(mc, []):
         with pytest.raises(NameNotFound):
-            mc.call({'from': caller}).return13()
+            mc.functions.return13().call({'from': caller})
 
     # what happen when name returns address to different contract
     with contract_ens_addresses(mc, [('thedao.eth', '0x' + '11' * 20)]):
         with pytest.raises(BadFunctionCallOutput):
-            mc.call({'from': caller}).return13()
+            mc.functions.return13().call({'from': caller})
 
     # contract works again when name resolves correctly
     with contract_ens_addresses(mc, [('thedao.eth', math_addr)]):
-        assert mc.call({'from': caller}).return13() == 13
+        assert mc.functions.return13().call({'from': caller}) == 13

--- a/tests/core/contracts/test_contract_transact_interface.py
+++ b/tests/core/contracts/test_contract_transact_interface.py
@@ -129,7 +129,7 @@ def test_transacting_with_contract_with_bytes32_array_argument(web3, arrays_cont
         b'\xad|[\xef\x02x\x16\xa8\x00\xda\x176DO\xb5\x8a\x80~\xf4\xc9`;xHg?~:h\xeb\x14\xa5',
         b"*\x80\xe1\xef\x1dxB\xf2\x7f.k\xe0\x97+\xb7\x08\xb9\xa15\xc3\x88`\xdb\xe7<'\xc3Hl4\xf4\xde",  # noqa: E501
     ]
-    txn_hash = arrays_contract.transact().setBytes32Value(new_bytes32_array)
+    txn_hash = arrays_contract.functions.setBytes32Value(new_bytes32_array).transact()
     txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
     assert txn_receipt is not None
 
@@ -139,7 +139,7 @@ def test_transacting_with_contract_with_bytes32_array_argument(web3, arrays_cont
 
 def test_transacting_with_contract_with_byte_array_argument(web3, arrays_contract):
     new_byte_array = [b'\x03', b'\x03', b'\x03', b'\x03', b'\x03', b'\x03']
-    txn_hash = arrays_contract.transact().setByteValue(new_byte_array)
+    txn_hash = arrays_contract.functions.setByteValue(new_byte_array).transact()
     txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
     assert txn_receipt is not None
 

--- a/tests/core/contracts/test_contract_transact_interface.py
+++ b/tests/core/contracts/test_contract_transact_interface.py
@@ -51,13 +51,13 @@ def arrays_contract(web3, ArraysContract):
 
 
 def test_transacting_with_contract_no_arguments(web3, math_contract):
-    initial_value = math_contract.call().counter()
+    initial_value = math_contract.functions.counter().call()
 
     txn_hash = math_contract.functions.increment().transact()
     txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
     assert txn_receipt is not None
 
-    final_value = math_contract.call().counter()
+    final_value = math_contract.functions.counter().call()
 
     assert final_value - initial_value == 1
 
@@ -133,7 +133,7 @@ def test_transacting_with_contract_with_bytes32_array_argument(web3, arrays_cont
     txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
     assert txn_receipt is not None
 
-    final_value = arrays_contract.call().getBytes32Value()
+    final_value = arrays_contract.functions.getBytes32Value().call()
     assert final_value == new_bytes32_array
 
 
@@ -143,7 +143,7 @@ def test_transacting_with_contract_with_byte_array_argument(web3, arrays_contrac
     txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
     assert txn_receipt is not None
 
-    final_value = arrays_contract.call().getByteValue()
+    final_value = arrays_contract.functions.getByteValue().call()
     assert final_value == new_byte_array
 
 

--- a/tests/core/filtering/test_contract_on_event_filtering.py
+++ b/tests/core/filtering/test_contract_on_event_filtering.py
@@ -18,7 +18,7 @@ def test_on_filter_using_get_entries_interface(
     else:
         event_filter = Emitter.eventFilter('LogNoArguments', {})
 
-    txn_hash = emitter.transact().logNoArgs(emitter_event_ids.LogNoArguments)
+    txn_hash = emitter.functions.logNoArgs(emitter_event_ids.LogNoArguments).transact()
     wait_for_transaction(web3, txn_hash)
 
     log_entries = event_filter.get_new_entries()
@@ -48,14 +48,15 @@ def test_on_sync_filter_with_event_name_and_single_argument(web3,
         }})
 
     txn_hashes = []
+    event_id = emitter_event_ids.LogTripleWithIndex
     txn_hashes.append(
-        emitter.transact().logTriple(emitter_event_ids.LogTripleWithIndex, 2, 1, 3)
+        emitter.functions.logTriple(event_id, 2, 1, 3).transact()
     )
     txn_hashes.append(
-        emitter.transact().logTriple(emitter_event_ids.LogTripleWithIndex, 1, 2, 3)
+        emitter.functions.logTriple(event_id, 1, 2, 3).transact()
     )
     txn_hashes.append(
-        emitter.transact().logTriple(emitter_event_ids.LogTripleWithIndex, 12345, 2, 54321)
+        emitter.functions.logTriple(event_id, 12345, 2, 54321).transact()
     )
     for txn_hash in txn_hashes:
         wait_for_transaction(web3, txn_hash)
@@ -83,14 +84,15 @@ def test_on_sync_filter_with_event_name_and_non_indexed_argument(web3,
         }})
 
     txn_hashes = []
+    event_id = emitter_event_ids.LogTripleWithIndex
     txn_hashes.append(
-        emitter.transact().logTriple(emitter_event_ids.LogTripleWithIndex, 2, 1, 3)
+        emitter.functions.logTriple(event_id, 2, 1, 3).transact()
     )
     txn_hashes.append(
-        emitter.transact().logTriple(emitter_event_ids.LogTripleWithIndex, 1, 2, 3)
+        emitter.functions.logTriple(event_id, 1, 2, 3).transact()
     )
     txn_hashes.append(
-        emitter.transact().logTriple(emitter_event_ids.LogTripleWithIndex, 12345, 2, 54321)
+        emitter.functions.logTriple(event_id, 12345, 2, 54321).transact()
     )
     for txn_hash in txn_hashes:
         wait_for_transaction(web3, txn_hash)

--- a/tests/core/filtering/test_contract_past_event_filtering.py
+++ b/tests/core/filtering/test_contract_past_event_filtering.py
@@ -18,7 +18,7 @@ def test_on_filter_using_get_all_entries_interface(
     else:
         event_filter = Emitter.eventFilter('LogNoArguments', {})
 
-    txn_hash = emitter.transact().logNoArgs(emitter_event_ids.LogNoArguments)
+    txn_hash = emitter.functions.logNoArgs(emitter_event_ids.LogNoArguments).transact()
     wait_for_transaction(web3, txn_hash)
 
     log_entries = event_filter.get_all_entries()
@@ -42,7 +42,7 @@ def test_get_all_entries_returned_block_data(
     emitter_event_ids,
     call_as_instance,
 ):
-    txn_hash = emitter.transact().logNoArgs(emitter_event_ids.LogNoArguments)
+    txn_hash = emitter.functions.logNoArgs(emitter_event_ids.LogNoArguments).transact()
     txn_receipt = wait_for_transaction(web3, txn_hash)
 
     if call_as_instance:

--- a/tests/core/filtering/test_filter_against_transaction_logs.py
+++ b/tests/core/filtering/test_filter_against_transaction_logs.py
@@ -20,7 +20,7 @@ def test_sync_filter_against_log_events(web3_empty,
     txn_filter = web3.eth.filter({})
 
     txn_hashes = []
-    txn_hashes.append(emitter.transact().logNoArgs(emitter_event_ids.LogNoArguments))
+    txn_hashes.append(emitter.functions.logNoArgs(emitter_event_ids.LogNoArguments).transact())
 
     for txn_hash in txn_hashes:
         wait_for_transaction(web3, txn_hash)
@@ -50,7 +50,7 @@ def test_async_filter_against_log_events(web3_empty,
 
     txn_hashes = []
 
-    txn_hashes.append(emitter.transact().logNoArgs(emitter_event_ids.LogNoArguments))
+    txn_hashes.append(emitter.functions.logNoArgs(emitter_event_ids.LogNoArguments).transact())
 
     for txn_hash in txn_hashes:
         wait_for_transaction(web3, txn_hash)

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -113,18 +113,27 @@ def ens_setup():
     public_resolver = deploy(w3, PublicResolverFactory, ens_key, args=[ens_contract.address])
 
     # set 'resolver.eth' to resolve to public resolver
-    ens_contract.transact({'from': ens_key}).setSubnodeOwner(
+    ens_contract.functions.setSubnodeOwner(
         b'\0' * 32,
         eth_labelhash,
         ens_key
-    )
-    ens_contract.transact({'from': ens_key}).setSubnodeOwner(
+    ).transact({'from': ens_key})
+
+    ens_contract.functions.setSubnodeOwner(
         eth_namehash,
         w3.sha3(text='resolver'),
         ens_key
-    )
-    ens_contract.transact({'from': ens_key}).setResolver(resolver_namehash, public_resolver.address)
-    public_resolver.transact({'from': ens_key}).setAddr(resolver_namehash, public_resolver.address)
+    ).transact({'from': ens_key})
+
+    ens_contract.functions.setResolver(
+        resolver_namehash,
+        public_resolver.address
+    ).transact({'from': ens_key})
+
+    public_resolver.functions.setAddr(
+        resolver_namehash,
+        public_resolver.address
+    ).transact({'from': ens_key})
 
     # create .eth auction registrar
     eth_registrar = deploy(
@@ -135,11 +144,15 @@ def ens_setup():
     )
 
     # set '.eth' to resolve to the registrar
-    ens_contract.transact({'from': ens_key}).setResolver(eth_namehash, public_resolver.address)
-    public_resolver.transact({'from': ens_key}).setAddr(
+    ens_contract.functions.setResolver(
+        eth_namehash,
+        public_resolver.address
+    ).transact({'from': ens_key})
+
+    public_resolver.functions.setAddr(
         eth_namehash,
         eth_registrar.address
-    )
+    ).transact({'from': ens_key})
 
     # create reverse resolver
     reverse_resolver = deploy(w3, DefaultReverseResolver, ens_key, args=[ens_contract.address])
@@ -153,40 +166,48 @@ def ens_setup():
     )
 
     # set 'addr.reverse' to resolve to reverse registrar
-    ens_contract.transact({'from': ens_key}).setSubnodeOwner(
+    ens_contract.functions.setSubnodeOwner(
         b'\0' * 32,
         w3.sha3(text='reverse'),
         ens_key
-    )
-    ens_contract.transact({'from': ens_key}).setSubnodeOwner(
+    ).transact({'from': ens_key})
+
+    ens_contract.functions.setSubnodeOwner(
         reverse_tld_namehash,
         w3.sha3(text='addr'),
         ens_key
-    )
-    ens_contract.transact({'from': ens_key}).setResolver(reverser_namehash, public_resolver.address)
-    public_resolver.transact({'from': ens_key}).setAddr(
+    ).transact({'from': ens_key})
+
+    ens_contract.functions.setResolver(
+        reverser_namehash,
+        public_resolver.address
+    ).transact({'from': ens_key})
+
+    public_resolver.functions.setAddr(
         reverser_namehash,
         reverse_registrar.address
-    )
+    ).transact({'from': ens_key})
 
     # set owner of tester.eth to an account controlled by tests
-    ens_contract.transact({'from': ens_key}).setSubnodeOwner(
+    ens_contract.functions.setSubnodeOwner(
         eth_namehash,
         w3.sha3(text='tester'),
         w3.eth.accounts[2]  # note that this does not have to be the default, only in the list
-    )
+    ).transact({'from': ens_key})
+
     # make the registrar the owner of the 'eth' name
-    ens_contract.transact({'from': ens_key}).setSubnodeOwner(
+    ens_contract.functions.setSubnodeOwner(
         b'\0' * 32,
         eth_labelhash,
         eth_registrar.address
-    )
+    ).transact({'from': ens_key})
+
     # make the reverse registrar the owner of the 'addr.reverse' name
-    ens_contract.transact({'from': ens_key}).setSubnodeOwner(
+    ens_contract.functions.setSubnodeOwner(
         reverse_tld_namehash,
         w3.sha3(text='addr'),
         reverse_registrar.address
-    )
+    ).transact({'from': ens_key})
 
     return ENS.fromWeb3(w3, ens_contract.address)
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -481,13 +481,13 @@ class Contract(object):
 
             >>> wallet = Wallet(address='0xDc3A9Db694BCdd55EBaE4A89B22aC6D12b3F0c24')
             # Deposit to the `web3.eth.coinbase` account.
-            >>> wallet.transact({'value': 12345}).deposit()
+            >>> wallet.functions.deposit().transact({'value': 12345})
             '0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060'
             # Deposit to some other account using funds from `web3.eth.coinbase`.
-            >>> wallet.transact({'value': 54321}).deposit(web3.eth.accounts[1])
+            >>> wallet.functions.deposit(web3.eth.accounts[1]).transact({'value': 54321})
             '0xe122ba26d25a93911e241232d3ba7c76f5a6bfe9f8038b66b198977115fb1ddf'
             # Withdraw 12345 wei.
-            >>> wallet.transact().withdraw(12345)
+            >>> wallet.functions.withdraw(12345).transact()
 
         The new public transaction will be created.  Transaction receipt will
         be available once the transaction has been mined.
@@ -667,11 +667,11 @@ class ConciseContract(object):
 
     This call
 
-    > contract.withdraw(amount, transact={'from': eth.accounts[1], 'gas': 100000, ...})
+    > contract.functions.withdraw(amount, transact={'from': eth.accounts[1], 'gas': 100000, ...})
 
     is equivalent to this call in the classic contract:
 
-    > contract.transact({'from': eth.accounts[1], 'gas': 100000, ...}).withdraw(amount)
+    > contract.functions.withdraw(amount).transact({'from': eth.accounts[1], 'gas': 100000, ...})
     '''
     def __init__(self, classic_contract):
         classic_contract._return_data_normalizers += CONCISE_NORMALIZERS
@@ -737,7 +737,7 @@ class ImplicitContract(ConciseContract):
 
     is equivalent to this call in the classic contract:
 
-    > contract.transact({}).withdraw(amount)
+    > contract.functions.withdraw(amount).transact({})
     '''
     def __getattr__(self, attr):
         contract_function = getattr(self._classic_contract.functions, attr)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -411,7 +411,7 @@ class Contract(object):
             contract = ContractFactory("0x2f70d3d26829e412A602E83FE8EeBF80255AEeA5")
 
             # Read "owner" public variable
-            addr = contract.call().owner()
+            addr = contract.functions.owner().call()
 
         :param transaction: Dictionary of transaction info for web3 interface
         :return: ``Caller`` object that has contract public functions
@@ -810,7 +810,7 @@ class ContractMethod(object):
             contract = ContractFactory("0x2f70d3d26829e412A602E83FE8EeBF80255AEeA5")
 
             # Read "owner" public variable
-            addr = contract.call().owner()
+            addr = contract.functions.owner().call()
 
         :param transaction: Dictionary of transaction info for web3 interface
         :return: ``Caller`` object that has contract public functions

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -3,6 +3,7 @@ from cytoolz.dicttoolz import (
 )
 
 from eth_utils import (
+    apply_to_return_value,
     is_checksum_address,
     is_string,
 )
@@ -19,6 +20,9 @@ from web3.module import (
 
 from web3.utils.blocks import (
     select_method_for_block_identifier,
+)
+from web3.utils.datastructures import (
+    HexBytes,
 )
 from web3.utils.empty import (
     empty,
@@ -224,6 +228,7 @@ class Eth(Module):
             "eth_sign", [account, message_hex],
         )
 
+    @apply_to_return_value(HexBytes)
     def call(self, transaction, block_identifier=None):
         # TODO: move to middleware
         if 'from' not in transaction and is_checksum_address(self.defaultAccount):

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -25,6 +25,10 @@ from .abi import (
     normalize_event_input_types,
 )
 
+from web3.utils.encoding import (
+    hexstr_if_str,
+    to_bytes,
+)
 from web3.utils.normalizers import (
     BASE_RETURN_NORMALIZERS,
 )
@@ -160,7 +164,7 @@ def get_event_data(event_abi, log_entry):
             len(log_topics),
         ))
 
-    log_data = log_entry['data']
+    log_data = hexstr_if_str(to_bytes, log_entry['data'])
     log_data_abi = exclude_indexed_event_inputs(event_abi)
     log_data_normalized_inputs = normalize_event_input_types(log_data_abi)
     log_data_types = get_event_abi_types_for_decoding(log_data_normalized_inputs)


### PR DESCRIPTION
### What was wrong?

Tests are spitting a *lot* of warnings again

### How was it fixed?

Cleaned up the eth_abi hex errors, and the old-style contract function errors. The rest should go away when removing pyethereum.

#### Cute Animal Picture

![Cute animal picture](https://i2-prod.mirror.co.uk/incoming/article8948749.ece/ALTERNATES/s1200/Baby-pandas.jpg)
