### PR TITLE
add doctest on w3.eth.account docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ build-docs:
 	sphinx-apidoc -o docs/ . setup.py "web3/utils/*" "*conftest*"
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
+	$(MAKE) -C docs doctest
 
 docs: build-docs
 	open docs/_build/html/index.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,11 @@ with open (os.path.join(DIR, '../setup.py'), 'r') as f:
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -280,3 +284,14 @@ intersphinx_mapping = {
 }
 
 autodoc_member_order = "bysource"
+
+# -- Doctest configuration ----------------------------------------
+
+import doctest
+
+doctest_default_flags = (0
+    | doctest.DONT_ACCEPT_TRUE_FOR_1
+    | doctest.ELLIPSIS
+    | doctest.IGNORE_EXCEPTION_DETAIL
+    | doctest.NORMALIZE_WHITESPACE
+)

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -48,24 +48,27 @@ Extract private key from geth keyfile
 Sign a Message
 ---------------
 
-.. code-block:: python
+.. doctest::
+
+    >>> from web3.auto import w3
 
     >>> msg = "I♥SF"
     >>> private_key = b"\xb2\\}\xb3\x1f\xee\xd9\x12''\xbf\t9\xdcv\x9a\x96VK-\xe4\xc4rm\x03[6\xec\xf1\xe5\xb3d"
     >>> signed_message = w3.eth.account.sign(message_text=msg, private_key=private_key)
-    {'message': b'I\xe2\x99\xa5SF',
+    >>> signed_message
+    AttrDict({'message': HexBytes('0x49e299a55346'),
      'messageHash': HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
      'r': 104389933075820307925104709181714897380569894203213074526835978196648170704563,
      's': 28205917190874851400050446352651915501321657673772411533993420917949420456142,
-     'signature': HexBytes('0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb33e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce1c'),
-     'v': 28}
+     'v': 28,
+     'signature': HexBytes('0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb33e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce1c')})
 
 Verify a Message
 ------------------------------------------------
 
 With the original message text and a signature:
 
-.. code-block:: python
+.. doctest::
 
     >>> w3.eth.account.recoverMessage(text="I♥SF", signature=signed_message.signature)
     '0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E'
@@ -76,7 +79,7 @@ Verify a message from message hash
 Sometimes you don't have the original message, all you have is the
 prefixed & hashed message. To verify it, use:
 
-.. code-block:: python
+.. doctest::
 
     >>> message_hash = '0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'
     >>> signature = '0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb33e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce1c'
@@ -96,19 +99,20 @@ Prepare message for ecrecover in Solidity
 
 Produce a signed_message as in `Sign a Message`_, then...
 
-.. code-block:: python
+.. doctest::
 
-    >>> from eth_utils import to_bytes, to_hex
+    >>> from web3 import Web3
 
     >>> def to_32byte_hex(val):
-        return to_hex(to_bytes(val).rjust(32, b'\0'))
+    ...   return Web3.toHex(Web3.toBytes(val).rjust(32, b'\0'))
 
     >>> ec_recover_args = (msghash, v, r, s) = (
-      signed_message.messageHash,
-      signed_message.v,
-      to_32byte_hex(signed_message.r),
-      to_32byte_hex(signed_message.s),
-    )
+    ...   signed_message.messageHash,
+    ...   signed_message.v,
+    ...   to_32byte_hex(signed_message.r),
+    ...   to_32byte_hex(signed_message.s),
+    ... )
+    >>> ec_recover_args
     (HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
      28,
      '0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb3',
@@ -142,25 +146,32 @@ Sign a Transaction
 Create a transaction, sign it locally, and then send it to your node for broadcasting,
 with :meth:`~web3.eth.Eth.sendRawTransaction`.
 
-    .. code-block:: python
+.. doctest::
 
-        >>> transaction = {
-                'to': '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
-                'value': 1000000000,
-                'gas': 2000000,
-                'gasPrice': 234567897654321,
-                'nonce': 0,
-                'chainId': 1
-            }
-        >>> key = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
-        >>> signed = w3.eth.account.signTransaction(transaction, key)
-        {'hash': HexBytes('0x6893a6ee8df79b0f5d64a180cd1ef35d030f3e296a5361cf04d02ce720d32ec5'),
-         'r': HexBytes('0x09ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9c'),
-         'rawTransaction': HexBytes('0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428'),
-         's': HexBytes('0x440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428'),
-         'v': 37}
+    >>> transaction = {
+    ...     'to': '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
+    ...     'value': 1000000000,
+    ...     'gas': 2000000,
+    ...     'gasPrice': 234567897654321,
+    ...     'nonce': 0,
+    ...     'chainId': 1
+    ... }
+    >>> key = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
+    >>> signed = w3.eth.account.signTransaction(transaction, key)
+    >>> signed.rawTransaction
+    HexBytes('0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428')
+    >>> signed.hash
+    HexBytes('0xd8f64a42b57be0d565f385378db2f6bf324ce14a594afc05de90436e9ce01f60')
+    >>> signed.r
+    4487286261793418179817841024889747115779324305375823110249149479905075174044
+    >>> signed.s
+    30785525769477805655994251009256770582792548537338581640010273753578382951464
+    >>> signed.v
+    37
 
-        >>> w3.eth.sendRawTransaction(signed.rawTransaction)
+    # When you run sendRawTransaction, you get back the hash of the transaction:
+    >>> w3.eth.sendRawTransaction(signed.rawTransaction)  # doctest: +SKIP
+    '0xd8f64a42b57be0d565f385378db2f6bf324ce14a594afc05de90436e9ce01f60'
 
 Sign a Contract Transaction
 -----------------------------------
@@ -173,37 +184,53 @@ To sign a transaction locally that will invoke a smart contract:
    <eth_account.account.Account.signTransaction>`
 #. Broadcast the transaction with :meth:`~web3.eth.Eth.sendRawTransaction`
 
-.. code-block:: python
+.. testsetup::
+
+    nonce = 0
+
+.. doctest::
 
     >>> from ethtoken.abi import EIP20_ABI
     >>> from web3.auto import w3
 
     >>> unicorns = w3.eth.contract(address="0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", abi=EIP20_ABI)
 
-    >>> send_unicorn_txn = unicorns.functions.transfer(
-        '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
-        1,
-    ).buildTransaction({
-        'chainId': 1,
-        'gas': 70000,
-        'gasPrice': w3.toWei('1', 'gwei'),
-        'nonce': w3.eth.getTransactionCount('0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E'),
-    })
-    {'chainId': 1,
-     'data': '0xa9059cbb000000000000000000000000fb6916095ca1df60bb79ce92ce3ea74c37c5d3590000000000000000000000000000000000000000000000000000000000000001',
+    >>> nonce = w3.eth.getTransactionCount('0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E')  # doctest: +SKIP
+
+    >>> unicorn_txn = unicorns.functions.transfer(
+    ...     '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
+    ...     1,
+    ... ).buildTransaction({
+    ...     'chainId': 1,
+    ...     'gas': 70000,
+    ...     'gasPrice': w3.toWei('1', 'gwei'),
+    ...     'nonce': nonce,
+    ... })
+
+    >>> unicorn_txn
+    {'value': 0,
+     'chainId': 1,
      'gas': 70000,
      'gasPrice': 1000000000,
      'nonce': 0,
      'to': '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
-     'value': 0}
+     'data': '0xa9059cbb000000000000000000000000fb6916095ca1df60bb79ce92ce3ea74c37c5d3590000000000000000000000000000000000000000000000000000000000000001'}
 
     >>> private_key = b"\xb2\\}\xb3\x1f\xee\xd9\x12''\xbf\t9\xdcv\x9a\x96VK-\xe4\xc4rm\x03[6\xec\xf1\xe5\xb3d"
-    >>> signed_txn = w3.eth.account.signTransaction(send_unicorn_txn, private_key=private_key)
-    {'hash': HexBytes('0x4795adc6a719fa64fa21822630c0218c04996e2689ded114b6553cef1ae36618'),
-     'r': 7104843568152743554992057394334744036860247658813231830421570918634460546288,
-     'rawTransaction': HexBytes('0xf8a980843b9aca008301117094fb6916095ca1df60bb79ce92ce3ea74c37c5d35980b844a9059cbb000000000000000000000000fb6916095ca1df60bb79ce92ce3ea74c37c5d359000000000000000000000000000000000000000000000000000000000000000125a00fb532eea06b8f17d858d82ad61986efd0647124406be65d359e96cac3e004f0a02e5d7ffcfb7a6073a723be38e6733f353cf9367743ae94e2ccd6f1eba37116f4'),
-     's': 20971591154030974221209741174186570949918731455961098911091818811306894497524,
-     'v': 37}
-
-    >>> w3.eth.sendRawTransaction(signed_txn.rawTransaction)
+    >>> signed_txn = w3.eth.account.signTransaction(unicorn_txn, private_key=private_key)
+    >>> signed_txn.hash
     HexBytes('0x4795adc6a719fa64fa21822630c0218c04996e2689ded114b6553cef1ae36618')
+    >>> signed_txn.rawTransaction
+    HexBytes('0xf8a980843b9aca008301117094fb6916095ca1df60bb79ce92ce3ea74c37c5d35980b844a9059cbb000000000000000000000000fb6916095ca1df60bb79ce92ce3ea74c37c5d359000000000000000000000000000000000000000000000000000000000000000125a00fb532eea06b8f17d858d82ad61986efd0647124406be65d359e96cac3e004f0a02e5d7ffcfb7a6073a723be38e6733f353cf9367743ae94e2ccd6f1eba37116f4')
+    >>> signed_txn.r
+    7104843568152743554992057394334744036860247658813231830421570918634460546288
+    >>> signed_txn.s
+    20971591154030974221209741174186570949918731455961098911091818811306894497524
+    >>> signed_txn.v
+    37
+
+    >>> w3.eth.sendRawTransaction(signed_txn.rawTransaction)  # doctest: +SKIP
+
+    # When you run sendRawTransaction, you get the same result as the hash of the transaction:
+    >>> w3.toHex(w3.sha3(signed_txn.rawTransaction))
+    '0x4795adc6a719fa64fa21822630c0218c04996e2689ded114b6553cef1ae36618'

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -9,6 +9,7 @@ configparser==3.5.0
 contextlib2>=0.5.4
 #eth-testrpc>=0.8.0
 #ethereum-tester-client>=1.1.0
+ethtoken
 py-geth>=1.4.0
 py-solc>=0.4.0
 #pysha3>=0.3

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=
     py{35,36}-core
     py{35,36}-integration-{goethereum,ethtester}
     lint
+    doctest
 
 [isort]
 combine_as_imports=True
@@ -29,8 +30,11 @@ commands=
     ens: py.test {posargs:tests/ens}
     integration-goethereum: py.test {posargs:tests/integration/test_goethereum.py}
     integration-ethtester: py.test {posargs:tests/integration/test_ethereum_tester.py}
+    doctest: make -C {toxinidir}/docs doctest
 deps =
     -r{toxinidir}/requirements-dev.txt
+    doctest: sphinx
+    doctest: ethtoken
 passenv =
     GETH_BINARY
     GETH_VERSION


### PR DESCRIPTION
### What was wrong?

Docs might get out of date, or be subtly broken.

### How was it fixed?

Set up doctests, convert w3.eth.account docs as doctests, to get a feel for how it might work. First impression: not bad. A lot of others will probably be harder, because they require chain interaction. Maybe we can do a setup with py-evm ethtester and work that way?

#### Cute Animal Picture

![Cute animal picture](http://cuteotters.com/wordpress/wp-content/uploads/2015/12/ottersmall.jpg)
