### PR TITLE
Replace mutable argument defaults in createFilter()

### DIFF
--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1167,9 +1167,6 @@ class ContractEvent:
         if argument_filters is None:
             argument_filters = dict()
 
-        if topics is None:
-            topics = dict()
-
         if not address:
             address = self.address
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1152,17 +1152,23 @@ class ContractEvent:
     @combomethod
     def createFilter(
             self, *,  # PEP 3102
-            argument_filters=dict(),
+            argument_filters=None,
             fromBlock=None,
             toBlock="latest",
             address=None,
-            topics=list()):
+            topics=None):
         """
         Create filter object that tracks logs emitted by this contract event.
         :param filter_params: other parameters to limit the events
         """
         if fromBlock is None:
             raise TypeError("Missing mandatory keyword argument to createFilter: fromBlock")
+
+        if argument_filters is None:
+            argument_filters = dict()
+
+        if topics is None:
+            topics = dict()
 
         if not address:
             address = self.address


### PR DESCRIPTION
### What was wrong?
createFilter() had arguments with mutable default values.


#### Cute Animal Picture

![Cute animal picture](https://pbs.twimg.com/media/CXLU2QPUEAAKGBc.jpg)
