### PR TITLE
dockerfile: add web3 to the image aswell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,17 @@ WORKDIR /usr/src/app
 RUN apt-get update && apt-get install -y libssl-dev
 
 # Copy over requirements
-COPY setup.py .
-COPY README.md .
 COPY requirements-dev.txt .
-
 # Install python dependencies
 RUN pip install -r requirements-dev.txt
+
+COPY web3 ./web3/
+COPY tests ./tests/
+COPY ens ./ens/
+
+COPY setup.py .
+COPY README.md .
+
 RUN pip install -e .
 
 WORKDIR /code


### PR DESCRIPTION
### What was wrong?

The dockerfile didn't actually include `web3`


### How was it fixed?

Adding the source code before running `setup.py`

#### Cute Animal Picture

![Cute animal picture](https://i.ytimg.com/vi/q625P-DBRd4/hqdefault.jpg)
