### PR TITLE
Allow attribute access to rich log object

### DIFF
--- a/ens/utils.py
+++ b/ens/utils.py
@@ -24,7 +24,6 @@ from ens.exceptions import (
     InvalidName,
 )
 
-
 default = object()
 
 

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -200,6 +200,9 @@ def test_event_rich_log(
     rich_log = rich_logs[0]
 
     assert rich_log['args'] == expected_args
+    assert rich_log.args == expected_args
+    for arg in expected_args:
+        assert getattr(rich_log.args, arg) == expected_args[arg]
     assert rich_log['blockHash'] == txn_receipt['blockHash']
     assert rich_log['blockNumber'] == txn_receipt['blockNumber']
     assert rich_log['transactionIndex'] == txn_receipt['transactionIndex']

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -40,9 +40,6 @@ from web3.utils.contracts import (
     get_function_info,
     prepare_transaction,
 )
-from web3.utils.datastructures import (
-    AttributeDict,
-)
 from web3.utils.datatypes import (
     PropertyCheckingFactory,
 )
@@ -970,7 +967,7 @@ class ContractEvent(object):
                 decoded_log = get_event_data(self.abi, log)
             except MismatchedABI:
                 continue
-            yield AttributeDict(decoded_log)
+            yield decoded_log
 
     @classmethod
     def factory(cls, class_name, **kwargs):

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -40,6 +40,9 @@ from web3.utils.contracts import (
     get_function_info,
     prepare_transaction,
 )
+from web3.utils.datastructures import (
+    AttributeDict,
+)
 from web3.utils.datatypes import (
     PropertyCheckingFactory,
 )
@@ -967,7 +970,7 @@ class ContractEvent(object):
                 decoded_log = get_event_data(self.abi, log)
             except MismatchedABI:
                 continue
-            yield decoded_log
+            yield AttributeDict(decoded_log)
 
     @classmethod
     def factory(cls, class_name, **kwargs):

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -19,6 +19,9 @@ from eth_utils import (
 from web3.exceptions import (
     MismatchedABI,
 )
+from web3.utils.datastructures import (
+    AttributeDict,
+)
 from web3.utils.encoding import (
     hexstr_if_str,
     to_bytes,
@@ -210,7 +213,7 @@ def get_event_data(event_abi, log_entry):
     ))
 
     event_data = {
-        'args': event_args,
+        'args': AttributeDict(event_args),
         'event': event_abi['name'],
         'logIndex': log_entry['logIndex'],
         'transactionIndex': log_entry['transactionIndex'],

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -213,7 +213,7 @@ def get_event_data(event_abi, log_entry):
     ))
 
     event_data = {
-        'args': AttributeDict(event_args),
+        'args': event_args,
         'event': event_abi['name'],
         'logIndex': log_entry['logIndex'],
         'transactionIndex': log_entry['transactionIndex'],
@@ -223,4 +223,4 @@ def get_event_data(event_abi, log_entry):
         'blockNumber': log_entry['blockNumber'],
     }
 
-    return event_data
+    return AttributeDict.recursive(event_data)


### PR DESCRIPTION
### What was wrong?

It would be nice to allow attribute style accesses to rich log object keys, like shown in the comment here: https://github.com/ethereum/web3.py/issues/429#issuecomment-344679488

### How was it fixed?

Wrapping the rich log and nested args dict in AttributeDict()

#### Cute Animal Picture

![Cute animal picture](http://i.dailymail.co.uk/i/pix/2012/08/28/article-2194561-14B7B856000005DC-576_634x433.jpg)
