### PR TITLE
New API to invoke ambiguous contract functions

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -351,6 +351,127 @@ Each Contract Factory exposes the following methods.
     Returns the transaction hash for the deploy transaction.
 
 
+.. py:classmethod:: Contract.all_functions()
+
+    Returns a list of all the functions present in a Contract where every function is
+    an instance of :py:class:`ContractFunction`.
+
+    .. code-block:: python
+
+        >> contract.all_functions()
+        [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]
+
+
+.. py:classmethod:: Contract.get_function_by_signature(signature)
+
+    Searches for a distinct function with matching signature. Returns an instance of
+    :py:class:`ContractFunction` upon finding a match. Raises `ValueError` if no
+    match is found.
+
+    .. code-block:: python
+
+        >> contract.get_function_by_signature('identity(uint256,bool)')
+        <Function identity(uint256,bool)>
+
+
+.. py:classmethod:: Contract.find_functions_by_name(name)
+
+    Searches for all function with matching name. Returns a list of matching functions
+    where every function is an instance of :py:class:`ContractFunction`. Returns an empty
+    list when no match is found.
+
+    .. code-block:: python
+
+        >> contract.find_functions_by_name('identity')
+        [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]
+
+
+.. py:classmethod:: Contract.get_function_by_name(name)
+
+    Searches for a distinct function with matching name. Returns an instance of
+    :py:class:`ContractFunction` upon finding a match. Raises `ValueError` if no
+    match is found or if multiple matches are found.
+
+    .. code-block:: python
+
+        >> contract.get_function_by_name('unique_name')
+        <Function unique_name(uint256)>
+
+
+.. py:classmethod:: Contract.get_function_by_selector(selector)
+
+    Searches for a distinct function with matching selector.
+    The selector can be a hexadecimal string, bytes or int.
+    Returns an instance of :py:class:`ContractFunction` upon finding a match.
+    Raises `ValueError` if no match is found.
+
+    .. code-block:: python
+
+        >> contract.get_function_by_selector('0xac37eebb')
+        <Function identity(uint256)'>
+        >> contract.get_function_by_selector(b'\xac7\xee\xbb')
+        <Function identity(uint256)'>
+        >> contract.get_function_by_selector(0xac37eebb)
+        <Function identity(uint256)'>
+
+
+.. py:classmethod:: Contract.find_functions_by_args(*args)
+
+    Searches for all function with matching args. Returns a list of matching functions
+    where every function is an instance of :py:class:`ContractFunction`. Returns an empty
+    list when no match is found.
+
+    .. code-block:: python
+
+        >> contract.find_functions_by_args(1, True)
+        [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]
+
+
+.. py:classmethod:: Contract.get_function_by_args(*args)
+
+    Searches for a distinct function with matching args. Returns an instance of
+    :py:class:`ContractFunction` upon finding a match. Raises `ValueError` if no
+    match is found or if multiple matches are found.
+
+    .. code-block:: python
+
+        >> contract.get_function_by_args(1)
+        <Function unique_func_with_args(uint256)>
+
+
+.. note::
+    `Contract` methods `all_functions`, `get_function_by_signature`, `find_functions_by_name`,
+    `get_function_by_name`, `get_function_by_selector`, `find_functions_by_args` and
+    `get_function_by_args` can only be used when abi is provided to the contract.
+
+
+Invoke Ambiguous Contract Functions Example
+-------------------------------------------
+
+Below is an example of a contract that has multiple functions of the same name,
+and the arguments are ambiguous.
+
+.. code-block:: python
+
+        >> contract_source_code = '''
+        pragma solidity ^0.4.21;
+        contract AmbiguousDuo {
+          function identity(uint256 input, bool uselessFlag) returns (uint256) {
+            return input;
+          }
+          function identity(int256 input, bool uselessFlag) returns (int256) {
+            return input;
+          }
+        }
+        '''
+        # fast forward all the steps of compiling and deploying the contract.
+        >> ambiguous_contract.functions.identity(1, True) # raises ValidationError
+
+        >> ambiguous_contract.get_function_by_signature('identity(uint256,bool)')(1, True)
+        <Function identity(uint256,bool)>
+
+
+
 .. _event-log-object:
 
 Event Log Object

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -358,7 +358,7 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >> contract.all_functions()
+        >>> contract.all_functions()
         [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]
 
 
@@ -370,7 +370,7 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >> contract.get_function_by_signature('identity(uint256,bool)')
+        >>> contract.get_function_by_signature('identity(uint256,bool)')
         <Function identity(uint256,bool)>
 
 
@@ -382,7 +382,7 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >> contract.find_functions_by_name('identity')
+        >>> contract.find_functions_by_name('identity')
         [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]
 
 
@@ -394,7 +394,7 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >> contract.get_function_by_name('unique_name')
+        >>> contract.get_function_by_name('unique_name')
         <Function unique_name(uint256)>
 
 
@@ -407,11 +407,11 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >> contract.get_function_by_selector('0xac37eebb')
+        >>> contract.get_function_by_selector('0xac37eebb')
         <Function identity(uint256)'>
-        >> contract.get_function_by_selector(b'\xac7\xee\xbb')
+        >>> contract.get_function_by_selector(b'\xac7\xee\xbb')
         <Function identity(uint256)'>
-        >> contract.get_function_by_selector(0xac37eebb)
+        >>> contract.get_function_by_selector(0xac37eebb)
         <Function identity(uint256)'>
 
 
@@ -423,7 +423,7 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >> contract.find_functions_by_args(1, True)
+        >>> contract.find_functions_by_args(1, True)
         [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]
 
 
@@ -435,7 +435,7 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        >> contract.get_function_by_args(1)
+        >>> contract.get_function_by_args(1)
         <Function unique_func_with_args(uint256)>
 
 
@@ -443,6 +443,14 @@ Each Contract Factory exposes the following methods.
     `Contract` methods `all_functions`, `get_function_by_signature`, `find_functions_by_name`,
     `get_function_by_name`, `get_function_by_selector`, `find_functions_by_args` and
     `get_function_by_args` can only be used when abi is provided to the contract.
+
+
+.. note::
+    `Web3.py` rejects the initialization of contracts that have more than one function
+    with the same selector or signature.
+    eg. `blockHashAddendsInexpansible(uint256)` and `blockHashAskewLimitary(uint256)` have the
+    same selector value equal to `0x00000000`. A contract containing both of these functions
+    will be rejected.
 
 
 Invoke Ambiguous Contract Functions Example
@@ -453,7 +461,7 @@ and the arguments are ambiguous.
 
 .. code-block:: python
 
-        >> contract_source_code = '''
+        >>> contract_source_code = '''
         pragma solidity ^0.4.21;
         contract AmbiguousDuo {
           function identity(uint256 input, bool uselessFlag) returns (uint256) {
@@ -465,10 +473,13 @@ and the arguments are ambiguous.
         }
         '''
         # fast forward all the steps of compiling and deploying the contract.
-        >> ambiguous_contract.functions.identity(1, True) # raises ValidationError
+        >>> ambiguous_contract.functions.identity(1, True) # raises ValidationError
 
-        >> ambiguous_contract.get_function_by_signature('identity(uint256,bool)')(1, True)
-        <Function identity(uint256,bool)>
+        >>> identity_func = ambiguous_contract.get_function_by_signature('identity(uint256,bool)')
+        >>> identity_func(1, True)
+        <Function identity(uint256,bool) bound to (1, True)>
+        >>> identity_func(1, True).call()
+        1
 
 
 

--- a/tests/core/contracts/test_contract_ambiguous_functions.py
+++ b/tests/core/contracts/test_contract_ambiguous_functions.py
@@ -1,0 +1,160 @@
+import pytest
+
+from web3.utils.toolz import (
+    compose,
+    curry,
+)
+
+AMBIGUOUS_CONTRACT_ABI = [
+    {
+        'constant': False,
+        'inputs': [{'name': 'input', 'type': 'uint256'}],
+        'name': 'blockHashAmphithyronVersify',
+        'outputs': [{'name': '', 'type': 'uint256'}],
+        'payable': False,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+    },
+    {
+        'constant': False,
+        'inputs': [{'name': 'input', 'type': 'uint256'}, {'name': 'uselessFlag', 'type': 'bool'}],
+        'name': 'identity',
+        'outputs': [{'name': '', 'type': 'uint256'}],
+        'payable': False,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+    },
+    {
+        'constant': False,
+        'inputs': [{'name': 'input', 'type': 'int256'}, {'name': 'uselessFlag', 'type': 'bool'}],
+        'name': 'identity',
+        'outputs': [{'name': '', 'type': 'int256'}],
+        'payable': False,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+    }
+]
+
+map_repr = compose(list, curry(map, lambda func: repr(func)))
+
+
+@pytest.mark.parametrize(
+    'method,args,repr_func,expected',
+    (
+        (
+            'all_functions',
+            (),
+            map_repr,
+            [
+                '<Function blockHashAmphithyronVersify(uint256)>',
+                '<Function identity(uint256,bool)>',
+                '<Function identity(int256,bool)>'
+            ]
+        ),
+        (
+            'get_function_by_signature',
+            ('identity(uint256,bool)',),
+            repr,
+            '<Function identity(uint256,bool)>'
+        ),
+        (
+            'find_functions_by_name',
+            ('identity',),
+            map_repr,
+            [
+                '<Function identity(uint256,bool)>',
+                '<Function identity(int256,bool)>'
+            ]
+        ),
+        (
+            'get_function_by_name',
+            ('blockHashAmphithyronVersify',),
+            repr,
+            '<Function blockHashAmphithyronVersify(uint256)>',
+        ),
+        (
+            'get_function_by_selector',
+            (b'\x00\x00\x00\x00',),
+            repr,
+            '<Function blockHashAmphithyronVersify(uint256)>',
+        ),
+        (
+            'get_function_by_selector',
+            (0x00000000,),
+            repr,
+            '<Function blockHashAmphithyronVersify(uint256)>',
+        ),
+        (
+            'get_function_by_selector',
+            ('0x00000000',),
+            repr,
+            '<Function blockHashAmphithyronVersify(uint256)>',
+        ),
+        (
+            'find_functions_by_args',
+            (1, True),
+            map_repr,
+            [
+                '<Function identity(uint256,bool)>',
+                '<Function identity(int256,bool)>'
+            ]
+        ),
+        (
+            'get_function_by_args',
+            (1,),
+            repr,
+            '<Function blockHashAmphithyronVersify(uint256)>',
+        ),
+    ),
+)
+def test_find_or_get_functions_by_type(web3, method, args, repr_func, expected):
+    contract = web3.eth.contract(abi=AMBIGUOUS_CONTRACT_ABI)
+    function = getattr(contract, method)(*args)
+    assert repr_func(function) == expected
+
+
+@pytest.mark.parametrize(
+    'method,args,expected_message,expected_error',
+    (
+        (
+            'get_function_by_signature',
+            ('identity(uint256, bool)', ),
+            r'Function signature should not contain any spaces.*',
+            ValueError
+        ),
+        (
+            'get_function_by_name',
+            ('identity', ),
+            r'Found multiple functions with matching name*',
+            ValueError
+        ),
+        (
+            'get_function_by_name',
+            ('undefined_function', ),
+            r'Could not find any function with matching name',
+            ValueError
+        ),
+        (
+            'get_function_by_selector',
+            (b'\x00' * (4 + 1), ),
+            r'expected value of size 4 bytes. Got: %s bytes' % (4 + 1),
+            ValueError
+        ),
+        (
+            'get_function_by_args',
+            (1, True),
+            r'Found multiple functions with matching args*',
+            ValueError
+        ),
+        (
+            'get_function_by_args',
+            (1,) * 50,
+            r'Could not find any function with matching args',
+            ValueError
+        ),
+    )
+)
+def test_functions_error_messages(web3, method, args, expected_message, expected_error):
+    contract = web3.eth.contract(abi=AMBIGUOUS_CONTRACT_ABI)
+    with pytest.raises(expected_error, match=expected_message):
+        getattr(contract, method)(*args)

--- a/tests/core/contracts/test_contract_ambiguous_functions.py
+++ b/tests/core/contracts/test_contract_ambiguous_functions.py
@@ -182,3 +182,11 @@ def test_contract_function_methods(string_contract):
     assert get_value_func().call() == 'Hello'
     assert isinstance(set_value_func('Hello World').estimateGas(), int)
     assert isinstance(set_value_func('Hello World').buildTransaction(), dict)
+
+
+def test_diff_between_fn_and_fn_called(string_contract):
+    get_value_func = string_contract.get_function_by_signature('getValue()')
+    get_value_func_called = get_value_func()
+    assert get_value_func is not get_value_func_called
+    assert repr(get_value_func) == '<Function getValue()>'
+    assert repr(get_value_func_called) == '<Function getValue() bound to ()>'

--- a/tests/core/utilities/test_validation.py
+++ b/tests/core/utilities/test_validation.py
@@ -22,6 +22,46 @@ ABI = [
 
 MALFORMED_ABI_1 = "NON-LIST ABI"
 MALFORMED_ABI_2 = [5, {"test": "value"}, True]
+MALFORMED_SELECTOR_COLLISION_ABI = [
+    {
+        'constant': False,
+        'inputs': [{'name': 'input', 'type': 'uint256'}],
+        'name': 'blockHashAmphithyronVersify',
+        'outputs': [{'name': '', 'type': 'uint256'}],
+        'payable': False,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+    },
+    {
+        'constant': False,
+        'inputs': [{'name': 'input', 'type': 'uint256'}],
+        'name': 'blockHashAskewLimitary',
+        'outputs': [{'name': '', 'type': 'uint256'}],
+        'payable': False,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+    }
+]
+MALFORMED_SIGNATURE_COLLISION_ABI = [
+    {
+        'constant': False,
+        'inputs': [{'name': 'input', 'type': 'uint256'}],
+        'name': 'blockHashAmphithyronVersify',
+        'outputs': [{'name': '', 'type': 'uint256'}],
+        'payable': False,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+    },
+    {
+        'constant': False,
+        'inputs': [{'name': 'input', 'type': 'uint256'}],
+        'name': 'blockHashAmphithyronVersify',
+        'outputs': [{'name': '', 'type': 'uint256'}],
+        'payable': False,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+    }
+]
 
 ADDRESS = '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 PADDED_ADDRESS = '0x000000000000000000000000d3cda913deb6f67967b99d67acdfa1712c293601'
@@ -35,6 +75,8 @@ NON_CHECKSUM_ADDRESS = '0xd3cda913deb6f67967b99d67acdfa1712c293601'
         (ABI, validate_abi, None),
         (MALFORMED_ABI_1, validate_abi, ValueError),
         (MALFORMED_ABI_2, validate_abi, ValueError),
+        (MALFORMED_SELECTOR_COLLISION_ABI, validate_abi, ValueError),
+        (MALFORMED_SIGNATURE_COLLISION_ABI, validate_abi, ValueError),
         (ADDRESS, validate_address, None),
         (PADDED_ADDRESS, validate_address, InvalidAddress),
         (INVALID_CHECKSUM_ADDRESS, validate_address, InvalidAddress),

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1,6 +1,7 @@
 """Interaction with smart contracts over Web3 connector.
 
 """
+import copy
 import functools
 import itertools
 
@@ -1011,17 +1012,18 @@ class ContractFunction:
         self.fn_name = type(self).__name__
 
     def __call__(self, *args, **kwargs):
+        clone = copy.copy(self)
         if args is None:
-            self.args = tuple()
+            clone.args = tuple()
         else:
-            self.args = args
+            clone.args = args
 
         if kwargs is None:
-            self.kwargs = {}
+            clone.kwargs = {}
         else:
-            self.kwargs = kwargs
-        self._set_function_info()
-        return self
+            clone.kwargs = kwargs
+        clone._set_function_info()
+        return clone
 
     def _set_function_info(self):
         if not self.abi:
@@ -1230,7 +1232,7 @@ class ContractFunction:
     def __repr__(self):
         if self.abi:
             _repr = '<Function %s' % abi_to_signature(self.abi)
-            if self.arguments:
+            if self.arguments is not None:
                 _repr += ' bound to %r' % (self.arguments,)
             return _repr + '>'
         return '<Function %s>' % self.fn_name

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -649,10 +649,14 @@ class Contract:
 
     @combomethod
     def get_function_by_signature(self, signature):
-        _signature = signature.replace(' ', '')
+        if ' ' in signature:
+            raise ValueError(
+                'Function signature should not contain any spaces. '
+                'Found spaces in input: %s' % signature
+            )
 
         def callable_check(fn_abi):
-            return abi_to_signature(fn_abi) == _signature
+            return abi_to_signature(fn_abi) == signature
 
         fns = find_functions_by_identifier(self.abi, self.web3, self.address, callable_check)
         return get_function_by_identifier(fns, 'signature')

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -13,7 +13,6 @@ from eth_utils import (
     is_hex,
     is_integer,
     is_list_like,
-    is_string,
     remove_0x_prefix,
     to_hex,
 )
@@ -267,27 +266,10 @@ class FriendlyJsonSerde:
 
 def to_4byte_hex(hex_or_str_or_bytes):
     size_of_4bytes = 4 * 8
-    if is_integer(hex_or_str_or_bytes):
-        byte_str = to_bytes(primitive=hex_or_str_or_bytes)
-        hex_str = to_hex_with_size(hex_or_str_or_bytes, size_of_4bytes)
-    elif is_bytes(hex_or_str_or_bytes):
-        byte_str = hex_or_str_or_bytes
-        hex_str = encode_hex(hex_or_str_or_bytes)
-    elif is_string(hex_or_str_or_bytes):
-        if not is_hex(hex_or_str_or_bytes):
-            raise ValueError(
-                'expected a hexadecimal string. Got {0!r}'.format(
-                    hex_or_str_or_bytes
-                )
-            )
-        byte_str = to_bytes(hexstr=hex_or_str_or_bytes)
-        hex_str = hex_or_str_or_bytes
-    else:
-        raise TypeError(
-            'expected a int, str, byte or bytearray. Got: %s' % type(hex_or_str_or_bytes)
-        )
+    byte_str = hexstr_if_str(to_bytes, hex_or_str_or_bytes)
     if len(byte_str) > 4:
         raise ValueError(
             'expected value of size 4 bytes. Got: %d bytes' % len(byte_str)
         )
-    return hex_str
+    hex_str = encode_hex(byte_str)
+    return pad_hex(hex_str, size_of_4bytes)

--- a/web3/utils/encoding.py
+++ b/web3/utils/encoding.py
@@ -13,6 +13,7 @@ from eth_utils import (
     is_hex,
     is_integer,
     is_list_like,
+    is_string,
     remove_0x_prefix,
     to_hex,
 )
@@ -262,3 +263,31 @@ class FriendlyJsonSerde:
             return self._friendly_json_encode(obj)
         except TypeError as exc:
             raise TypeError("Could not encode to JSON: {}".format(exc))
+
+
+def to_4byte_hex(hex_or_str_or_bytes):
+    size_of_4bytes = 4 * 8
+    if is_integer(hex_or_str_or_bytes):
+        byte_str = to_bytes(primitive=hex_or_str_or_bytes)
+        hex_str = to_hex_with_size(hex_or_str_or_bytes, size_of_4bytes)
+    elif is_bytes(hex_or_str_or_bytes):
+        byte_str = hex_or_str_or_bytes
+        hex_str = encode_hex(hex_or_str_or_bytes)
+    elif is_string(hex_or_str_or_bytes):
+        if not is_hex(hex_or_str_or_bytes):
+            raise ValueError(
+                'expected a hexadecimal string. Got {0!r}'.format(
+                    hex_or_str_or_bytes
+                )
+            )
+        byte_str = to_bytes(hexstr=hex_or_str_or_bytes)
+        hex_str = hex_or_str_or_bytes
+    else:
+        raise TypeError(
+            'expected a int, str, byte or bytearray. Got: %s' % type(hex_or_str_or_bytes)
+        )
+    if len(byte_str) > 4:
+        raise ValueError(
+            'expected value of size 4 bytes. Got: %d bytes' % len(byte_str)
+        )
+    return hex_str

--- a/web3/utils/validation.py
+++ b/web3/utils/validation.py
@@ -1,6 +1,8 @@
 import itertools
 
 from eth_utils import (
+    encode_hex,
+    function_abi_to_4byte_selector,
     is_0x_prefixed,
     is_boolean,
     is_bytes,
@@ -33,11 +35,19 @@ def validate_abi(abi):
     """
     Helper function for validating an ABI
     """
+    seen_selectors = set()
     if not is_list_like(abi):
         raise ValueError("'abi' is not a list")
     for e in abi:
         if not is_dict(e):
             raise ValueError("The elements of 'abi' are not all dictionaries")
+        if e['type'] == 'function':
+            selector = encode_hex(function_abi_to_4byte_selector(e))
+            if selector in seen_selectors:
+                raise ValueError(
+                    'Found collisions of functions with selector: %s' % selector
+                )
+            seen_selectors.add(selector)
 
 
 def validate_abi_type(abi_type):

--- a/web3/utils/validation.py
+++ b/web3/utils/validation.py
@@ -18,6 +18,7 @@ from web3.exceptions import (
     InvalidAddress,
 )
 from web3.utils.abi import (
+    abi_to_signature,
     is_address_type,
     is_array_type,
     is_bool_type,
@@ -35,7 +36,7 @@ def validate_abi(abi):
     """
     Helper function for validating an ABI
     """
-    seen_selectors = set()
+    seen_selectors = dict()
     if not is_list_like(abi):
         raise ValueError("'abi' is not a list")
     for e in abi:
@@ -45,9 +46,13 @@ def validate_abi(abi):
             selector = encode_hex(function_abi_to_4byte_selector(e))
             if selector in seen_selectors:
                 raise ValueError(
-                    'Found collisions of functions with selector: %s' % selector
+                    'Found collisions for functions: [{0}] '
+                    'with selector: {1}'.format(
+                        ', '.join([seen_selectors[selector], abi_to_signature(e)]),
+                        selector
+                    )
                 )
-            seen_selectors.add(selector)
+            seen_selectors[selector] = abi_to_signature(e)
 
 
 def validate_abi_type(abi_type):

--- a/web3/utils/validation.py
+++ b/web3/utils/validation.py
@@ -46,12 +46,8 @@ from web3.utils.toolz import (
 
 def _prepare_selector_collision_msg(duplicates):
     dup_sel = valmap(apply_formatter_to_array(abi_to_signature), duplicates)
-    joined_func_groups = map(lambda funcs: ', '.join(funcs), dup_sel.values())
-    sel_func_groups = zip(joined_func_groups, dup_sel.keys())
-    func_sel_msg_list = map(
-        lambda func_sel_pair: ' have selector '.join(func_sel_pair),
-        sel_func_groups
-    )
+    joined_funcs = valmap(lambda funcs: ', '.join(funcs), dup_sel)
+    func_sel_msg_list = [funcs + ' have selector ' + sel for sel, funcs in joined_funcs.items()]
     return ' and\n'.join(func_sel_msg_list)
 
 
@@ -63,7 +59,7 @@ def validate_abi(abi):
         raise ValueError("'abi' is not a list")
 
     if not all(is_dict(e) for e in abi):
-        raise ValueError("'abi' is not a list")
+        raise ValueError("'abi' is not a list of dictionaries")
 
     functions = filter_by_type('function', abi)
     selectors = groupby(


### PR DESCRIPTION
### What was wrong?
Invoking ambiguous contract functions was not  possible
see  #775

### How was it fixed?
Added a new API to invoke ambiguous contract functions.
Here are some manual tests from my console:
```python
In [1]: from web3.auto import w3
   ...: from solc import compile_source
   ...: code = """
   ...: pragma solidity ^0.4.21;
   ...: contract AmbiguousDuo {
   ...:   function identity(uint256 input, bool uselessFlag) returns (uint256) {
   ...:     return input;
   ...:   }
   ...:   function identity(int256 input, bool uselessFlag) returns (int256) {
   ...:     return input;
   ...:   }
   ...:   function uniquefn(bool input) returns (bool){
   ...:       return input;
   ...:   }
   ...:   function blockHashAmphithyronVersify(uint256 input) returns (uint256) {
   ...:   ^I  return input;
   ...:   }
   ...: }
   ...: """
   ...:
   ...: c = compile_source(code)
   ...: co = c['<stdin>:AmbiguousDuo']
   ...: contract = w3.eth.contract(abi=co['abi'])
   ...:
   ...:

In [2]: contract.all_functions()
Out[2]:
[<Function blockHashAmphithyronVersify(uint256)>,
 <Function identity(uint256,bool)>,
 <Function identity(int256,bool)>,
 <Function uniquefn(bool)>]

In [3]: contract.get_function_by_signature('identity(uint256,bool)')
Out[3]: <Function identity(uint256,bool)>

In [4]: contract.find_functions_by_name('identity')
Out[4]: [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]

In [5]: contract.get_function_by_name('identity')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-5-119547cbbe73> in <module>()
----> 1 contract.get_function_by_name('identity')

~/Projects/web3.py/web3/utils/decorators.py in _wrapper(*args, **kwargs)
     14                 return self.method(obj, *args, **kwargs)
     15             else:
---> 16                 return self.method(objtype, *args, **kwargs)
     17         return _wrapper
     18

~/Projects/web3.py/web3/contract.py in get_function_by_name(self, fn_name)
    670     def get_function_by_name(self, fn_name):
    671         fns = self.find_functions_by_name(fn_name)
--> 672         return get_function_by_identifier(fns, 'name')
    673
    674     @combomethod

~/Projects/web3.py/web3/contract.py in get_function_by_identifier(fns, identifier)
   1481         raise ValueError(
   1482             'Found multiple functions with matching {0}. '
-> 1483             'Found: {1!r}'.format(identifier, fns)
   1484         )
   1485     elif len(fns) == 0:

ValueError: Found multiple functions with matching name. Found: [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]

In [6]: contract.get_function_by_name('uniquefn')
Out[6]: <Function uniquefn(bool)>

In [7]: contract.get_function_by_selector(0x00000000)
Out[7]: <Function blockHashAmphithyronVersify(uint256)>

In [8]: contract.get_function_by_selector('0x00000000')
Out[8]: <Function blockHashAmphithyronVersify(uint256)>

In [9]: contract.get_function_by_selector(b'\x00\x00\x00\x00')
Out[9]: <Function blockHashAmphithyronVersify(uint256)>

In [10]: contract.find_functions_by_args(1, True)
Out[10]: [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]

In [11]: contract.get_function_by_args(False)
Out[11]: <Function uniquefn(bool)>
```


TODO List: 
- [x]  Add tests
- [x] Add docs

#### Cute Animal Picture

![](https://data.whicdn.com/images/6648817/large.jpg)
