### PR TITLE
Pop and validate chainId, if provided with txn

### DIFF
--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -1,0 +1,42 @@
+import pytest
+
+from web3.exceptions import (
+    ValidationError,
+)
+
+
+@pytest.mark.parametrize(
+    'make_chain_id, expect_success',
+    (
+        (
+            lambda web3: web3.version.network,
+            True,
+        ),
+        (
+            lambda web3: int(web3.version.network),
+            True,
+        ),
+        (
+            lambda web3: int(web3.version.network) + 1,
+            False,
+        ),
+        (
+            lambda web3: str(int(web3.version.network) + 1),
+            False,
+        ),
+    ),
+)
+def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_success):
+    transaction = {
+        'to': web3.eth.accounts[1],
+        'chainId': make_chain_id(web3),
+    }
+
+    if expect_success:
+        # just be happy that we didn't crash
+        web3.eth.sendTransaction(transaction)
+    else:
+        with pytest.raises(ValidationError) as exc_info:
+            web3.eth.sendTransaction(transaction)
+
+        assert 'chain ID' in str(exc_info.value)

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -70,3 +70,10 @@ class FallbackNotFound(Exception):
     Raised when fallback function doesn't exist in contract.
     """
     pass
+
+
+class ValidationError(Exception):
+    """
+    Raised when a supplied value is invalid.
+    """
+    pass

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -14,6 +14,7 @@ from web3.middleware import (
     gas_price_strategy_middleware,
     name_to_address_middleware,
     pythonic_middleware,
+    validation_middleware,
 )
 from web3.providers import (
     AutoProvider,
@@ -69,6 +70,7 @@ class RequestManager:
             (name_to_address_middleware(web3), 'name_to_address'),
             (attrdict_middleware, 'attrdict'),
             (pythonic_middleware, 'pythonic'),
+            (validation_middleware, 'validation'),
             (abi_middleware, 'abi'),
         ]
 

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -42,6 +42,10 @@ from .exception_retry_request import (  # noqa: F401
     http_retry_request_middleware
 )
 
+from .validation import (  # noqa: F401
+    validation_middleware,
+)
+
 
 def combine_middlewares(middlewares, web3, provider_request_fn):
     """

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -233,6 +233,11 @@ filter_result_formatter = apply_one_of_formatters((
     (apply_formatter_to_array(to_hexbytes(32)), is_array_of_strings),
 ))
 
+TRANSACTION_PARAM_FORMATTERS = {
+    'chainId': apply_formatter_if(is_integer, str),
+}
+
+transaction_param_formatter = apply_formatters_to_dict(TRANSACTION_PARAM_FORMATTERS)
 
 pythonic_middleware = construct_formatting_middleware(
     request_formatters={
@@ -253,6 +258,9 @@ pythonic_middleware = construct_formatting_middleware(
         'eth_getUncleCountByBlockNumber': apply_formatter_at_index(block_number_formatter, 0),
         'eth_newFilter': apply_formatter_at_index(filter_params_formatter, 0),
         'eth_getLogs': apply_formatter_at_index(filter_params_formatter, 0),
+        'eth_call': apply_formatter_at_index(transaction_param_formatter, 0),
+        'eth_estimateGas': apply_formatter_at_index(transaction_param_formatter, 0),
+        'eth_sendTransaction': apply_formatter_at_index(transaction_param_formatter, 0),
         # personal
         'personal_importRawKey': apply_formatter_at_index(
             compose(remove_0x_prefix, hexstr_if_str(to_hex)),

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -1,0 +1,47 @@
+from cytoolz import (
+    compose,
+    curry,
+    dissoc,
+)
+from eth_utils.curried import (
+    apply_formatter_at_index,
+    apply_formatters_to_dict,
+)
+
+from web3.exceptions import (
+    ValidationError,
+)
+
+
+@curry
+def validate_chain_id(web3, chain_id):
+    if chain_id == web3.version.network:
+        return None
+    else:
+        raise ValidationError(
+            "The transaction declared chain ID %r, "
+            "but the connected node is on %r" % (
+                chain_id,
+                web3.version.network,
+            )
+        )
+
+
+def transaction_normalizer(transaction):
+    return dissoc(transaction, 'chainId')
+
+
+def validation_middleware(make_request, web3):
+    transaction_validator = apply_formatters_to_dict({
+        'chainId': validate_chain_id(web3),
+    })
+
+    transaction_sanitizer = compose(transaction_normalizer, transaction_validator)
+
+    def middleware(method, params):
+        if method in ('eth_sendTransaction', 'eth_estimateGas', 'eth_call'):
+            post_validated_params = apply_formatter_at_index(transaction_sanitizer, 0, params)
+            return make_request(method, post_validated_params)
+        else:
+            return make_request(method, params)
+    return middleware


### PR DESCRIPTION
### What was wrong?

`chainId` is a part of a transaction only used during local signing. Remote nodes don't know what to do with `chainId` as a field in `eth_sendTransaction`, according to spec.

#595 should be after merging this change.

### How was it fixed?

If sending a transaction to a remote node, strip out the `chainId` field, after validating the value. Added a new middleware layer that make make sense as a place to move more validation, in general.

#### Cute Animal Picture

![Cute animal picture](https://s-media-cache-ak0.pinimg.com/originals/e8/ca/88/e8ca883f633a4decd309dea8ea9969c0.jpg)