### PR TITLE
pin eth-account version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "cytoolz>=0.9.0,<1.0.0",
         "eth-abi>=1.0.0,<2",
-        "eth-account>=0.1.0-alpha.2,<1.0.0",
+        "eth-account==0.1.0-alpha.2",
         "eth-utils>=1.0.1,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "lru-dict>=1.1.6,<2.0.0",


### PR DESCRIPTION
### What was wrong?

eth-account is not API-stable, and a recent upgrade caused compatibility problems in web3.py tests.

### How was it fixed?

Pin the eth-account version explicitly, until it is API-stable.

#### Cute Animal Picture

![Cute animal picture](https://i.ytimg.com/vi/IfnNh61s5fo/maxresdefault.jpg)
