### PR TITLE
eth-account v0.2.0a0 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "cytoolz>=0.9.0,<1.0.0",
         "eth-abi>=1.0.0,<2",
-        "eth-account==0.1.0-alpha.2",
+        "eth-account==0.2.0-alpha.0",
         "eth-utils>=1.0.1,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "lru-dict>=1.1.6,<2.0.0",


### PR DESCRIPTION
### What was wrong?

Didn't support the latest eth-account version.

### How was it fixed?

Change all tests and docs to use the latest eth-account v0.2.0a0 API.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/51/69/61/516961ce0e30fdbc7f941ab3ecdf436f.jpg)