### PR TITLE
 accept integers for block ids in w3.eth.call

### DIFF
--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -6,8 +6,8 @@ from hexbytes import (
 
 from web3.exceptions import (
     BadFunctionCallOutput,
+    BlockNumberOutofRange,
     InvalidAddress,
-    BlockNumberOutofRange
 )
 from web3.utils.ens import (
     contract_ens_addresses,

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -413,13 +413,13 @@ def test_neg_block_indexes_from_the_end(web3, math_contract):
 
 
 def test_returns_data_from_specified_block(web3, math_contract):
+    start_num = web3.eth.getBlock('latest').number
     web3.providers[0].make_request(method='evm_mine', params=[5])
     math_contract.functions.increment().transact()
     math_contract.functions.increment().transact()
-    web3.providers[0].make_request(method='evm_mine', params=[5])
 
-    output1 = math_contract.functions.counter().call(block_identifier=7)
-    output2 = math_contract.functions.counter().call(block_identifier=8)
+    output1 = math_contract.functions.counter().call(block_identifier=start_num + 6)
+    output2 = math_contract.functions.counter().call(block_identifier=start_num + 7)
 
     assert output1 == 1
     assert output2 == 2

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -178,12 +178,14 @@ def not_implemented(method, exc_type=NotImplementedError):
 def disable_auto_mine(func):
     @functools.wraps(func)
     def func_wrapper(self, eth_tester, *args, **kwargs):
+        snapshot = eth_tester.take_snapshot()
         eth_tester.disable_auto_mine_transactions()
         try:
             func(self, eth_tester, *args, **kwargs)
         finally:
             eth_tester.enable_auto_mine_transactions()
             eth_tester.mine_block()
+            eth_tester.revert_to_snapshot(snapshot)
     return func_wrapper
 
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -235,6 +235,20 @@ class TestEthereumTesterEthModule(EthModuleTest):
     def test_eth_modifyTransaction(self, eth_tester, web3, unlocked_account):
         super().test_eth_modifyTransaction(web3, unlocked_account)
 
+    @disable_auto_mine
+    def test_eth_call_old_contract_state(self, eth_tester, web3, math_contract, unlocked_account):
+        # For now, ethereum tester cannot give call results in the pending block.
+        # Once that feature is added, then delete the except/else blocks.
+        try:
+            super().test_eth_call_old_contract_state(web3, math_contract, unlocked_account)
+        except AssertionError as err:
+            if str(err) == "pending call result was 0 instead of 1":
+                pass
+            else:
+                raise err
+        else:
+            raise AssertionError("eth-tester was unexpectedly able to give the pending call result")
+
 
 class TestEthereumTesterVersionModule(VersionModuleTest):
     pass

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -26,6 +26,7 @@ from web3.exceptions import (
     BadFunctionCallOutput,
     FallbackNotFound,
     MismatchedABI,
+    BlockNumberOutofRange,
 )
 from web3.utils.abi import (
     fallback_func_abi_exists,
@@ -72,6 +73,10 @@ from web3.utils.normalizers import (
 )
 from web3.utils.transactions import (
     fill_transaction_defaults,
+)
+
+from web3.utils.blocks import (
+    is_hex_encoded_block_hash,
 )
 
 DEPRECATED_SIGNATURE_MESSAGE = (
@@ -445,6 +450,7 @@ class Contract:
                     contract._return_data_normalizers,
                     function_name,
                     call_transaction,
+                    'latest',
                 )
                 return callable_fn
 
@@ -805,7 +811,7 @@ class ContractFunction:
 
         self.arguments = merge_args_and_kwargs(self.abi, self.args, self.kwargs)
 
-    def call(self, transaction=None):
+    def call(self, transaction=None, block_identifier='latest'):
         """
         Execute a contract function call using the `eth_call` interface.
 
@@ -854,6 +860,7 @@ class ContractFunction:
                 raise ValueError(
                     "Please ensure that this contract instance has an address."
                 )
+        block_id = parse_block_identifier(self.web3, block_identifier)
 
         return call_contract_function(self.contract_abi,
                                       self.web3,
@@ -861,6 +868,7 @@ class ContractFunction:
                                       self._return_data_normalizers,
                                       self.function_identifier,
                                       call_transaction,
+                                      block_id,
                                       *self.args,
                                       **self.kwargs)
 
@@ -1030,6 +1038,7 @@ def call_contract_function(abi,
                            normalizers,
                            function_identifier,
                            transaction,
+                           block_id=None,
                            *args,
                            **kwargs):
     """
@@ -1046,7 +1055,10 @@ def call_contract_function(abi,
         transaction=transaction,
     )
 
-    return_data = web3.eth.call(call_transaction)
+    if block_id is None:
+        return_data = web3.eth.call(call_transaction)
+    else:
+        return_data = web3.eth.call(call_transaction, block_identifier=block_id)
 
     function_abi = find_matching_fn_abi(abi, function_identifier, args, kwargs)
 
@@ -1087,6 +1099,21 @@ def call_contract_function(abi,
         return normalized_data[0]
     else:
         return normalized_data
+
+
+def parse_block_identifier(web3, block_identifier):
+    last_block = web3.eth.getBlock('latest').number
+    if isinstance(block_identifier, int) and abs(block_identifier) <= last_block:
+        if block_identifier >= 0:
+            return block_identifier
+        else:
+            return last_block + block_identifier + 1
+    elif block_identifier in ['latest', 'earliest', 'pending']:
+        return block_identifier
+    elif isinstance(block_identifier, bytes) or is_hex_encoded_block_hash(block_identifier):
+        return web3.eth.getBlock(block_identifier).number
+    else:
+        raise BlockNumberOutofRange
 
 
 def transact_with_contract_function(abi,

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -24,9 +24,9 @@ from toolz.functoolz import (
 
 from web3.exceptions import (
     BadFunctionCallOutput,
+    BlockNumberOutofRange,
     FallbackNotFound,
     MismatchedABI,
-    BlockNumberOutofRange,
 )
 from web3.utils.abi import (
     fallback_func_abi_exists,
@@ -35,6 +35,9 @@ from web3.utils.abi import (
     get_constructor_abi,
     map_abi_data,
     merge_args_and_kwargs,
+)
+from web3.utils.blocks import (
+    is_hex_encoded_block_hash,
 )
 from web3.utils.contracts import (
     encode_abi,
@@ -73,10 +76,6 @@ from web3.utils.normalizers import (
 )
 from web3.utils.transactions import (
     fill_transaction_defaults,
-)
-
-from web3.utils.blocks import (
-    is_hex_encoded_block_hash,
 )
 
 DEPRECATED_SIGNATURE_MESSAGE = (

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -269,7 +269,6 @@ class Eth(Module):
         # TODO: move to middleware
         if block_identifier is None:
             block_identifier = self.defaultBlock
-
         return self.web3.manager.request_blocking(
             "eth_call",
             [transaction, block_identifier],

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -11,6 +11,13 @@ class BadFunctionCallOutput(Exception):
     pass
 
 
+class BlockNumberOutofRange(Exception):
+    '''
+    block_identifier passed does not match known block.
+    '''
+    pass
+
+
 class CannotHandleRequest(Exception):
     """
     Raised by a provider to signal that it cannot handle an RPC request and

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -14,6 +14,7 @@ from cytoolz.functoolz import (
     partial,
 )
 from eth_utils.curried import (
+    combine_argument_formatters,
     is_address,
     is_bytes,
     is_integer,
@@ -258,7 +259,10 @@ pythonic_middleware = construct_formatting_middleware(
         'eth_getUncleCountByBlockNumber': apply_formatter_at_index(block_number_formatter, 0),
         'eth_newFilter': apply_formatter_at_index(filter_params_formatter, 0),
         'eth_getLogs': apply_formatter_at_index(filter_params_formatter, 0),
-        'eth_call': apply_formatter_at_index(transaction_param_formatter, 0),
+        'eth_call': combine_argument_formatters(
+            transaction_param_formatter,
+            block_number_formatter,
+        ),
         'eth_estimateGas': apply_formatter_at_index(transaction_param_formatter, 0),
         'eth_sendTransaction': apply_formatter_at_index(transaction_param_formatter, 0),
         # personal

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -39,7 +39,7 @@ def validation_middleware(make_request, web3):
     transaction_sanitizer = compose(transaction_normalizer, transaction_validator)
 
     def middleware(method, params):
-        if method in ('eth_sendTransaction', 'eth_estimateGas', 'eth_call'):
+        if method in {'eth_sendTransaction', 'eth_estimateGas', 'eth_call'}:
             post_validated_params = apply_formatter_at_index(transaction_sanitizer, 0, params)
             return make_request(method, post_validated_params)
         else:

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -188,6 +188,7 @@ ethereum_tester_middleware = construct_formatting_middleware(
         ),
         'eth_call': apply_formatters_to_args(
             transaction_params_transformer,
+            apply_formatter_if(is_not_named_block, to_integer_if_hex),
         ),
         'eth_uninstallFilter': apply_formatters_to_args(hex_to_integer),
         # EVM

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -717,7 +717,9 @@ class EthModuleTest:
         assert block_num_call_result == 0
         assert latest_call_result == 0
         assert default_call_result == 0
-        assert pending_call_result == 1
+
+        if pending_call_result != 1:
+            raise AssertionError("pending call result was %d instead of 1" % pending_call_result)
 
     def test_eth_uninstallFilter(self, web3):
         filter = web3.eth.filter({})

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -694,6 +694,15 @@ class EthModuleTest:
         result = web3.eth.getLogs(filter_params)
         assert_contains_log(result)
 
+    def test_eth_call_old_contract_state(self, web3, math_contract, unlocked_account):
+        math_contract.functions.increment().transact()
+
+        call_result_old = math_contract.functions.counter().call(block_identifier=6)
+        call_result = math_contract.functions.counter().call(block_identifier='latest')
+
+        assert call_result_old == 0
+        assert call_result == 1
+
     def test_eth_uninstallFilter(self, web3):
         filter = web3.eth.filter({})
         assert is_string(filter.filter_id)

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -695,13 +695,29 @@ class EthModuleTest:
         assert_contains_log(result)
 
     def test_eth_call_old_contract_state(self, web3, math_contract, unlocked_account):
-        math_contract.functions.increment().transact()
+        start_block = web3.eth.getBlock('latest')
+        block_num = start_block.number
+        block_hash = start_block.hash
 
-        call_result_old = math_contract.functions.counter().call(block_identifier=6)
-        call_result = math_contract.functions.counter().call(block_identifier='latest')
+        math_contract.functions.increment().transact({'from': unlocked_account})
 
-        assert call_result_old == 0
-        assert call_result == 1
+        # This isn't an incredibly convincing test since we can't mine, and
+        # the default resolved block is latest, So if block_identifier was ignored
+        # we would get the same result. For now, we mostly depend on core tests.
+        # Ideas to improve this test:
+        #  - Enable on-demand mining in more clients
+        #  - Increment the math contract in all of the fixtures, and check the value in an old block
+        block_hash_call_result = math_contract.functions.counter().call(block_identifier=block_hash)
+        block_num_call_result = math_contract.functions.counter().call(block_identifier=block_num)
+        latest_call_result = math_contract.functions.counter().call(block_identifier='latest')
+        default_call_result = math_contract.functions.counter().call()
+        pending_call_result = math_contract.functions.counter().call(block_identifier='pending')
+
+        assert block_hash_call_result == 0
+        assert block_num_call_result == 0
+        assert latest_call_result == 0
+        assert default_call_result == 0
+        assert pending_call_result == 1
 
     def test_eth_uninstallFilter(self, web3):
         filter = web3.eth.filter({})


### PR DESCRIPTION
### What was wrong?

Fixes #576 

### How was it fixed?

- convert int block numbers to hex in `pythonic` middleware
- convert hex back to int for eth-tester provider
- a little leftover fix from #656 
- bugfix in eth-tester middleware: only convert to integer if value is valid hex in `to_integer_if_hex` (was converting any `str` previously)
- pin to eth-utils beta1 until all the cleanup is complete

#### Cute Animal Picture

![Cute animal picture](https://img.wonkette.com/wp-content/uploads/2016/08/cute-bunnies.jpg)
