### PR TITLE
Insert middleware to the bottom of the stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,6 @@ geth_steps: &geth_steps
           mkdir -p $HOME/.ethash
           pip install --user py-geth>=1.10.1
           export GOROOT=/usr/local/go
-          export GETH_VERSION=v1.7.2
           export GETH_BINARY="$HOME/.py-geth/geth-$GETH_VERSION/bin/geth"
           if [ ! -e "$GETH_BINARY" ]; then
             curl -O https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz
@@ -80,10 +79,10 @@ geth_steps: &geth_steps
             sudo apt-get update;
             sudo apt-get install -y build-essential;
             python -m geth.install $GETH_VERSION;
-            sudo ln -s /home/circleci/.py-geth/geth-v1.7.2/bin/geth /usr/local/bin/geth
           fi
-          $GETH_BINARY version
-          $GETH_BINARY makedag 0 $HOME/.ethash
+          sudo ln -s /home/circleci/.py-geth/geth-$GETH_VERSION/bin/geth /usr/local/bin/geth
+          geth version
+          geth makedag 0 $HOME/.ethash
     - run:
         name: run tox
         command: ~/.local/bin/tox

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -77,6 +77,28 @@ Middleware can be added, removed, replaced, and cleared at runtime. To make that
 can name the middleware for later reference. Alternatively, you can use a reference to the
 middleware itself.
 
+Middleware Order
+~~~~~~~~~~~~~~~~~~
+
+The "stack" of middlewares used for requests is maintained in ``Web3.middleware_stack``. See
+below for the API.
+
+That stack is ordered, so you can think of the stack as a list. Below you can find
+how the order of that list maps to the middleware execution during a request.
+
+When you send a request to your node, the last middleware in the list has the first opportunity
+to modify the request, and then the second to last, and so on to the first. Then, when the
+node returns the result, the first element in the list has the first opportunity to modify
+the response, then the second, and so on to the last. In other words, the first element is
+"closest" to the node, and the last element is "closest" to your Web3.py request.
+
+See "Internals: :ref:`internals__middlewares`" for a deeper dive to how middlewares work.
+
+Middleware Stack API
+~~~~~~~~~~~~~~~~~~~~~
+
+To add or remove items in different parts of the stack, use the following API:
+
 .. py:method:: Web3.middleware_stack.add(middleware, name=None)
 
     Middleware will be added to the top of the stack. That means the new middleware will modify the
@@ -89,6 +111,22 @@ middleware itself.
         >>> w3.middleware_stack.add(web3.middleware.pythonic_middleware)
         # or
         >>> w3.middleware_stack.add(web3.middleware.pythonic_middleware, 'pythonic')
+
+.. py:method:: Web3.middleware_stack.insert(index, middleware, name=None)
+
+    Insert a named middleware to an arbitrary location in the stack.
+
+    The current implementation only supports insertion at the beginning,
+    or at the end. Note that inserting to the end is equivalent to calling
+    :meth:`Web3.middleware_stack.add` .
+
+    .. code-block:: python
+
+        # Either of these will put the pythonic middleware at the bottom of the middleware stack.
+        >>> w3 = Web3(...)
+        >>> w3.middleware_stack.insert(0, web3.middleware.pythonic_middleware)
+        # or
+        >>> w3.middleware_stack.insert(0, web3.middleware.pythonic_middleware, 'pythonic')
 
 .. py:method:: Web3.middleware_stack.remove(middleware)
 

--- a/tests/core/manager/test_middleware_add_and_clear_api.py
+++ b/tests/core/manager/test_middleware_add_and_clear_api.py
@@ -114,6 +114,36 @@ def test_replace_middleware_without_name(middleware_factory):
     assert tuple(manager.middleware_stack) == (mw1, mw3)
 
 
+def test_bury_middleware(middleware_factory):
+    mw1 = middleware_factory()
+    mw2 = middleware_factory()
+    mw3 = middleware_factory()
+
+    manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2])
+
+    manager.middleware_stack.insert(0, mw3)
+
+    assert tuple(manager.middleware_stack) == (mw3, mw1, mw2)
+
+
+def test_bury_named_middleware(middleware_factory):
+    mw1 = middleware_factory()
+    mw2 = middleware_factory()
+    mw3 = middleware_factory()
+
+    manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2])
+
+    manager.middleware_stack.insert(0, mw3, name='middleware3')
+
+    assert tuple(manager.middleware_stack) == (mw3, mw1, mw2)
+
+    # make sure middleware was inserted with correct name, by trying to remove
+    # it by name.
+    manager.middleware_stack.remove('middleware3')
+
+    assert tuple(manager.middleware_stack) == (mw1, mw2)
+
+
 def test_remove_middleware(middleware_factory):
     mw1 = middleware_factory()
     mw2 = middleware_factory()

--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -7,6 +7,10 @@ from collections import (
     Sequence,
 )
 
+from eth_utils import (
+    is_integer,
+)
+
 from web3.utils.formatters import (
     recursive_map,
 )
@@ -113,6 +117,36 @@ class NamedElementStack(Mapping):
                 raise ValueError("You can't add the same name again, use replace instead")
 
         self._queue[name] = element
+
+    def insert(self, index, element, name=None):
+        '''
+        Insert a named element to an arbitrary location in the stack.
+
+        The current implementation only supports insertion at the beginning,
+        or at the end. Note that inserting to the end is equivalent to calling :meth:`add` .
+        '''
+        if not is_integer(index):
+            raise TypeError("The index for insertion must be an int.")
+        elif index != 0 and index != len(self._queue):
+            raise NotImplementedError(
+                "You can only insert to the beginning or end of a %s, currently. "
+                "You tried to insert to %d, but only 0 and %d are permitted. " % (
+                    type(self),
+                    index,
+                    len(self._queue),
+                )
+            )
+
+        self.add(element, name=name)
+
+        if index == 0:
+            if name is None:
+                name = element
+            self._queue.move_to_end(name)
+        elif index == len(self._queue):
+            return
+        else:
+            raise AssertionError("Impossible to reach: earlier validation raises an error")
 
     def clear(self):
         self._queue.clear()


### PR DESCRIPTION
### What was wrong?

I will soon add a geth-dev compatibility middleware, which needs to be inserted to the bottom of the middleware stack. There was no convenient way to do that.

### How was it fixed?

Added `middleware_stack.insert(index, element, name=None)`.  At first I had `middleware_stack.bury(element, name=None)`, which made sense to me, but I decided that consistency with the python `list` method was probably better than whatever API name made most sense to me, and it's (ultimately) flexible to inserting middleware to the middle of the stack.

I skipped implementing anything but adding to the bottom for now. The underlying implementation of `OrderedDict` would actually make it a bit annoying. Totally doable, it's just not something we need right away.

#### Cute Animal Picture

![Cute animal picture](https://screenshotscdn.firefoxusercontent.com/images/f442bdfe-e494-4246-9437-53fd3be46c46.png)
