### PR TITLE
Undoing the mixup between Chain ID and Network ID

### DIFF
--- a/docs/web3.net.rst
+++ b/docs/web3.net.rst
@@ -17,15 +17,15 @@ The following properties are available on the ``web3.net`` namespace.
 
 .. py:method:: Net.chainId(self)
 
-    * Delegates to ``net_version`` RPC Method
+    This method is not implemented. You must manually determine your chain ID for now.
 
-    Returns the current network chainId/version and is an alias of ``web3.net.version``.
+    It will always return `None`, which is a valid chainId to specify in the transaction.
+    It means the transaction (may be) replayable on other forks of the network.
 
     .. code-block:: python
 
         >>> web3.net.chainId
-        1
-
+        None
 
 .. py:method:: Net.version(self)
 

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -35,7 +35,7 @@ def test_build_transaction_with_contract_no_arguments(web3, math_contract, build
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 1,
-        'chainId': 1
+        'chainId': None,
     }
 
 
@@ -46,7 +46,7 @@ def test_build_transaction_with_contract_fallback_function(web3, fallback_functi
         'data': '0x',
         'value': 0,
         'gasPrice': 1,
-        'chainId': 1
+        'chainId': None,
     }
 
 
@@ -65,7 +65,7 @@ def test_build_transaction_with_contract_class_method(
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 1,
-        'chainId': 1
+        'chainId': None,
     }
 
 
@@ -79,7 +79,7 @@ def test_build_transaction_with_contract_default_account_is_set(
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 1,
-        'chainId': 1
+        'chainId': None,
     }
 
 
@@ -93,7 +93,7 @@ def test_build_transaction_with_gas_price_strategy_set(web3, math_contract, buil
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 5,
-        'chainId': 1
+        'chainId': None,
     }
 
 
@@ -121,31 +121,31 @@ def test_build_transaction_with_contract_to_address_supplied_errors(web3,
         (
             {}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'chainId': 1
+                'value': 0, 'gasPrice': 1, 'chainId': None,
             }, False
         ),
         (
             {'gas': 800000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'chainId': 1
+                'value': 0, 'gasPrice': 1, 'chainId': None,
             }, False
         ),
         (
             {'gasPrice': 21000000000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 21000000000, 'chainId': 1
+                'value': 0, 'gasPrice': 21000000000, 'chainId': None,
             }, False
         ),
         (
             {'nonce': 7}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'nonce': 7, 'chainId': 1
+                'value': 0, 'gasPrice': 1, 'nonce': 7, 'chainId': None,
             }, True
         ),
         (
             {'value': 20000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 20000, 'gasPrice': 1, 'chainId': 1
+                'value': 20000, 'gasPrice': 1, 'chainId': None,
             }, False
         ),
     ),

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -12,20 +12,13 @@ from web3.middleware.simulate_unmined_transaction import (
     'make_chain_id, expect_success',
     (
         (
-            lambda web3: web3.version.network,
+            lambda web3: web3.net.chainId,
             True,
         ),
-        (
-            lambda web3: int(web3.version.network),
-            True,
-        ),
-        (
-            lambda web3: int(web3.version.network) + 1,
+        pytest.param(
+            lambda web3: 999999999999,
             False,
-        ),
-        (
-            lambda web3: str(int(web3.version.network) + 1),
-            False,
+            marks=pytest.mark.xfail,
         ),
     ),
 )

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -15,8 +15,8 @@ from web3.exceptions import (
 
 @curry
 def validate_chain_id(web3, chain_id):
-    if chain_id is None:
-        return None
+    if chain_id == web3.net.chainId:
+        return chain_id
     else:
         raise ValidationError(
             "The transaction declared chain ID %r, "

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -15,14 +15,14 @@ from web3.exceptions import (
 
 @curry
 def validate_chain_id(web3, chain_id):
-    if chain_id == web3.version.network:
+    if chain_id is None:
         return None
     else:
         raise ValidationError(
             "The transaction declared chain ID %r, "
             "but the connected node is on %r" % (
                 chain_id,
-                web3.version.network,
+                "UNKNOWN",
             )
         )
 
@@ -33,7 +33,6 @@ def transaction_normalizer(transaction):
 
 def validation_middleware(make_request, web3):
     transaction_validator = apply_formatters_to_dict({
-        'chainId': validate_chain_id(web3),
     })
 
     transaction_sanitizer = compose(transaction_normalizer, transaction_validator)

--- a/web3/net.py
+++ b/web3/net.py
@@ -14,7 +14,7 @@ class Net(Module):
 
     @property
     def chainId(self):
-        return self.version
+        return None
 
     @property
     def version(self):

--- a/web3/utils/transactions.py
+++ b/web3/utils/transactions.py
@@ -26,7 +26,7 @@ TRANSACTION_DEFAULTS = {
     'data': b'',
     'gas': lambda web3, tx: web3.eth.estimateGas(tx),
     'gasPrice': lambda web3, tx: web3.eth.generateGasPrice(tx) or web3.eth.gasPrice,
-    'chainId': lambda web3, tx: int(web3.net.version),
+    'chainId': lambda web3, tx: web3.net.chainId,
 }
 
 


### PR DESCRIPTION
### What was wrong?

web3py was returning `networkId` when asked for `chainId`.

### How was it fixed?

There is no quick/foolproof way to determine the value, and `None` is valid in all cases, so we just return that.

- There were incorrect `chainId` validations in place, remove them
- Always return `None` from `w3.net.chainId`
- Document

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/6c/78/10/6c78103e845e928c6d68139cb25f3313.jpg)
