### PR TITLE
solve contract() constructor error in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
 contract_address = tx_receipt['contractAddress']
 
 # Contract instance in concise mode
-contract_instance = w3.eth.contract(contract_interface['abi'], contract_address, ContractFactoryClass=ConciseContract)
+abi = contract_interface['abi']
+contract_instance = w3.eth.contract(address=contract_address, abi=abi,ContractFactoryClass=ConciseContract)
 
 # Getters + Setters for web3.eth.contract object
 print('Contract value: {}'.format(contract_instance.greet()))


### PR DESCRIPTION
… to 2 positional arguments but 3 were given"

### What was wrong?
we get this error because of constructor contain ("**kwargs")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-9-b355b57215f9> in <module>()
      1 # Contract instance in concise mode
----> 2 contract_instance = w3.eth.contract(contract_interface['abi'], contract_address, ContractFactoryClass=ConciseContract)
      3 # abi = contract_interface['abi']
      4 # contract_instance = w3.eth.contract(address=contract_address, abi=abi,ContractFactoryClass=ConciseContract)

TypeError: contract() takes from 1 to 2 positional arguments but 3 were given


### How was it fixed?

fixed by set parameters name 

abi = contract_interface['abi']
contract_instance = w3.eth.contract(address=contract_address, abi=abi,ContractFactoryClass=ConciseContract)

#### Cute Animal Picture

![Cute animal picture]()
