### PR TITLE
Check for attribute in ANY base

### DIFF
--- a/tests/core/utilities/test_datatypes.py
+++ b/tests/core/utilities/test_datatypes.py
@@ -1,0 +1,35 @@
+import pytest
+
+from web3.utils.datatypes import (
+    PropertyCheckingFactory,
+)
+
+
+class InheritedBaseClass(object):
+    arg0 = None
+    arg1 = None
+
+
+class BaseClass(InheritedBaseClass):
+    arg2 = None
+    arg3 = None
+
+
+def test_property_checking_metaclass_attribute_error():
+    # Test proper attribute checking, arg from both bases.
+    namespace = {'arg2': True, 'arg0': True, 'arg4': True}
+    with pytest.raises(AttributeError):
+        PropertyCheckingFactory('class_name', (BaseClass,), namespace)
+
+    # Test proper attribute checking, only absent arg.
+    namespace = {'arg4': True}
+    with pytest.raises(AttributeError):
+        PropertyCheckingFactory('class_name', (BaseClass,), namespace)
+
+
+def test_property_checking_metaclass_inherited_attributes():
+    from_inherited_namespace = {'arg0': True, 'arg1': True}
+    PropertyCheckingFactory('class_name', (BaseClass,), from_inherited_namespace)
+
+    from_base_namespace = {'arg2': True, 'arg3': True}
+    PropertyCheckingFactory('class_name', (BaseClass,), from_base_namespace)

--- a/web3/utils/datatypes.py
+++ b/web3/utils/datatypes.py
@@ -28,7 +28,7 @@ class PropertyCheckingFactory(type):
         all_bases = set(concat(base.__mro__ for base in bases))
         for key in namespace:
             verify_key_attr = verify_attr(name, key)
-            verify_key_attr(concat(base.__dict__ for base in all_bases))
+            verify_key_attr(concat(base.__dict__.keys() for base in all_bases))
 
         if normalizers:
             processed_namespace = web3.utils.formatters.apply_formatters_to_dict(

--- a/web3/utils/datatypes.py
+++ b/web3/utils/datatypes.py
@@ -9,8 +9,8 @@ import web3.utils.formatters
 
 
 @curry
-def verify_attr(class_name, key, base):
-    if not hasattr(base, key):
+def verify_attr(class_name, key, namespace):
+    if key not in namespace:
         raise AttributeError(
             "Property {0} not found on {1} class. "
             "`{1}.factory` only accepts keyword arguments which are "
@@ -25,9 +25,10 @@ class PropertyCheckingFactory(type):
         super().__init__(name, bases, namespace)
 
     def __new__(mcs, name, bases, namespace, normalizers=None):
+        all_bases = set(concat(base.__mro__ for base in bases))
         for key in namespace:
             verify_key_attr = verify_attr(name, key)
-            map(verify_key_attr, set(concat(base.__mro__ for base in bases)))
+            verify_key_attr(concat(base.__dict__ for base in all_bases))
 
         if normalizers:
             processed_namespace = web3.utils.formatters.apply_formatters_to_dict(


### PR DESCRIPTION
### What was wrong?

I introduced a bug in web3.utils.datatypes.PropertyCheckingFactory.  The parameter checking should fail only if the parameter is missing from ALL bases.

### How was it fixed?

It now combines all bases into a single namespace before checking.


#### Cute Animal Picture

![Cute animal picture](https://doctorallife.files.wordpress.com/2015/06/ice_bear_fall.jpg)
