### PR TITLE
Docs - missing parentheses in Filters async example

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -229,7 +229,7 @@ entries to a handler.
                     loop.run_until_complete(
                         asyncio.gather(
                             log_loop(block_filter, 2),
-                            log_loop(tx_filter, 2))
+                            log_loop(tx_filter, 2)))
                 finally:
                     loop.close()
 


### PR DESCRIPTION
### What was wrong?

Missing parentheses, example code wouldn't run

### How was it fixed?

Add parentheses🥇 

#### Cute Animal Picture

![Cute animal picture](https://i.redd.it/0s4n0q0j2do01.jpg)
