### PR TITLE
Make createFilter test more robust

### DIFF
--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from eth_utils import (
+    apply_key_map,
     encode_hex,
     event_signature_to_log_topic,
 )
@@ -113,17 +114,10 @@ def return_filter_by_api(
         return contract.eventFilter(*args)
     elif api_style == 'v4':
         event_name = args[0]
-        argument_filters = args[1].get('filter', {})
-        topics = args[1].get('topics')
-        fromBlock = args[1].get('fromBlock', 'latest')
-        toBlock = args[1].get('toBlock')
-        address = args[1].get('address')
-        return getattr(contract.events, event_name).createFilter(
-            argument_filters=argument_filters,
-            topics=topics,
-            fromBlock=fromBlock,
-            toBlock=toBlock,
-            address=address)
+        kwargs = apply_key_map({'filter': 'argument_filters'}, args[1])
+        if 'fromBlock' not in kwargs:
+            kwargs['fromBlock'] = 'latest'
+        return getattr(contract.events, event_name).createFilter(**kwargs)
     else:
         raise ValueError("api_style must be 'v3 or v4'")
 


### PR DESCRIPTION
### What was wrong?
Previously #730 was not being caught, because the
topic parameter was being overrided with `None`

### How was it fixed?
Pass the test parameters through with as little manipulation as possible to the arguments fed to the dual api createFilter/eventFilter fixture.


#### Cute Animal Picture

![Cute animal picture](https://thumbs.dreamstime.com/b/monkey-eating-jackfruit-22845256.jpg)
