### PR TITLE
Allow instatiating existing filters by id

### DIFF
--- a/tests/core/filtering/test_existing_filter_instance.py
+++ b/tests/core/filtering/test_existing_filter_instance.py
@@ -18,11 +18,11 @@ def filter_id(web3):
 
 
 def test_instatiate_existing_filter(web3, sleep_interval, wait_for_block, filter_id):
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         web3.eth.filter('latest', filter_id)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         web3.eth.filter('latest', filter_id=filter_id)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         web3.eth.filter(filter_params='latest', filter_id=filter_id)
 
     block_filter = web3.eth.filter(filter_id=filter_id)

--- a/tests/core/filtering/test_existing_filter_instance.py
+++ b/tests/core/filtering/test_existing_filter_instance.py
@@ -1,0 +1,45 @@
+import pytest
+
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
+from web3.utils.threads import (
+    Timeout,
+)
+
+
+@pytest.fixture()
+def filter_id(web3):
+    if EthereumTesterProvider not in map(type, web3.providers):
+        web3.providers = EthereumTesterProvider()
+
+    block_filter = web3.eth.filter("latest")
+    return block_filter.filter_id
+
+
+def test_instatiate_existing_filter(web3, sleep_interval, wait_for_block, filter_id):
+    with pytest.raises(ValueError):
+        web3.eth.filter('latest', filter_id)
+    with pytest.raises(ValueError):
+        web3.eth.filter('latest', filter_id=filter_id)
+    with pytest.raises(ValueError):
+        web3.eth.filter(filter_params='latest', filter_id=filter_id)
+
+    block_filter = web3.eth.filter(filter_id=filter_id)
+
+    current_block = web3.eth.blockNumber
+
+    wait_for_block(web3, current_block + 3)
+
+    found_block_hashes = []
+    with Timeout(5) as timeout:
+        while len(found_block_hashes) < 3:
+            found_block_hashes.extend(block_filter.get_new_entries())
+            timeout.sleep(sleep_interval())
+
+    assert len(found_block_hashes) == 3
+
+    expected_block_hashes = [
+        web3.eth.getBlock(n + 1).hash for n in range(current_block, current_block + 3)
+    ]
+    assert found_block_hashes == expected_block_hashes

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -270,7 +270,11 @@ class Eth(Module):
             [transaction],
         )
 
-    def filter(self, filter_params):
+    def filter(self, filter_params=None, filter_id=None):
+        if filter_id and filter_params:
+            raise ValueError("Ambiguous invocation: provide either a \
+                    `filter_params` or a `filter_id` argument. \
+                    Both were supplied.")
         if is_string(filter_params):
             if filter_params == "latest":
                 filter_id = self.web3.manager.request_blocking(
@@ -288,13 +292,17 @@ class Eth(Module):
                     "`latest` for string based filters"
                 )
         elif isinstance(filter_params, dict):
-            filter_id = self.web3.manager.request_blocking(
+            _filter_id = self.web3.manager.request_blocking(
                 "eth_newFilter",
                 [filter_params],
             )
+            return LogFilter(self.web3, _filter_id)
+        elif filter_id and not filter_params:
             return LogFilter(self.web3, filter_id)
         else:
-            raise ValueError("Must provide either a string or a valid filter object")
+            raise ValueError("Must provide either filter_params as a \
+                    string or a valid filter object, or a filter_id as a \
+                    string or hex")
 
     def getFilterChanges(self, filter_id):
         return self.web3.manager.request_blocking(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -301,9 +301,9 @@ class Eth(Module):
         elif filter_id and not filter_params:
             return LogFilter(self.web3, filter_id)
         else:
-            raise ValueError("Must provide either filter_params as a \
-                    string or a valid filter object, or a filter_id as a \
-                    string or hex")
+            raise TypeError("Must provide either filter_params as a string or "
+                            "a valid filter object, or a filter_id as a string "
+                            "or hex.")
 
     def getFilterChanges(self, filter_id):
         return self.web3.manager.request_blocking(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -272,9 +272,10 @@ class Eth(Module):
 
     def filter(self, filter_params=None, filter_id=None):
         if filter_id and filter_params:
-            raise ValueError("Ambiguous invocation: provide either a \
-                    `filter_params` or a `filter_id` argument. \
-                    Both were supplied.")
+            raise TypeError(
+                "Ambiguous invocation: provide either a `filter_params` or a `filter_id` argument. "
+                "Both were supplied."
+            )
         if is_string(filter_params):
             if filter_params == "latest":
                 filter_id = self.web3.manager.request_blocking(


### PR DESCRIPTION
### What was wrong?

There was not public method to attach a filter instance to an existing client-side filter.

### How was it fixed?

Now `web3.eth.filter()` accepts either a `filter_params` or `filter_id` argument.

#### Cute Animal Picture

![Cute animal picture](http://cuteoverload.files.wordpress.com/2014/09/5877262415_83af8b8f8e_z.jpg?w=560&h=420)
