### PR TITLE
specified a version for pypiwin32 and moved it to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "eth-hash[pycryptodome]",
         "requests>=2.16.0,<3.0.0",
         "websockets>=4.0.1",
+        "pypiwin32>=223;platform_system=='Windows'",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.5, <4',
@@ -38,9 +39,6 @@ setup(
         'linter': [
             "flake8==3.4.1",
             "isort>=4.2.15,<5",
-        ],
-        'platform_system=="Windows"': [
-            'pypiwin32'  # TODO: specify a version number, move under install_requires
         ],
     },
     py_modules=['web3', 'ens'],


### PR DESCRIPTION
### What was wrong?

`pypiwin32` did not have a version number.

### How was it fixed?
specified a version for pypiwin32 and moved it to install_requires.

I have tested this change on a windows machine. Also tested on Mac to make sure that the `platform_system` check works as expected.


#### Cute Animal Picture
![980x](https://user-images.githubusercontent.com/8171193/39242205-e8ea7cc2-48a6-11e8-8772-1ca14c4de986.jpg)

