### PR TITLE
Update filters.rst

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -17,7 +17,7 @@ The :meth:`web3.eth.Eth.filter` method can be used to setup filters for:
 
     .. code-block:: python
 
-        event_filter = mycontract.events.myEvent.createEvent({'filter': {'arg1':10}})
+        event_filter = mycontract.events.myEvent.createEvent(fromBlock=latest, {'filter': {'arg1':10}})
 
     Or built manually by supplying `valid filter params <http://https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter/>`_:
 

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -17,7 +17,7 @@ The :meth:`web3.eth.Eth.filter` method can be used to setup filters for:
 
     .. code-block:: python
 
-        event_filter = mycontract.events.myEvent.createEvent(fromBlock=latest, {'filter': {'arg1':10}})
+        event_filter = mycontract.events.myEvent.createEvent(fromBlock='latest', {'filter': {'arg1':10}})
 
     Or built manually by supplying `valid filter params <http://https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter/>`_:
 


### PR DESCRIPTION
### What was wrong?
The contracts.rst states: 
``fromBlock`` is a mandatory field.


### How was it fixed?
Added fromBlock example to filters.rst 