### PR TITLE
Contract.py: `ABI` not provided error message

### DIFF
--- a/tests/core/contracts/test_legacy_constructor_adapter.py
+++ b/tests/core/contracts/test_legacy_constructor_adapter.py
@@ -71,7 +71,8 @@ class ContactClassForTest(Contract):
         ),
         ((ABI, ADDRESS), {'abi': ABI}, TypeError),
         ((ABI, ADDRESS), {'address': ADDRESS}, TypeError),
-        ((ADDRESS,), {}, {'address': ADDRESS}),
+        ((ABI, ADDRESS), {}, {'address': ADDRESS}),
+        ((ADDRESS,), {}, TypeError),
         ((), {'abi': MALFORMED_ABI_1, 'address': ADDRESS}, ValueError),
         ((), {'abi': MALFORMED_ABI_2, 'address': ADDRESS}, ValueError),
         ((), {'abi': ABI, 'address': CODE}, ValueError),
@@ -108,15 +109,16 @@ def test_deprecated_properties():
 
 @pytest.mark.skipif(sys.version_info.major == 2, reason="Python2 fails weirdly on this test")
 def test_deprecated_instantiation():
+
     with pytest.warns(Warning) as record:
-        ContactClassForTest(ADDRESS)
-        ContactClassForTest(address=ADDRESS)
+        ContactClassForTest(address=ADDRESS, abi=ABI)
+        ContactClassForTest(ADDRESS, abi=ABI)
         warnings.warn(Warning('test'))
 
-    assert len(record) == 1
+    assert len(record) == 3
 
-    with pytest.warns(DeprecationWarning):
-        ContactClassForTest()  # no address
+    with pytest.raises(TypeError):
+        ContactClassForTest()  # no address, no abi
 
     with pytest.warns(DeprecationWarning):
         ContactClassForTest(ABI, ADDRESS)  # no address
@@ -124,5 +126,5 @@ def test_deprecated_instantiation():
     with pytest.warns(DeprecationWarning):
         ContactClassForTest(ABI)  # no address
 
-    with pytest.warns(DeprecationWarning):
-        ContactClassForTest(code='0x1')  # no address
+    with pytest.raises(TypeError):
+        ContactClassForTest(code='0x1')  # no address, no abi

--- a/tests/core/eth-module/test_eth_contract.py
+++ b/tests/core/eth-module/test_eth_contract.py
@@ -14,8 +14,8 @@ INVALID_CHECKSUM_ADDRESS = '0xd3CDA913deB6f67967B99D67aCDFa1712C293601'
 @pytest.mark.parametrize(
     'args,kwargs,expected',
     (
-        ((ADDRESS,), {}, None),
-        ((ADDRESS, ABI), {}, None),
+        ((ADDRESS,), {}, TypeError),
+        ((ADDRESS), {'abi': ABI}, None),
         ((INVALID_CHECKSUM_ADDRESS,), {}, ValueError),
         ((), {'address': INVALID_CHECKSUM_ADDRESS}, ValueError),
         ((ABI), {'address': INVALID_CHECKSUM_ADDRESS}, ValueError),

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -202,6 +202,9 @@ class Contract(object):
                 "instantiation.  Please update your code to reflect this change"
             ))
 
+        if self.abi is None:
+            raise TypeError("The 'abi' argument is required was not found")
+
     @classmethod
     def factory(cls, web3, contract_name=None, **kwargs):
         if contract_name is None:


### PR DESCRIPTION
Now raises TypeError if ABI is not provided with the contract.
### What was wrong?

Part of #698 

### How was it fixed?
Added check for abi, if `None` raises `TypeError`

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://scontent-bom1-1.cdninstagram.com/vp/9dd9f9140da2586e01bdbd4a814f2851/5B79666F/t51.2885-15/e35/30602362_420374555056812_5653699879629750272_n.jpg)
