### PR TITLE
upgrade eth-abi for eth-utils b2 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "cytoolz>=0.9.0,<1.0.0",
-        "eth-abi>=1.0.0-beta.0,<2",
+        "eth-abi>=1.0.0-beta.1,<2",
         "eth-account>=0.1.0a2,<1.0.0",
         "eth-utils>=1.0.0b1,<2.0.0",
         "hexbytes>=0.1.0b0,<1.0.0",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     extras_require={
         'tester': [
-            "eth-tester[py-evm]==0.1.0b16",
+            "eth-tester[py-evm]==0.1.0b19",
         ],
         'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],
         'linter': [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "eth-abi>=1.0.0-beta.1,<2",
         "eth-account>=0.1.0a2,<1.0.0",
         "eth-utils>=1.0.0b1,<2.0.0",
-        "hexbytes>=0.1.0b0,<1.0.0",
+        "hexbytes>=0.1.0b1,<1.0.0",
         "lru-dict>=1.1.6,<2.0.0",
         "pysha3>=1.0.0,<2.0.0",
         "requests>=2.16.0,<3.0.0",

--- a/web3/iban.py
+++ b/web3/iban.py
@@ -2,9 +2,7 @@ import functools
 import re
 
 from eth_utils import (
-    coerce_args_to_text,
     is_string,
-    pad_left,
     to_checksum_address,
 )
 
@@ -14,7 +12,7 @@ from web3.utils.validation import (
 
 
 def pad_left_hex(value, num_bytes):
-    return pad_left(value, num_bytes * 2, '0')
+    return value.rjust(num_bytes * 2, '0')
 
 
 def iso13616Prepare(iban):
@@ -88,7 +86,6 @@ class IsValid:
         return functools.partial(self.validate, instance._iban)
 
     @staticmethod
-    @coerce_args_to_text
     def validate(iban_address):
         if not is_string(iban_address):
             return False

--- a/web3/utils/contracts.py
+++ b/web3/utils/contracts.py
@@ -39,10 +39,9 @@ from web3.utils.function_identifiers import (
 )
 from web3.utils.normalizers import (
     abi_address_to_hex,
-    abi_bytes_to_hex,
+    abi_bytes_to_bytes,
     abi_ens_resolver,
-    abi_string_to_hex,
-    hexstrs_to_bytes,
+    abi_string_to_text,
 )
 
 
@@ -118,9 +117,8 @@ def encode_abi(web3, abi, arguments, data=None):
         normalizers = [
             abi_ens_resolver(web3),
             abi_address_to_hex,
-            abi_bytes_to_hex,
-            abi_string_to_hex,
-            hexstrs_to_bytes,
+            abi_bytes_to_bytes,
+            abi_string_to_text,
         ]
         normalized_arguments = map_abi_data(
             normalizers,

--- a/web3/utils/normalizers.py
+++ b/web3/utils/normalizers.py
@@ -24,6 +24,7 @@ from web3.utils.encoding import (
     text_if_str,
     to_bytes,
     to_hex,
+    to_text,
 )
 from web3.utils.ens import (
     is_ens_name,
@@ -102,9 +103,15 @@ def abi_string_to_hex(abi_type, data):
 
 
 @implicitly_identity
-def hexstrs_to_bytes(abi_type, data):
+def abi_string_to_text(abi_type, data):
+    if abi_type == 'string':
+        return abi_type, text_if_str(to_text, data)
+
+
+@implicitly_identity
+def abi_bytes_to_bytes(abi_type, data):
     base, sub, arrlist = process_type(abi_type)
-    if base in {'string', 'bytes'} and not arrlist:
+    if base == 'bytes' and not arrlist:
         return abi_type, hexstr_if_str(to_bytes, data)
 
 


### PR DESCRIPTION
### What was wrong?

eth-abi v1b0 was not compatible with eth-utils v1b2

### How was it fixed?

upgraded to beta 1

#### Cute Animal Picture

![Cute animal picture]()
