### PR TITLE
Update ImplicitContract

### DIFF
--- a/web3/contract.py
+++ b/web3/contract.py
@@ -766,6 +766,30 @@ class ContractConstructor:
             raise ValueError("Cannot set {} in transaction".format(', '.join(keys_found)))
 
 
+class ConciseMethod:
+    ALLOWED_MODIFIERS = set(['call', 'estimateGas', 'transact', 'buildTransaction'])
+
+    def __init__(self, function, normalizers=None):
+        self._function = function
+        self._function._return_data_normalizers = normalizers
+
+    def __call__(self, *args, **kwargs):
+        return self.__prepared_function(*args, **kwargs)
+
+    def __prepared_function(self, *args, **kwargs):
+        if not kwargs:
+            modifier, modifier_dict = 'call', {}
+        elif len(kwargs) == 1:
+            modifier, modifier_dict = kwargs.popitem()
+            if modifier not in self.ALLOWED_MODIFIERS:
+                raise TypeError(
+                    "The only allowed keyword arguments are: %s" % self.ALLOWED_MODIFIERS)
+        else:
+            raise TypeError("Use up to one keyword argument, one of: %s" % self.ALLOWED_MODIFIERS)
+
+        return getattr(self._function(*args), modifier)(modifier_dict)
+
+
 class ConciseContract:
     '''
     An alternative Contract Factory which invokes all methods as `call()`,
@@ -824,28 +848,20 @@ CONCISE_NORMALIZERS = (
 )
 
 
-class ConciseMethod:
-    ALLOWED_MODIFIERS = set(['call', 'estimateGas', 'transact', 'buildTransaction'])
+class ImplicitMethod(ConciseMethod):
+    def __call_by_default(self, args):
+        function_abi = find_matching_fn_abi(self._function.contract_abi,
+                                            fn_identifier=self._function.function_identifier,
+                                            args=args)
 
-    def __init__(self, function, normalizers=None):
-        self._function = function
-        self._function._return_data_normalizers = normalizers
+        return function_abi['constant'] if 'constant' in function_abi.keys() else False
 
     def __call__(self, *args, **kwargs):
-        return self.__prepared_function(*args, **kwargs)
-
-    def __prepared_function(self, *args, **kwargs):
-        if not kwargs:
-            modifier, modifier_dict = 'call', {}
-        elif len(kwargs) == 1:
-            modifier, modifier_dict = kwargs.popitem()
-            if modifier not in self.ALLOWED_MODIFIERS:
-                raise TypeError(
-                    "The only allowed keyword arguments are: %s" % self.ALLOWED_MODIFIERS)
+        # Modifier is not provided and method is not constant/pure do a transaction instead
+        if not kwargs and not self.__call_by_default(args):
+            return super().__call__(*args, transact={})
         else:
-            raise TypeError("Use up to one keyword argument, one of: %s" % self.ALLOWED_MODIFIERS)
-
-        return getattr(self._function(*args), modifier)(modifier_dict)
+            return super().__call__(*args, **kwargs)
 
 
 class ImplicitContract(ConciseContract):
@@ -865,22 +881,6 @@ class ImplicitContract(ConciseContract):
     > contract.functions.withdraw(amount).transact({})
     '''
     method_class = ImplicitMethod
-
-
-class ImplicitMethod(ConciseMethod):
-    def __call_by_default(self, args):
-        function_abi = find_matching_fn_abi(self._function.contract_abi,
-                                            fn_identifier=self._function.function_identifier,
-                                            args=args)
-
-        return function_abi['constant'] if 'constant' in function_abi.keys() else False
-
-    def __call__(self, *args, **kwargs):
-        # Modifier is not provided and method is not constant/pure do a transaction instead
-        if not kwargs and not self.__call_by_default(args):
-            return super().__call__(*args, transact={})
-        else:
-            return super().__call__(*args, **kwargs)
 
 
 class NonExistentFallbackFunction:

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -879,7 +879,7 @@ class ImplicitContract(ConciseContract):
     > contract.functions.withdraw(amount).transact({})
     '''
     def __init__(self, classic_contract, method_class=ImplicitMethod):
-        super().__init__(self, classic_contract, method_class=method_class)
+        super().__init__(classic_contract, method_class=method_class)
 
 
 class NonExistentFallbackFunction:

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -767,7 +767,7 @@ class ContractConstructor:
 
 
 class ConciseMethod:
-    ALLOWED_MODIFIERS = set(['call', 'estimateGas', 'transact', 'buildTransaction'])
+    ALLOWED_MODIFIERS = {'call', 'estimateGas', 'transact', 'buildTransaction'}
 
     def __init__(self, function, normalizers=None):
         self._function = function

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -779,6 +779,8 @@ class ConciseContract:
 
     > contract.functions.withdraw(amount).transact({'from': eth.accounts[1], 'gas': 100000, ...})
     '''
+    method_class = ConciseMethod
+
     def __init__(self, classic_contract):
 
         classic_contract._return_data_normalizers += CONCISE_NORMALIZERS
@@ -798,7 +800,7 @@ class ConciseContract:
                     self._classic_contract.functions,
                     fn_name)
 
-                _concise_method = ConciseMethod(
+                _concise_method = self.method_class(
                     _classic_method,
                     self._classic_contract._return_data_normalizers
                 )
@@ -862,9 +864,7 @@ class ImplicitContract(ConciseContract):
 
     > contract.functions.withdraw(amount).transact({})
     '''
-    def __getattr__(self, attr):
-        contract_function = getattr(self._classic_contract.functions, attr)
-        return ImplicitMethod(contract_function, self._classic_contract._return_data_normalizers)
+    method_class = ImplicitMethod
 
 
 class ImplicitMethod(ConciseMethod):

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -803,9 +803,7 @@ class ConciseContract:
 
     > contract.functions.withdraw(amount).transact({'from': eth.accounts[1], 'gas': 100000, ...})
     '''
-    method_class = ConciseMethod
-
-    def __init__(self, classic_contract):
+    def __init__(self, classic_contract, method_class=ConciseMethod):
 
         classic_contract._return_data_normalizers += CONCISE_NORMALIZERS
         self._classic_contract = classic_contract
@@ -824,7 +822,7 @@ class ConciseContract:
                     self._classic_contract.functions,
                     fn_name)
 
-                _concise_method = self.method_class(
+                _concise_method = method_class(
                     _classic_method,
                     self._classic_contract._return_data_normalizers
                 )
@@ -880,7 +878,8 @@ class ImplicitContract(ConciseContract):
 
     > contract.functions.withdraw(amount).transact({})
     '''
-    method_class = ImplicitMethod
+    def __init__(self, classic_contract, method_class=ImplicitMethod):
+        super().__init__(self, classic_contract, method_class=method_class)
 
 
 class NonExistentFallbackFunction:


### PR DESCRIPTION
### What was wrong?
ConciseContract changed how it was operating significantly, ImplicitContract was inheriting from it.
I use ImplicitContract for a testing tool so that users don't execute a state-changing function as a call by accident.

### How was it fixed?
Updated ConciseContract to use a class variable when it creates a Method handler object
Updated ImplicitContract so it just changes this class variable, removing all custom code.
NOTE: Had to switch the order of the *Method and *Contract classes for that to work.

#### Cute Animal Picture

![Who, me?](http://images6.fanpop.com/image/polls/1118000/1118643_1347881481360_full.jpg)
