### PR TITLE
fixed name key missing exception raised for error message constructor…

### DIFF
--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -207,9 +207,17 @@ def merge_args_and_kwargs(function_abi, args, kwargs):
 
     unknown_kwargs = {key for key in kwargs.keys() if key not in sorted_arg_names}
     if unknown_kwargs:
+        if function_abi.get('name'):
+            raise TypeError(
+                "{fn_name}() got unexpected keyword argument(s) '{dups}'".format(
+                    fn_name=function_abi.get('name'),
+                    dups=', '.join(unknown_kwargs),
+                )
+            )
+        #show type instead of name in the error message incase key 'name' is missing.
         raise TypeError(
-            "{fn_name}() got unexpected keyword argument(s) '{dups}'".format(
-                fn_name=function_abi.get('name'),
+            "Type: '{_type}' got unexpected keyword argument(s) '{dups}'".format(
+                _type=function_abi.get('type'),
                 dups=', '.join(unknown_kwargs),
             )
         )

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -209,7 +209,7 @@ def merge_args_and_kwargs(function_abi, args, kwargs):
     if unknown_kwargs:
         raise TypeError(
             "{fn_name}() got unexpected keyword argument(s) '{dups}'".format(
-                fn_name=function_abi['name'],
+                fn_name=function_abi.get('name'),
                 dups=', '.join(unknown_kwargs),
             )
         )

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -214,7 +214,7 @@ def merge_args_and_kwargs(function_abi, args, kwargs):
                     dups=', '.join(unknown_kwargs),
                 )
             )
-        #show type instead of name in the error message incase key 'name' is missing.
+        # show type instead of name in the error message incase key 'name' is missing.
         raise TypeError(
             "Type: '{_type}' got unexpected keyword argument(s) '{dups}'".format(
                 _type=function_abi.get('type'),


### PR DESCRIPTION
… incase of invalid kwargs

### What was wrong?

#614 Error constructor was querying function name to display as part of error message but the 'name' key is missing


### How was it fixed?
Now it returns None incase the key is missing


#### Cute Animal Picture

![Cute animal picture]()
