### PR TITLE
bugfix: automatically infer provider in ENS

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -17,6 +17,7 @@ from ens.exceptions import (
 from ens.utils import (
     address_in,
     address_to_reverse_domain,
+    default,
     dict_copy,
     dot_eth_name,
     dot_eth_namehash,
@@ -28,8 +29,6 @@ from ens.utils import (
 )
 
 ENS_MAINNET_ADDR = '0x314159265dD8dbb310642f98f50C066173C1259b'
-
-default = object()
 
 
 class ENS:
@@ -48,7 +47,7 @@ class ENS:
     is_valid_name = staticmethod(is_valid_name)
     reverse_domain = staticmethod(address_to_reverse_domain)
 
-    def __init__(self, providers=None, addr=None):
+    def __init__(self, providers=default, addr=None):
         '''
         :param providers: a list or single provider used to connect to Ethereum
         :type providers: instance of `web3.providers.base.BaseProvider`


### PR DESCRIPTION
### What was wrong?

`ENS()` is supposed to automatically infer the provider if it is not created with one. Instead it was setting the provider to `None` (after a change in how `Web3()` is initialized).

### How was it fixed?

Instead of initializing as `Web3(providers=None)` in ENS, when no providers are supplied, leave out the `providers` argument altogether, like `Web3()`.

This should probably be held till after the v4-stable, to go in a follow-up patch release, including some of the other pending PRs.

#### Cute Animal Picture

![Cute animal picture](https://i.imgur.com/5BOgfJp.jpg?1)
