### PR TITLE
Eth account unstable

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -99,4 +99,15 @@ def wait_for_transaction():
 @pytest.fixture()
 def web3():
     provider = EthereumTesterProvider()
-    return Web3(provider)
+    w3 = Web3(provider)
+
+    # Delete this whole block after eth-account has passed security audit
+    try:
+        w3.eth.account
+    except AttributeError:
+        pass
+    else:
+        raise AssertionError("Unaudited features must be disabled by default")
+    w3.eth.enable_unaudited_features()
+
+    return w3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,6 +83,7 @@ exclude_patterns = [
     'web3.rst',
     'modules.rst',
     'web3.auto.rst',
+    'web3.gas_strategies.rst',
     'web3.middleware.rst',
     'web3.providers.rst',
     'web3.providers.eth_tester.rst',

--- a/docs/gas_price.rst
+++ b/docs/gas_price.rst
@@ -104,14 +104,14 @@ Available gas price strategies
       recommended that a caching solution be used to reduce the amount of chain
       data that needs to be re-fetched for each request.
 
-.. code-block:: python
+    .. code-block:: python
 
-    from web3 import Web3, middleware
-    from web3.gas_strategies.time_based import medium_gas_price_strategy
+        from web3 import Web3, middleware
+        from web3.gas_strategies.time_based import medium_gas_price_strategy
 
-    w3 = Web3()
-    w3.eth.setGasPriceStrategy(medium_gas_price_strategy)
+        w3 = Web3()
+        w3.eth.setGasPriceStrategy(medium_gas_price_strategy)
 
-    w3.middleware_stack.add(middleware.time_based_cache_middleware)
-    w3.middleware_stack.add(middleware.latest_block_based_cache_middleware)
-    w3.middleware_stack.add(middleware.simple_cache_middleware)
+        w3.middleware_stack.add(middleware.time_based_cache_middleware)
+        w3.middleware_stack.add(middleware.latest_block_based_cache_middleware)
+        w3.middleware_stack.add(middleware.simple_cache_middleware)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Contents
     web3.eth.account
     web3.shh
     web3.personal
+    web3.net
     web3.version
     web3.txpool
     web3.miner

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -1,30 +1,87 @@
 Working with Local Private Keys
 ==========================================
 
+Not Acceptable for Production
+---------------------------------
+
+.. WARNING::
+  **Do not use** this module in production. It is still in beta. A security audit is pending.
+
+Now is a great time to get familiar with the API, and test out writing
+code that uses some of the great upcoming features.
+
+By default, access to this module has been turned off in the stable version of Web3.py:
+
+.. code-block:: python
+
+    >>> from web3.auto import w3
+    >>> w3.eth.account
+    ...
+    AttributeError: This feature is disabled, pending security audit. ...
+
+In order to access these features, you can either:
+
+1. Turn it on inside web3 with:
+
+   .. code-block:: python
+
+       >>> from web3.auto import w3
+       >>> w3.eth.enable_unaudited_features()
+       >>> w3.eth.account
+
+2. Load the beta version of :class:`eth_account.Account <eth_account.account.Account>`
+   directly, with:
+
+   .. code-block:: python
+
+       >>> from eth_account import Account
+       >>> account = Account()
+
+.. testsetup::
+
+    from web3.auto import w3
+    w3.eth.enable_unaudited_features()
+
+Local vs Hosted Nodes
+---------------------------------
+
+Local Node
+  A local node is started and controlled by you. It is as safe as you keep it.
+  When you run ``geth`` or ``parity`` on your machine, you are running a local node.
+
+Hosted Node
+  A hosted node is controlled by someone else. When you connect to Infura, you are
+  connected to a hosted node.
+
+Local vs Hosted Keys
+---------------------------------
+
 Local Private Key
   A key is 32 :class:`bytes` of data that you can use to sign transactions and messages,
-  before sending them to your node. That node can be local (like Geth or Parity),
-  or remote (like Infura). You must use :meth:`~web3.eth.Eth.sendRawTransaction`
+  before sending them to your node.
+  You must use :meth:`~web3.eth.Eth.sendRawTransaction`
   when working with local keys, instead of
   :meth:`~web3.eth.Eth.sendTransaction` .
 
-Managed Private Key
-  A managed key is like a `Local Private Key`, but managed by your local node.
-  This allows you to use
-  :meth:`~web3.eth.Eth.sendTransaction`.
+Hosted Private Key
+  This is a common way to use accounts with local nodes.
   Each account returned by :attr:`w3.eth.accounts <web3.eth.Eth.accounts>`
-  has a key associated
-  with it, which is managed by your node.
+  has a hosted private key stored in your node.
+  This allows you to use :meth:`~web3.eth.Eth.sendTransaction`.
+
 
 .. WARNING::
-  It is unnacceptable for a remote
-  node to manage your private keys, because of the likelihood of theft.
-  Any reputable 3rd-party node (like Infura) will not offer a `Managed Private Key`.
+  It is unnacceptable for a hosted node to offer hosted private keys. It
+  gives other people complete control over your account. "Not your keys,
+  not your Ether" in the wise words of Andreas Antonopoulos.
 
 Some Common Uses for Local Private Keys
 -------------------------------------------
 
-Some common things you might want to do with Local Private Keys are:
+A very common reason to work with local private keys is to interact
+with a hosted node.
+
+Some common things you might want to do with a `Local Private Key` are:
 
 - `Sign a Transaction`_
 - `Sign a Contract Transaction`_

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -456,7 +456,7 @@ The following methods are available on the ``web3.eth`` namespace.
     following 2 values will be used:
 
     * The pending transaction's ``gasPrice`` * 1.1 - This is typically the minimum
-    ``gasPrice`` increase a node requires before it accepts a replacement transaction.
+      ``gasPrice`` increase a node requires before it accepts a replacement transaction.
     * The ``gasPrice`` as calculated by the current gas price strategy(See :ref:`Gas_Price`).
 
     .. code-block:: python

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -47,12 +47,27 @@ from web3.utils.transactions import (
 
 
 class Eth(Module):
-    account = Account()
+    _account = None
     defaultAccount = empty
     defaultBlock = "latest"
     defaultContractFactory = Contract
     iban = Iban
     gasPriceStrategy = None
+
+    @property
+    def account(self):
+        if self._account is not None:
+            return self._account
+        else:
+            raise AttributeError(
+                "This feature is disabled, pending security audit. "
+                "If you want to use unaudited code dealing with private keys, "
+                "despite the risks, you can run `w3.eth.enable_unaudited_features()` "
+                "and try again."
+            )
+
+    def enable_unaudited_features(self):
+        self._account = Account()
 
     def namereg(self):
         raise NotImplementedError()


### PR DESCRIPTION
### What was wrong?

Fixes #678 

### How was it fixed?

- raise `AttributeError` on `w3.eth.account` by default, saying "This feature is disabled, pending security audit. ..."
- Re-enable the feature with `w3.eth.enable_unaudited_features()`
- Add big docs warning: "**Do not use** this module in production. It is still in beta. A security audit is pending."
- The docs build had started to generate some warning cruft again. Cleaned it up.

#### Cute Animal Picture

![Cute animal picture](http://www.animalslook.com/media/beware-cute-but-deadly-ahead-10-pictures/beware-cute-but-deadly-ahead-10-pictures-8.jpg)
