### PR TITLE
eth-utils v1 compatibility across all dependencies

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,7 +4,7 @@ Release Notes
 v4.0.0-beta.7
 -------------
 
-Released Jan 29, 2017
+Released Jan 29, 2018
 
 - Support for :meth:`web3.eth.Eth.getLogs` in eth-tester with py-evm
 - Process transaction receipts with Event ABI, using
@@ -20,7 +20,7 @@ Released Jan 29, 2017
 v4.0.0-beta.6
 -------------
 
-Released Jan 18, 2017
+Released Jan 18, 2018
 
 - New contract function call API: `my_contract.functions.my_func().call()` is preferred over the now
   deprecated `my_contract.call().my_func()` API.

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ setup(
         "cytoolz>=0.9.0,<1.0.0",
         "eth-abi>=0.5.0,<1.0.0",
         "eth-account>=0.1.0a2,<1.0.0",
-        "eth-keyfile>=0.4.0,<1.0.0",
-        "eth-keys>=0.1.0b4,<0.2.0",
         "eth-utils>=1.0.0b1,<2.0.0",
         "hexbytes>=0.1.0b0,<1.0.0",
         "lru-dict>=1.1.6,<2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "cytoolz>=0.9.0,<1.0.0",
-        "eth-abi>=0.5.0,<1.0.0",
+        "eth-abi>=1.0.0-beta.0,<2",
         "eth-account>=0.1.0a2,<1.0.0",
         "eth-utils>=1.0.0b1,<2.0.0",
         "hexbytes>=0.1.0b0,<1.0.0",
@@ -29,7 +29,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     extras_require={
         'tester': [
-            "eth-tester[py-evm]==0.1.0b15",
+            "eth-tester[py-evm]==0.1.0b16",
         ],
         'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],
         'linter': [


### PR DESCRIPTION
### What was wrong?

Some dependencies required eth-utils pre v1:

- eth-abi
- eth-tester

This broke web3 v4 installs after eth-utils v1 was released. Example: https://github.com/ethereum/eth-abi/issues/25

### How was it fixed?

Released eth-utils v1-compatible versions of abi and tester, and upgrade to them in web3.

#### Cute Animal Picture

![Cute animal picture](http://cuteotters.com/wordpress/wp-content/uploads/2015/12/ottersmall.jpg)