### PR TITLE
conditionally install cytoolz or toolz  based on python implementation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from setuptools import (
-    setup,
     find_packages,
+    setup,
 )
 
 
@@ -17,7 +17,8 @@ setup(
     url='https://github.com/ethereum/web3.py',
     include_package_data=True,
     install_requires=[
-        "cytoolz>=0.9.0,<1.0.0",
+        "toolz>=0.9.0,<1.0.0;implementation_name=='pypy'",
+        "cytoolz>=0.9.0,<1.0.0;implementation_name=='cpython'",
         "eth-abi>=1.0.0,<2",
         "eth-account>=0.2.1,<0.3.0",
         "eth-utils>=1.0.1,<2.0.0",

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from cytoolz import (
+from web3.utils.toolz import (
     dissoc,
 )
 

--- a/tests/core/core/block-utils/test_select_method_for_block_identifier.py
+++ b/tests/core/core/block-utils/test_select_method_for_block_identifier.py
@@ -3,7 +3,7 @@ import pytest
 from web3.utils.blocks import (
     select_method_for_block_identifier,
 )
-from web3.utils.toolz.functoolz import (
+from web3.utils.toolz import (
     partial,
 )
 

--- a/tests/core/core/block-utils/test_select_method_for_block_identifier.py
+++ b/tests/core/core/block-utils/test_select_method_for_block_identifier.py
@@ -1,11 +1,10 @@
 import pytest
 
-from cytoolz.functoolz import (
-    partial,
-)
-
 from web3.utils.blocks import (
     select_method_for_block_identifier,
+)
+from web3.utils.toolz.functoolz import (
+    partial,
 )
 
 selector_fn = partial(

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -2,9 +2,6 @@
 
 import pytest
 
-from cytoolz import (
-    dissoc,
-)
 from eth_account.messages import (
     defunct_hash_message,
 )
@@ -25,6 +22,9 @@ from web3.providers.eth_tester import (
 from web3.utils.encoding import (
     to_bytes,
     to_hex,
+)
+from web3.utils.toolz import (
+    dissoc,
 )
 
 # from https://github.com/ethereum/tests/blob/3930ca3a9a377107d5792b3e7202f79c688f1a67/BasicTests/txtest.json # noqa: 501

--- a/tests/generate_go_ethereum_fixture.py
+++ b/tests/generate_go_ethereum_fixture.py
@@ -10,10 +10,6 @@ import sys
 import tempfile
 import time
 
-from cytoolz import (
-    merge,
-    valmap,
-)
 from eth_utils.curried import (
     apply_formatter_if,
     is_bytes,
@@ -35,6 +31,10 @@ from web3.utils.module_testing.emitter_contract import (
 from web3.utils.module_testing.math_contract import (
     MATH_ABI,
     MATH_BYTECODE,
+)
+from web3.utils.toolz import (
+    merge,
+    valmap,
 )
 
 COINBASE = '0xdc544d1aa88ff8bbd2f2aec754b1f1e99e1812fd'

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -5,9 +5,6 @@ import pprint
 import shutil
 import sys
 
-from cytoolz import (
-    merge,
-)
 from eth_utils import (
     is_dict,
     is_same_address,
@@ -23,6 +20,9 @@ from web3.utils.module_testing.emitter_contract import (
 from web3.utils.module_testing.math_contract import (
     MATH_ABI,
     MATH_BYTECODE,
+)
+from web3.utils.toolz import (
+    merge,
 )
 
 

--- a/tests/integration/generate_fixtures/parity.py
+++ b/tests/integration/generate_fixtures/parity.py
@@ -6,9 +6,6 @@ import shutil
 import sys
 import time
 
-from cytoolz import (
-    merge,
-)
 from eth_utils import (
     to_text,
 )
@@ -16,6 +13,9 @@ from eth_utils import (
 import common
 import go_ethereum
 from web3 import Web3
+from web3.utils.toolz import (
+    merge,
+)
 
 CHAIN_CONFIG = {
     "name": "CrossClient",

--- a/tests/integration/go_ethereum/conftest.py
+++ b/tests/integration/go_ethereum/conftest.py
@@ -4,13 +4,14 @@ import pytest
 import shutil
 import subprocess
 
-from cytoolz import (
-    assoc,
-)
 from eth_utils import (
     is_checksum_address,
     is_dict,
     to_text,
+)
+
+from web3.utils.toolz import (
+    assoc,
 )
 
 from .utils import (

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -72,7 +72,7 @@ from web3.utils.normalizers import (
     normalize_address,
     normalize_bytecode,
 )
-from web3.utils.toolz.functoolz import (
+from web3.utils.toolz import (
     compose,
     partial,
 )

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -17,10 +17,6 @@ from eth_utils import (
     is_text,
     to_tuple,
 )
-from toolz.functoolz import (
-    compose,
-    partial,
-)
 
 from web3.exceptions import (
     BadFunctionCallOutput,
@@ -75,6 +71,10 @@ from web3.utils.normalizers import (
     normalize_abi,
     normalize_address,
     normalize_bytecode,
+)
+from web3.utils.toolz.functoolz import (
+    compose,
+    partial,
 )
 from web3.utils.transactions import (
     fill_transaction_defaults,

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -1,7 +1,3 @@
-from cytoolz.dicttoolz import (
-    assoc,
-    merge,
-)
 from eth_account import (
     Account,
 )
@@ -39,6 +35,10 @@ from web3.utils.filters import (
     BlockFilter,
     LogFilter,
     TransactionFilter,
+)
+from web3.utils.toolz.dicttoolz import (
+    assoc,
+    merge,
 )
 from web3.utils.transactions import (
     assert_valid_transaction_params,

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -36,7 +36,7 @@ from web3.utils.filters import (
     LogFilter,
     TransactionFilter,
 )
-from web3.utils.toolz.dicttoolz import (
+from web3.utils.toolz import (
     assoc,
     merge,
 )

--- a/web3/gas_strategies/time_based.py
+++ b/web3/gas_strategies/time_based.py
@@ -2,13 +2,14 @@ import collections
 import math
 import operator
 
-from cytoolz import (
+from eth_utils import (
+    to_tuple,
+)
+
+from web3.utils.toolz import (
     curry,
     groupby,
     sliding_window,
-)
-from eth_utils import (
-    to_tuple,
 )
 
 MinerData = collections.namedtuple('MinerData', ['miner', 'num_blocks', 'min_gas_price'])

--- a/web3/middleware/attrdict.py
+++ b/web3/middleware/attrdict.py
@@ -1,12 +1,12 @@
-from cytoolz.dicttoolz import (
-    assoc,
-)
 from eth_utils import (
     is_dict,
 )
 
 from web3.utils.datastructures import (
     AttributeDict,
+)
+from web3.utils.toolz.dicttoolz import (
+    assoc,
 )
 
 

--- a/web3/middleware/attrdict.py
+++ b/web3/middleware/attrdict.py
@@ -5,7 +5,7 @@ from eth_utils import (
 from web3.utils.datastructures import (
     AttributeDict,
 )
-from web3.utils.toolz.dicttoolz import (
+from web3.utils.toolz import (
     assoc,
 )
 

--- a/web3/middleware/exception_handling.py
+++ b/web3/middleware/exception_handling.py
@@ -1,4 +1,4 @@
-from web3.utils.toolz.functoolz import (
+from web3.utils.toolz import (
     excepts,
 )
 

--- a/web3/middleware/exception_handling.py
+++ b/web3/middleware/exception_handling.py
@@ -1,4 +1,4 @@
-from cytoolz.functoolz import (
+from web3.utils.toolz.functoolz import (
     excepts,
 )
 

--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -1,9 +1,7 @@
 from web3.utils.toolz import (
+    assoc,
     curry,
     merge,
-)
-from web3.utils.toolz.dicttoolz import (
-    assoc,
 )
 
 

--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -1,8 +1,8 @@
-from cytoolz import (
+from web3.utils.toolz import (
     curry,
     merge,
 )
-from cytoolz.dicttoolz import (
+from web3.utils.toolz.dicttoolz import (
     assoc,
 )
 

--- a/web3/middleware/gas_price_strategy.py
+++ b/web3/middleware/gas_price_strategy.py
@@ -1,4 +1,4 @@
-from cytoolz.dicttoolz import (
+from web3.utils.toolz.dicttoolz import (
     assoc,
 )
 

--- a/web3/middleware/gas_price_strategy.py
+++ b/web3/middleware/gas_price_strategy.py
@@ -1,4 +1,4 @@
-from web3.utils.toolz.dicttoolz import (
+from web3.utils.toolz import (
     assoc,
 )
 

--- a/web3/middleware/geth_poa.py
+++ b/web3/middleware/geth_poa.py
@@ -1,6 +1,3 @@
-from cytoolz import (
-    compose,
-)
 from eth_utils.curried import (
     apply_formatters_to_dict,
     apply_key_map,
@@ -11,6 +8,9 @@ from hexbytes import (
 
 from web3.middleware.formatting import (
     construct_formatting_middleware,
+)
+from web3.utils.toolz import (
+    compose,
 )
 
 remap_geth_poa_fields = apply_key_map({

--- a/web3/middleware/normalize_errors.py
+++ b/web3/middleware/normalize_errors.py
@@ -1,4 +1,4 @@
-from cytoolz import (
+from web3.utils.toolz import (
     assoc,
     dissoc,
 )

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -1,18 +1,6 @@
 import codecs
 import operator
 
-from cytoolz import (
-    curry,
-)
-from cytoolz.curried import (
-    keymap,
-    valmap,
-)
-from cytoolz.functoolz import (
-    complement,
-    compose,
-    partial,
-)
 from eth_utils.curried import (
     combine_argument_formatters,
     is_address,
@@ -43,6 +31,18 @@ from web3.utils.formatters import (
     is_array_of_dicts,
     is_array_of_strings,
     remove_key_if,
+)
+from web3.utils.toolz import (
+    curry,
+)
+from web3.utils.toolz.curried import (
+    keymap,
+    valmap,
+)
+from web3.utils.toolz.functoolz import (
+    complement,
+    compose,
+    partial,
 )
 
 from .formatting import (

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -33,16 +33,14 @@ from web3.utils.formatters import (
     remove_key_if,
 )
 from web3.utils.toolz import (
+    complement,
+    compose,
     curry,
+    partial,
 )
 from web3.utils.toolz.curried import (
     keymap,
     valmap,
-)
-from web3.utils.toolz.functoolz import (
-    complement,
-    compose,
-    partial,
 )
 
 from .formatting import (

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -1,9 +1,3 @@
-from cytoolz import (
-    complement,
-    compose,
-    curry,
-    dissoc,
-)
 from eth_utils.curried import (
     apply_formatter_at_index,
     apply_formatter_if,
@@ -19,6 +13,12 @@ from web3.exceptions import (
 )
 from web3.middleware.formatting import (
     construct_web3_formatting_middleware,
+)
+from web3.utils.toolz import (
+    complement,
+    compose,
+    curry,
+    dissoc,
 )
 
 MAX_EXTRADATA_LENGTH = 32

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -2,11 +2,6 @@ import operator
 import random
 import sys
 
-from cytoolz.functoolz import (
-    compose,
-    curry,
-    excepts,
-)
 from eth_tester.exceptions import (
     BlockNotFound,
     FilterNotFound,
@@ -22,6 +17,11 @@ from eth_utils import (
 
 from web3.utils.formatters import (
     apply_formatter_if,
+)
+from web3.utils.toolz.functoolz import (
+    compose,
+    curry,
+    excepts,
 )
 
 

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -18,7 +18,7 @@ from eth_utils import (
 from web3.utils.formatters import (
     apply_formatter_if,
 )
-from web3.utils.toolz.functoolz import (
+from web3.utils.toolz import (
     compose,
     curry,
     excepts,

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -1,14 +1,5 @@
 import operator
 
-from cytoolz import (
-    assoc,
-    complement,
-    compose,
-    curry,
-    identity,
-    partial,
-    pipe,
-)
 from eth_utils import (
     is_dict,
     is_hex,
@@ -30,6 +21,15 @@ from web3.utils.formatters import (
     is_array_of_dicts,
     remove_key_if,
     static_return,
+)
+from web3.utils.toolz import (
+    assoc,
+    complement,
+    compose,
+    curry,
+    identity,
+    partial,
+    pipe,
 )
 
 

--- a/web3/providers/tester.py
+++ b/web3/providers/tester.py
@@ -2,13 +2,6 @@ from wsgiref.simple_server import (
     make_server,
 )
 
-from cytoolz import (
-    valmap,
-)
-from cytoolz.functoolz import (
-    complement,
-    compose,
-)
 from eth_utils import (
     decode_hex,
     is_integer,
@@ -33,6 +26,13 @@ from web3.utils.formatters import (
 )
 from web3.utils.threads import (
     spawn,
+)
+from web3.utils.toolz import (
+    valmap,
+)
+from web3.utils.toolz.functoolz import (
+    complement,
+    compose,
 )
 
 from .base import (

--- a/web3/providers/tester.py
+++ b/web3/providers/tester.py
@@ -28,11 +28,9 @@ from web3.utils.threads import (
     spawn,
 )
 from web3.utils.toolz import (
-    valmap,
-)
-from web3.utils.toolz.functoolz import (
     complement,
     compose,
+    valmap,
 )
 
 from .base import (

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -4,11 +4,6 @@ from collections import (
 import itertools
 import re
 
-from cytoolz import (
-    curry,
-    partial,
-    pipe,
-)
 from eth_abi.abi import (
     collapse_type,
     process_type,
@@ -32,6 +27,11 @@ from web3.utils.ens import (
 )
 from web3.utils.formatters import (
     recursive_map,
+)
+from web3.utils.toolz import (
+    curry,
+    partial,
+    pipe,
 )
 
 

--- a/web3/utils/contracts.py
+++ b/web3/utils/contracts.py
@@ -1,8 +1,5 @@
 import functools
 
-from cytoolz import (
-    pipe,
-)
 from eth_abi import (
     encode_abi as eth_abi_encode_abi,
 )
@@ -17,9 +14,6 @@ from eth_utils import (
 )
 from hexbytes import (
     HexBytes,
-)
-from toolz.dicttoolz import (
-    valmap,
 )
 
 from web3.exceptions import (
@@ -49,6 +43,12 @@ from web3.utils.normalizers import (
     abi_bytes_to_bytes,
     abi_ens_resolver,
     abi_string_to_text,
+)
+from web3.utils.toolz import (
+    pipe,
+)
+from web3.utils.toolz.dicttoolz import (
+    valmap,
 )
 
 

--- a/web3/utils/contracts.py
+++ b/web3/utils/contracts.py
@@ -46,8 +46,6 @@ from web3.utils.normalizers import (
 )
 from web3.utils.toolz import (
     pipe,
-)
-from web3.utils.toolz.dicttoolz import (
     valmap,
 )
 

--- a/web3/utils/datatypes.py
+++ b/web3/utils/datatypes.py
@@ -1,9 +1,7 @@
 import web3.utils.formatters
-from web3.utils.toolz.functoolz import (
-    curry,
-)
-from web3.utils.toolz.itertoolz import (
+from web3.utils.toolz import (
     concat,
+    curry,
 )
 
 

--- a/web3/utils/datatypes.py
+++ b/web3/utils/datatypes.py
@@ -1,11 +1,10 @@
-from cytoolz.functoolz import (
+import web3.utils.formatters
+from web3.utils.toolz.functoolz import (
     curry,
 )
-from toolz.itertoolz import (
+from web3.utils.toolz.itertoolz import (
     concat,
 )
-
-import web3.utils.formatters
 
 
 @curry

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -1,9 +1,6 @@
 # String encodings and numeric representations
 import re
 
-from cytoolz import (
-    curry,
-)
 from eth_utils import (
     add_0x_prefix,
     big_endian_to_int,
@@ -28,6 +25,9 @@ from web3.utils.abi import (
     is_uint_type,
     size_of_type,
     sub_type_of_array_type,
+)
+from web3.utils.toolz import (
+    curry,
 )
 from web3.utils.validation import (
     assert_one_val,

--- a/web3/utils/formatters.py
+++ b/web3/utils/formatters.py
@@ -3,13 +3,6 @@ from collections import (
     Mapping,
 )
 
-from cytoolz import (
-    dissoc,
-)
-from cytoolz.functoolz import (
-    compose,
-    curry,
-)
 from eth_utils import (
     is_dict,
     is_list_like,
@@ -20,6 +13,13 @@ from eth_utils import (
 
 from web3.utils.decorators import (
     reject_recursive_repeats,
+)
+from web3.utils.toolz import (
+    dissoc,
+)
+from web3.utils.toolz.functoolz import (
+    compose,
+    curry,
 )
 
 

--- a/web3/utils/formatters.py
+++ b/web3/utils/formatters.py
@@ -15,11 +15,9 @@ from web3.utils.decorators import (
     reject_recursive_repeats,
 )
 from web3.utils.toolz import (
-    dissoc,
-)
-from web3.utils.toolz.functoolz import (
     compose,
     curry,
+    dissoc,
 )
 
 

--- a/web3/utils/normalizers.py
+++ b/web3/utils/normalizers.py
@@ -3,9 +3,6 @@ import codecs
 import functools
 import json
 
-from cytoolz import (
-    curry,
-)
 from eth_abi.abi import (
     process_type,
 )
@@ -29,6 +26,9 @@ from web3.utils.encoding import (
 from web3.utils.ens import (
     is_ens_name,
     validate_name_has_address,
+)
+from web3.utils.toolz import (
+    curry,
 )
 from web3.utils.validation import (
     validate_abi,

--- a/web3/utils/rpc_abi.py
+++ b/web3/utils/rpc_abi.py
@@ -1,6 +1,3 @@
-from cytoolz import (
-    curry,
-)
 from eth_utils import (
     to_dict,
 )
@@ -10,6 +7,9 @@ from web3.utils.abi import (
 )
 from web3.utils.formatters import (
     apply_formatter_at_index,
+)
+from web3.utils.toolz import (
+    curry,
 )
 
 TRANSACTION_PARAMS_ABIS = {

--- a/web3/utils/toolz.py
+++ b/web3/utils/toolz.py
@@ -1,0 +1,47 @@
+import sys
+
+try:
+    from cytoolz import (
+        assoc,
+        complement,
+        compose,
+        curried,
+        curry,
+        dicttoolz,
+        dissoc,
+        functoolz,
+        groupby,
+        identity,
+        itertoolz,
+        merge,
+        partial,
+        pipe,
+        sliding_window,
+        valmap,
+    )
+except ImportError:
+    from toolz import (  # noqa: F401
+        assoc,
+        complement,
+        compose,
+        curried,
+        curry,
+        dicttoolz,
+        dissoc,
+        functoolz,
+        groupby,
+        identity,
+        itertoolz,
+        merge,
+        partial,
+        pipe,
+        sliding_window,
+        valmap,
+    )
+
+
+modules = [curried, dicttoolz, functoolz, itertoolz]
+for module in modules:
+    module_name = module.__name__.split('.')[-1]
+    sys.modules['web3.utils.toolz.{0}'.format(module_name)] = module
+del sys, modules

--- a/web3/utils/toolz/__init__.py
+++ b/web3/utils/toolz/__init__.py
@@ -1,14 +1,13 @@
-import sys
-
 try:
     from cytoolz import (
         assoc,
         complement,
         compose,
-        curried,
+        concat,
         curry,
         dicttoolz,
         dissoc,
+        excepts,
         functoolz,
         groupby,
         identity,
@@ -24,10 +23,11 @@ except ImportError:
         assoc,
         complement,
         compose,
-        curried,
+        concat,
         curry,
         dicttoolz,
         dissoc,
+        excepts,
         functoolz,
         groupby,
         identity,
@@ -38,10 +38,3 @@ except ImportError:
         sliding_window,
         valmap,
     )
-
-
-modules = [curried, dicttoolz, functoolz, itertoolz]
-for module in modules:
-    module_name = module.__name__.split('.')[-1]
-    sys.modules['web3.utils.toolz.{0}'.format(module_name)] = module
-del sys, modules

--- a/web3/utils/toolz/curried.py
+++ b/web3/utils/toolz/curried.py
@@ -1,0 +1,10 @@
+try:
+    from cytoolz.curried import (
+        keymap,
+        valmap,
+    )
+except ImportError:
+    from toolz.curried import (  # noqa: F401
+        keymap,
+        valmap,
+    )

--- a/web3/utils/transactions.py
+++ b/web3/utils/transactions.py
@@ -1,13 +1,12 @@
 import math
 
-from cytoolz import (
+from web3.utils.threads import (
+    Timeout,
+)
+from web3.utils.toolz import (
     assoc,
     curry,
     merge,
-)
-
-from web3.utils.threads import (
-    Timeout,
 )
 
 VALID_TRANSACTION_PARAMS = [


### PR DESCRIPTION
### What was wrong?
@pipermerriam This is for you 😃 
addresses https://github.com/ethereum/web3.py/pull/789#issuecomment-385447090

### How was it fixed?

Conditionally install cytoolz or toolz  based on python implementation. 

In my first attempt I tried to avoid imports from `dicttoolz`, `curried` by importing directly from `cytoolz` or `toolz`. However `from cytoolz import keymap` is different from `from cytoolz.curried import keymap`. So I kept the import order the same as before: `from web3.utils.toolz.dictoolz ...` 

#### Cute Animal Picture


![](http://www.kinyu-z.net/data/wallpapers/58/904266.jpg)

