### PR TITLE
added personal_sendTransaction to request_formatters in the pythonic middleware

### DIFF
--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -279,6 +279,7 @@ pythonic_middleware = construct_formatting_middleware(
         ),
         'personal_sign': apply_formatter_at_index(text_if_str(to_hex), 0),
         'personal_ecRecover': apply_formatter_at_index(text_if_str(to_hex), 0),
+        'personal_sendTransaction': apply_formatter_at_index(transaction_param_formatter, 0),
         # Snapshot and Revert
         'evm_revert': apply_formatter_at_index(integer_to_hex, 0),
     },


### PR DESCRIPTION
### What was wrong?

`personal_sendTransaction` was missing in the list of `request_formatters` in the pythonic middleware.
fixes #816

### How was it fixed?
added `personal_sendTransaction` to `request_formatters` in the pythonic middleware.


#### Cute Animal Picture

![](https://www.50-best.com/images/cute_animal_pictures/baby_bunny.jpg)
