### PR TITLE
Add auto-complete support for contract methods. 

### DIFF
--- a/tests/core/contracts/test_implicit_contract.py
+++ b/tests/core/contracts/test_implicit_contract.py
@@ -58,13 +58,13 @@ def test_implicitcontract_call_default(math_contract, get_transaction_count):
     assert get_transaction_count("pending") == (blocknum, 0)
 
 
-def test_implicitcontract_transact_default(math_contract, get_transaction_count):
+def test_implicitcontract_transact_default(web3, math_contract, get_transaction_count):
     # Use to verify correct operation later on
     start_count = math_contract.counter()
     assert is_integer(start_count)  # Verify correct type
     # When a function is called that defaults to transact
     blocknum, starting_txns = get_transaction_count("pending")
-    math_contract.increment()
+    math_contract.increment(transact={})
     # Check that a transaction was made and not a call
     assert math_contract.counter() - start_count == 1
     # (Auto-mining is enabled, so query by block number)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -106,6 +106,13 @@ class ContractFunctions:
                         address=address,
                         function_identifier=func['name']))
 
+    def __iter__(self):
+        if not hasattr(self, '_functions') or not self._functions:
+            return
+
+        for func in self._functions:
+            yield func['name']
+
 
 class ContractEvents:
     """Class containing contract event objects
@@ -656,13 +663,21 @@ class ConciseContract:
         self._classic_contract = classic_contract
         self.address = self._classic_contract.address
 
+        for func_name in self._classic_contract.functions:
+            func = getattr(self._classic_contract.functions, func_name)
+
+            setattr(
+                self,
+                func_name,
+                ConciseMethod(
+                    func,
+                    self._classic_contract._return_data_normalizers
+                )
+            )
+
     @classmethod
     def factory(cls, *args, **kwargs):
         return compose(cls, Contract.factory(*args, **kwargs))
-
-    def __getattr__(self, attr):
-        contract_function = getattr(self._classic_contract.functions, attr)
-        return ConciseMethod(contract_function, self._classic_contract._return_data_normalizers)
 
     @staticmethod
     def _none_addr(datatype, data):


### PR DESCRIPTION
### What was wrong?
According to #654, auto-complete didn't work in environments like ipython as loading contracts does not attach `ConciseMethod` callables to the current contract instance.

### How was it fixed?

Introduced iterable functionality to `ContractFunctions` so that `ConciseFunction` could go through the list of function names, fetch the contract function and attach it to the current instance.


#### Cute Animal Picture
This was the hardest part about the PR.

![Cute animal picture](https://cdn.shopify.com/s/files/1/1576/6413/products/1pcs-Cute-Pet-Hat-Costume-Lion-Mane-Cat-Wig-Halloween-Dress-Up-With-Ears-Grey-Brown_5931bea2-c2eb-4560-9b71-e132279a259c_1024x1024.jpg?v=1509664910)

Fixes #654