### PR TITLE
Enable geth --dev and rinkeby access

### DIFF
--- a/tests/core/eth-module/test_poa.py
+++ b/tests/core/eth-module/test_poa.py
@@ -1,0 +1,36 @@
+import pytest
+
+from web3.middleware import (
+    construct_fixture_middleware,
+    geth_poa_compatibility,
+)
+
+
+# In the spec, a block with extra data longer than 32 bytes is invalid
+def test_long_extra_data(web3):
+    return_block_with_long_extra_data = construct_fixture_middleware({
+        'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 33},
+    })
+    web3.middleware_stack.insert(0, return_block_with_long_extra_data)
+    with pytest.raises(ValueError):
+        web3.eth.getBlock('latest')
+
+
+def test_full_extra_data(web3):
+    return_block_with_long_extra_data = construct_fixture_middleware({
+        'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 32},
+    })
+    web3.middleware_stack.insert(0, return_block_with_long_extra_data)
+    block = web3.eth.getBlock('latest')
+    assert block.extraData == b'\xff' * 32
+
+
+def test_geth_proof_of_authority(web3):
+    return_block_with_long_extra_data = construct_fixture_middleware({
+        'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 33},
+    })
+    web3.middleware_stack.insert(0, geth_poa_compatibility)
+    web3.middleware_stack.insert(0, return_block_with_long_extra_data)
+    block = web3.eth.getBlock('latest')
+    assert 'extraData' not in block
+    assert block.proofOfAuthorityData == b'\xff' * 33

--- a/tests/core/manager/test_middleware_add_and_clear_api.py
+++ b/tests/core/manager/test_middleware_add_and_clear_api.py
@@ -114,6 +114,18 @@ def test_replace_middleware_without_name(middleware_factory):
     assert tuple(manager.middleware_stack) == (mw1, mw3)
 
 
+def test_add_middleware(middleware_factory):
+    mw1 = middleware_factory()
+    mw2 = middleware_factory()
+    mw3 = middleware_factory()
+
+    manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2])
+
+    manager.middleware_stack.add(mw3)
+
+    assert tuple(manager.middleware_stack) == (mw3, mw1, mw2)
+
+
 def test_bury_middleware(middleware_factory):
     mw1 = middleware_factory()
     mw2 = middleware_factory()
@@ -123,7 +135,7 @@ def test_bury_middleware(middleware_factory):
 
     manager.middleware_stack.insert(0, mw3)
 
-    assert tuple(manager.middleware_stack) == (mw3, mw1, mw2)
+    assert tuple(manager.middleware_stack) == (mw1, mw2, mw3)
 
 
 def test_bury_named_middleware(middleware_factory):
@@ -135,7 +147,7 @@ def test_bury_named_middleware(middleware_factory):
 
     manager.middleware_stack.insert(0, mw3, name='middleware3')
 
-    assert tuple(manager.middleware_stack) == (mw3, mw1, mw2)
+    assert tuple(manager.middleware_stack) == (mw1, mw2, mw3)
 
     # make sure middleware was inserted with correct name, by trying to remove
     # it by name.

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -42,6 +42,10 @@ from .exception_retry_request import (  # noqa: F401
     http_retry_request_middleware
 )
 
+from .geth_poa import (  # noqa: F401
+    geth_poa_compatibility,
+)
+
 
 def combine_middlewares(middlewares, web3, provider_request_fn):
     """

--- a/web3/middleware/geth_poa.py
+++ b/web3/middleware/geth_poa.py
@@ -1,0 +1,31 @@
+from cytoolz import (
+    compose,
+)
+from eth_utils.curried import (
+    apply_formatters_to_dict,
+    apply_key_map,
+)
+from hexbytes import (
+    HexBytes,
+)
+
+from web3.middleware.formatting import (
+    construct_formatting_middleware,
+)
+
+remap_geth_poa_fields = apply_key_map({
+    'extraData': 'proofOfAuthorityData',
+})
+
+pythonic_geth_poa = apply_formatters_to_dict({
+    'proofOfAuthorityData': HexBytes,
+})
+
+geth_poa_cleanup = compose(pythonic_geth_poa, remap_geth_poa_fields)
+
+geth_poa_compatibility = construct_formatting_middleware(
+    result_formatters={
+        'eth_getBlockByHash': geth_poa_cleanup,
+        'eth_getBlockByNumber': geth_poa_cleanup,
+    },
+)

--- a/web3/utils/datastructures.py
+++ b/web3/utils/datastructures.py
@@ -142,7 +142,7 @@ class NamedElementStack(Mapping):
         if index == 0:
             if name is None:
                 name = element
-            self._queue.move_to_end(name)
+            self._queue.move_to_end(name, last=False)
         elif index == len(self._queue):
             return
         else:


### PR DESCRIPTION
### What was wrong?

Rinkeby and geth --dev use a geth prototype of poa that uses a long `extraData` field. That field is invalid according to the main spec / yellow paper. So access was 

### How was it fixed?

- Add a new middleware that moves `extraData` to `proofOfAuthorityData` (and still converts it to `HexBytes`).
- A bugfix in the middleware insertion code

TODO:

- Add docs for new middleware, with example of inserting it to layer 0.

#### Cute Animal Picture

![Cute animal picture](https://static01.nyt.com/images/2017/03/07/science/07COVERBOOBIE/07COVERBOOBIE-superJumbo.jpg)
