### PR TITLE
provide workaround to allow usage of geth --dev (re #549)

### DIFF
--- a/tests/sandbox/README.md
+++ b/tests/sandbox/README.md
@@ -1,0 +1,5 @@
+You can use the sandbox test-folder to provide manually executed tests.
+
+This helps if you are not familiar with the automated test-system.
+
+Those tests can then be used by the QA to provide the automated tests.

--- a/tests/sandbox/geth-dev.py
+++ b/tests/sandbox/geth-dev.py
@@ -1,0 +1,87 @@
+""" Demonstration / Test Code For "geth --dev" compatibility
+
+Adopts the example from the web3.py manual.
+
+This code demonstrates the activation of the "geth -dev" / Rinkeby compatibility
+
+Usage:
+
+    geth --dev --ipc
+    python tests/sandbox/geth-dev.py
+
+"""
+
+from solc import (
+    compile_source,
+)
+from web3 import (
+    HTTPProvider,
+    Web3,
+)
+from web3.contract import (
+    ConciseContract,
+)
+from web3.middleware.geth_dev import (
+    geth_dev_middleware,
+)
+
+# w3 = Web3(IPCProvider('/tmp/geth.ipc'))
+w3 = Web3(HTTPProvider('http://127.0.0.1:8545'))
+
+# ========================== MIDDLEWARE WORKAROUND =============================
+
+# from web3.middleware.geth_dev import geth_dev_middleware
+w3.manager.middleware_stack.add_bottom(geth_dev_middleware, 'addedspec')
+
+# disable above line and enable the below will trigger error on dev-nets
+# w3.manager.middleware_stack.add(geth_dev_middleware, 'addedspec')
+
+# ==============================================================================
+
+# Solidity source code
+contract_source_code = '''
+pragma solidity ^0.4.0;
+
+contract Greeter {
+    string public greeting;
+
+    function Greeter() {
+        greeting = 'Hello';
+    }
+
+    function setGreeting(string _greeting) public {
+        greeting = _greeting;
+    }
+
+    function greet() constant returns (string) {
+        return greeting;
+    }
+}
+'''
+
+compiled_sol = compile_source(contract_source_code)
+contract_interface = compiled_sol['<stdin>:Greeter']
+
+# Instantiate and deploy contract
+contract = w3.eth.contract(abi=contract_interface['abi'], bytecode=contract_interface['bin'])
+
+# Get transaction hash from deployed contract
+tx_hash = contract.deploy(transaction={'from': w3.eth.accounts[0], 'gas': 410000})
+print('hash:', tx_hash)
+
+# Get tx receipt to get contract address
+tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+print('txreceipt ', tx_receipt)
+
+contract_address = tx_receipt['contractAddress']
+
+# Contract instance in concise mode
+contract_instance = w3.eth.contract(
+    contract_address, abi=contract_interface['abi'], ContractFactoryClass=ConciseContract
+)
+
+# Getters + Setters for web3.eth.contract object
+print('Contract value: {}'.format(contract_instance.greet()))
+contract_instance.setGreeting('Nihao', transact={'from': w3.eth.accounts[0]})
+print('Setting value to: Nihao')
+print('Contract value: {}'.format(contract_instance.greet()))

--- a/web3/middleware/geth_dev.py
+++ b/web3/middleware/geth_dev.py
@@ -1,0 +1,33 @@
+"""
+
+Middleware workaround implementation to allow for larger extraData field
+
+For more information and a for a suggested full implementaion, see:
+
+https://github.com/ethereum/web3.py/issues/647
+
+"""
+
+from eth_utils.curried import (
+    apply_key_map,
+)
+
+from web3.middleware.formatting import (
+    construct_formatting_middleware,
+)
+
+remap_geth_dev_fields = apply_key_map({
+    'extraData': 'proofOfAuthorityData',
+})
+
+geth_dev_middleware = construct_formatting_middleware(
+    result_formatters={
+        'eth_getBlockByHash': remap_geth_dev_fields,
+        'eth_getBlockByNumber': remap_geth_dev_fields,
+    },
+)
+
+#
+# A placeholder, to reserve a predefined position within a predefined middleware list
+#
+placeholder_middleware = construct_formatting_middleware()

--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -102,7 +102,7 @@ class NamedElementStack(Mapping):
             else:
                 self.add(*element)
 
-    def add(self, element, name=None):
+    def add(self, element, name=None, bottom=False):
         if name is None:
             name = element
 
@@ -113,6 +113,16 @@ class NamedElementStack(Mapping):
                 raise ValueError("You can't add the same name again, use replace instead")
 
         self._queue[name] = element
+
+        if bottom:
+            # entry 'name' becomes first entry of queue, which  (bottom of stack)
+            self._queue.move_to_end(name, last=False)
+
+    #
+    # Adds a named element at the bottom of the stack
+    #
+    def add_bottom(self, element, name=None):
+        self.add(element, name, bottom=True)
 
     def clear(self):
         self._queue.clear()


### PR DESCRIPTION
### What was wrong?

geth --dev not working

### How was it fixed?

workaround, using middleware provided by @carver 

Could be further simplified to e.g.:

```python
w3.manager.geth_dev(True)
```

But you should know best which classes you want to  touch and which  not.

Note that my direction was another one, I realigned my efforts to provide this like this (simplified, non-automated detection).

#### Cute Animal Picture

(this is really distracting, took me 10 min... the arms are cute, for sure! )

![Cute animal picture](https://i.ytimg.com/vi/3oNdf4ebPIE/maxresdefault.jpg)
