### PR TITLE
Remove audit warnings about eth-account

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -100,18 +100,7 @@ def wait_for_transaction():
 @pytest.fixture()
 def web3():
     provider = EthereumTesterProvider()
-    w3 = Web3(provider)
-
-    # Delete this whole block after eth-account has passed security audit
-    try:
-        w3.eth.account
-    except AttributeError:
-        pass
-    else:
-        raise AssertionError("Unaudited features must be disabled by default")
-    w3.eth.enable_unaudited_features()
-
-    return w3
+    return Web3(provider)
 
 
 @pytest.fixture(autouse=True)

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -1,47 +1,6 @@
 Working with Local Private Keys
 ==========================================
 
-Not Acceptable for Production
----------------------------------
-
-.. WARNING::
-  **Do not use** this module in production. It is still in beta. A security audit is pending.
-
-Now is a great time to get familiar with the API, and test out writing
-code that uses some of the great upcoming features.
-
-By default, access to this module has been turned off in the stable version of Web3.py:
-
-.. code-block:: python
-
-    >>> from web3.auto import w3
-    >>> w3.eth.account
-    ...
-    AttributeError: This feature is disabled, pending security audit. ...
-
-In order to access these features, you can either:
-
-1. Turn it on inside web3 with:
-
-   .. code-block:: python
-
-       >>> from web3.auto import w3
-       >>> w3.eth.enable_unaudited_features()
-       >>> w3.eth.account
-
-2. Load the beta version of :class:`eth_account.Account <eth_account.account.Account>`
-   directly, with:
-
-   .. code-block:: python
-
-       >>> from eth_account import Account
-       >>> account = Account()
-
-.. testsetup::
-
-    from web3.auto import w3
-    w3.eth.enable_unaudited_features()
-
 Local vs Hosted Nodes
 ---------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "cytoolz>=0.9.0,<1.0.0",
         "eth-abi>=1.0.0,<2",
-        "eth-account==0.2.0-alpha.0",
+        "eth-account>=0.2.1,<0.3.0",
         "eth-utils>=1.0.1,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "lru-dict>=1.1.6,<2.0.0",

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -26,6 +26,9 @@ from web3.module import (
 from web3.utils.blocks import (
     select_method_for_block_identifier,
 )
+from web3.utils.decorators import (
+    deprecated_for,
+)
 from web3.utils.empty import (
     empty,
 )
@@ -48,27 +51,16 @@ from web3.utils.transactions import (
 
 
 class Eth(Module):
-    _account = None
+    account = Account()
     defaultAccount = empty
     defaultBlock = "latest"
     defaultContractFactory = Contract
     iban = Iban
     gasPriceStrategy = None
 
-    @property
-    def account(self):
-        if self._account is not None:
-            return self._account
-        else:
-            raise AttributeError(
-                "This feature is disabled, pending security audit. "
-                "If you want to use unaudited code dealing with private keys, "
-                "despite the risks, you can run `w3.eth.enable_unaudited_features()` "
-                "and try again."
-            )
-
+    @deprecated_for("doing nothing at all")
     def enable_unaudited_features(self):
-        self._account = Account()
+        pass
 
     def namereg(self):
         raise NotImplementedError()


### PR DESCRIPTION
### What was wrong?

The audit is complete, all issues resolved. The warning is no longer necessary.

### How was it fixed?

- removed the warning in the docs
- enable `w3.eth.account` by default
- make `w3.eth.enable_unaudited_features()` a noop and add a deprecation warning (to be removed in #722 )
- bump to eth-account version, so that it accepts transactions with `'from'` as long as it matches the private key used

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/88/87/99/8887998f7059bffb0f8158c9900dcc77.jpg)