### PR TITLE
Add timeout parameter to IPCProvider class

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -95,7 +95,7 @@ HTTPProvider
 IPCProvider
 ~~~~~~~~~~~
 
-.. py:class:: web3.providers.ipc.IPCProvider(ipc_path=None, testnet=False)
+.. py:class:: web3.providers.ipc.IPCProvider(ipc_path=None, testnet=False, timeout=10)
 
     This provider handles interaction with an IPC Socket based JSON-RPC
     server.

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -136,12 +136,14 @@ def get_default_ipc_path(testnet=False):
 class IPCProvider(JSONBaseProvider):
     _socket = None
 
-    def __init__(self, ipc_path=None, testnet=False, *args, **kwargs):
+    def __init__(self, ipc_path=None, testnet=False, timeout=10,
+                 *args, **kwargs):
         if ipc_path is None:
             self.ipc_path = get_default_ipc_path(testnet)
         else:
             self.ipc_path = ipc_path
 
+        self.timeout = timeout
         self._lock = threading.Lock()
         self._socket = PersistantSocket(self.ipc_path)
         super(IPCProvider, self).__init__(*args, **kwargs)
@@ -158,7 +160,7 @@ class IPCProvider(JSONBaseProvider):
                 sock.sendall(request)
 
             raw_response = b""
-            with Timeout(10) as timeout:
+            with Timeout(self.timeout) as timeout:
                 while True:
                     try:
                         raw_response += sock.recv(4096)

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -136,8 +136,7 @@ def get_default_ipc_path(testnet=False):
 class IPCProvider(JSONBaseProvider):
     _socket = None
 
-    def __init__(self, ipc_path=None, testnet=False, timeout=10,
-                 *args, **kwargs):
+    def __init__(self, ipc_path=None, testnet=False, timeout=10, *args, **kwargs):
         if ipc_path is None:
             self.ipc_path = get_default_ipc_path(testnet)
         else:


### PR DESCRIPTION
### What was wrong?

Issue #309 requested that a timeout parameter be added to the IPCProvider class to allow more rapid retrying after timeouts.

### How was it fixed?

Fixed #309 by adding a timeout parameter to the IPCProvider class.

#### Cute Animal Picture

![His name is Buddha!](https://i.redd.it/vdq9iu2nvsb01.jpg)
[via reddit](https://www.reddit.com/r/aww/comments/7sdp8r/his_name_is_buddha/)
