### PR TITLE
fix namespace, typo in Miner documentation examples

### DIFF
--- a/docs/web3.miner.rst
+++ b/docs/web3.miner.rst
@@ -43,7 +43,7 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.makeDag(10000)
+        >>> web3.miner.makeDag(10000)
 
 
 .. py:method:: Miner.setExtra(extra)
@@ -55,7 +55,7 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.setExtra('abcdefghijklmnopqrstuvwxyzABCDEF')
+        >>> web3.miner.setExtra('abcdefghijklmnopqrstuvwxyzABCDEF')
 
 
 .. py:method:: Miner.setGasPrice(gas_price)
@@ -68,18 +68,18 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.setGasPrice(19999999999)
+        >>> web3.miner.setGasPrice(19999999999)
 
 
 .. py:method:: Miner.start(num_threads)
 
     * Delegates to ``miner_start`` RPC Method
 
-    Start the CPU mining proccess using the given number of threads.
+    Start the CPU mining process using the given number of threads.
 
     .. code-block:: python
 
-        >>> web3.eth.start(2)
+        >>> web3.miner.start(2)
 
 
 .. py:method:: Miner.stop()
@@ -90,7 +90,7 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.stop()
+        >>> web3.miner.stop()
 
 
 .. py:method:: Miner.startAutoDAG()
@@ -101,7 +101,7 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.startAutoDAG()
+        >>> web3.miner.startAutoDAG()
 
 
 .. py:method:: Miner.stopAutoDAG()
@@ -112,4 +112,4 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.stopAutoDAG()
+        >>> web3.miner.stopAutoDAG()


### PR DESCRIPTION
### What was wrong?
namespace in documentation for Miner [examples](http://web3py.readthedocs.io/en/stable/web3.miner.html) is incorrect.


### How was it fixed?
replaced 'eth' with 'miner'
