### PR TITLE
Update web3.eth.account.rst

### DIFF
--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -58,6 +58,9 @@ or see a full list of things you can do in the docs for
 Extract private key from geth keyfile
 ---------------------------------------------
 
+.. NOTE::
+  The amount of available ram should be greater than 1GB.
+  
 .. code-block:: python
 
     with open('~/.ethereum/keystore/UTC--...--5ce9454909639D2D17A3F753ce7d93fa0b9aB12E') as keyfile:


### PR DESCRIPTION
### What was wrong?

I was having errors trying to decrypt a keystore file using the example in the docs.

I found this: https://github.com/Legrandin/pycryptodome/commit/5d712a784e3248b38d5c5fbe0add33da6913cb4a

Note that this is only for the pycryptodome test suite. `eth_accounts` is using this raw import lib: https://github.com/Legrandin/pycryptodome/blob/master/lib/Crypto/Protocol/KDF.py#L42

Which doesn't have the same error handling as the test suite.

### How was it fixed?

I increased the ram on my VM (Amazon ec2 free tier is 1GB of ram) and I was capable of decrypting keys. Hopefully this note in the docs makes it easier for some other people. 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/b2ql6jjbhbv01.png)
