### PR TITLE
Eth tester middleware: conform nonce parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     extras_require={
         'tester': [
-            "eth-tester[py-evm]==0.1.0b13",
+            "eth-tester[py-evm]==0.1.0b15",
         ],
         'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],
         'platform_system=="Windows"': [

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -109,6 +109,7 @@ TRANSACTION_PARAMS_FORMATTERS = {
     'gas': to_integer_if_hex,
     'gasPrice': to_integer_if_hex,
     'value': to_integer_if_hex,
+    'nonce': to_integer_if_hex,
 }
 
 

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -218,9 +218,10 @@ class EthModuleTest(object):
         txn_params = {
             'from': unlocked_account,
             'to': unlocked_account,
-            'value': 3214,  # Random value to ensure transaction hash different from other tests
+            'value': 1,
             'gas': 21000,
-            'gas_price': web3.eth.gasPrice,
+            # Increased gas price to ensure transaction hash different from other tests
+            'gas_price': web3.eth.gasPrice * 2,
             'nonce': web3.eth.getTransactionCount(unlocked_account),
         }
         txn_hash = web3.eth.sendTransaction(txn_params)
@@ -228,7 +229,7 @@ class EthModuleTest(object):
 
         assert is_same_address(txn['from'], txn_params['from'])
         assert is_same_address(txn['to'], txn_params['to'])
-        assert txn['value'] == 3214
+        assert txn['value'] == 1
         assert txn['gas'] == 21000
         assert txn['gasPrice'] == txn_params['gas_price']
         assert txn['nonce'] == txn_params['nonce']

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -218,7 +218,7 @@ class EthModuleTest(object):
         txn_params = {
             'from': unlocked_account,
             'to': unlocked_account,
-            'value': 1,
+            'value': 3214,  # Random value to ensure transaction hash different from other tests
             'gas': 21000,
             # Increased gas price to ensure transaction hash different from other tests
             'gas_price': web3.eth.gasPrice * 2,
@@ -229,7 +229,7 @@ class EthModuleTest(object):
 
         assert is_same_address(txn['from'], txn_params['from'])
         assert is_same_address(txn['to'], txn_params['to'])
-        assert txn['value'] == 1
+        assert txn['value'] == 3214
         assert txn['gas'] == 21000
         assert txn['gasPrice'] == txn_params['gas_price']
         assert txn['nonce'] == txn_params['nonce']

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -214,7 +214,7 @@ class EthModuleTest(object):
         assert txn['gas'] == 21000
         assert txn['gasPrice'] == txn_params['gas_price']
 
-    def test_eth_sendTransaction_with_nonce(self, web3, eth_tester, unlocked_account):
+    def test_eth_sendTransaction_with_nonce(self, web3, unlocked_account):
         txn_params = {
             'from': unlocked_account,
             'to': unlocked_account,

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -186,7 +186,7 @@ class EthModuleTest(object):
             'to': unlocked_account,
             'value': 1,
             'gas': 21000,
-            'gas_price': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gasPrice,
         }
 
         with pytest.raises(InvalidAddress):
@@ -203,7 +203,7 @@ class EthModuleTest(object):
             'to': unlocked_account,
             'value': 1,
             'gas': 21000,
-            'gas_price': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gasPrice,
         }
         txn_hash = web3.eth.sendTransaction(txn_params)
         txn = web3.eth.getTransaction(txn_hash)
@@ -212,16 +212,16 @@ class EthModuleTest(object):
         assert is_same_address(txn['to'], txn_params['to'])
         assert txn['value'] == 1
         assert txn['gas'] == 21000
-        assert txn['gasPrice'] == txn_params['gas_price']
+        assert txn['gasPrice'] == txn_params['gasPrice']
 
     def test_eth_sendTransaction_with_nonce(self, web3, unlocked_account):
         txn_params = {
             'from': unlocked_account,
             'to': unlocked_account,
-            'value': 3214,  # Random value to ensure transaction hash different from other tests
+            'value': 1,
             'gas': 21000,
             # Increased gas price to ensure transaction hash different from other tests
-            'gas_price': web3.eth.gasPrice * 2,
+            'gasPrice': web3.eth.gasPrice * 2,
             'nonce': web3.eth.getTransactionCount(unlocked_account),
         }
         txn_hash = web3.eth.sendTransaction(txn_params)
@@ -229,9 +229,9 @@ class EthModuleTest(object):
 
         assert is_same_address(txn['from'], txn_params['from'])
         assert is_same_address(txn['to'], txn_params['to'])
-        assert txn['value'] == 3214
+        assert txn['value'] == 1
         assert txn['gas'] == 21000
-        assert txn['gasPrice'] == txn_params['gas_price']
+        assert txn['gasPrice'] == txn_params['gasPrice']
         assert txn['nonce'] == txn_params['nonce']
 
     @pytest.mark.parametrize(
@@ -366,7 +366,7 @@ class EthModuleTest(object):
             'to': unlocked_account,
             'value': 1,
             'gas': 21000,
-            'gas_price': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gasPrice,
         })
         receipt = web3.eth.getTransactionReceipt(txn_hash)
         assert receipt is None

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -218,7 +218,7 @@ class EthModuleTest(object):
         txn_params = {
             'from': unlocked_account,
             'to': unlocked_account,
-            'value': 1,
+            'value': 3214,  # Random value to ensure transaction hash different from other tests
             'gas': 21000,
             'gas_price': web3.eth.gasPrice,
             'nonce': web3.eth.getTransactionCount(unlocked_account),
@@ -228,7 +228,7 @@ class EthModuleTest(object):
 
         assert is_same_address(txn['from'], txn_params['from'])
         assert is_same_address(txn['to'], txn_params['to'])
-        assert txn['value'] == 1
+        assert txn['value'] == 3214
         assert txn['gas'] == 21000
         assert txn['gasPrice'] == txn_params['gas_price']
         assert txn['nonce'] == txn_params['nonce']

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -214,6 +214,25 @@ class EthModuleTest(object):
         assert txn['gas'] == 21000
         assert txn['gasPrice'] == txn_params['gas_price']
 
+    def test_eth_sendTransaction_with_nonce(self, web3, eth_tester, unlocked_account):
+        txn_params = {
+            'from': unlocked_account,
+            'to': unlocked_account,
+            'value': 1,
+            'gas': 21000,
+            'gas_price': web3.eth.gasPrice,
+            'nonce': web3.eth.getTransactionCount(unlocked_account),
+        }
+        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn = web3.eth.getTransaction(txn_hash)
+
+        assert is_same_address(txn['from'], txn_params['from'])
+        assert is_same_address(txn['to'], txn_params['to'])
+        assert txn['value'] == 1
+        assert txn['gas'] == 21000
+        assert txn['gasPrice'] == txn_params['gas_price']
+        assert txn['nonce'] == txn_params['nonce']
+
     @pytest.mark.parametrize(
         'raw_transaction, expected_hash',
         [


### PR DESCRIPTION
### What was wrong?

Eth_tester validates nonces as integers however web3.py passes hex when using the eth tester middleware. This causes transactions with a nonce to fail when using this middleware. example:

```
from web3 import Web3, HTTPProvider
from eth_tester import EthereumTester

from web3.providers.eth_tester import EthereumTesterProvider
web3 = Web3(EthereumTesterProvider(tester))
tx = web3.eth.sendTransaction({
    'from': '0x82A978B3f5962A5b0957d9ee9eEf472EE55B42F1',
    'to': '0x7d577a597B2742b498Cb5Cf0C26cDCD726d39E6e',
    'value': 10000000,
    'gas': 23500,
    'nonce': 1
})
```

results in

`eth_tester.exceptions.ValidationError: Value must be positive integers. Got: 0x1`

### How was it fixed?

Transform hex to integer for the nonce parameter by the eth_tester middleware.

#### Cute Animal Picture

![Cute animal picture](http://cdn.kickvick.com/wp-content/uploads/2015/09/cutest-bunny-rabbits-12.jpg)
