### PR TITLE
parse transaction receipts for event log data

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -156,7 +156,7 @@ Each Contract Factory exposes the following methods.
         54321  # the token balance for the account `web3.eth.accounts[1]`
 
 
-.. py:method:: Contract.estimateGas(transaction).myMethod(*args, **kwargs)
+.. py:method:: Contract.functions.myMethod(*args, **kwargs).estimateGas(transaction)
 
     Call a contract function, executing the transaction locally using the
     ``eth_call`` API.  This will not create a new public transaction.
@@ -253,6 +253,8 @@ Events
     If the :py:attr:`Contract.address` attribute for this contract is
     non-null, the contract address will be added to the ``filter_params``.
 
+.. _event-log-object:
+
     The Event Log Object is a python dictionary with the following keys:
 
     * ``args``: Dictionary - The arguments coming from the event.
@@ -282,3 +284,16 @@ Events
 
         >>> transfer_filter.get_all_entries()
         [...]  # all events that match the filter.
+
+.. py:method:: Contract.events.myEvent(*args, **kwargs).processReceipt(transaction_receipt)
+
+   Returns a tuple of :ref:`Event Log Objects <event-log-object>`, emitted from the event (e.g. ``myEvent``), 
+   with decoded ouput.
+
+   .. code-block:: python
+
+       >>> tx_hash = contract.functions.myFunction(12345).transact({'to':contract_address})
+       >>> tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+       >>> rich_logs = contract.events.myEvent().processReceipt(tx_receipt)
+       >>> rich_logs[0]['args']
+       {'myArg': 12345}

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -137,3 +137,71 @@ def test_dynamic_length_argument_extraction(web3,
     assert event_data['transactionIndex'] == txn_receipt['transactionIndex']
     assert is_same_address(event_data['address'], emitter.address)
     assert event_data['event'] == 'LogDynamicArgs'
+
+
+@pytest.mark.parametrize(
+    'contract_fn,event_name,call_args,expected_args',
+    (
+        ('logNoArgs', 'LogAnonymous', [], {}),
+        ('logNoArgs', 'LogNoArguments', [], {}),
+        ('logSingle', 'LogSingleArg', [12345], {'arg0': 12345}),
+        ('logSingle', 'LogSingleWithIndex', [12345], {'arg0': 12345}),
+        ('logSingle', 'LogSingleAnonymous', [12345], {'arg0': 12345}),
+        ('logDouble', 'LogDoubleArg', [12345, 54321], {'arg0': 12345, 'arg1': 54321}),
+        ('logDouble', 'LogDoubleAnonymous', [12345, 54321], {'arg0': 12345, 'arg1': 54321}),
+        ('logDouble', 'LogDoubleWithIndex', [12345, 54321], {'arg0': 12345, 'arg1': 54321}),
+        (
+            'logTriple',
+            'LogTripleArg',
+            [12345, 54321, 98765],
+            {'arg0': 12345, 'arg1': 54321, 'arg2': 98765},
+        ),
+        (
+            'logTriple',
+            'LogTripleWithIndex',
+            [12345, 54321, 98765],
+            {'arg0': 12345, 'arg1': 54321, 'arg2': 98765},
+        ),
+        (
+            'logQuadruple',
+            'LogQuadrupleArg',
+            [12345, 54321, 98765, 56789],
+            {'arg0': 12345, 'arg1': 54321, 'arg2': 98765, 'arg3': 56789},
+        ),
+        (
+            'logQuadruple',
+            'LogQuadrupleWithIndex',
+            [12345, 54321, 98765, 56789],
+            {'arg0': 12345, 'arg1': 54321, 'arg2': 98765, 'arg3': 56789},
+        ),
+    )
+)
+def test_event_rich_log(
+        web3,
+        emitter,
+        emitter_event_ids,
+        wait_for_transaction,
+        contract_fn,
+        event_name,
+        call_args,
+        expected_args):
+
+    emitter_fn = getattr(emitter.functions, contract_fn)
+    event_id = getattr(emitter_event_ids, event_name)
+    txn_hash = emitter_fn(event_id, *call_args).transact()
+    txn_receipt = wait_for_transaction(web3, txn_hash)
+
+    event_instance = getattr(emitter.events, event_name)()
+
+    rich_logs = event_instance.processReceipt(txn_receipt)
+
+    assert len(rich_logs) == 1
+
+    rich_log = rich_logs[0]
+
+    assert rich_log['args'] == expected_args
+    assert rich_log['blockHash'] == txn_receipt['blockHash']
+    assert rich_log['blockNumber'] == txn_receipt['blockNumber']
+    assert rich_log['transactionIndex'] == txn_receipt['transactionIndex']
+    assert is_same_address(rich_log['address'], emitter.address)
+    assert rich_log['event'] == event_name

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -205,3 +205,7 @@ def test_event_rich_log(
     assert rich_log['transactionIndex'] == txn_receipt['transactionIndex']
     assert is_same_address(rich_log['address'], emitter.address)
     assert rich_log['event'] == event_name
+
+    quiet_event = getattr(emitter.events, 'LogBytes')
+    empty_rich_log = quiet_event().processReceipt(txn_receipt)
+    assert empty_rich_log == tuple()

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -966,9 +966,6 @@ class ContractEvent(object):
             decoded_log = get_event_data(self.abi, log)
             yield decoded_log
 
-    def _decode_log(self, log):
-        return get_event_data(self.abi, log)
-
     @classmethod
     def factory(cls, class_name, **kwargs):
         return PropertyCheckingFactory(class_name, (cls,), kwargs)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -615,28 +615,10 @@ class Contract(object):
 
     @classmethod
     def _find_matching_event_abi(cls, event_name=None, argument_names=None):
-        filters = [
-            functools.partial(filter_by_type, 'event'),
-        ]
-
-        if event_name is not None:
-            filters.append(functools.partial(filter_by_name, event_name))
-
-        if argument_names is not None:
-            filters.append(
-                functools.partial(filter_by_argument_name, argument_names)
-            )
-
-        filter_fn = compose(*filters)
-
-        event_abi_candidates = filter_fn(cls.abi)
-
-        if len(event_abi_candidates) == 1:
-            return event_abi_candidates[0]
-        elif not event_abi_candidates:
-            raise ValueError("No matching functions found")
-        else:
-            raise ValueError("Multiple functions found")
+        return find_matching_fn_abi(
+            contract_abi=cls.abi,
+            event_name=event_name,
+            argument_names=argument_names)
 
     @combomethod
     @coerce_return_to_text

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -24,6 +24,7 @@ from toolz.functoolz import (
 
 from web3.exceptions import (
     BadFunctionCallOutput,
+    MismatchedABI,
 )
 
 from web3.utils.abi import (
@@ -957,13 +958,17 @@ class ContractEvent(object):
             cls.contract_abi,
             event_name=cls.event_name)
 
+    @combomethod
     def processReceipt(self, txn_receipt):
         return self._parse_logs(txn_receipt)
 
     @to_tuple
     def _parse_logs(self, txn_receipt):
         for log in txn_receipt['logs']:
-            decoded_log = get_event_data(self.abi, log)
+            try:
+                decoded_log = get_event_data(self.abi, log)
+            except MismatchedABI:
+                continue
             yield decoded_log
 
     @classmethod

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -56,3 +56,10 @@ class UnhandledRequest(Exception):
     Raised by the manager when none of it's providers responds to a request.
     """
     pass
+
+
+class MismatchedABI(Exception):
+    """
+    Raised when an ABI does not match with supplied parameters.
+    """
+    pass

--- a/web3/utils/contracts.py
+++ b/web3/utils/contracts.py
@@ -67,6 +67,7 @@ def find_matching_event_abi(abi, event_name=None, argument_names=None):
     else:
         raise ValueError("Multiple functions found")
 
+
 def find_matching_fn_abi(abi, fn_name=None, args=None, kwargs=None):
     filters = []
 

--- a/web3/utils/contracts.py
+++ b/web3/utils/contracts.py
@@ -1,4 +1,5 @@
 import functools
+
 from eth_abi import (
     encode_abi as eth_abi_encode_abi
 )
@@ -7,9 +8,15 @@ from eth_utils import (
     encode_hex,
     add_0x_prefix,
 )
+
+from toolz.functoolz import (
+    compose,
+)
+
 from web3.utils.abi import (
     filter_by_type,
     filter_by_name,
+    filter_by_argument_name,
     filter_by_argument_count,
     filter_by_encodability,
     get_abi_input_types,
@@ -34,6 +41,31 @@ from eth_abi.exceptions import (
     EncodingError,
 )
 
+
+def find_matching_event_abi(abi, event_name=None, argument_names=None):
+
+    filters = [
+        functools.partial(filter_by_type, 'event'),
+    ]
+
+    if event_name is not None:
+        filters.append(functools.partial(filter_by_name, event_name))
+
+    if argument_names is not None:
+        filters.append(
+            functools.partial(filter_by_argument_name, argument_names)
+        )
+
+    filter_fn = compose(*filters)
+
+    event_abi_candidates = filter_fn(abi)
+
+    if len(event_abi_candidates) == 1:
+        return event_abi_candidates[0]
+    elif not event_abi_candidates:
+        raise ValueError("No matching functions found")
+    else:
+        raise ValueError("Multiple functions found")
 
 def find_matching_fn_abi(abi, fn_name=None, args=None, kwargs=None):
     filters = []

--- a/web3/utils/contracts.py
+++ b/web3/utils/contracts.py
@@ -10,7 +10,7 @@ from eth_utils import (
 )
 
 from toolz.functoolz import (
-    compose,
+    pipe,
 )
 
 from web3.utils.abi import (
@@ -56,16 +56,14 @@ def find_matching_event_abi(abi, event_name=None, argument_names=None):
             functools.partial(filter_by_argument_name, argument_names)
         )
 
-    filter_fn = compose(*filters)
-
-    event_abi_candidates = filter_fn(abi)
+    event_abi_candidates = pipe(abi, *filters)
 
     if len(event_abi_candidates) == 1:
         return event_abi_candidates[0]
     elif not event_abi_candidates:
-        raise ValueError("No matching functions found")
+        raise ValueError("No matching events found")
     else:
-        raise ValueError("Multiple functions found")
+        raise ValueError("Multiple events found")
 
 
 def find_matching_fn_abi(abi, fn_name=None, args=None, kwargs=None):
@@ -88,14 +86,10 @@ def find_matching_fn_abi(abi, fn_name=None, args=None, kwargs=None):
 
     function_candidates = filter_by_type('function', abi)
 
-    for filter_fn in filters:
-        function_candidates = filter_fn(function_candidates)
+    function_candidates = pipe(abi, *filters)
 
-        if len(function_candidates) == 1:
-            return function_candidates[0]
-        elif not function_candidates:
-            break
-
+    if len(function_candidates) == 1:
+        return function_candidates[0]
     if not function_candidates:
         raise ValueError("No matching functions found")
     else:

--- a/web3/utils/datatypes.py
+++ b/web3/utils/datatypes.py
@@ -1,0 +1,45 @@
+from functools import (
+    partial,
+)
+from eth_utils import (
+    to_dict,
+)
+
+from web3.utils.normalizers import (
+    normalize_abi,
+    normalize_address,
+    normalize_bytecode,
+)
+
+
+class PropertyCheckingFactory(type):
+    ens = None
+
+    @to_dict
+    def normalize_properties(attributes, values, ens):
+        normalizers = {
+            'abi': normalize_abi,
+            'address': partial(normalize_address, ens),
+            'bytecode': normalize_bytecode,
+            'bytecode_runtime': normalize_bytecode,
+        }
+
+        for attribute, value in zip(attributes, values):
+            if attribute in normalizers:
+                normalizer = normalizers[attribute]
+                yield attribute, normalizer(value)
+            else:
+                yield attribute, value
+
+    def __new__(mcs, name, bases, namespace):
+        for key in namespace:
+            if not hasattr(bases[0], key):
+                raise AttributeError(
+                    "Property {0} not found on {1} class. "
+                    "`{1}.factory` only accepts keyword arguments which are "
+                    "present on the {1} class".format(key, name)
+                )
+        attributes, values = zip(*namespace.items())
+        ens = namespace['web3'].ens
+        normalized_namespace = mcs.normalize_properties(tuple(attributes), tuple(values), ens)
+        return super().__new__(mcs, name, bases, normalized_namespace)

--- a/web3/utils/datatypes.py
+++ b/web3/utils/datatypes.py
@@ -28,6 +28,11 @@ class PropertyCheckingFactory(type):
             else:
                 yield attribute, value
 
+    def __init__(cls, name, bases, namespace, **kargs):
+        # see PEP487.  To accept kwargs in __new__, they need to be
+        # filtered out here.
+        super().__init__(name, bases, namespace)
+
     def __new__(mcs, name, bases, namespace, normalizers={}):
         for key in namespace:
             verify_key_attr = partial(verify_attr, name, key)

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -25,6 +25,10 @@ from .abi import (
     normalize_event_input_types,
 )
 
+from web3.exceptions import (
+    MismatchedABI,
+)
+
 from web3.utils.encoding import (
     hexstr_if_str,
     to_bytes,
@@ -147,11 +151,15 @@ def get_event_abi_types_for_decoding(event_inputs):
 def get_event_data(event_abi, log_entry):
     """
     Given an event ABI and a log entry for that event, return the decoded
+    event data
     """
     if event_abi['anonymous']:
         log_topics = log_entry['topics']
     else:
         log_topics = log_entry['topics'][1:]
+        raw_signature = next(iter(log_entry['topics']), None)
+        if event_abi_to_log_topic(event_abi) != raw_signature:
+            raise MismatchedABI()
 
     log_topics_abi = get_indexed_event_inputs(event_abi)
     log_topic_normalized_inputs = normalize_event_input_types(log_topics_abi)

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -155,11 +155,12 @@ def get_event_data(event_abi, log_entry):
     """
     if event_abi['anonymous']:
         log_topics = log_entry['topics']
+    elif not log_entry['topics']:
+        raise MismatchedABI("Expected non-anonymous event to have 1 or more topics")
+    elif event_abi_to_log_topic(event_abi) != log_entry['topics'][0]:
+        raise MismatchedABI("The event signature did not match the provided ABI")
     else:
         log_topics = log_entry['topics'][1:]
-        raw_signature = next(iter(log_entry['topics']), None)
-        if event_abi_to_log_topic(event_abi) != raw_signature:
-            raise MismatchedABI()
 
     log_topics_abi = get_indexed_event_inputs(event_abi)
     log_topic_normalized_inputs = normalize_event_input_types(log_topics_abi)

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -98,10 +98,10 @@ def construct_event_data_set(event_abi, arguments=None):
         for key, value in arguments.items()
     }
 
-    indexed_args = exclude_indexed_event_inputs(event_abi)
+    non_indexed_args = exclude_indexed_event_inputs(event_abi)
     zipped_abi_and_args = [
         (arg, normalized_args.get(arg['name'], [None]))
-        for arg in indexed_args
+        for arg in non_indexed_args
     ]
     encoded_args = [
         [

--- a/web3/utils/normalizers.py
+++ b/web3/utils/normalizers.py
@@ -48,7 +48,9 @@ def implicitly_identity(to_wrap):
     return wrapper
 
 
-# ----- Return Normalizers -----
+#
+# Return Normalizers
+#
 
 
 @implicitly_identity
@@ -63,7 +65,9 @@ def decode_abi_strings(abi_type, data):
         return abi_type, codecs.decode(data, 'utf8', 'backslashreplace')
 
 
-# ----- Argument Normalizers -----
+#
+# Argument Normalizers
+#
 
 
 @implicitly_identity
@@ -131,7 +135,9 @@ BASE_RETURN_NORMALIZERS = [
 ]
 
 
-# ----- Property Normalizers -----
+#
+# Property Normalizers
+#
 
 
 def normalize_abi(abi):

--- a/web3/utils/normalizers.py
+++ b/web3/utils/normalizers.py
@@ -1,6 +1,7 @@
 
 import codecs
 import functools
+import json
 
 from cytoolz import (
     curry,
@@ -17,6 +18,9 @@ from eth_utils import (
 from web3.exceptions import (
     InvalidAddress,
 )
+from web3.utils.datastructures import (
+    HexBytes,
+)
 from web3.utils.encoding import (
     hexstr_if_str,
     text_if_str,
@@ -28,6 +32,7 @@ from web3.utils.ens import (
     validate_name_has_address,
 )
 from web3.utils.validation import (
+    validate_abi,
     validate_address,
 )
 
@@ -124,3 +129,28 @@ BASE_RETURN_NORMALIZERS = [
     addresses_checksummed,
     decode_abi_strings,
 ]
+
+
+# ----- Property Normalizers -----
+
+
+def normalize_abi(abi):
+    if isinstance(abi, str):
+        abi = json.loads(abi)
+    validate_abi(abi)
+    return abi
+
+
+def normalize_address(ens, address):
+    if address:
+        if is_ens_name(address):
+            validate_name_has_address(ens, address)
+        else:
+            validate_address(address)
+    return address
+
+
+def normalize_bytecode(bytecode):
+    if bytecode:
+        bytecode = HexBytes(bytecode)
+    return bytecode


### PR DESCRIPTION
### What was wrong?

See https://github.com/ethereum/web3.py/issues/429

### How was it fixed?

Im putting up this is a quick implementation, while Im still exploring the feature.  It simply passes the logs through the already existing function: utils.events.get_event_data.

#### Cute Animal Picture

![Cute animal picture](https://www.oddee.com/wp-content/uploads/_media/imgs/articles2/a99460_332.jpg)
