### PR TITLE
remove eth-key* dependencies, lock eth-utils <v1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "requests>=2.12.4",
         "rlp>=0.4.7",
         "toolz>=0.8.2",
-        "eth-tester~=0.1.0b5",
+        "eth-tester==0.1.0b11",
     ],
     setup_requires=['setuptools-markdown'],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "cytoolz>=0.8.2",
-        "eth-abi>=0.5.0",
-        "eth-keyfile>=0.4.0",
-        "eth-keys>=0.1.0-beta.3",
-        "eth-utils>=0.7.1",
+        "eth-abi>=0.5.0,<0.6.0",
+        "eth-utils>=0.7.1,<1.0.0",
         "lru-dict>=1.1.6",
         "pysha3>=0.3",
         "requests>=2.12.4",


### PR DESCRIPTION
### What was wrong?

v3 had an (accidental) dependency on eth-keys, eth-keyfile, causing https://github.com/ethereum/eth-abi/issues/25

### How was it fixed?

Remove dependencies, also lock eth-utils below v1

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/70/e3/d6/70e3d6224c34716b29248f36868c7fe3.jpg)