### PR TITLE
Increase post chain import wait time before launching parity

### DIFF
--- a/tests/integration/test_parity.py
+++ b/tests/integration/test_parity.py
@@ -149,20 +149,26 @@ def passwordfile():
 def parity_process(
         parity_import_blocks_process,
         parity_binary,
-        ipc_path, datadir,
+        ipc_path,
+        datadir,
         passwordfile,
         author):
-
-    run_parity_command = (
+    command_arguments = (
         parity_binary,
         '--chain', os.path.join(datadir, 'chain_config.json'),
         '--ipc-path', ipc_path,
-        '--base-path', str(datadir),
-        '--unlock', str(author),
-        '--password', str(passwordfile),
+        '--base-path', datadir,
+        '--unlock', author,
+        '--password', passwordfile,
     )
+    time.sleep(1)
+    yield from get_process(command_arguments)
+
+
+def get_process(command_list):
+
     proc = subprocess.Popen(
-        run_parity_command,
+        command_list,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -185,35 +191,15 @@ def parity_process(
 
 @pytest.fixture(scope="session")
 def parity_import_blocks_process(parity_binary, ipc_path, datadir, passwordfile):
-    run_parity_command = (
+    command_arguments = (
         parity_binary,
         'import', os.path.join(datadir, 'blocks_export.rlp'),
         '--chain', os.path.join(datadir, 'chain_config.json'),
         '--ipc-path', ipc_path,
-        '--base-path', str(datadir),
-        '--unlock', str(author),
-        '--password', str(passwordfile),
+        '--base-path', datadir,
+        '--password', passwordfile,
     )
-    proc = subprocess.Popen(
-        run_parity_command,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        bufsize=1,
-    )
-    try:
-        yield proc
-    finally:
-        kill_proc_gracefully(proc)
-        output, errors = proc.communicate()
-        print(
-            "Parity Process Exited:\n"
-            "stdout:{0}\n\n"
-            "stderr:{1}\n\n".format(
-                force_text(output),
-                force_text(errors),
-            )
-        )
+    yield from get_process(command_arguments)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_parity.py
+++ b/tests/integration/test_parity.py
@@ -161,11 +161,10 @@ def parity_process(
         '--unlock', author,
         '--password', passwordfile,
     )
-    time.sleep(1)
     yield from get_process(command_arguments)
 
 
-def get_process(command_list):
+def get_process(command_list, terminates=False):
 
     proc = subprocess.Popen(
         command_list,
@@ -174,6 +173,8 @@ def get_process(command_list):
         stderr=subprocess.PIPE,
         bufsize=1,
     )
+    if terminates:
+        wait_for_popen(proc, 30)
     try:
         yield proc
     finally:
@@ -199,7 +200,7 @@ def parity_import_blocks_process(parity_binary, ipc_path, datadir, passwordfile)
         '--base-path', datadir,
         '--password', passwordfile,
     )
-    yield from get_process(command_arguments)
+    yield from get_process(command_arguments, terminates=True)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### What was wrong?

Accidental check in of large binary files with parity test fixtures, files have since been removed.  The parity process that imports the rlp file now takes a little bit longer to release the chain db.

### How was it fixed?

Added 1 second wait before launching the parity client process.

#### Cute Animal Picture

![Cute animal picture](http://i0.wp.com/nonewz.co/wp-content/uploads/2014/12/sad-animal-christmas-7.jpg?resize=456%2C342)
