### PR TITLE
Support fixedMxN ABI type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "toolz>=0.9.0,<1.0.0;implementation_name=='pypy'",
         "cytoolz>=0.9.0,<1.0.0;implementation_name=='cpython'",
-        "eth-abi>=1.0.0,<2",
+        "eth-abi>=1.1.0,<2",
         "eth-account>=0.2.1,<0.3.0",
         "eth-utils>=1.0.1,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",

--- a/tests/core/utilities/test_abi_is_encodable.py
+++ b/tests/core/utilities/test_abi_is_encodable.py
@@ -21,8 +21,8 @@ from web3.utils.abi import (
         (True, 'bytes32', False),  # no wrong types
         (0, 'bytes32', False),  # no wrong types
         # int
-        (-1 * 2**255, 'int256', False),
-        (-1 * 2**255 + 1, 'int256', True),
+        (-1 * 2**255 - 1, 'int256', False),
+        (-1 * 2**255, 'int256', True),
         (-1, 'int256', True),
         (0, 'int256', True),
         (1, 'int256', True),

--- a/tests/core/utilities/test_abi_is_encodable.py
+++ b/tests/core/utilities/test_abi_is_encodable.py
@@ -55,6 +55,12 @@ from web3.utils.abi import (
         ('ff', 'address', True),  # this could theoretically be a top-level domain (TLD)
         ('0xname.eth', 'address', True),  # 0x in name is fine, if it is not a TLD
         ('0xff', 'address', False),  # but any valid hex starting with 0x should be rejected
+        # string
+        ('', 'string', True),
+        ('anything', 'string', True),
+        (b'', 'string', True),
+        (b'anything', 'string', True),
+        (b'\x80', 'string', False),  # bytes that cannot be decoded with utf-8 are invalid
     ),
 )
 def test_is_encodable(value, _type, expected):

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -15,6 +15,7 @@ from eth_utils import (
     is_hex,
     is_list_like,
     to_bytes,
+    to_text,
     to_tuple,
 )
 
@@ -135,6 +136,14 @@ def is_encodable(_type, value):
             return eth_abi_is_encodable(_type, bytes_val)
         else:
             return False
+    elif base == 'string' and isinstance(value, bytes):
+        # bytes that were encoded with utf-8 can be used anywhere a string is needed
+        try:
+            string_val = to_text(value)
+        except UnicodeDecodeError:
+            return False
+        else:
+            return eth_abi_is_encodable(_type, string_val)
     else:
         return eth_abi_is_encodable(_type, value)
 

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -4,18 +4,17 @@ from collections import (
 import itertools
 import re
 
+from eth_abi import (
+    is_encodable as eth_abi_is_encodable,
+)
 from eth_abi.abi import (
     collapse_type,
     process_type,
 )
 from eth_utils import (
-    decode_hex,
-    is_address,
-    is_boolean,
     is_hex,
-    is_integer,
     is_list_like,
-    is_string,
+    to_bytes,
     to_tuple,
 )
 
@@ -124,50 +123,20 @@ def is_encodable(_type, value):
             return False
         sub_type = (base, sub, arrlist[:-1])
         return all(is_encodable(sub_type, sub_value) for sub_value in value)
-    elif base == 'bool':
-        return is_boolean(value)
-    elif base == 'uint':
-        if not is_integer(value):
-            return False
-        exp = int(sub)
-        if value < 0 or value >= 2**exp:
-            return False
+    elif base == 'address' and is_ens_name(value):
+        # ENS names can be used anywhere an address is needed
+        # Web3.py will resolve the name to an address before encoding it
         return True
-    elif base == 'int':
-        if not is_integer(value):
-            return False
-        exp = int(sub)
-        if value <= -1 * 2**(exp - 1) or value >= 2**(exp - 1):
-            return False
-        return True
-    elif base == 'string':
-        if not is_string(value):
-            return False
-        return True
-    elif base == 'bytes':
-        if not is_string(value):
-            return False
-
-        if not sub:
-            return True
-
-        max_length = int(sub)
-        if isinstance(value, str):
-            decodable = is_hex(value) and len(value) % 2 == 0
-            return decodable and len(decode_hex(value)) <= max_length
-        elif isinstance(value, bytes):
-            return len(value) <= max_length
-        else:
-            return False
-    elif base == 'address':
-        if is_ens_name(value):
-            return True
-        elif is_address(value):
-            return True
+    elif base == 'bytes' and isinstance(value, str):
+        # Hex-encoded bytes values can be used anywhere a bytes value is needed
+        if is_hex(value) and len(value) % 2 == 0:
+            # Require hex-encoding of full bytes (even length)
+            bytes_val = to_bytes(hexstr=value)
+            return eth_abi_is_encodable(_type, bytes_val)
         else:
             return False
     else:
-        raise ValueError("Unsupported type")
+        return eth_abi_is_encodable(_type, value)
 
 
 def filter_by_encodability(args, kwargs, contract_abi):


### PR DESCRIPTION
### What was wrong?

No support for Fixed ABI type (needed by Casper)

### How was it fixed?

- upgrade to eth-abi v1.1
- Move most of the is_encodable test to eth-abi
- Special handling of ENS addresses and hex-encoded bytes values specially
- Update minimum allowed int256 value in tests (from `-2 ** 255 + 1` to `-2 ** 255`)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/736x/3a/d4/ae/3ad4aed619a5c1cc22eba0c569f79c30--hamster-eating-funny-shit.jpg)
