### PR TITLE
fix function.myFunction().estimateGas()

### DIFF
--- a/tests/core/contracts/test_contract_estimateGas.py
+++ b/tests/core/contracts/test_contract_estimateGas.py
@@ -36,3 +36,14 @@ def test_contract_estimateGas(web3, math_contract, estimateGas):
     except AssertionError:
         assert abs(gas_estimate - 32772) < 200  # eth-tester with py-evm
         pass
+
+
+def test_contract_estimateGas_with_arguments(web3, math_contract, estimateGas):
+    gas_estimate = estimateGas(contract=math_contract,
+                               contract_function='add',
+                               func_args=[5, 6])
+    try:
+        assert abs(gas_estimate - 21984) < 200  # Geth
+    except AssertionError:
+        assert abs(gas_estimate - 30000) < 200  # eth-tester with py-evm
+        pass

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -877,8 +877,8 @@ class ContractFunction:
         return estimate_gas_for_function(self.contract_abi,
                                          self.address,
                                          self.web3,
-                                         function_name=self.function_name,
-                                         transaction=estimate_transaction,
+                                         self.function_name,
+                                         estimate_transaction,
                                          *self.args,
                                          **self.kwargs)
 


### PR DESCRIPTION
### What was wrong?

```
>>> contracts.StoreVar.functions.setVar(255).estimateGas()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dwilson/Develop/Eth/contract_testing/venv36/lib/python3.6/site-packages/web3/contract.py", line 883, in estimateGas
    **self.kwargs)
TypeError: estimate_gas_for_function() got multiple values for argument 'function_name'
```

### How was it fixed?

Call `estimate_gas_for_function` with positional arguments instead of kwargs.

#### Cute Animal Picture

![Cute animal picture](http://www.funnyanimalsite.com/pictures/Animal_Argument.jpg)
