### PR TITLE
Add eth-tester dependency for vanilla web3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "cytoolz>=0.9.0,<1.0.0",
         "eth-abi>=1.0.0,<2",
         "eth-account>=0.1.0-alpha.2,<1.0.0",
+        "eth-tester==0.1.0-beta.21",
         "eth-utils>=1.0.1,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "lru-dict>=1.1.6,<2.0.0",
@@ -29,7 +30,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     extras_require={
         'tester': [
-            "eth-tester[py-evm]==0.1.0-beta.21",
+            "eth-tester[py-evm]",
             "py-geth>=2.0.1,<3.0.0",
         ],
         'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],


### PR DESCRIPTION
### What was wrong?

web3py's `__init__.py` imports `EthereumTesterProvider`, which imports `eth_tester`, which isn't there in a vanilla install.

### How was it fixed?

Add `eth_tester` dependency to install (but not py-evm).

#### Cute Animal Picture

![Cute animal picture](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSyeZLQlr33vAGwmLsPEeWGGQUlxjv8pnrbDbMBoKKe5x0XrlRVGQ)
