### PR TITLE
Use py-evm in place of pyethereum as a backend for eth-tester, in all tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For different environments, you can set up multiple virtualenvs, like:
 virtualenv -p python3 venvpy3
 . venvpy3/bin/activate
 pip install -r requirements-dev.txt
-pip install -e .
+pip install -e .[tester]
 ```
 
 **Docs**

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ bumpversion
 flaky>=3.3.0
 flake8==3.4.1
 hypothesis>=3.31.2
-py-evm>=0.2.0a8,<1.0
 py-geth==1.10.2
 pytest==3.2.5
 pytest-mock==1.*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 bumpversion
-ethereum>=1.6.1,<2.0
 flaky>=3.3.0
 flake8==3.4.1
 hypothesis>=3.31.2
+py-evm>=0.2.0a8,<1.0
 py-geth==1.10.2
 pytest==3.2.5
 pytest-mock==1.*

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'tester': [
             "eth-tester[py-evm]>=0.1.0b12,<0.2.0",
             # eth-tester only works with evm alpha 8 in beta 12. Starting with eth-tester beta 13,
-            # which freezes py-evm, this comment and the following py-evm requirement can be deleted:
+            # which freezes py-evm, this comment and the following py-evm requirement can be deleted
             "py-evm==0.2.0a8",
         ],
         'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     extras_require={
         'tester': [
-            "eth-tester[py-evm]>=0.1.0b12,<0.2.0",
-            # eth-tester only works with evm alpha 8 in beta 12. Starting with eth-tester beta 13,
-            # which freezes py-evm, this comment and the following py-evm requirement can be deleted
-            "py-evm==0.2.0a8",
+            "eth-tester[py-evm]==0.1.0b13",
         ],
         'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],
         'platform_system=="Windows"': [

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     ],
     setup_requires=['setuptools-markdown'],
     extras_require={
-        'tester': ["eth-testrpc>=1.3.3,<2.0.0"],
+        'tester': ["py-evm>=0.2.0a8,<1.0"],
+        'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],
         'platform_system=="Windows"': [
             'pypiwin32'  # TODO: specify a version number, move under install_requires
         ],

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,15 @@ setup(
         "pysha3>=1.0.0,<2.0.0",
         "requests>=2.12.4,<3.0.0",
         "rlp>=0.4.7,<1.0.0",
-        "eth-tester>=0.1.0b11,<0.2.0",
     ],
     setup_requires=['setuptools-markdown'],
     extras_require={
-        'tester': ["py-evm>=0.2.0a8,<1.0"],
+        'tester': [
+            "eth-tester[py-evm]>=0.1.0b12,<0.2.0",
+            # eth-tester only works with evm alpha 8 in beta 12. Starting with eth-tester beta 13,
+            # which freezes py-evm, this comment and the following py-evm requirement can be deleted:
+            "py-evm==0.2.0a8",
+        ],
         'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],
         'platform_system=="Windows"': [
             'pypiwin32'  # TODO: specify a version number, move under install_requires

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from cytoolz import (
+    dissoc,
+)
+
 import pytest
 
 # Ignore warning in pyethereum 1.6 - will go away with the upgrade
@@ -17,42 +21,43 @@ def math_contract(web3, MathContract):
 
 def test_build_transaction_with_contract_no_arguments(web3, math_contract, buildTransaction):
     txn = buildTransaction(contract=math_contract, contract_function='increment')
-    assert txn == {
+    assert dissoc(txn, 'gas') == {
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'gas': 43120,
         'gasPrice': 1,
         'chainId': 1
     }
 
 
-def test_build_transaction_with_contract_class_method(web3,
-                                                      MathContract,
-                                                      math_contract,
-                                                      buildTransaction):
-    txn = buildTransaction(contract=MathContract,
-                           contract_function='increment',
-                           tx_params={'to': math_contract.address})
-    assert txn == {
+def test_build_transaction_with_contract_class_method(
+        web3,
+        MathContract,
+        math_contract,
+        buildTransaction):
+    txn = buildTransaction(
+        contract=MathContract,
+        contract_function='increment',
+        tx_params={'to': math_contract.address},
+    )
+    assert dissoc(txn, 'gas') == {
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'gas': 43120,
         'gasPrice': 1,
         'chainId': 1
     }
 
 
-def test_build_transaction_with_contract_default_account_is_set(web3,
-                                                                math_contract,
-                                                                buildTransaction):
+def test_build_transaction_with_contract_default_account_is_set(
+        web3,
+        math_contract,
+        buildTransaction):
     txn = buildTransaction(contract=math_contract, contract_function='increment')
-    assert txn == {
+    assert dissoc(txn, 'gas') == {
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'gas': 43120,
         'gasPrice': 1,
         'chainId': 1
     }
@@ -63,11 +68,10 @@ def test_build_transaction_with_gas_price_strategy_set(web3, math_contract, buil
         return 5
     web3.eth.setGasPriceStrategy(my_gas_price_strategy)
     txn = buildTransaction(contract=math_contract, contract_function='increment')
-    assert txn == {
+    assert dissoc(txn, 'gas') == {
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'gas': 43120,
         'gasPrice': 5,
         'chainId': 1
     }
@@ -97,31 +101,31 @@ def test_build_transaction_with_contract_to_address_supplied_errors(web3,
         (
             {}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gas': 43242, 'gasPrice': 1, 'chainId': 1
+                'value': 0, 'gasPrice': 1, 'chainId': 1
             }, False
         ),
         (
             {'gas': 800000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gas': 800000, 'gasPrice': 1, 'chainId': 1
+                'value': 0, 'gasPrice': 1, 'chainId': 1
             }, False
         ),
         (
             {'gasPrice': 21000000000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gas': 43242, 'gasPrice': 21000000000, 'chainId': 1
+                'value': 0, 'gasPrice': 21000000000, 'chainId': 1
             }, False
         ),
         (
             {'nonce': 7}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gas': 43242, 'gasPrice': 1, 'nonce': 7, 'chainId': 1
+                'value': 0, 'gasPrice': 1, 'nonce': 7, 'chainId': 1
             }, True
         ),
         (
             {'value': 20000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 20000, 'gas': 43242, 'gasPrice': 1, 'chainId': 1
+                'value': 20000, 'gasPrice': 1, 'chainId': 1
             }, False
         ),
     ),
@@ -150,4 +154,8 @@ def test_build_transaction_with_contract_with_arguments(web3, skip_if_testrpc, m
                            tx_params=transaction_args)
     expected['to'] = math_contract.address
     assert txn is not None
-    assert txn == expected
+    if 'gas' in transaction_args:
+        assert txn['gas'] == transaction_args['gas']
+    else:
+        assert 'gas' in txn
+    assert dissoc(txn, 'gas') == expected

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -21,6 +21,7 @@ def deploy(web3, Contract, args=None):
     deploy_receipt = web3.eth.getTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     contract = Contract(address=deploy_receipt['contractAddress'])
+    assert len(web3.eth.getCode(contract.address)) > 0
     return contract
 
 

--- a/tests/core/contracts/test_contract_estimateGas.py
+++ b/tests/core/contracts/test_contract_estimateGas.py
@@ -34,5 +34,5 @@ def test_contract_estimateGas(web3, math_contract, estimateGas):
     try:
         assert abs(gas_estimate - 21472) < 200  # Geth
     except AssertionError:
-        assert abs(gas_estimate - 43020) < 200  # TestRPC
+        assert abs(gas_estimate - 32772) < 200  # eth-tester with py-evm
         pass

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     py{35,36}-ens
     py{35,36}-core
-    py{35,36}-integration-{ethtestrpc,goethereum,ethtester}
+    py{35,36}-integration-{goethereum,ethtester}
     flake8
 
 [flake8]
@@ -15,14 +15,11 @@ usedevelop=True
 commands=
     core: py.test {posargs:tests/core}
     ens: py.test {posargs:tests/ens}
-    integration-ethtestrpc: py.test {posargs:tests/integration/test_ethtestrpc.py}
     integration-goethereum: py.test {posargs:tests/integration/test_goethereum.py}
     integration-ethtester: py.test {posargs:tests/integration/test_ethereum_tester.py}
 deps =
     -r{toxinidir}/requirements-dev.txt
     ethtester: eth-tester>=0.1.0b9
-setenv =
-    gevent: THREADING_BACKEND=gevent
 passenv =
     GETH_BINARY
     GETH_VERSION

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ commands=
     integration-ethtester: py.test {posargs:tests/integration/test_ethereum_tester.py}
 deps =
     -r{toxinidir}/requirements-dev.txt
-    ethtester: eth-tester>=0.1.0b9
 passenv =
     GETH_BINARY
     GETH_VERSION
@@ -29,6 +28,7 @@ passenv =
 basepython =
     py35: python3.5
     py36: python3.6
+extras = tester
 
 [testenv:flake8]
 basepython=python

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -263,7 +263,7 @@ def guess_from(web3, transaction):
 
 
 def guess_gas(web3, transaction):
-    return web3.eth.estimateGas(transaction)
+    return web3.eth.estimateGas(transaction) * 2
 
 
 @curry
@@ -281,6 +281,7 @@ fill_default_gas = fill_default('gas', guess_gas)
 
 def default_transaction_fields_middleware(make_request, web3):
     def middleware(method, params):
+        # TODO send call to eth-tester without gas, and remove guess_gas entirely
         if method == 'eth_call':
             filled_transaction = pipe(
                 params[0],


### PR DESCRIPTION
### What was wrong?

`pyethereum` is deprecated, in favor of py-evm.

### How was it fixed?

Moved eth-tester onto a py-evm backend so that all ongoing development is aligned in the same ecosystem. The latest eth-tester & py-evm is now good enough to replace pyethereum. :tada: 

(Although some incoming improvements to `call` and gas estimation will continue to simplify the web3 implementation)

closes #505 

#### Cute Animal Picture

![Cute animal picture](http://1.bp.blogspot.com/-TecWftl8EUw/TkUI6LnJkMI/AAAAAAAAR5Y/IPz56I4io_k/s1600/cute%2Blion%2Bcub-1.jpg)
