### PR TITLE
Raising exception when constrained_sample_size becomes 0

### DIFF
--- a/web3/gas_strategies/time_based.py
+++ b/web3/gas_strategies/time_based.py
@@ -6,6 +6,9 @@ from eth_utils import (
     to_tuple,
 )
 
+from web3.exceptions import (
+    ValidationError,
+)
 from web3.utils.toolz import (
     curry,
     groupby,
@@ -19,10 +22,10 @@ Probability = collections.namedtuple('Probability', ['gas_price', 'prob'])
 def _get_avg_block_time(w3, sample_size):
     latest = w3.eth.getBlock('latest')
 
-    if latest['number'] == 0 or sample_size == 0:
-        return 0
-
     constrained_sample_size = min(sample_size, latest['number'])
+    if constrained_sample_size == 0:
+        raise ValidationError('Constrained sample size is 0')
+
     oldest = w3.eth.getBlock(latest['number'] - constrained_sample_size)
     return (latest['timestamp'] - oldest['timestamp']) / constrained_sample_size
 


### PR DESCRIPTION
### What was wrong?
`_get_avg_block_time` will return zero in some cases

Fix https://github.com/ethereum/web3.py/issues/825

### How was it fixed?
For now we can hardcode this to 15 per suggestion

#### Cute Animal Picture
![Put a link to a cute animal picture inside the parenthesis-->](https://vignette.wikia.nocookie.net/animal-jam-clans-1/images/d/d4/Cute-animal-wallpapers-hd-wild-life-photos-pet-images-lovely-animals-hairy-claws-amazing-eyes-cool-884x627.jpg/revision/latest/scale-to-width-down/640?cb=20160123042737)
