### PR TITLE
Accomodate input param in transaction processing (#770)

### DIFF
--- a/tests/core/utilities/test_valid_transaction_params.py
+++ b/tests/core/utilities/test_valid_transaction_params.py
@@ -38,31 +38,47 @@ def test_assert_valid_transaction_params_invalid_param():
 
 
 def test_extract_valid_transaction_params():
-    from copy import deepcopy
-    base_input = {
+    ''' baseline test for clean param dict '''
+    input = {
         'from': '0x0',
         'to': '0x0',
         'gas': 21000,
         'gasPrice': 5000000,
+        'data': '0x0',
         'value': 1,
         'nonce': 2,
         'chainId': 1,
     }
-
-    input = deepcopy(base_input)
-    input['data'] = '0x0'
     valid_transaction_params = extract_valid_transaction_params(input)
     assert valid_transaction_params == input
 
-    in_input = deepcopy(base_input)
-    in_input['input'] = '0x0'
-    in_input['data'] = '0x0'
-    valid_transaction_params = extract_valid_transaction_params(in_input)
-    assert valid_transaction_params == input
 
-    input['input'] = '0x1'
-    with pytest.raises(AttributeError, match=r'.* You need to resolve this conflict.'):
-        extract_valid_transaction_params(input)
+test_data = [({'data': '0x0', 'input': '0x0'}, {'data': '0x0'}), ]
+@pytest.mark.parametrize("transaction_params, expected", test_data)  # noqa E302
+def test_extract_valid_transaction_params_2(transaction_params, expected):
+    valid_transaction_params = extract_valid_transaction_params(transaction_params)
+    assert valid_transaction_params == expected
+
+
+test_data = [({'input': '0x0'}, {'data': '0x0'}), ]
+@pytest.mark.parametrize("transaction_params, expected", test_data)  # noqa E302
+def test_extract_valid_transaction_params_3(transaction_params, expected):
+    valid_transaction_params = extract_valid_transaction_params(transaction_params)
+    assert valid_transaction_params == expected
+
+
+test_data = [({}, {}), ]
+@pytest.mark.parametrize("transaction_params, expected", test_data)  # noqa E302
+def test_extract_valid_transaction_params_4(transaction_params, expected):
+    valid_transaction_params = extract_valid_transaction_params(transaction_params)
+    assert valid_transaction_params == expected
+
+
+
+@pytest.mark.xfail(raises=AttributeError, strict=True)  # noqa E302
+def test_extract_valid_transaction_params_5():
+    transaction_params = {'data': '0x0', 'input': '0x1'}
+    extract_valid_transaction_params(transaction_params)
 
 
 def test_extract_valid_transaction_params_includes_invalid():

--- a/tests/core/utilities/test_valid_transaction_params.py
+++ b/tests/core/utilities/test_valid_transaction_params.py
@@ -38,18 +38,31 @@ def test_assert_valid_transaction_params_invalid_param():
 
 
 def test_extract_valid_transaction_params():
-    input = {
+    from copy import deepcopy
+    base_input = {
         'from': '0x0',
         'to': '0x0',
         'gas': 21000,
         'gasPrice': 5000000,
         'value': 1,
-        'data': '0x0',
         'nonce': 2,
         'chainId': 1,
     }
+
+    input = deepcopy(base_input)
+    input['data'] = '0x0'
     valid_transaction_params = extract_valid_transaction_params(input)
     assert valid_transaction_params == input
+
+    in_input = deepcopy(base_input)
+    in_input['input'] = '0x0'
+    in_input['data'] = '0x0'
+    valid_transaction_params = extract_valid_transaction_params(in_input)
+    assert valid_transaction_params == input
+
+    input['input'] = '0x1'
+    with pytest.raises(AttributeError, match=r'.* You need to resolve this conflict.'):
+        extract_valid_transaction_params(input)
 
 
 def test_extract_valid_transaction_params_includes_invalid():

--- a/tests/core/utilities/test_valid_transaction_params.py
+++ b/tests/core/utilities/test_valid_transaction_params.py
@@ -37,48 +37,42 @@ def test_assert_valid_transaction_params_invalid_param():
         })
 
 
-def test_extract_valid_transaction_params():
-    ''' baseline test for clean param dict '''
-    input = {
-        'from': '0x0',
-        'to': '0x0',
-        'gas': 21000,
-        'gasPrice': 5000000,
-        'data': '0x0',
-        'value': 1,
-        'nonce': 2,
-        'chainId': 1,
-    }
-    valid_transaction_params = extract_valid_transaction_params(input)
-    assert valid_transaction_params == input
+FULL_TXN_DICT = {
+    'from': '0x0',
+    'to': '0x1',
+    'gas': 21000,
+    'gasPrice': 5000000,
+    'data': '0x2',
+    'value': 3,
+    'nonce': 2,
+    'chainId': 1,
+}
 
 
-test_data = [({'data': '0x0', 'input': '0x0'}, {'data': '0x0'}), ]
-@pytest.mark.parametrize("transaction_params, expected", test_data)  # noqa E302
-def test_extract_valid_transaction_params_2(transaction_params, expected):
+@pytest.mark.parametrize(
+    "transaction_params, expected",
+    ((FULL_TXN_DICT, FULL_TXN_DICT),
+     ({'data': '0x0', 'input': '0x0'}, {'data': '0x0'}),
+     ({'input': '0x0'}, {'data': '0x0'}),
+     ({}, {}),
+     )
+)
+def test_extract_valid_transaction_params(transaction_params, expected):
     valid_transaction_params = extract_valid_transaction_params(transaction_params)
     assert valid_transaction_params == expected
 
 
-test_data = [({'input': '0x0'}, {'data': '0x0'}), ]
-@pytest.mark.parametrize("transaction_params, expected", test_data)  # noqa E302
-def test_extract_valid_transaction_params_3(transaction_params, expected):
-    valid_transaction_params = extract_valid_transaction_params(transaction_params)
-    assert valid_transaction_params == expected
+INVALID_TXN_PARAMS = {'data': '0x0', 'input': '0x1'}
+EXPECTED_EXC_MSG = r'.* "input:(.*)" and "data:(.*)" .*'
 
 
-test_data = [({}, {}), ]
-@pytest.mark.parametrize("transaction_params, expected", test_data)  # noqa E302
-def test_extract_valid_transaction_params_4(transaction_params, expected):
-    valid_transaction_params = extract_valid_transaction_params(transaction_params)
-    assert valid_transaction_params == expected
-
-
-
-@pytest.mark.xfail(raises=AttributeError, strict=True)  # noqa E302
-def test_extract_valid_transaction_params_5():
-    transaction_params = {'data': '0x0', 'input': '0x1'}
-    extract_valid_transaction_params(transaction_params)
+@pytest.mark.parametrize(
+    "transaction_params, expected_exc_msg",
+    ((INVALID_TXN_PARAMS, EXPECTED_EXC_MSG),)
+)
+def test_extract_valid_transaction_params_invalid(transaction_params, expected_exc_msg):
+    with pytest.raises(AttributeError, match=expected_exc_msg):
+        extract_valid_transaction_params(transaction_params)
 
 
 def test_extract_valid_transaction_params_includes_invalid():

--- a/web3/utils/transactions.py
+++ b/web3/utils/transactions.py
@@ -107,12 +107,11 @@ def extract_valid_transaction_params(transaction_params):
             return extracted_params
     elif extracted_params.get('data') is None:
         if transaction_params.get('input') is not None:
-            extracted_params['data'] = transaction_params['input']
-            return extracted_params
+            return assoc(extracted_params, 'data', transaction_params['input'])
         else:
             return extracted_params
     else:
-        return extracted_params
+        raise Exception("Unreachable path: transaction's 'data' is either set or not set")
 
 
 def assert_valid_transaction_params(transaction_params):

--- a/web3/utils/transactions.py
+++ b/web3/utils/transactions.py
@@ -91,8 +91,19 @@ def get_required_transaction(web3, transaction_hash):
 
 
 def extract_valid_transaction_params(transaction_params):
-    return {key: transaction_params[key]
-            for key in VALID_TRANSACTION_PARAMS if key in transaction_params}
+    t_params = {key: transaction_params[key]
+                for key in VALID_TRANSACTION_PARAMS if key in transaction_params}
+
+    if t_params.get('data') is not None and transaction_params.get('input') is not None:
+        if t_params['data'] != transaction_params['input']:
+            msg = 'failure to handle this transaction due to both "input: {}" and'
+            msg += ' "data: {}" are populated. You need to resolve this conflict.'
+            raise AttributeError(msg.format(transaction_params['input'], t_params['data']))
+
+    if t_params.get('data') is None and transaction_params.get('input') is not None:
+        t_params['data'] = transaction_params['input']
+
+    return t_params
 
 
 def assert_valid_transaction_params(transaction_params):

--- a/web3/utils/transactions.py
+++ b/web3/utils/transactions.py
@@ -91,19 +91,28 @@ def get_required_transaction(web3, transaction_hash):
 
 
 def extract_valid_transaction_params(transaction_params):
-    t_params = {key: transaction_params[key]
-                for key in VALID_TRANSACTION_PARAMS if key in transaction_params}
+    extracted_params = {key: transaction_params[key]
+                        for key in VALID_TRANSACTION_PARAMS if key in transaction_params}
 
-    if t_params.get('data') is not None and transaction_params.get('input') is not None:
-        if t_params['data'] != transaction_params['input']:
-            msg = 'failure to handle this transaction due to both "input: {}" and'
-            msg += ' "data: {}" are populated. You need to resolve this conflict.'
-            raise AttributeError(msg.format(transaction_params['input'], t_params['data']))
-
-    if t_params.get('data') is None and transaction_params.get('input') is not None:
-        t_params['data'] = transaction_params['input']
-
-    return t_params
+    if extracted_params.get('data') is not None:
+        if transaction_params.get('input') is not None:
+            if extracted_params['data'] != transaction_params['input']:
+                msg = 'failure to handle this transaction due to both "input: {}" and'
+                msg += ' "data: {}" are populated. You need to resolve this conflict.'
+                err_vals = (transaction_params['input'], extracted_params['data'])
+                raise AttributeError(msg.format(*err_vals))
+            else:
+                return extracted_params
+        else:
+            return extracted_params
+    elif extracted_params.get('data') is None:
+        if transaction_params.get('input') is not None:
+            extracted_params['data'] = transaction_params['input']
+            return extracted_params
+        else:
+            return extracted_params
+    else:
+        return extracted_params
 
 
 def assert_valid_transaction_params(transaction_params):


### PR DESCRIPTION
### What was wrong?
transactions with only input but not data param fail to re-key thereby dropping data. see # 770

Related to Issue # 770

### How was it fixed?
update extract_valid_transaction_params to test for input param

### x-module issue:
the (same) extract_valid_transaction_params() is also in eth-tester.utils.transactions.py. assuming the PR passes, want this updated commensurately ?