### PR TITLE
removed warning filter adjustement

### DIFF
--- a/web3/utils/decorators.py
+++ b/web3/utils/decorators.py
@@ -50,12 +50,10 @@ def deprecated_for(replace_message):
     def decorator(to_wrap):
         @functools.wraps(to_wrap)
         def wrapper(*args, **kwargs):
-            warnings.simplefilter('always', DeprecationWarning)
             warnings.warn(
                 "%s is deprecated in favor of %s" % (to_wrap.__name__, replace_message),
                 category=DeprecationWarning,
                 stacklevel=2)
-            warnings.simplefilter('default', DeprecationWarning)
             return to_wrap(*args, **kwargs)
         return wrapper
     return decorator


### PR DESCRIPTION
removed filter adjustement since it disallows to filter out deprication warnings

### What was wrong?

The warning filter configuration applied in decorator switched off any filtering and then turned it on again. It caused impossibility to suppress deprication warning by contstruction like this: 

```
warnings.simplefilter("ignore", category=DeprecationWarning)
```

### How was it fixed?

The warning filter adjustment was removed.

#### Cute Animal Picture

![Cute animal picture]()
