### PR TITLE
Update contract deployment logic in tests to use contract.constructor

### DIFF
--- a/tests/core/contracts/conftest.py
+++ b/tests/core/contracts/conftest.py
@@ -296,7 +296,7 @@ def emitter(web3_empty, Emitter, wait_for_transaction, wait_for_block):
     web3 = web3_empty
 
     wait_for_block(web3)
-    deploy_txn_hash = Emitter.deploy({'from': web3.eth.coinbase, 'gas': 1000000})
+    deploy_txn_hash = Emitter.constructor().transact({'from': web3.eth.coinbase, 'gas': 1000000})
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = deploy_receipt['contractAddress']
 

--- a/tests/core/contracts/test_concise_contract.py
+++ b/tests/core/contracts/test_concise_contract.py
@@ -15,8 +15,9 @@ from web3.contract import (
 
 
 def deploy(web3, Contract, args=None):
-    deploy_txn = Contract.deploy(args=args)
-    deploy_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    args = args or []
+    deploy_txn = Contract.constructor(*args).transact()
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     contract = Contract(address=deploy_receipt['contractAddress'])
     assert len(web3.eth.getCode(contract.address)) > 0
@@ -30,10 +31,10 @@ def EMPTY_ADDR():
 
 @pytest.fixture()
 def zero_address_contract(web3, WithConstructorAddressArgumentsContract, EMPTY_ADDR):
-    deploy_txn = WithConstructorAddressArgumentsContract.deploy(args=[
+    deploy_txn = WithConstructorAddressArgumentsContract.constructor(
         EMPTY_ADDR,
-    ])
-    deploy_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    ).transact()
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     _address_contract = WithConstructorAddressArgumentsContract(
         address=deploy_receipt['contractAddress'],

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -12,8 +12,8 @@ pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
 
 @pytest.fixture()
 def math_contract(web3, MathContract):
-    deploy_txn = MathContract.deploy()
-    deploy_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    deploy_txn = MathContract.constructor().transact()
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     _math_contract = MathContract(address=deploy_receipt['contractAddress'])
     return _math_contract
@@ -21,8 +21,8 @@ def math_contract(web3, MathContract):
 
 @pytest.fixture()
 def fallback_function_contract(web3, FallballFunctionContract):
-    deploy_txn = FallballFunctionContract.deploy()
-    deploy_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    deploy_txn = FallballFunctionContract.constructor().transact()
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     _fallback_contract = FallballFunctionContract(address=deploy_receipt['contractAddress'])
     return _fallback_contract

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -18,8 +18,9 @@ pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
 
 
 def deploy(web3, Contract, args=None):
-    deploy_txn = Contract.deploy(args=args)
-    deploy_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    args = args or []
+    deploy_txn = Contract.constructor(*args).transact()
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     contract = Contract(address=deploy_receipt['contractAddress'])
     assert len(web3.eth.getCode(contract.address)) > 0
@@ -90,8 +91,8 @@ def undeployed_math_contract(web3, MathContract):
 
 @pytest.fixture()
 def mismatched_math_contract(web3, StringContract, MathContract):
-    deploy_txn = StringContract.deploy(args=["Caqalai"])
-    deploy_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    deploy_txn = StringContract.constructor("Caqalai").transact()
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
 
     _mismatched_math_contract = MathContract(address=deploy_receipt['contractAddress'])
@@ -105,9 +106,9 @@ def fallback_function_contract(web3, FallballFunctionContract):
 
 def test_invalid_address_in_deploy_arg(web3, WithConstructorAddressArgumentsContract):
     with pytest.raises(InvalidAddress):
-        WithConstructorAddressArgumentsContract.deploy(args=[
+        WithConstructorAddressArgumentsContract.constructor(
             "0xd3cda913deb6f67967b99d67acdfa1712c293601",
-        ])
+        ).transact()
 
 
 def test_call_with_no_arguments(math_contract, call):

--- a/tests/core/contracts/test_contract_constructor.py
+++ b/tests/core/contracts/test_contract_constructor.py
@@ -66,7 +66,7 @@ def test_contract_constructor_gas_estimate_with_constructor_with_address_argumen
 def test_contract_constructor_transact_no_constructor(web3, MathContract, MATH_RUNTIME):
     deploy_txn = MathContract.constructor().transact()
 
-    txn_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -80,7 +80,7 @@ def test_contract_constructor_transact_with_constructor_without_arguments(
         web3, SimpleConstructorContract, SIMPLE_CONSTRUCTOR_RUNTIME):
     deploy_txn = SimpleConstructorContract.constructor().transact()
 
-    txn_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -110,7 +110,7 @@ def test_contract_constructor_transact_with_constructor_with_arguments(
     deploy_txn = WithConstructorArgumentsContract.constructor(
         *constructor_args, **constructor_kwargs).transact()
 
-    txn_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -127,7 +127,7 @@ def test_contract_constructor_transact_with_constructor_with_arguments(
 def test_contract_constructor_transact_with_constructor_with_address_arguments(
         web3, WithConstructorAddressArgumentsContract, WITH_CONSTRUCTOR_ADDRESS_RUNTIME):
     deploy_txn = WithConstructorAddressArgumentsContract.constructor(TEST_ADDRESS).transact()
-    txn_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert txn_receipt is not None
     assert txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']

--- a/tests/core/contracts/test_contract_deployment.py
+++ b/tests/core/contracts/test_contract_deployment.py
@@ -11,9 +11,9 @@ pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
 
 def test_contract_deployment_no_constructor(web3, MathContract,
                                             MATH_RUNTIME):
-    deploy_txn = MathContract.deploy()
+    deploy_txn = MathContract.constructor().transact()
 
-    txn_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -26,9 +26,9 @@ def test_contract_deployment_no_constructor(web3, MathContract,
 def test_contract_deployment_with_constructor_without_args(web3,
                                                            SimpleConstructorContract,
                                                            SIMPLE_CONSTRUCTOR_RUNTIME):
-    deploy_txn = SimpleConstructorContract.deploy()
+    deploy_txn = SimpleConstructorContract.constructor().transact()
 
-    txn_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -41,9 +41,9 @@ def test_contract_deployment_with_constructor_without_args(web3,
 def test_contract_deployment_with_constructor_with_arguments(web3,
                                                              WithConstructorArgumentsContract,
                                                              WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME):
-    deploy_txn = WithConstructorArgumentsContract.deploy(args=[1234, 'abcd'])
+    deploy_txn = WithConstructorArgumentsContract.constructor(1234, 'abcd').transact()
 
-    txn_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -56,11 +56,11 @@ def test_contract_deployment_with_constructor_with_arguments(web3,
 def test_contract_deployment_with_constructor_with_address_argument(web3,
                                                                     WithConstructorAddressArgumentsContract,  # noqa: E501
                                                                     WITH_CONSTRUCTOR_ADDRESS_RUNTIME):  # noqa: E501
-    deploy_txn = WithConstructorAddressArgumentsContract.deploy(
-        args=["0x16D9983245De15E7A9A73bC586E01FF6E08dE737"],
-    )
+    deploy_txn = WithConstructorAddressArgumentsContract.constructor(
+        "0x16D9983245De15E7A9A73bC586E01FF6E08dE737",
+    ).transact()
 
-    txn_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']

--- a/tests/core/contracts/test_contract_estimateGas.py
+++ b/tests/core/contracts/test_contract_estimateGas.py
@@ -17,8 +17,8 @@ def math_contract(web3,
         bytecode=MATH_CODE,
         bytecode_runtime=MATH_RUNTIME,
     )
-    deploy_txn = MathContract.deploy({'from': web3.eth.coinbase})
-    deploy_receipt = wait_for_transaction(web3, deploy_txn)
+    deploy_txn = MathContract.constructor().transact({'from': web3.eth.coinbase})
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
 
     assert deploy_receipt is not None
     contract_address = deploy_receipt['contractAddress']
@@ -39,8 +39,8 @@ def fallback_function_contract(web3,
         bytecode=FALLBACK_FUNCTION_CODE,
         bytecode_runtime=FALLBACK_FUNCTION_RUNTIME
     )
-    deploy_txn = fallback_contract.deploy({'from': web3.eth.coinbase})
-    deploy_receipt = wait_for_transaction(web3, deploy_txn)
+    deploy_txn = fallback_contract.constructor().transact({'from': web3.eth.coinbase})
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
 
     assert deploy_receipt is not None
     contract_address = deploy_receipt['contractAddress']

--- a/tests/core/contracts/test_contract_init.py
+++ b/tests/core/contracts/test_contract_init.py
@@ -13,8 +13,8 @@ from web3.utils.ens import (
 @pytest.fixture
 def math_addr(MathContract):
     web3 = MathContract.web3
-    deploy_txn = MathContract.deploy({'from': web3.eth.coinbase})
-    deploy_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+    deploy_txn = MathContract.constructor().transact({'from': web3.eth.coinbase})
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     return deploy_receipt['contractAddress']
 

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -20,8 +20,8 @@ def Emitter(web3, EMITTER):
 @pytest.fixture()
 def emitter(web3, Emitter, wait_for_transaction, wait_for_block):
     wait_for_block(web3)
-    deploy_txn_hash = Emitter.deploy({'from': web3.eth.coinbase, 'gas': 1000000})
-    deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
+    deploy_txn_hash = Emitter.constructor().transact({'from': web3.eth.coinbase, 'gas': 1000000})
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn_hash)
     contract_address = deploy_receipt['contractAddress']
 
     bytecode = web3.eth.getCode(contract_address)

--- a/tests/core/contracts/test_extracting_event_data_old.py
+++ b/tests/core/contracts/test_extracting_event_data_old.py
@@ -20,8 +20,8 @@ def Emitter(web3, EMITTER):
 @pytest.fixture()
 def emitter(web3, Emitter, wait_for_transaction, wait_for_block):
     wait_for_block(web3)
-    deploy_txn_hash = Emitter.deploy({'from': web3.eth.coinbase, 'gas': 1000000})
-    deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
+    deploy_txn_hash = Emitter.constructor().transact({'from': web3.eth.coinbase, 'gas': 1000000})
+    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn_hash)
     contract_address = deploy_receipt['contractAddress']
 
     bytecode = web3.eth.getCode(contract_address)

--- a/tests/core/contracts/test_implicit_contract.py
+++ b/tests/core/contracts/test_implicit_contract.py
@@ -18,8 +18,8 @@ def math_contract(web3, MATH_ABI, MATH_CODE, MATH_RUNTIME):
         bytecode=MATH_CODE,
         bytecode_runtime=MATH_RUNTIME,
     )
-    tx_hash = MathContract.deploy()
-    tx_receipt = web3.eth.getTransactionReceipt(tx_hash)
+    tx_hash = MathContract.constructor().transact()
+    tx_receipt = web3.eth.waitForTransactionReceipt(tx_hash)
     math_address = tx_receipt['contractAddress']
     # Return interactive contract instance at deployed address
     # TODO Does parent class not implement 'deploy()' for a reason?

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -55,7 +55,7 @@ def Emitter(web3, EMITTER):
 @pytest.fixture()
 def emitter(web3, Emitter, wait_for_transaction, wait_for_block):
     wait_for_block(web3)
-    deploy_txn_hash = Emitter.deploy({'from': web3.eth.coinbase, 'gas': 1000000})
+    deploy_txn_hash = Emitter.constructor().transact({'from': web3.eth.coinbase, 'gas': 1000000})
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = deploy_receipt['contractAddress']
 

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -42,9 +42,10 @@ def bytes32(val):
 
 
 def deploy(w3, Factory, from_address, args=None):
+    args = args or []
     factory = Factory(w3)
-    deploy_txn = factory.deploy(transaction={'from': from_address}, args=args)
-    deploy_receipt = w3.eth.getTransactionReceipt(deploy_txn)
+    deploy_txn = factory.constructor(*args).transact({'from': from_address})
+    deploy_receipt = w3.eth.waitForTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     return factory(address=deploy_receipt['contractAddress'])
 

--- a/tests/generate_go_ethereum_fixture.py
+++ b/tests/generate_go_ethereum_fixture.py
@@ -291,7 +291,7 @@ def generate_go_ethereum_fixture(destination_dir):
 
 
 def verify_chain_state(web3, chain_data):
-    receipt = web3.eth.getTransactionReceipt(chain_data['mined_txn_hash'])
+    receipt = web3.eth.waitForTransactionReceipt(chain_data['mined_txn_hash'])
     latest = web3.eth.getBlock('latest')
     assert receipt.blockNumber <= latest.number
 
@@ -300,7 +300,7 @@ def mine_transaction_hash(web3, txn_hash):
     start_time = time.time()
     web3.miner.start(1)
     while time.time() < start_time + 60:
-        receipt = web3.eth.getTransactionReceipt(txn_hash)
+        receipt = web3.eth.waitForTransactionReceipt(txn_hash)
         if receipt is not None:
             web3.miner.stop()
             return receipt
@@ -328,7 +328,7 @@ def mine_block(web3):
 
 def deploy_contract(web3, name, factory):
     web3.personal.unlockAccount(web3.eth.coinbase, KEYFILE_PW)
-    deploy_txn_hash = factory.deploy({'from': web3.eth.coinbase})
+    deploy_txn_hash = factory.constructor().transact({'from': web3.eth.coinbase})
     print('{0}_CONTRACT_DEPLOY_HASH: '.format(name.upper()), deploy_txn_hash)
     deploy_receipt = mine_transaction_hash(web3, deploy_txn_hash)
     print('{0}_CONTRACT_DEPLOY_TRANSACTION_MINED'.format(name.upper()))

--- a/tests/integration/generate_fixtures/common.py
+++ b/tests/integration/generate_fixtures/common.py
@@ -230,7 +230,7 @@ def mine_transaction_hash(web3, txn_hash):
 
 def deploy_contract(web3, name, factory):
     web3.personal.unlockAccount(web3.eth.coinbase, KEYFILE_PW)
-    deploy_txn_hash = factory.deploy({'from': web3.eth.coinbase})
+    deploy_txn_hash = factory.constructor().transact({'from': web3.eth.coinbase})
     print('{0}_CONTRACT_DEPLOY_HASH: '.format(name.upper()), deploy_txn_hash)
     deploy_receipt = mine_transaction_hash(web3, deploy_txn_hash)
     print('{0}_CONTRACT_DEPLOY_TRANSACTION_MINED'.format(name.upper()))

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -50,13 +50,13 @@ def web3(eth_tester_provider):
 #
 @pytest.fixture(scope="module")
 def math_contract_deploy_txn_hash(web3, math_contract_factory):
-    deploy_txn_hash = math_contract_factory.deploy({'from': web3.eth.coinbase})
+    deploy_txn_hash = math_contract_factory.constructor().transact({'from': web3.eth.coinbase})
     return deploy_txn_hash
 
 
 @pytest.fixture(scope="module")
 def math_contract(web3, math_contract_factory, math_contract_deploy_txn_hash):
-    deploy_receipt = web3.eth.getTransactionReceipt(math_contract_deploy_txn_hash)
+    deploy_receipt = web3.eth.waitForTransactionReceipt(math_contract_deploy_txn_hash)
     assert is_dict(deploy_receipt)
     contract_address = deploy_receipt['contractAddress']
     assert is_checksum_address(contract_address)
@@ -68,13 +68,13 @@ def math_contract(web3, math_contract_factory, math_contract_deploy_txn_hash):
 #
 @pytest.fixture(scope="module")
 def emitter_contract_deploy_txn_hash(web3, emitter_contract_factory):
-    deploy_txn_hash = emitter_contract_factory.deploy({'from': web3.eth.coinbase})
+    deploy_txn_hash = emitter_contract_factory.constructor().transact({'from': web3.eth.coinbase})
     return deploy_txn_hash
 
 
 @pytest.fixture(scope="module")
 def emitter_contract(web3, emitter_contract_factory, emitter_contract_deploy_txn_hash):
-    deploy_receipt = web3.eth.getTransactionReceipt(emitter_contract_deploy_txn_hash)
+    deploy_receipt = web3.eth.waitForTransactionReceipt(emitter_contract_deploy_txn_hash)
     assert is_dict(deploy_receipt)
     contract_address = deploy_receipt['contractAddress']
     assert is_checksum_address(contract_address)


### PR DESCRIPTION
### What was wrong?
Tests were throwing warnings since `contract.deploy` has been deprecated.  Also, it looked like in many places `web3.eth.getTransactionReceipt` was being used where `web3.eth.waitForTransactionReceipt` is more appropriate. I made replacements here as well. I also think that it might be time to remove the `@pytest.fixture(params=['func_first', 'func_last'])` decorators, since "func comes last" has been deprecated. Should we be maintaining tests for deprecated code(?). Removal of 'func_last' will get rid of most (all?) warnings being thrown at the moment.


### How was it fixed?
`contract.deploy` has been replaced in tests with `contract.constructor`. `web3.eth.getTransactionReceipt` has been replaced with `web3.eth.waitForTransactionReceipt`.

