### PR TITLE
A sprinkle of doc cleanups

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -453,7 +453,7 @@ Methods
         "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd"
 
 
-.. py:method:: ContractFunction.call(transaction)
+.. py:method:: ContractFunction.call(transaction, block_identifier='latest')
 
     Call a contract function, executing the transaction locally using the
     ``eth_call`` API.  This will not create a new public transaction.

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -41,7 +41,7 @@ Released Apr 9, 2018
 - Various documentation updates
 - Pinned eth-account to older version
 
-v4.0.0 (stable)
+v4.0.0
 -----------------
 
 Released Apr 2, 2018

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -266,6 +266,7 @@ To sign a transaction locally that will invoke a smart contract:
 
     >>> nonce = w3.eth.getTransactionCount('0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E')  # doctest: +SKIP
 
+    # Build a transaction that invokes this contract's function, called transfer
     >>> unicorn_txn = unicorns.functions.transfer(
     ...     '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
     ...     1,


### PR DESCRIPTION
### What was wrong?

Things in the docs confused people

### How was it fixed?

Address the three different points of confusion:

- how to call a contract at an old block
- v4.0.0 isn't a "special" kind of stable, it was just the first one in the v4 series. Remove the "stable" tag, since they are all stable.
- Maybe overkill, but someone didn't understand that `transfer` was a contract's function, rather than something built into web3.py.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/236x/2d/61/7c/2d617cd7ae89c61235d24137e5481830--organization-ideas-hilarious-animals.jpg)