### PR TITLE
Replaced All super(ClassName, self) with super() and  Stopped inheriting from object to define new style classes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@ from web3.utils.threads import (
 from web3.main import Web3
 
 
-class PollDelayCounter(object):
+class PollDelayCounter:
     def __init__(self, initial_delay=0, max_delay=1, initial_step=0.01):
         self.initial_delay = initial_delay
         self.initial_step = initial_step

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -166,7 +166,7 @@ It is also possible to implement middlewares as a class.
 
 .. code-block:: python
 
-    class SimpleMiddleware(object):
+    class SimpleMiddleware:
         def __init__(self, make_request, web3):
             self.web3 = web3
             self.make_request = make_request

--- a/tests/core/contracts/conftest.py
+++ b/tests/core/contracts/conftest.py
@@ -385,7 +385,7 @@ def ArraysContract(web3, ARRAYS_CONTRACT):
     return web3.eth.contract(**ARRAYS_CONTRACT)
 
 
-class LogFunctions(object):
+class LogFunctions:
     LogAnonymous = 0
     LogNoArguments = 1
     LogSingleArg = 2
@@ -409,7 +409,7 @@ def _encode_to_topic(event_signature):
     return event_signature_to_log_topic(event_signature)
 
 
-class LogTopics(object):
+class LogTopics:
     LogAnonymous = _encode_to_topic("LogAnonymous()")
     LogNoArguments = _encode_to_topic("LogNoArguments()")
     LogSingleArg = _encode_to_topic("LogSingleArg(uint256)")

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -62,7 +62,7 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block):
     return Emitter(address=contract_address)
 
 
-class LogFunctions(object):
+class LogFunctions:
     LogAnonymous = 0
     LogNoArguments = 1
     LogSingleArg = 2
@@ -82,7 +82,7 @@ def emitter_event_ids():
     return LogFunctions
 
 
-class LogTopics(object):
+class LogTopics:
     LogAnonymous = encode_hex(event_signature_to_log_topic("LogAnonymous()"))
     LogNoArguments = encode_hex(event_signature_to_log_topic("LogNoArguments()"))
     LogSingleArg = encode_hex(event_signature_to_log_topic("LogSingleArg(uint256)"))

--- a/tests/core/utilities/test_datatypes.py
+++ b/tests/core/utilities/test_datatypes.py
@@ -5,7 +5,7 @@ from web3.utils.datatypes import (
 )
 
 
-class InheritedBaseClass(object):
+class InheritedBaseClass:
     arg0 = None
     arg1 = None
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -181,7 +181,7 @@ class TestEthereumTesterEthModule(EthModuleTest):
     def test_eth_getTransactionReceipt_unmined(self, eth_tester, web3, unlocked_account):
         eth_tester.disable_auto_mine_transactions()
         try:
-            super(TestEthereumTesterEthModule, self).test_eth_getTransactionReceipt_unmined(
+            super().test_eth_getTransactionReceipt_unmined(
                 web3, unlocked_account,
             )
         finally:

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -79,7 +79,7 @@ DEPRECATED_SIGNATURE_MESSAGE = (
 ACCEPTABLE_EMPTY_STRINGS = ["0x", b"0x", "", b""]
 
 
-class ContractFunctions(object):
+class ContractFunctions:
     """Class containing contract function objects
     """
 
@@ -102,7 +102,7 @@ class ContractFunctions(object):
                         function_name=function['name']))
 
 
-class ContractEvents(object):
+class ContractEvents:
     """Class containing contract event objects
     """
 
@@ -125,7 +125,7 @@ class ContractEvents(object):
                         event_name=event['name']))
 
 
-class Contract(object):
+class Contract:
     """Base class for Contract proxy classes.
 
     First you need to create your Contract classes using
@@ -355,7 +355,7 @@ class Contract(object):
 
         contract = self
 
-        class Caller(object):
+        class Caller:
             def __getattr__(self, function_name):
                 callable_fn = functools.partial(
                     estimate_gas_for_function,
@@ -422,7 +422,7 @@ class Contract(object):
 
         contract = self
 
-        class Caller(object):
+        class Caller:
             def __getattr__(self, function_name):
                 callable_fn = functools.partial(
                     call_contract_function,
@@ -505,7 +505,7 @@ class Contract(object):
 
         contract = self
 
-        class Transactor(object):
+        class Transactor:
             def __getattr__(self, function_name):
                 callable_fn = functools.partial(
                     transact_with_contract_function,
@@ -551,7 +551,7 @@ class Contract(object):
 
         contract = self
 
-        class Caller(object):
+        class Caller:
             def __getattr__(self, function_name):
                 callable_fn = functools.partial(
                     build_transaction_for_function,
@@ -621,7 +621,7 @@ class Contract(object):
         return deploy_data
 
 
-class ConciseContract(object):
+class ConciseContract:
     '''
     An alternative Contract Factory which invokes all methods as `call()`,
     unless you add a keyword argument. The keyword argument assigns the prep method.
@@ -721,7 +721,7 @@ class ImplicitMethod(ConciseMethod):
             return super().__call__(*args, **kwargs)
 
 
-class ContractFunction(object):
+class ContractFunction:
     """Base class for contract functions
 
     A function accessed via the api contract.functions.myMethod(*args, **kwargs)
@@ -929,7 +929,7 @@ class ContractFunction(object):
         return PropertyCheckingFactory(class_name, (cls,), kwargs)
 
 
-class ContractEvent(object):
+class ContractEvent:
     """Base class for contract events
 
     An event accessed via the api contract.events.myEvents(*args, **kwargs)

--- a/web3/iban.py
+++ b/web3/iban.py
@@ -72,7 +72,7 @@ def baseN(num, b, numerals="0123456789abcdefghijklmnopqrstuvwxyz"):
         (baseN(num // b, b, numerals).lstrip(numerals[0]) + numerals[num % b])
 
 
-class IsValid(object):
+class IsValid:
     """
     Should be called to check if iban is correct
 
@@ -100,7 +100,7 @@ class IsValid(object):
         return False
 
 
-class Iban(object):
+class Iban:
     def __init__(self, iban):
         self._iban = iban
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -74,7 +74,7 @@ def get_default_modules():
     }
 
 
-class Web3(object):
+class Web3:
     # Providers
     HTTPProvider = HTTPProvider
     IPCProvider = IPCProvider

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -29,7 +29,7 @@ from web3.utils.threads import (
 )
 
 
-class RequestManager(object):
+class RequestManager:
     def __init__(self, web3, providers, middlewares=None):
         self.web3 = web3
         self.pending_requests = {}

--- a/web3/module.py
+++ b/web3/module.py
@@ -1,4 +1,4 @@
-class Module(object):
+class Module:
     web3 = None
 
     def __init__(self, web3):

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -12,7 +12,7 @@ from web3.middleware import (
 )
 
 
-class BaseProvider(object):
+class BaseProvider:
     _middlewares = ()
     _request_func_cache = (None, None)  # a tuple of (all_middlewares, request_func)
 

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -30,7 +30,7 @@ def get_ipc_socket(ipc_path, timeout=0.1):
         return sock
 
 
-class PersistantSocket(object):
+class PersistantSocket:
     sock = None
 
     def __init__(self, ipc_path):

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -147,7 +147,7 @@ class IPCProvider(JSONBaseProvider):
         self.timeout = timeout
         self._lock = threading.Lock()
         self._socket = PersistantSocket(self.ipc_path)
-        super(IPCProvider, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def make_request(self, method, params):
         request = self.encode_rpc_request(method, params)

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -41,7 +41,7 @@ class HTTPProvider(JSONBaseProvider):
         else:
             self.endpoint_uri = endpoint_uri
         self._request_kwargs = request_kwargs or {}
-        super(HTTPProvider, self).__init__()
+        super().__init__()
 
     def __str__(self):
         return "RPC connection {0}".format(self.endpoint_uri)

--- a/web3/providers/tester.py
+++ b/web3/providers/tester.py
@@ -159,4 +159,4 @@ class TestRPCProvider(HTTPProvider):
         self.thread = spawn(self.server.serve_forever)
         endpoint_uri = 'http://{0}:{1}'.format(host, port)
 
-        super(TestRPCProvider, self).__init__(endpoint_uri, *args, **kwargs)
+        super().__init__(endpoint_uri, *args, **kwargs)

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -497,7 +497,7 @@ class ABITypedData(namedtuple('ABITypedData', 'abi_type, data')):
     interface of all other relevant collections.
     '''
     def __new__(cls, iterable):
-        return super(ABITypedData, cls).__new__(cls, *iterable)
+        return super().__new__(cls, *iterable)
 
 
 def abi_sub_tree(data_type, data_value):

--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -76,7 +76,7 @@ class AttributeDict(ReadableAttributeDict, Hashable):
 
     def __setattr__(self, attr, val):
         if attr == '__dict__':
-            super(AttributeDict, self).__setattr__(attr, val)
+            super().__setattr__(attr, val)
         else:
             raise TypeError('This data is immutable -- create a copy instead of modifying')
 

--- a/web3/utils/decorators.py
+++ b/web3/utils/decorators.py
@@ -3,7 +3,7 @@ import threading
 import warnings
 
 
-class combomethod(object):
+class combomethod:
     def __init__(self, method):
         self.method = method
 

--- a/web3/utils/empty.py
+++ b/web3/utils/empty.py
@@ -1,4 +1,4 @@
-class Empty(object):
+class Empty:
     def __bool__(self):
         return False
 

--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -77,7 +77,7 @@ class Filter:
         self.web3 = web3
         self.filter_id = filter_id
         self.callbacks = []
-        super(Filter, self).__init__()
+        super().__init__()
 
     def __str__(self):
         return "Filter for {0}".format(self.filter_id)
@@ -152,7 +152,7 @@ class LogFilter(Filter):
         )
         if 'data_filter_set' in kwargs:
             self.set_data_filters(kwargs.pop('data_filter_set'))
-        super(LogFilter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def format_entry(self, entry):
         if self.log_entry_formatter:

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -27,7 +27,7 @@ UNKNOWN_ADDRESS = '0xdeadbeef00000000000000000000000000000000'
 UNKNOWN_HASH = '0xdeadbeef00000000000000000000000000000000000000000000000000000000'
 
 
-class EthModuleTest(object):
+class EthModuleTest:
     def test_eth_protocolVersion(self, web3):
         protocol_version = web3.version.ethereum
 

--- a/web3/utils/module_testing/net_module.py
+++ b/web3/utils/module_testing/net_module.py
@@ -5,7 +5,7 @@ from eth_utils import (
 )
 
 
-class NetModuleTest(object):
+class NetModuleTest:
     def test_net_version(self, web3):
         version = web3.net.version
 

--- a/web3/utils/module_testing/personal_module.py
+++ b/web3/utils/module_testing/personal_module.py
@@ -13,7 +13,7 @@ PRIVATE_KEY_FOR_UNLOCK = '0x392f63a79b1ff8774845f3fa69de4a13800a59e7083f5187f155
 ACCOUNT_FOR_UNLOCK = '0x12efDc31B1a8FA1A1e756DFD8A1601055C971E13'
 
 
-class PersonalModuleTest(object):
+class PersonalModuleTest:
     def test_personal_importRawKey(self, web3):
         actual = web3.personal.importRawKey(PRIVATE_KEY_HEX, PASSWORD)
         assert actual == ADDRESS

--- a/web3/utils/module_testing/version_module.py
+++ b/web3/utils/module_testing/version_module.py
@@ -3,7 +3,7 @@ from eth_utils import (
 )
 
 
-class VersionModuleTest(object):
+class VersionModuleTest:
     def test_net_version(self, web3):
         version = web3.version.network
 

--- a/web3/utils/module_testing/web3_module.py
+++ b/web3/utils/module_testing/web3_module.py
@@ -13,7 +13,7 @@ from web3.utils.ens import (
 )
 
 
-class Web3ModuleTest(object):
+class Web3ModuleTest:
     def test_web3_clientVersion(self, web3):
         client_version = web3.version.node
         self._check_web3_clientVersion(client_version)

--- a/web3/utils/threads.py
+++ b/web3/utils/threads.py
@@ -70,7 +70,7 @@ class Timeout(Exception):
 
 class ThreadWithReturn(threading.Thread):
     def __init__(self, target=None, args=None, kwargs=None):
-        super(ThreadWithReturn, self).__init__(
+        super().__init__(
             target=target,
             args=args or tuple(),
             kwargs=kwargs or {},

--- a/web3/utils/windows.py
+++ b/web3/utils/windows.py
@@ -9,7 +9,7 @@ import win32file  # noqa: E402
 import pywintypes  # noqa: E402
 
 
-class NamedPipe(object):
+class NamedPipe:
     def __init__(self, ipc_path):
         try:
             self.handle = win32file.CreateFile(


### PR DESCRIPTION
### What was wrong?
Some code changes in python3 that could have been part of #339:
1. `super(ClassName, self)` can be replaced by `super()`.
2.  stopped inheriting from `object`. `ClassName(object):` can be replaced by `ClassName:`.


### How was it fixed?
This PR has been split into two commits:

commit 1:  replaced `super(ClassName, self)` with `super()`. I've skipped super calls that call grandparent instead of the parent. Found only one such occurrence [here](https://github.com/ethereum/web3.py/blob/master/web3/providers/tester.py#L122).

commit 2: stopped inheriting from object to define new style classes.


#### Cute Animal Picture

![224142282-image-cute](https://user-images.githubusercontent.com/8171193/36093380-7bb00d62-1010-11e8-9e9c-3e551a3bbb87.jpg)

