### PR TITLE
Documentation updates inspired by EthCC 2018 Workshop

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -1,8 +1,72 @@
+.. _contracts:
+
 Contracts
 =========
 
 .. py:module:: web3.contract
 
+It is worth taking your time to understand all about contracts. To get started,
+check out this example:
+
+.. _contract_example:
+
+Simple Contract Example
+-----------------------
+
+.. code-block:: python
+
+    import json
+    import web3
+
+    from web3 import Web3, TestRPCProvider
+    from solc import compile_source
+    from web3.contract import ConciseContract
+
+    # Solidity source code
+    contract_source_code = '''
+    pragma solidity ^0.4.0;
+
+    contract Greeter {
+        string public greeting;
+
+        function Greeter() {
+            greeting = 'Hello';
+        }
+
+        function setGreeting(string _greeting) public {
+            greeting = _greeting;
+        }
+
+        function greet() constant returns (string) {
+            return greeting;
+        }
+    }
+    '''
+
+    compiled_sol = compile_source(contract_source_code) # Compiled source code
+    contract_interface = compiled_sol['<stdin>:Greeter']
+
+    # web3.py instance
+    w3 = Web3(TestRPCProvider())
+
+    # Instantiate and deploy contract
+    contract = w3.eth.contract(abi=contract_interface['abi'], bytecode=contract_interface['bin'])
+
+    # Get transaction hash from deployed contract
+    tx_hash = contract.deploy(transaction={'from': w3.eth.accounts[0], 'gas': 410000})
+
+    # Get tx receipt to get contract address
+    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+    contract_address = tx_receipt['contractAddress']
+
+    # Contract instance in concise mode
+    contract_instance = w3.eth.contract(abi=contract_interface['abi'], address=contract_address, ContractFactoryClass=ConciseContract)
+
+    # Getters + Setters for web3.eth.contract object
+    print('Contract value: {}'.format(contract_instance.greet()))
+    contract_instance.setGreeting('Nihao', transact={'from': w3.eth.accounts[0]})
+    print('Setting value to: Nihao')
+    print('Contract value: {}'.format(contract_instance.greet()))
 
 Contract Factories
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Contents
 
     quickstart
     overview
+    node
     v4_migration
     filters
     contracts

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Web3.py
 =======
 
-Web3.py is a python library for interacting with Ethereum.  It's API is derived
+Web3.py is a python library for interacting with Ethereum.  Its API is derived
 from the `Web3.js`_ Javascript API and should be familiar to anyone who has
 used ``web3.js``.
 
@@ -21,6 +21,7 @@ Contents
     ens_overview
     middleware
     examples
+    troubleshooting
     web3.main
     web3.eth
     web3.eth.account
@@ -36,12 +37,6 @@ Contents
     internals
     conventions
     releases
-
-Release notes
--------------
-
-`View release notes on Github <https://github.com/ethereum/web3.py/blob/master/CHANGELOG>`_.
-
 
 Indices and tables
 ------------------

--- a/docs/node.rst
+++ b/docs/node.rst
@@ -27,8 +27,8 @@ evolving quickly, so please do your own research about the current options.
 We won't advocate for any particular node,
 but list some popular options and some basic details on each.
 
-One of the primary decisions to make is whether to use a local node or a hosted
-node. A quick summary is at :ref:`local-vs-hosted`.
+One of the key decisions is whether to use a local node or a hosted
+node. A quick summary is at :ref:`local_vs_hosted`.
 
 A local node requires less trust than a hosted one.
 A malicious hosted node can give you incorrect information, log your
@@ -56,7 +56,7 @@ You can find a fuller list of node software at `ethdocs.org
 <http://ethdocs.org/en/latest/ethereum-clients/>`_.
 
 Some people decide that the time it takes to sync a local node from scratch is too
-high, especially those just experimenting for the first time. One way to
+high, especially if they are just exploring Ethereum for the first time. One way to
 work around this issue is to use a hosted node.
 
 The most popular hosted node option is `Infura <infura.io>`_.
@@ -66,9 +66,9 @@ you, meaning that some common methods like :meth:`w3.eth.sendTransaction()
 <web3.eth.Eth.sendTransaction>` are not directly available. To send trensactions
 to a hosted node, read about :ref:`eth-account`.
 
-Once you decide what node option you want, you need to choose how to connect to it.
-Any given node software provides a variety of options. See
-:ref:`choosing_provider`.
+Once you decide what node option you want, you need to choose which network to connect to.
+Typically, you are choosing between the main network and one of the available test networks.
+See :ref:`choosing_network`
 
 Can I use MetaMask as a node?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -80,4 +80,39 @@ By default, MetaMask connects to an Infura node.
 You can also set up MetaMask to use a node that you run locally.
 
 If you are trying to use accounts that were already created in MetaMask, see
-:ref:`use-metamask-accounts`
+:ref:`use_metamask_accounts`
+
+.. _choosing_network:
+
+Which network should I connect to?
+------------------------------------
+
+Once you have answered :ref:`choosing_node` you have to pick which network
+to connect to. This is easy for some scenarios: if you have ether and you want
+to spend it, or you want to interact with any production smart contracts,
+then you connect to the main Ethereum network.
+
+If you want to test these things without using real ether, though, then you
+need to connect to a test network. There are several test networks to
+choose from. One test network, Ropsten, is the most similar to the production network.
+However, spam and mining attacks have happened,
+which is disruptive when you want to test out a contract.
+
+There are some alternative networks that limit the damage of spam attacks, but
+they are not standardized across node software. Geth runs their own (Rinkeby),
+and Parity runs their own (Kovan). See a full comparison in this `Stackexchange Q&A
+<https://ethereum.stackexchange.com/a/30072/1461>`_.
+
+So roughly, choose this way:
+
+- If using Parity, connect to Kovan
+- If using Geth, connect to Rinkeby
+- If using a different node, or testing mining, connect to Ropsten
+
+Each of their networks has their own version of Ether. Main network ether must
+be purchased, naturally, but test network ether is usually available for free.
+See :ref:`faucets`
+
+Once you have decided which network to connect to, and set up your node for that network,
+you need to decide how to connect to it. There are a handful of options in most nodes.
+See :ref:`choosing_provider`.

--- a/docs/node.rst
+++ b/docs/node.rst
@@ -1,0 +1,83 @@
+Your Ethereum Node
+===================
+
+.. _why_need_connection:
+
+Why do I need to connect to a node?
+--------------------------------------
+
+The Ethereum protocol defines a way for people to interact with
+smart contracts and each other over a network.
+In order to have up-to-date information about the status of contracts,
+balances, and new transactions, the protocol requires a connection
+to nodes on the network. These nodes are constantly sharing new data
+with each other.
+
+Web3.py is a python library for connecting to these nodes. It does
+not run its own node internally.
+
+.. _choosing_node:
+
+How do I choose which node to use?
+--------------------------------------
+
+Due to the nature of Ethereum, this is largely a question of personal preference, but
+it has significant ramifications on security and usability. Further, node software is
+evolving quickly, so please do your own research about the current options.
+We won't advocate for any particular node,
+but list some popular options and some basic details on each.
+
+One of the primary decisions to make is whether to use a local node or a hosted
+node. A quick summary is at :ref:`local-vs-hosted`.
+
+A local node requires less trust than a hosted one.
+A malicious hosted node can give you incorrect information, log your
+sent transactions with your IP address, or simply go offline. Incorrect information
+can cause all kinds of problems, including loss of assets.
+
+On the other hand, with a local node your machine is individually verifying
+all the transactions on the network, and providing you with the latest state.
+Unfortunately, this means using up a
+significant amount of disk space, and sometimes notable
+bandwidth and computation.
+Additionally, there is a big up-front time cost for downloading the full blockchain history.
+
+If you want to have your
+node manage keys for you (a popular option), you must use a local node.
+Note that even if you run a node on your own machine, you are still trusting
+the node software with any accounts you create on the node.
+
+The most popular self-run node options are:
+
+- `geth (go-ethereum) <https://ethereum.github.io/go-ethereum/>`_
+- `parity <https://www.parity.io/>`_
+
+You can find a fuller list of node software at `ethdocs.org
+<http://ethdocs.org/en/latest/ethereum-clients/>`_.
+
+Some people decide that the time it takes to sync a local node from scratch is too
+high, especially those just experimenting for the first time. One way to
+work around this issue is to use a hosted node.
+
+The most popular hosted node option is `Infura <infura.io>`_.
+You can connect to it as if it were a local node,
+with a few caveats. It cannot (and *should not*) host private keys for
+you, meaning that some common methods like :meth:`w3.eth.sendTransaction()
+<web3.eth.Eth.sendTransaction>` are not directly available. To send trensactions
+to a hosted node, read about :ref:`eth-account`.
+
+Once you decide what node option you want, you need to choose how to connect to it.
+Any given node software provides a variety of options. See
+:ref:`choosing_provider`.
+
+Can I use MetaMask as a node?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MetaMask is not a node. It is an interface for interacting with a node.
+Roughly, it's what you get if you turn Web3.py into a browser extension.
+
+By default, MetaMask connects to an Infura node.
+You can also set up MetaMask to use a node that you run locally.
+
+If you are trying to use accounts that were already created in MetaMask, see
+:ref:`use-metamask-accounts`

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -10,6 +10,40 @@ request to an HTTP or IPC socket based server.
 If you are already happily connected to your Ethereum node, then you
 can skip the rest of the Providers section.
 
+.. _choosing_provider:
+
+Choosing How to Connect to Your Node
+--------------------------------------
+
+Most nodes have a variety of ways to connect to them. If you have not
+decided what kind of node to use, head on over to :ref:`choosing_node`
+
+As an example, go-ethereum supports IPC, HTTP, and Websockets. IPC is a protocol for
+connecting over a local filesystem, so it is not an option when using a
+remote hosted node, like Infura. In general, you're likely to want to choose
+connections in this order:
+
+1. IPC (fastest and most secure: works locally)
+2. Websockets (works remotely)
+3. HTTP (works remotely, more nodes support it)
+
+If you have the option of running Web3.py on the same machine as the node, choose IPC.
+
+If you must connect to a node on a different computer, use Websockets.
+
+If your node does not support Websockets, use HTTP.
+
+Most nodes have a way of "turning off" connection options.
+We recommend turning off all connection options that you are not using.
+This provides a safer setup: it reduces the
+number of ways that malicious hackers can try to steal your ether.
+
+Once you have decided how to connect, you specify the details using a Provider.
+Typically, you provide some kind of connection parameter. With IPC,
+you provide the path to the IPC file.
+
+Read on to learn more about using providers.
+
 Automatic vs Manual Providers
 -----------------------------
 
@@ -30,8 +64,8 @@ You can manually create a connection by specifying a provider like so:
 
 .. code-block:: python
 
-    from web3 import Web3, HTTPProvider
-    provider = HTTPProvider('http://localhost:8545')
+    from web3 import Web3
+    provider = Web3.HTTPProvider('http://localhost:8545')
     web3 = Web3(provider)
 
 .. _automatic_provider_detection:
@@ -51,7 +85,7 @@ succesful connection it can make:
    - :ref:`overview_type_conversions`
    - :ref:`overview_currency_conversions`
    - :ref:`overview_addresses`
-   - :class:`~web3.account.Account`
+   - :ref:`eth-account`
    - etc.
 
 .. _automatic_provider_detection_examples:

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -18,20 +18,17 @@ Choosing How to Connect to Your Node
 Most nodes have a variety of ways to connect to them. If you have not
 decided what kind of node to use, head on over to :ref:`choosing_node`
 
-As an example, go-ethereum supports IPC, HTTP, and Websockets. IPC is a protocol for
-connecting over a local filesystem, so it is not an option when using a
-remote hosted node, like Infura. In general, you're likely to want to choose
-connections in this order:
+The most common ways to connect to your node are:
 
-1. IPC (fastest and most secure: works locally)
-2. Websockets (works remotely)
-3. HTTP (works remotely, more nodes support it)
+1. IPC (uses local filesystem: fastest and most secure)
+2. Websockets (works remotely, faster than HTTP)
+3. HTTP (more nodes support it)
 
-If you have the option of running Web3.py on the same machine as the node, choose IPC.
+If you're not sure how to decide, choose this way:
 
-If you must connect to a node on a different computer, use Websockets.
-
-If your node does not support Websockets, use HTTP.
+- If you have the option of running Web3.py on the same machine as the node, choose IPC.
+- If you must connect to a node on a different computer, use Websockets.
+- If your node does not support Websockets, use HTTP.
 
 Most nodes have a way of "turning off" connection options.
 We recommend turning off all connection options that you are not using.
@@ -39,10 +36,28 @@ This provides a safer setup: it reduces the
 number of ways that malicious hackers can try to steal your ether.
 
 Once you have decided how to connect, you specify the details using a Provider.
-Typically, you provide some kind of connection parameter. With IPC,
-you provide the path to the IPC file.
+Providers are Web3.py classes that are configured for the kind of connection you want.
 
-Read on to learn more about using providers.
+See:
+
+- :class:`~web3.providers.ipc.IPCProvider`
+- :class:`~web3.providers.websocket.WebsocketProvider`
+- :class:`~web3.providers.rpc.HTTPProvider`
+
+Once you have configured your provider, for example:
+
+.. code-block:: python
+
+    from web3 import Web3
+    my_provider = Web3.IPCProvider('/my/node/ipc/path')
+
+Then you are ready to initialize your Web3 instance, like so:
+
+.. code-block:: python
+
+    w3 = Web3(my_provider)
+
+Finally, you are ready to :ref:`get started with Web3.py<first_w3_use>`.
 
 Automatic vs Manual Providers
 -----------------------------
@@ -60,13 +75,16 @@ when you initialize like so:
     from web3 import Web3
     w3 = Web3()
 
-You can manually create a connection by specifying a provider like so:
+Sometimes, web3 cannot automatically detect where your node is.
 
-.. code-block:: python
+- If you are not sure which kind of connection method to use, see
+  :ref:`choosing_provider`.
+- If you know the connection method, but not the other information
+  needed to connect (like the path to the IPC file), you will need to look up
+  that information in your node's configuration.
+- If you're not sure which node you are using, see :ref:`choosing_node`
 
-    from web3 import Web3
-    provider = Web3.HTTPProvider('http://localhost:8545')
-    web3 = Web3(provider)
+For a deeper dive into how automated detection works, see:
 
 .. _automatic_provider_detection:
 
@@ -93,18 +111,17 @@ succesful connection it can make:
 Examples Using Automated Detection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Some nodes provide APIs beyond the standards. Sometimes the same information is provided
+in different ways across nodes. If you want to write code that works
+across multiple nodes, you may want to look up the node type you are connected to.
 
-    There are client specific APIs.  If you are writing client agnostic code, in some situations
-    you may want to know what ethereum implementation is connected, and proceed
-    accordingly.
-
-    The following retrieves the client enode endpoint verifying there is a connected provider:
+For example, the following retrieves the client enode endpoint for both geth and parity:
 
 .. code-block:: python
 
     from web3.auto import w3
 
-    connected = any(provider.isConnected for provider in w3.providers)
+    connected = w3.isConnected()
 
     if connected and w3.version.node.startswith('Parity'):
         enode = w3.parity.enode
@@ -114,6 +131,19 @@ Examples Using Automated Detection
 
     else:
         enode = None
+
+.. _provider_uri:
+
+Provider via Environment Variable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Alternatively, you can set the environment variable ``WEB3_PROVIDER_URI``
+before starting your script, and web3 will look for that provider first.
+
+Valid formats for the this environment variable are:
+
+- ``file:///path/to/node/rpc-json/file.ipc``
+- ``http://192.168.1.2:8545``
 
 
 Built In Providers
@@ -141,6 +171,10 @@ HTTPProvider
 
         >>> from web3 import Web3
         >>> web3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545")
+
+    Note that you should create only one HTTPProvider per python
+    process, as the HTTPProvider recycles underlying TCP/IP network connections,
+    for better performance.
 
     Under the hood, the ``HTTPProvider`` uses the python requests library for
     making requests.  If you would like to modify how requests are made, you can

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,7 +10,8 @@ Quickstart
 Installation
 ------------
 
-Web3.py can be installed (preferably in a virtualenv) using ``pip`` as follows:
+Web3.py can be installed (preferably in a :ref:`virtualenv <setup_environment>`)
+using ``pip`` as follows:
 
 .. code-block:: shell
 
@@ -18,7 +19,7 @@ Web3.py can be installed (preferably in a virtualenv) using ``pip`` as follows:
 
 
 .. NOTE:: If you run into problems during installation, you might have a
-    broken environment. See the troubleshooting guide to :ref:`setup-environment`.
+    broken environment. See the troubleshooting guide to :ref:`setup_environment`.
 
 
 Installation from source can be done from the root of the project with the
@@ -35,7 +36,8 @@ Using Web3
 To use the web3 library you will need to initialize the
 :class:`~web3.Web3` class.
 
-Use the ``auto`` module to guess at common node connection options.
+Use the ``auto`` module to :ref:`guess at common node connection options
+<automatic_provider_detection>`.
 
 .. code-block:: python
 
@@ -48,118 +50,42 @@ blockchain.
 
 .. NOTE:: If you get the result ``UnhandledRequest: No providers responded to the RPC request``
     then you are not connected to a node. See :ref:`why_need_connection` and
-    :ref:`choosing_node`
+    :ref:`choosing_provider`
 
-To peek under the hood, see: :ref:`automatic_provider_detection`
+.. _first_w3_use:
 
+Getting Blockchain Info
+----------------------------------------
 
-Connecting to your Node
------------------------
-
-Sometimes, web3 cannot automatically detect where your node is.
-
-You can connect to your Ethereum node (for example: geth or parity) using one of
-the available :ref:`providers`, typically IPC or HTTP.
-
-If your node is running locally, IPC will be faster and safer to expose.
-If sharing the node across machines on a network, use HTTP instead.
-
-IPC Provider
-~~~~~~~~~~~~
+It's time to start using Web3.py! Try getting all the information about the latest block.
 
 .. code-block:: python
 
-    >>> from web3 import Web3, IPCProvider
+    >>> w3.eth.getBlock('latest')
+    {'difficulty': 1,
+     'gasLimit': 6283185,
+     'gasUsed': 0,
+     'hash': HexBytes('0x53b983fe73e16f6ed8178f6c0e0b91f23dc9dad4cb30d0831f178291ffeb8750'),
+     'logsBloom': HexBytes('0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'),
+     'miner': '0x0000000000000000000000000000000000000000',
+     'mixHash': HexBytes('0x0000000000000000000000000000000000000000000000000000000000000000'),
+     'nonce': HexBytes('0x0000000000000000'),
+     'number': 0,
+     'parentHash': HexBytes('0x0000000000000000000000000000000000000000000000000000000000000000'),
+     'proofOfAuthorityData': HexBytes('0x0000000000000000000000000000000000000000000000000000000000000000dddc391ab2bf6701c74d0c8698c2e13355b2e4150000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'),
+     'receiptsRoot': HexBytes('0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'),
+     'sha3Uncles': HexBytes('0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'),
+     'size': 622,
+     'stateRoot': HexBytes('0x1f5e460eb84dc0606ab74189dbcfe617300549f8f4778c3c9081c119b5b5d1c1'),
+     'timestamp': 0,
+     'totalDifficulty': 1,
+     'transactions': [],
+     'transactionsRoot': HexBytes('0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'),
+     'uncles': []}
 
-    # for an IPC based connection
-    >>> w3 = Web3(IPCProvider('/path/to/node/rpc-json/file.ipc'))
+Many of the typical things you'll want to do will be in the :class:`w3.eth <web3.eth.Eth>` API,
+so that is a good place to start.
 
-    >>> w3.eth.blockNumber
-    4000000
-
-
-HTTP Provider
-~~~~~~~~~~~~~
-
-.. code-block:: python
-
-    >>> from web3 import Web3, HTTPProvider
-
-    # Note that you should create only one HTTPProvider per
-    # process, as it recycles underlying TCP/IP network connections between
-    # your process and Ethereum node
-    >>> w3 = Web3(HTTPProvider('http://192.168.1.2:8545'))
-
-    >>> w3.eth.blockNumber
-    4000000
-
-.. _provider_uri:
-
-Provider via Environment Variable
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Alternatively, you can set the environment variable ``WEB3_PROVIDER_URI``
-before starting your script, and web3 will look for that provider first.
-
-Valid formats for the this environment variable are:
-
-- ``file:///path/to/node/rpc-json/file.ipc``
-- ``http://192.168.1.2:8545``
-
-Simple Contract Example
------------------------
-
-.. code-block:: python
-
-    import json
-    import web3
-
-    from web3 import Web3, TestRPCProvider
-    from solc import compile_source
-    from web3.contract import ConciseContract
-
-    # Solidity source code
-    contract_source_code = '''
-    pragma solidity ^0.4.0;
-
-    contract Greeter {
-        string public greeting;
-
-        function Greeter() {
-            greeting = 'Hello';
-        }
-
-        function setGreeting(string _greeting) public {
-            greeting = _greeting;
-        }
-
-        function greet() constant returns (string) {
-            return greeting;
-        }
-    }
-    '''
-
-    compiled_sol = compile_source(contract_source_code) # Compiled source code
-    contract_interface = compiled_sol['<stdin>:Greeter']
-
-    # web3.py instance
-    w3 = Web3(TestRPCProvider())
-
-    # Instantiate and deploy contract
-    contract = w3.eth.contract(abi=contract_interface['abi'], bytecode=contract_interface['bin'])
-
-    # Get transaction hash from deployed contract
-    tx_hash = contract.deploy(transaction={'from': w3.eth.accounts[0], 'gas': 410000})
-
-    # Get tx receipt to get contract address
-    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
-    contract_address = tx_receipt['contractAddress']
-
-    # Contract instance in concise mode
-    contract_instance = w3.eth.contract(abi=contract_interface['abi'], address=contract_address, ContractFactoryClass=ConciseContract)
-
-    # Getters + Setters for web3.eth.contract object
-    print('Contract value: {}'.format(contract_instance.greet()))
-    contract_instance.setGreeting('Nihao', transact={'from': w3.eth.accounts[0]})
-    print('Setting value to: Nihao')
-    print('Contract value: {}'.format(contract_instance.greet()))
+If you want to dive straight into contracts, check out the section on :ref:`contracts`,
+including a :ref:`contract_example`, and how to create a contract instance using
+:meth:`w3.eth.contract() <web3.eth.Eth.contract>`.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -43,14 +43,14 @@ Use the ``auto`` module to guess at common node connection options.
     >>> w3.eth.blockNumber
     4000000
 
-.. NOTE:: If you get the result ``UnhandledRequest: No providers responded to the RPC request``
-    then you are not connected to a node. See :ref:`why_need_connection` and
-    :ref:`choosing_node`, and :ref:`choosing_provider`.
-
-To peek under the hood, see: :ref:`automatic_provider_detection`
-
 This ``w3`` instance will now allow you to interact with the Ethereum
 blockchain.
+
+.. NOTE:: If you get the result ``UnhandledRequest: No providers responded to the RPC request``
+    then you are not connected to a node. See :ref:`why_need_connection` and
+    :ref:`choosing_node`
+
+To peek under the hood, see: :ref:`automatic_provider_detection`
 
 
 Connecting to your Node

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,31 +3,22 @@ Quickstart
 
 .. contents:: :local:
 
-
-Environment
-------------
-
-Web3.py requires Python 3. Often, the
-best way to guarantee a clean Python 3 environment is with ``virtualenv``, like:
-
-.. code-block:: shell
-
-    # once:
-    $ virtualenv -p python3 ~/.venv-py3
-
-    # each session:
-    $ source ~/.venv-py3/bin/activate
-
-    # with virtualenv active, install...
+.. NOTE:: All code starting with a ``$`` is meant to run on your terminal.
+    All code starting with a ``>>>`` is meant to run in a python interpreter,
+    like `ipython <https://pypi.org/project/ipython/>`_.
 
 Installation
 ------------
 
-Web3.py can be installed using ``pip`` as follows.
+Web3.py can be installed (preferably in a virtualenv) using ``pip`` as follows:
 
 .. code-block:: shell
 
    $ pip install web3
+
+
+.. NOTE:: If you run into problems during installation, you might have a
+    broken environment. See the troubleshooting guide to :ref:`setup-environment`.
 
 
 Installation from source can be done from the root of the project with the
@@ -51,6 +42,10 @@ Use the ``auto`` module to guess at common node connection options.
     >>> from web3.auto import w3
     >>> w3.eth.blockNumber
     4000000
+
+.. NOTE:: If you get the result ``UnhandledRequest: No providers responded to the RPC request``
+    then you are not connected to a node. See :ref:`why_need_connection` and
+    :ref:`choosing_node`, and :ref:`choosing_provider`.
 
 To peek under the hood, see: :ref:`automatic_provider_detection`
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,0 +1,46 @@
+Troubleshooting
+=============================
+
+.. _setup-environment:
+
+Set up a clean environment
+------------------------------------------------
+
+Many things can cause a broken environment. You might be on an unsupported version of Python.
+Another package might be installed that has a name or version conflict.
+Often, the best way to guarantee a correct environment is with ``virtualenv``, like:
+
+.. code-block:: shell
+
+    # Install virtualenv if it is not available:
+    $ which virtualenv || pip install --upgrade virtualenv
+
+    # *If* the above command displays an error, you can try installing as root:
+    $ sudo pip install virtualenv
+
+    # Create a virtual environment:
+    $ virtualenv -p python3 ~/.venv-py3
+
+    # Activate your new virtual environment:
+    $ source ~/.venv-py3/bin/activate
+
+    # With virtualenv active, make sure you have the latest packaging tools
+    $ pip install --upgrade pip setuptools
+
+    # Now we can install web3.py...
+    $ pip install --upgrade web3
+
+.. NOTE:: Remember that each new terminal session requires you to reactivate your virtualenv, like:
+    ``$ source ~/.venv-py3/bin/activate``
+
+.. _use-metamask-accounts:
+
+How do I use my Metamask accounts from Web3.py?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This requires exporting your private key from metamask, and using
+the local private key tools in web3 to sign and send transactions.
+
+See `how to export your private key
+<https://ethereum.stackexchange.com/questions/33053/what-is-a-private-key-in-an-ethereum-wallet-like-metamask-and-how-do-i-find-it>`_
+and :ref:`eth-account`.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,16 +1,19 @@
 Troubleshooting
 =============================
 
-.. _setup-environment:
+.. _setup_environment:
 
 Set up a clean environment
-------------------------------------------------
+----------------------------------------------
 
 Many things can cause a broken environment. You might be on an unsupported version of Python.
 Another package might be installed that has a name or version conflict.
 Often, the best way to guarantee a correct environment is with ``virtualenv``, like:
 
 .. code-block:: shell
+
+    # Install pip if it is not available:
+    $ which pip || curl https://bootstrap.pypa.io/get-pip.py | python
 
     # Install virtualenv if it is not available:
     $ which virtualenv || pip install --upgrade virtualenv
@@ -33,10 +36,12 @@ Often, the best way to guarantee a correct environment is with ``virtualenv``, l
 .. NOTE:: Remember that each new terminal session requires you to reactivate your virtualenv, like:
     ``$ source ~/.venv-py3/bin/activate``
 
-.. _use-metamask-accounts:
+.. _use_metamask_accounts:
 
 How do I use my MetaMask accounts from Web3.py?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------
+Often you don't need to do this, just make a new account in Web3.py,
+and transfer funds from your MetaMask account into it. But if you must...
 
 Export your private key from MetaMask, and use
 the local private key tools in Web3.py to sign and send transactions.
@@ -44,3 +49,24 @@ the local private key tools in Web3.py to sign and send transactions.
 See `how to export your private key
 <https://ethereum.stackexchange.com/questions/33053/what-is-a-private-key-in-an-ethereum-wallet-like-metamask-and-how-do-i-find-it>`_
 and :ref:`eth-account`.
+
+.. _faucets:
+
+How do I get ether for my test network?
+--------------------------------------------------------
+
+Test networks usually have something called a "faucet" to
+help get test ether to people who want to use it. The faucet
+simply sends you test ether when you visit a web page, or ping a chat bot, etc.
+
+Each test network has its own version of test ether, so each one
+must maintain its own faucet. If you're not sure which test network
+to use, see :ref:`choosing_network`
+
+Faucet mechanisms tend to come and go, so if any information here is
+out of date, try the `Ethereum Stackexchange <https://ethereum.stackexchange.com/>`_.
+Here are some links to testnet ether instructions (in no particular order):
+
+- `Kovan <https://github.com/kovan-testnet/faucet>`_
+- `Rinkeby <https://www.rinkeby.io/#faucet>`_
+- `Ropsten <https://www.reddit.com/r/ethdev/comments/72ltwj/the_new_if_you_need_some_ropsten_testnet_ethers/>`_

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -35,11 +35,11 @@ Often, the best way to guarantee a correct environment is with ``virtualenv``, l
 
 .. _use-metamask-accounts:
 
-How do I use my Metamask accounts from Web3.py?
+How do I use my MetaMask accounts from Web3.py?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This requires exporting your private key from metamask, and using
-the local private key tools in web3 to sign and send transactions.
+Export your private key from MetaMask, and use
+the local private key tools in Web3.py to sign and send transactions.
 
 See `how to export your private key
 <https://ethereum.stackexchange.com/questions/33053/what-is-a-private-key-in-an-ethereum-wallet-like-metamask-and-how-do-i-find-it>`_

--- a/docs/v4_migration.rst
+++ b/docs/v4_migration.rst
@@ -156,3 +156,9 @@ Contracts
   value by decoding the underlying bytes using UTF-8.
 - When a contract returns the ABI type ``bytes`` (of any length),
   Web3.py v4 now returns a :class:`bytes` value
+
+Personal API
+--------------
+
+``w3.personal.signAndSendTransaction`` is no longer available. Use
+:meth:`w3.personal.sendTransaction() <web3.personal.sendTransaction>` instead.

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -3,7 +3,7 @@
 Working with Local Private Keys
 ==========================================
 
-.. _local-vs-hosted:
+.. _local_vs_hosted:
 
 Local vs Hosted Nodes
 ---------------------------------

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -71,10 +71,10 @@ Sign a Message
     like `EIP-683 <https://github.com/ethereum/EIPs/pull/683>`_,
     `EIP-712 <https://github.com/ethereum/EIPs/pull/712>`_, and
     `EIP-719 <https://github.com/ethereum/EIPs/pull/719>`_. Consider
-    the :meth:`w3.eth.Eth.sign` approach be deprecated.
+    the :meth:`w3.eth.sign() <web3.eth.Eth.sign>` approach be deprecated.
 
 For this example, we will use the same message hashing mechanism that
-is provided by :meth:`w3.eth.Eth.sign`.
+is provided by :meth:`w3.eth.sign() <web3.eth.Eth.sign>`.
 
 .. doctest::
 

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -3,6 +3,8 @@
 Working with Local Private Keys
 ==========================================
 
+.. _local-vs-hosted:
+
 Local vs Hosted Nodes
 ---------------------------------
 
@@ -201,6 +203,8 @@ Then call ecr with these arguments from `Prepare message for ecrecover in Solidi
 
 The message is verified, because we get the correct sender of
 the message back in response: ``0x5ce9454909639d2d17a3f753ce7d93fa0b9ab12e``.
+
+.. _local-sign-transaction:
 
 Sign a Transaction
 ------------------------

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -21,16 +21,15 @@ you can find the latest block number in these two ways:
           'number': 4022281,
           # ... etc ...
         })
+
         >>> block['number']
         4022281
         >>> block.number
         4022281
+
         >>> block.number = 4022282
         Traceback # ... etc ...
         TypeError: This data is immutable -- create a copy instead of modifying
-        >>> next_block = web3.utils.datastructures.AttributeDict(block, number=4022282)
-        >>> next_block.number
-        4022282
 
 
 Properties

--- a/docs/web3.personal.rst
+++ b/docs/web3.personal.rst
@@ -82,3 +82,9 @@ The following methods are available on the ``web3.personal`` namespace.
         False
         >>> web3.personal.unlockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601', 'the-passphrase')
         True
+
+.. py:method:: sendTransaction(self, transaction, passphrase)
+
+    * Delegates to ``personal_sendTransaction`` RPC Method
+
+    Sends the transaction.

--- a/web3/main.py
+++ b/web3/main.py
@@ -23,6 +23,9 @@ from web3.testing import Testing
 from web3.txpool import TxPool
 from web3.version import Version
 
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
 from web3.providers.ipc import (
     IPCProvider,
 )
@@ -31,7 +34,6 @@ from web3.providers.rpc import (
 )
 from web3.providers.tester import (
     TestRPCProvider,
-    EthereumTesterProvider,
 )
 from web3.providers.websocket import (
     WebsocketProvider


### PR DESCRIPTION
### What was wrong?

Related to Issue #719 

People are still pretty confused. Trying to do better, at least for the people who actually read the docs.

### How was it fixed?

A lot of new documentation. Simplify the quickstart a bit, but link out to bigger explanations for common problems. Some explainers/tutorials on what Web3.py (and Ethereum) are all about.

- [x] Add pip & setuptools update to quickstart instructions
- [x] Clarify distinction between shell and python interpreter
- [x] Add (link to) instructions for installing virtualenv
- [x] Use the new pip setup.py attribute python_requires to give a cleaner error message
- [x] Deep dive on basic questions, like "Why do I need to connect to a node?"
- [x] In docs, link to a list of several faucets for different testnets. (There's probably already a good ESE post with this)
- [x] Add (link to) pip install instructions for a variety of platforms

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://photos1.blogger.com/blogger/3706/840/1600/squirrels.jpg)
