### PR TITLE
Implement item lookup for ContractFunctions and ContractEvents

### DIFF
--- a/tests/core/contracts/conftest.py
+++ b/tests/core/contracts/conftest.py
@@ -498,7 +498,7 @@ def invoke_contract(api_style=None,
         raise ValueError("allowable_invoke_method must be one of: %s" % allowable_call_desig)
 
     if api_style == 'func_first':
-        function = getattr(contract.functions, contract_function)
+        function = contract.functions[contract_function]
         result = getattr(function(*func_args, **func_kwargs), api_call_desig)(tx_params)
     elif api_style == 'func_last':
         api_call_cls = getattr(contract, api_call_desig)

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -75,7 +75,7 @@ def test_event_data_extraction(web3,
                                event_name,
                                call_args,
                                expected_args):
-    emitter_fn = getattr(emitter.functions, contract_fn)
+    emitter_fn = emitter.functions[contract_fn]
     event_id = getattr(emitter_event_ids, event_name)
     txn_hash = emitter_fn(event_id, *call_args).transact()
     txn_receipt = wait_for_transaction(web3, txn_hash)
@@ -186,12 +186,12 @@ def test_event_rich_log(
         call_args,
         expected_args):
 
-    emitter_fn = getattr(emitter.functions, contract_fn)
+    emitter_fn = emitter.functions[contract_fn]
     event_id = getattr(emitter_event_ids, event_name)
     txn_hash = emitter_fn(event_id, *call_args).transact()
     txn_receipt = wait_for_transaction(web3, txn_hash)
 
-    event_instance = getattr(emitter.events, event_name)()
+    event_instance = emitter.events[event_name]()
 
     rich_logs = event_instance.processReceipt(txn_receipt)
 
@@ -209,6 +209,6 @@ def test_event_rich_log(
     assert is_same_address(rich_log['address'], emitter.address)
     assert rich_log['event'] == event_name
 
-    quiet_event = getattr(emitter.events, 'LogBytes')
+    quiet_event = emitter.events['LogBytes']
     empty_rich_log = quiet_event().processReceipt(txn_receipt)
     assert empty_rich_log == tuple()

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -117,7 +117,7 @@ def return_filter_by_api(
         kwargs = apply_key_map({'filter': 'argument_filters'}, args[1])
         if 'fromBlock' not in kwargs:
             kwargs['fromBlock'] = 'latest'
-        return getattr(contract.events, event_name).createFilter(**kwargs)
+        return contract.events[event_name].createFilter(**kwargs)
     else:
         raise ValueError("api_style must be 'v3 or v4'")
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -117,6 +117,9 @@ class ContractFunctions:
         for func in self._functions:
             yield func['name']
 
+    def __getitem__(self, function_name):
+        return getattr(self, function_name)
+
 
 class ContractEvents:
     """Class containing contract event objects

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -143,6 +143,9 @@ class ContractEvents:
                         address=address,
                         event_name=event['name']))
 
+    def __getitem__(self, event_name):
+        return getattr(self, event_name)
+
 
 class Contract:
     """Base class for Contract proxy classes.


### PR DESCRIPTION
### What was wrong?

See issue #705

### How was it fixed?

Implemented `__getitem__(...)` for `ContractFunctions` and `ContractEvents` to allow a simple function/event lookup, i.e.:

```
contract_func = contract.functions[function_name]
contract_event = contract.events[event_name]
```

I would be happy to mention it in the docs, but I couldn't find a relevant section.

#### Cute Animal Picture

![Cute animal picture]()
