### PR TITLE
CircleCI config, for the next time Travis stalls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,99 @@
+version: 2.0
+
+# heavily inspired by https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
+
+common: &common
+  working_directory: ~/repo
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: pip install --user tox
+    - run:
+        name: build geth if missing
+        command: |
+          mkdir -p $HOME/.ethash
+          pip install --user py-geth>=1.10.1
+          export GOROOT=/usr/local/go
+          export GETH_VERSION=v1.7.2
+          export GETH_BINARY="$HOME/.py-geth/geth-$GETH_VERSION/bin/geth"
+          if [ ! -e "$GETH_BINARY" ]; then
+            curl -O https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz
+            tar xvf go1.7.4.linux-amd64.tar.gz
+            sudo chown -R root:root ./go
+            sudo mv go /usr/local
+            sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
+            sudo apt-get update;
+            sudo apt-get install -y build-essential;
+            python -m geth.install $GETH_VERSION;
+            sudo ln -s /home/circleci/.py-geth/geth-v1.7.2/bin/geth /usr/local/bin/geth
+          fi
+
+          $GETH_BINARY version
+          $GETH_BINARY makedag 0 $HOME/.ethash
+    - run:
+        name: run tox
+        command: ~/.local/bin/tox
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+          - ./eggs
+          - ~/.ethash
+          - ~/.py-geth
+        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+
+jobs:
+  lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: flake8
+  py35-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-core
+  py35-ens:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-ens
+  py35-integration-goethereum:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-integration-goethereum
+  py35-integration-ethtester-pyethereum:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-integration-ethtester
+          ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEthereum16Backend
+  py35-integration-ethtester-pyevm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-integration-ethtester
+          ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - lint
+      - py35-core
+      - py35-ens
+      - py35-integration-goethereum
+      - py35-integration-ethtester-pyethereum
+      - py35-integration-ethtester-pyevm


### PR DESCRIPTION
### What was wrong?

Travis is a SPOF and blocks progress when it is down or slow.

### How was it fixed?

Add a circle-ci config. We can turn on integration (temporarily?) the next time Travis goes down.

Some things I looked at along the way:

- https://github.com/pinax/pinax/wiki/Converting-to-CircleCi-and-Codecov
- https://github.com/cherrypy/cherrypy/blob/master/.circleci/config.yml
- https://github.com/coveralls-clients/coveralls-python/blob/master/.circleci/config.yml
- https://discuss.circleci.com/t/cached-venv-in-tox/1499/5

#### Cute Animal Picture

![Cute animal picture](http://cdn.smosh.com/sites/default/files/bloguploads/baby-deadly-alligator.jpg)
