### PR TITLE
update eth-tester to version that supports byzantium

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     extras_require={
         'tester': [
-            "eth-tester[py-evm]==0.1.0-beta.22",
+            "eth-tester[py-evm]==0.1.0-beta.23",
             "py-geth>=2.0.1,<3.0.0",
         ],
         'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],


### PR DESCRIPTION
link #729 

### What was wrong?

The version of `eth-tester` specified by this project didn't support byzantium fork rules.

### How was it fixed?

Bump version to new release which does.

#### Cute Animal Picture

![flying-cat](https://user-images.githubusercontent.com/824194/38276980-119f4f26-3754-11e8-9887-55cea9db5384.jpg)
