### PR TITLE
Remove deprecation warnings in unit tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 import time
+import warnings
 
 from web3.providers.eth_tester import (
     EthereumTesterProvider,
@@ -111,3 +112,8 @@ def web3():
     w3.eth.enable_unaudited_features()
 
     return w3
+
+
+@pytest.fixture(autouse=True)
+def print_warnings():
+    warnings.simplefilter('always')

--- a/tests/core/contracts/conftest.py
+++ b/tests/core/contracts/conftest.py
@@ -502,7 +502,8 @@ def invoke_contract(api_style=None,
         result = getattr(function(*func_args, **func_kwargs), api_call_desig)(tx_params)
     elif api_style == 'func_last':
         api_call_cls = getattr(contract, api_call_desig)
-        result = getattr(api_call_cls(tx_params), contract_function)(*func_args, **func_kwargs)
+        with pytest.deprecated_call():
+            result = getattr(api_call_cls(tx_params), contract_function)(*func_args, **func_kwargs)
     else:
         raise ValueError("api_style must be 'func_first or func_last'")
 

--- a/tests/core/contracts/test_extracting_event_data_old.py
+++ b/tests/core/contracts/test_extracting_event_data_old.py
@@ -75,9 +75,9 @@ def test_event_data_extraction(web3,
                                event_name,
                                call_args,
                                expected_args):
-    transact_fn = getattr(emitter.transact(), contract_fn)
+    function = getattr(emitter.functions, contract_fn)
     event_id = getattr(emitter_event_ids, event_name)
-    txn_hash = transact_fn(event_id, *call_args)
+    txn_hash = function(event_id, *call_args).transact()
     txn_receipt = wait_for_transaction(web3, txn_hash)
 
     assert len(txn_receipt['logs']) == 1
@@ -110,7 +110,7 @@ def test_dynamic_length_argument_extraction(web3,
                                             emitter_event_ids):
     string_0 = "this-is-the-first-string-which-exceeds-32-bytes-in-length"
     string_1 = "this-is-the-second-string-which-exceeds-32-bytes-in-length"
-    txn_hash = emitter.transact().logDynamicArgs(string_0, string_1)
+    txn_hash = emitter.functions.logDynamicArgs(string_0, string_1).transact()
     txn_receipt = wait_for_transaction(web3, txn_hash)
 
     assert len(txn_receipt['logs']) == 1

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -111,7 +111,8 @@ def return_filter_by_api(
         contract=None,
         args=[]):
     if api_style == 'v3':
-        return contract.eventFilter(*args)
+        with pytest.deprecated_call():
+            return contract.eventFilter(*args)
     elif api_style == 'v4':
         event_name = args[0]
         kwargs = apply_key_map({'filter': 'argument_filters'}, args[1])

--- a/tests/core/filtering/test_contract_past_event_filtering.py
+++ b/tests/core/filtering/test_contract_past_event_filtering.py
@@ -14,9 +14,9 @@ def test_on_filter_using_get_all_entries_interface(
     call_as_instance,
 ):
     if call_as_instance:
-        event_filter = emitter.eventFilter('LogNoArguments', {})
+        event_filter = emitter.events.LogNoArguments.createFilter(fromBlock='latest')
     else:
-        event_filter = Emitter.eventFilter('LogNoArguments', {})
+        event_filter = Emitter.events.LogNoArguments.createFilter(fromBlock='latest')
 
     txn_hash = emitter.functions.logNoArgs(emitter_event_ids.LogNoArguments).transact()
     wait_for_transaction(web3, txn_hash)
@@ -50,7 +50,7 @@ def test_get_all_entries_returned_block_data(
     else:
         contract = Emitter
 
-    events = contract.eventFilter('LogNoArguments', {'fromBlock': txn_receipt['blockNumber'] - 1})
+    events = contract.events.LogNoArguments.createFilter(fromBlock=txn_receipt['blockNumber'])
 
     log_entries = events.get_all_entries()
 

--- a/tests/generate_go_ethereum_fixture.py
+++ b/tests/generate_go_ethereum_fixture.py
@@ -363,9 +363,11 @@ def setup_chain_state(web3):
     emitter_deploy_receipt = deploy_contract(web3, 'emitter', emitter_contract_factory)
     emitter_contract = emitter_contract_factory(emitter_deploy_receipt['contractAddress'])
 
-    txn_hash_with_log = emitter_contract.transact({
+    txn_hash_with_log = emitter_contract.functions.logDouble(
+        which=EMITTER_ENUM['LogDoubleWithIndex'], arg0=12345, arg1=54321,
+    ).transact({
         'from': web3.eth.coinbase,
-    }).logDouble(which=EMITTER_ENUM['LogDoubleWithIndex'], arg0=12345, arg1=54321)
+    })
     print('TXN_HASH_WITH_LOG:', txn_hash_with_log)
     txn_receipt_with_log = mine_transaction_hash(web3, txn_hash_with_log)
     block_with_log = web3.eth.getBlock(txn_receipt_with_log['blockHash'])

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -91,9 +91,11 @@ def setup_chain_state(web3):
     emitter_deploy_receipt = common.deploy_contract(web3, 'emitter', emitter_contract_factory)
     emitter_contract = emitter_contract_factory(emitter_deploy_receipt['contractAddress'])
 
-    txn_hash_with_log = emitter_contract.transact({
+    txn_hash_with_log = emitter_contract.functions.logDouble(
+        which=EMITTER_ENUM['LogDoubleWithIndex'], arg0=12345, arg1=54321,
+    ).transact({
         'from': web3.eth.coinbase,
-    }).logDouble(which=EMITTER_ENUM['LogDoubleWithIndex'], arg0=12345, arg1=54321)
+    })
     print('TXN_HASH_WITH_LOG:', txn_hash_with_log)
     txn_receipt_with_log = common.mine_transaction_hash(web3, txn_hash_with_log)
     block_with_log = web3.eth.getBlock(txn_receipt_with_log['blockHash'])

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -110,9 +110,11 @@ def mined_txn_hash(block_with_txn):
 
 @pytest.fixture(scope="module")
 def block_with_txn_with_log(web3, emitter_contract):
-    txn_hash = emitter_contract.transact({
+    txn_hash = emitter_contract.functions.logDouble(
+        which=EMITTER_ENUM['LogDoubleWithIndex'], arg0=12345, arg1=54321,
+    ).transact({
         'from': web3.eth.coinbase,
-    }).logDouble(which=EMITTER_ENUM['LogDoubleWithIndex'], arg0=12345, arg1=54321)
+    })
     txn = web3.eth.getTransaction(txn_hash)
     block = web3.eth.getBlock(txn['blockNumber'])
     return block

--- a/web3/utils/decorators.py
+++ b/web3/utils/decorators.py
@@ -50,12 +50,10 @@ def deprecated_for(replace_message):
     def decorator(to_wrap):
         @functools.wraps(to_wrap)
         def wrapper(*args, **kwargs):
-            warnings.simplefilter('always', DeprecationWarning)
             warnings.warn(
                 "%s is deprecated in favor of %s" % (to_wrap.__name__, replace_message),
                 category=DeprecationWarning,
                 stacklevel=2)
-            warnings.simplefilter('default', DeprecationWarning)
             return to_wrap(*args, **kwargs)
         return wrapper
     return decorator


### PR DESCRIPTION
### What was wrong?
There were a lot of deprecation warnings thrown after running unit tests. @voith Sorry for jumping on this, had to work off some steam and took it out on the unit tests.

### How was it fixed?
Function calls were either brought up to date to remove deprecation warnings, or pytest assertions were used to explicitly state that a deprecation warning should be raised. Used in conjunction with #760, there should be no more warnings throw when running tests.