### PR TITLE
added parity trace functions

### DIFF
--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -125,6 +125,8 @@ class ParityParityModuleTest(ParityModuleTest):
         super().test_trace_replay_transaction(web3, mined_txn_hash)
 
     def test_trace_replay_block_transactions(self, web3, block_with_txn):
+
+        pytest.xfail('This method does not exist in older parity versions')
         super().test_trace_replay_block_transactions(web3, block_with_txn)
 
     def test_trace_block(self, web3, block_with_txn):

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -124,12 +124,27 @@ class ParityTraceModuleTest(TraceModuleTest):
     def test_trace_replay_transaction(self, web3, parity_fixture_data):
         super().test_trace_replay_transaction(web3, parity_fixture_data)
 
-    def test_trace_replay_block_transactions(self, web3, block_with_txn):
+    def test_trace_replay_block_with_transactions(self,
+                                                  web3,
+                                                  block_with_txn,
+                                                  parity_fixture_data):
         pytest.xfail('This method does not exist in older parity versions')
-        super().test_trace_replay_block_transactions(web3, block_with_txn)
+        super().test_trace_replay_block_with_transactions(web3,
+                                                          block_with_txn,
+                                                          parity_fixture_data)
+
+    def test_trace_replay_block_without_transactions(self, web3, empty_block):
+        pytest.xfail('This method does not exist in older parity versions')
+        super().test_trace_replay_block_without_transactions(web3, empty_block)
 
     def test_trace_block(self, web3, block_with_txn):
         super().test_trace_block(web3, block_with_txn)
 
     def test_trace_transaction(self, web3, parity_fixture_data):
         super().test_trace_transaction(web3, parity_fixture_data)
+
+    def test_trace_call(self, web3, math_contract):
+        super().test_trace_call(web3, math_contract)
+
+    def test_eth_call_with_0_result(self, web3, math_contract):
+        super().test_eth_call_with_0_result(web3, math_contract)

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -5,6 +5,7 @@ from web3.utils.module_testing import (
     EthModuleTest,
     PersonalModuleTest,
     Web3ModuleTest,
+    ParityModuleTest,
 )
 
 
@@ -117,3 +118,17 @@ class ParityPersonalModuleTest(PersonalModuleTest):
             web3,
             unlockable_account,
             unlockable_account_pw)
+
+
+class ParityParityModuleTest(ParityModuleTest):
+    def test_trace_replay_transaction(self, web3, mined_txn_hash):
+        super().test_trace_replay_transaction(web3, mined_txn_hash)
+
+    def test_trace_replay_block_transactions(self, web3, block_with_txn):
+        super().test_trace_replay_block_transactions(web3, block_with_txn)
+
+    def test_trace_block(self, web3, block_with_txn):
+        super().test_trace_block(web3, block_with_txn)
+
+    def test_trace_transaction(self, web3, mined_txn_hash):
+        super().test_trace_transaction(web3, mined_txn_hash

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -3,9 +3,9 @@ import socket
 
 from web3.utils.module_testing import (
     EthModuleTest,
+    ParityModuleTest as TraceModuleTest,
     PersonalModuleTest,
     Web3ModuleTest,
-    ParityModuleTest as TraceModuleTest,
 )
 
 

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -131,4 +131,4 @@ class ParityParityModuleTest(ParityModuleTest):
         super().test_trace_block(web3, block_with_txn)
 
     def test_trace_transaction(self, web3, mined_txn_hash):
-        super().test_trace_transaction(web3, mined_txn_hash
+        super().test_trace_transaction(web3, mined_txn_hash)

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -5,7 +5,7 @@ from web3.utils.module_testing import (
     EthModuleTest,
     PersonalModuleTest,
     Web3ModuleTest,
-    ParityModuleTest,
+    ParityModuleTest as TraceModuleTest,
 )
 
 
@@ -120,17 +120,16 @@ class ParityPersonalModuleTest(PersonalModuleTest):
             unlockable_account_pw)
 
 
-class ParityParityModuleTest(ParityModuleTest):
-    def test_trace_replay_transaction(self, web3, mined_txn_hash):
-        super().test_trace_replay_transaction(web3, mined_txn_hash)
+class ParityTraceModuleTest(TraceModuleTest):
+    def test_trace_replay_transaction(self, web3, parity_fixture_data):
+        super().test_trace_replay_transaction(web3, parity_fixture_data)
 
     def test_trace_replay_block_transactions(self, web3, block_with_txn):
-
         pytest.xfail('This method does not exist in older parity versions')
         super().test_trace_replay_block_transactions(web3, block_with_txn)
 
     def test_trace_block(self, web3, block_with_txn):
         super().test_trace_block(web3, block_with_txn)
 
-    def test_trace_transaction(self, web3, mined_txn_hash):
-        super().test_trace_transaction(web3, mined_txn_hash)
+    def test_trace_transaction(self, web3, parity_fixture_data):
+        super().test_trace_transaction(web3, parity_fixture_data)

--- a/tests/integration/parity/test_parity_http.py
+++ b/tests/integration/parity/test_parity_http.py
@@ -14,7 +14,7 @@ from .common import (
     ParityEthModuleTest,
     ParityPersonalModuleTest,
     ParityWeb3ModuleTest,
-    ParityParityModuleTest,
+    ParityTraceModuleTest,
     get_open_port,
 )
 
@@ -93,5 +93,5 @@ class TestParityPersonalModuleTest(ParityPersonalModuleTest):
     pass
 
 
-class TestParityParityModuleTest(ParityParityModuleTest):
+class TestParityTraceModuleTest(ParityTraceModuleTest):
     pass

--- a/tests/integration/parity/test_parity_http.py
+++ b/tests/integration/parity/test_parity_http.py
@@ -14,6 +14,7 @@ from .common import (
     ParityEthModuleTest,
     ParityPersonalModuleTest,
     ParityWeb3ModuleTest,
+    ParityParityModuleTest,
     get_open_port,
 )
 
@@ -46,6 +47,7 @@ def parity_command_arguments(
         '--jsonrpc-port', rpc_port,
         '--no-ipc',
         '--no-ws',
+        '--tracing', 'on'
     )
 
 
@@ -87,4 +89,8 @@ class TestParityNetModule(NetModuleTest):
 
 
 class TestParityPersonalModuleTest(ParityPersonalModuleTest):
+    pass
+
+
+class TestParityParityModuleTest(ParityParityModuleTest):
     pass

--- a/tests/integration/parity/test_parity_http.py
+++ b/tests/integration/parity/test_parity_http.py
@@ -13,8 +13,8 @@ from web3.utils.module_testing import (
 from .common import (
     ParityEthModuleTest,
     ParityPersonalModuleTest,
-    ParityWeb3ModuleTest,
     ParityTraceModuleTest,
+    ParityWeb3ModuleTest,
     get_open_port,
 )
 
@@ -47,7 +47,6 @@ def parity_command_arguments(
         '--jsonrpc-port', rpc_port,
         '--no-ipc',
         '--no-ws',
-        '--tracing', 'on'
     )
 
 
@@ -62,7 +61,7 @@ def parity_import_blocks_command(parity_binary, rpc_port, datadir, passwordfile)
         '--jsonrpc-port', str(rpc_port),
         '--no-ipc',
         '--no-ws',
-	'--tracing', 'on'
+        '--tracing', 'on',
     )
 
 

--- a/tests/integration/parity/test_parity_http.py
+++ b/tests/integration/parity/test_parity_http.py
@@ -62,6 +62,7 @@ def parity_import_blocks_command(parity_binary, rpc_port, datadir, passwordfile)
         '--jsonrpc-port', str(rpc_port),
         '--no-ipc',
         '--no-ws',
+	'--tracing', 'on'
     )
 
 

--- a/tests/integration/parity/test_parity_ipc.py
+++ b/tests/integration/parity/test_parity_ipc.py
@@ -14,8 +14,8 @@ from web3.utils.module_testing import (
 from .common import (
     ParityEthModuleTest,
     ParityPersonalModuleTest,
-    ParityWeb3ModuleTest,
     ParityTraceModuleTest,
+    ParityWeb3ModuleTest,
 )
 
 
@@ -46,7 +46,7 @@ def parity_command_arguments(
         '--unlock', author,
         '--password', passwordfile,
         '--no-jsonrpc',
-        '--no-ws'
+        '--no-ws',
     )
 
 
@@ -61,7 +61,7 @@ def parity_import_blocks_command(parity_binary, ipc_path, datadir, passwordfile)
         '--password', passwordfile,
         '--no-jsonrpc',
         '--no-ws',
-        '--tracing', 'on'
+        '--tracing', 'on',
     )
 
 

--- a/tests/integration/parity/test_parity_ipc.py
+++ b/tests/integration/parity/test_parity_ipc.py
@@ -15,7 +15,7 @@ from .common import (
     ParityEthModuleTest,
     ParityPersonalModuleTest,
     ParityWeb3ModuleTest,
-    ParityParityModuleTest,
+    ParityTraceModuleTest,
 )
 
 
@@ -92,5 +92,5 @@ class TestParityPersonalModuleTest(ParityPersonalModuleTest):
     pass
 
 
-class TestParityParityModuleTest(ParityParityModuleTest):
+class TestParityTraceModuleTest(ParityTraceModuleTest):
     pass

--- a/tests/integration/parity/test_parity_ipc.py
+++ b/tests/integration/parity/test_parity_ipc.py
@@ -15,6 +15,7 @@ from .common import (
     ParityEthModuleTest,
     ParityPersonalModuleTest,
     ParityWeb3ModuleTest,
+    ParityParityModuleTest,
 )
 
 
@@ -60,6 +61,7 @@ def parity_import_blocks_command(parity_binary, ipc_path, datadir, passwordfile)
         '--password', passwordfile,
         '--no-jsonrpc',
         '--no-ws',
+        '--tracing', 'on'
     )
 
 
@@ -87,4 +89,8 @@ class TestParityNetModule(NetModuleTest):
 
 
 class TestParityPersonalModuleTest(ParityPersonalModuleTest):
+    pass
+
+
+class TestParityParityModuleTest(ParityParityModuleTest):
     pass

--- a/tests/integration/parity/test_parity_ipc.py
+++ b/tests/integration/parity/test_parity_ipc.py
@@ -46,7 +46,7 @@ def parity_command_arguments(
         '--unlock', author,
         '--password', passwordfile,
         '--no-jsonrpc',
-        '--no-ws',
+        '--no-ws'
     )
 
 

--- a/tests/integration/parity/test_parity_ws.py
+++ b/tests/integration/parity/test_parity_ws.py
@@ -13,8 +13,8 @@ from web3.utils.module_testing import (
 from .common import (
     ParityEthModuleTest,
     ParityPersonalModuleTest,
-    ParityWeb3ModuleTest,
     ParityTraceModuleTest,
+    ParityWeb3ModuleTest,
     get_open_port,
 )
 
@@ -48,7 +48,6 @@ def parity_command_arguments(
         '--ws-origins', '*',
         '--no-ipc',
         '--no-jsonrpc',
-        '--tracing', 'on'
     )
 
 
@@ -64,7 +63,7 @@ def parity_import_blocks_command(parity_binary, ws_port, datadir, passwordfile):
         '--ws-origins', '*',
         '--no-ipc',
         '--no-jsonrpc',
-	'--tracing', 'on'
+        '--tracing', 'on',
     )
 
 

--- a/tests/integration/parity/test_parity_ws.py
+++ b/tests/integration/parity/test_parity_ws.py
@@ -14,7 +14,7 @@ from .common import (
     ParityEthModuleTest,
     ParityPersonalModuleTest,
     ParityWeb3ModuleTest,
-    ParityParityModuleTest,
+    ParityTraceModuleTest,
     get_open_port,
 )
 
@@ -95,5 +95,5 @@ class TestParityPersonalModuleTest(ParityPersonalModuleTest):
     pass
 
 
-class TestParityParityModuleTest(ParityParityModuleTest):
+class TestParityTraceModuleTest(ParityTraceModuleTest):
     pass

--- a/tests/integration/parity/test_parity_ws.py
+++ b/tests/integration/parity/test_parity_ws.py
@@ -14,6 +14,7 @@ from .common import (
     ParityEthModuleTest,
     ParityPersonalModuleTest,
     ParityWeb3ModuleTest,
+    ParityParityModuleTest,
     get_open_port,
 )
 
@@ -47,6 +48,7 @@ def parity_command_arguments(
         '--ws-origins', '*',
         '--no-ipc',
         '--no-jsonrpc',
+        '--tracing', 'on'
     )
 
 
@@ -89,4 +91,8 @@ class TestParityNetModule(NetModuleTest):
 
 
 class TestParityPersonalModuleTest(ParityPersonalModuleTest):
+    pass
+
+
+class TestParityParityModuleTest(ParityParityModuleTest):
     pass

--- a/tests/integration/parity/test_parity_ws.py
+++ b/tests/integration/parity/test_parity_ws.py
@@ -64,6 +64,7 @@ def parity_import_blocks_command(parity_binary, ws_port, datadir, passwordfile):
         '--ws-origins', '*',
         '--no-ipc',
         '--no-jsonrpc',
+	'--tracing', 'on'
     )
 
 

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -287,6 +287,10 @@ pythonic_middleware = construct_formatting_middleware(
         'evm_revert': apply_formatter_at_index(integer_to_hex, 0),
         'trace_replayBlockTransactions': apply_formatter_at_index(block_number_formatter, 0),
         'trace_block': apply_formatter_at_index(block_number_formatter, 0),
+        'trace_call': compose(
+            apply_formatter_at_index(transaction_param_formatter, 0),
+            apply_formatter_at_index(block_number_formatter, 2)
+        ),
     },
     result_formatters={
         # Eth

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -285,6 +285,8 @@ pythonic_middleware = construct_formatting_middleware(
         'personal_sendTransaction': apply_formatter_at_index(transaction_param_formatter, 0),
         # Snapshot and Revert
         'evm_revert': apply_formatter_at_index(integer_to_hex, 0),
+        'trace_replayBlockTransactions': apply_formatter_at_index(block_number_formatter, 0),
+        'trace_block': apply_formatter_at_index(block_number_formatter, 0),
     },
     result_formatters={
         # Eth

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -2,6 +2,19 @@ from web3.module import (
     Module,
 )
 
+from web3.utils.blocks import (
+    is_predefined_block_number,
+    is_hex_encoded_block_hash
+)
+
+from eth_utils import (
+    is_integer,
+)
+
+from web3.utils.encoding import (
+    to_hex
+)
+
 
 class Parity(Module):
     """
@@ -17,4 +30,44 @@ class Parity(Module):
         return self.web3.manager.request_blocking(
             "parity_netPeers",
             [],
+        )
+
+    def traceReplayTransaction(self, transaction_hash, mode=['trace']):
+        return self.web3.manager.request_blocking(
+            "trace_replayTransaction",
+            [transaction_hash, mode],
+        )
+
+    def traceReplayBlockTransactions(self, block_identifier, mode=['trace']):
+
+        if is_integer(block_identifier):
+            block = to_hex(block_identifier)
+        elif is_predefined_block_number or is_hex_encoded_block_hash:
+            block = block_identifier
+        else:
+            raise ValueError('The block identifier is not valid')
+
+        return self.web3.manager.request_blocking(
+            "trace_replayBlockTransactions",
+            [block, mode]
+        )
+
+    def traceBlock(self, block_identifier):
+
+        if is_integer(block_identifier):
+            block = to_hex(block_identifier)
+        elif is_predefined_block_number or is_hex_encoded_block_hash:
+            block = block_identifier
+        else:
+            raise ValueError('The block identifier is not valid')
+
+        return self.web3.manager.request_blocking(
+            "trace_block",
+            [block]
+        )
+
+    def traceTransaction(self, transaction_hash):
+        return self.web3.manager.request_blocking(
+            "trace_transaction",
+            [transaction_hash]
         )

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -1,18 +1,12 @@
+from eth_utils import (
+    is_checksum_address,
+)
+
 from web3.module import (
     Module,
 )
-
-from web3.utils.blocks import (
-    is_predefined_block_number,
-    is_hex_encoded_block_hash
-)
-
-from eth_utils import (
-    is_integer,
-)
-
-from web3.utils.encoding import (
-    to_hex
+from web3.utils.toolz import (
+    assoc,
 )
 
 
@@ -20,6 +14,8 @@ class Parity(Module):
     """
     https://paritytech.github.io/wiki/JSONRPC-parity-module
     """
+    defaultBlock = "latest"
+
     def enode(self):
         return self.web3.manager.request_blocking(
             "parity_enode",
@@ -39,14 +35,12 @@ class Parity(Module):
         )
 
     def traceReplayBlockTransactions(self, block_identifier, mode=['trace']):
-
         return self.web3.manager.request_blocking(
             "trace_replayBlockTransactions",
             [block_identifier, mode]
         )
 
     def traceBlock(self, block_identifier):
-
         return self.web3.manager.request_blocking(
             "trace_block",
             [block_identifier]
@@ -56,4 +50,23 @@ class Parity(Module):
         return self.web3.manager.request_blocking(
             "trace_transaction",
             [transaction_hash]
+        )
+
+    def traceCall(self, transaction, mode=['trace'], block_identifier=None):
+        # TODO: move to middleware
+        if 'from' not in transaction and is_checksum_address(self.defaultAccount):
+            transaction = assoc(transaction, 'from', self.defaultAccount)
+
+        # TODO: move to middleware
+        if block_identifier is None:
+            block_identifier = self.defaultBlock
+        return self.web3.manager.request_blocking(
+            "trace_call",
+            [transaction, mode, block_identifier],
+        )
+
+    def traceRawTransaction(self, raw_transaction, mode=['trace']):
+        return self.web3.manager.request_blocking(
+            "trace_rawTransaction",
+            [raw_transaction, mode],
         )

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -40,30 +40,16 @@ class Parity(Module):
 
     def traceReplayBlockTransactions(self, block_identifier, mode=['trace']):
 
-        if is_integer(block_identifier):
-            block = to_hex(block_identifier)
-        elif is_predefined_block_number or is_hex_encoded_block_hash:
-            block = block_identifier
-        else:
-            raise ValueError('The block identifier is not valid')
-
         return self.web3.manager.request_blocking(
             "trace_replayBlockTransactions",
-            [block, mode]
+            [block_identifier, mode]
         )
 
     def traceBlock(self, block_identifier):
 
-        if is_integer(block_identifier):
-            block = to_hex(block_identifier)
-        elif is_predefined_block_number or is_hex_encoded_block_hash:
-            block = block_identifier
-        else:
-            raise ValueError('The block identifier is not valid')
-
         return self.web3.manager.request_blocking(
             "trace_block",
-            [block]
+            [block_identifier]
         )
 
     def traceTransaction(self, transaction_hash):

--- a/web3/utils/module_testing/__init__.py
+++ b/web3/utils/module_testing/__init__.py
@@ -13,3 +13,7 @@ from .personal_module import (  # noqa: F401
 from .version_module import (  # noqa: F401
     VersionModuleTest,
 )
+
+from .parity_module import (
+    ParityModuleTest,
+)

--- a/web3/utils/module_testing/__init__.py
+++ b/web3/utils/module_testing/__init__.py
@@ -14,6 +14,6 @@ from .version_module import (  # noqa: F401
     VersionModuleTest,
 )
 
-from .parity_module import (
+from .parity_module import (  # noqa: F401
     ParityModuleTest,
 )

--- a/web3/utils/module_testing/parity_module.py
+++ b/web3/utils/module_testing/parity_module.py
@@ -2,20 +2,20 @@ class ParityModuleTest:
 
     def test_trace_replay_transaction(self, web3, mined_txn_hash):
         trace = web3.parity.traceReplayTransaction(mined_txn_hash)
-        print trace
+        print(trace)
         pass
 
     def test_trace_replay_block_transactions(self, web3, block_with_txn):
         trace = web3.parity.traceReplayBlockTransactions(block_with_txn['number'])
-        print trace
+        print(trace)
         pass
 
     def test_trace_block(self, web3, block_with_txn):
         trace = web3.parity.traceBlock(block_with_txn['number'])
-        print trace
+        print(trace)
         pass
 
     def test_trace_transaction(self, web3, mined_txn_hash):
-        trace = web3.parity.traceBlock(mined_txn_hash)
-        print trace
+        trace = web3.parity.traceTransaction(mined_txn_hash)
+        print(trace)
         pass

--- a/web3/utils/module_testing/parity_module.py
+++ b/web3/utils/module_testing/parity_module.py
@@ -1,7 +1,11 @@
 class ParityModuleTest:
 
-    def test_trace_replay_transaction(self, web3, mined_txn_hash):
-        trace = web3.parity.traceReplayTransaction(mined_txn_hash)
+    def test_trace_replay_transaction(self, web3, parity_fixture_data):
+        trace = web3.parity.traceReplayTransaction(parity_fixture_data['mined_txn_hash'])
+
+        assert trace['stateDiff'] is None
+        assert trace['vmTrace'] is None
+        assert trace['trace'][0]['action']['from'] == '0x'+parity_fixture_data['coinbase']
         pass
 
     def test_trace_replay_block_transactions(self, web3, block_with_txn):
@@ -10,8 +14,11 @@ class ParityModuleTest:
 
     def test_trace_block(self, web3, block_with_txn):
         trace = web3.parity.traceBlock(block_with_txn['number'])
+        assert trace[0]['blockNumber'] == block_with_txn['number']
         pass
 
-    def test_trace_transaction(self, web3, mined_txn_hash):
-        trace = web3.parity.traceTransaction(mined_txn_hash)
+    def test_trace_transaction(self, web3, parity_fixture_data):
+        trace = web3.parity.traceTransaction(parity_fixture_data['mined_txn_hash'])
+        print(trace)
+        assert trace[0]['action']['from'] == '0x'+parity_fixture_data['coinbase']
         pass

--- a/web3/utils/module_testing/parity_module.py
+++ b/web3/utils/module_testing/parity_module.py
@@ -1,0 +1,21 @@
+class ParityModuleTest:
+
+    def test_trace_replay_transaction(self, web3, mined_txn_hash):
+        trace = web3.parity.traceReplayTransaction(mined_txn_hash)
+        print trace
+        pass
+
+    def test_trace_replay_block_transactions(self, web3, block_with_txn):
+        trace = web3.parity.traceReplayBlockTransactions(block_with_txn['number'])
+        print trace
+        pass
+
+    def test_trace_block(self, web3, block_with_txn):
+        trace = web3.parity.traceBlock(block_with_txn['number'])
+        print trace
+        pass
+
+    def test_trace_transaction(self, web3, mined_txn_hash):
+        trace = web3.parity.traceBlock(mined_txn_hash)
+        print trace
+        pass

--- a/web3/utils/module_testing/parity_module.py
+++ b/web3/utils/module_testing/parity_module.py
@@ -2,20 +2,16 @@ class ParityModuleTest:
 
     def test_trace_replay_transaction(self, web3, mined_txn_hash):
         trace = web3.parity.traceReplayTransaction(mined_txn_hash)
-        print(trace)
         pass
 
     def test_trace_replay_block_transactions(self, web3, block_with_txn):
         trace = web3.parity.traceReplayBlockTransactions(block_with_txn['number'])
-        print(trace)
         pass
 
     def test_trace_block(self, web3, block_with_txn):
         trace = web3.parity.traceBlock(block_with_txn['number'])
-        print(trace)
         pass
 
     def test_trace_transaction(self, web3, mined_txn_hash):
         trace = web3.parity.traceTransaction(mined_txn_hash)
-        print(trace)
         pass

--- a/web3/utils/module_testing/parity_module.py
+++ b/web3/utils/module_testing/parity_module.py
@@ -18,8 +18,18 @@ class ParityModuleTest:
         assert trace['vmTrace'] is None
         assert trace['trace'][0]['action']['from'] == add_0x_prefix(parity_fixture_data['coinbase'])
 
-    def test_trace_replay_block_transactions(self, web3, block_with_txn):
-        web3.parity.traceReplayBlockTransactions(block_with_txn['number'])
+    def test_trace_replay_block_with_transactions(self,
+                                                  web3,
+                                                  block_with_txn,
+                                                  parity_fixture_data):
+        trace = web3.parity.traceReplayBlockTransactions(block_with_txn['number'])
+        assert len(trace) > 0
+        trace_0_action = trace[0]['trace'][0]['action']
+        assert trace_0_action['from'] == add_0x_prefix(parity_fixture_data['coinbase'])
+
+    def test_trace_replay_block_without_transactions(self, web3, empty_block):
+        trace = web3.parity.traceReplayBlockTransactions(empty_block['number'])
+        assert len(trace) == 0
 
     def test_trace_block(self, web3, block_with_txn):
         trace = web3.parity.traceBlock(block_with_txn['number'])
@@ -71,5 +81,4 @@ class ParityModuleTest:
         trace = web3.parity.traceRawTransaction(raw_transaction)
         assert trace['stateDiff'] is None
         assert trace['vmTrace'] is None
-        print(trace['trace'][0]['action'])
         assert trace['trace'][0]['action']['from'] == funded_account_for_raw_txn.lower()

--- a/web3/utils/module_testing/parity_module.py
+++ b/web3/utils/module_testing/parity_module.py
@@ -1,3 +1,14 @@
+import pytest
+
+from eth_utils import (
+    add_0x_prefix,
+)
+
+from web3.utils.formatters import (
+    hex_to_integer,
+)
+
+
 class ParityModuleTest:
 
     def test_trace_replay_transaction(self, web3, parity_fixture_data):
@@ -5,20 +16,60 @@ class ParityModuleTest:
 
         assert trace['stateDiff'] is None
         assert trace['vmTrace'] is None
-        assert trace['trace'][0]['action']['from'] == '0x'+parity_fixture_data['coinbase']
-        pass
+        assert trace['trace'][0]['action']['from'] == add_0x_prefix(parity_fixture_data['coinbase'])
 
     def test_trace_replay_block_transactions(self, web3, block_with_txn):
-        trace = web3.parity.traceReplayBlockTransactions(block_with_txn['number'])
-        pass
+        web3.parity.traceReplayBlockTransactions(block_with_txn['number'])
 
     def test_trace_block(self, web3, block_with_txn):
         trace = web3.parity.traceBlock(block_with_txn['number'])
         assert trace[0]['blockNumber'] == block_with_txn['number']
-        pass
 
     def test_trace_transaction(self, web3, parity_fixture_data):
         trace = web3.parity.traceTransaction(parity_fixture_data['mined_txn_hash'])
-        print(trace)
-        assert trace[0]['action']['from'] == '0x'+parity_fixture_data['coinbase']
-        pass
+        assert trace[0]['action']['from'] == add_0x_prefix(parity_fixture_data['coinbase'])
+
+    def test_trace_call(self, web3, math_contract):
+        coinbase = web3.eth.coinbase
+        txn_params = math_contract._prepare_transaction(
+            fn_name='add',
+            fn_args=(7, 11),
+            transaction={'from': coinbase, 'to': math_contract.address},
+        )
+        trace = web3.parity.traceCall(txn_params)
+        assert trace['stateDiff'] is None
+        assert trace['vmTrace'] is None
+        result = hex_to_integer(trace['output'])
+        assert result == 18
+
+    def test_eth_call_with_0_result(self, web3, math_contract):
+        coinbase = web3.eth.coinbase
+        txn_params = math_contract._prepare_transaction(
+            fn_name='add',
+            fn_args=(0, 0),
+            transaction={'from': coinbase, 'to': math_contract.address},
+        )
+        trace = web3.parity.traceCall(txn_params)
+        assert trace['stateDiff'] is None
+        assert trace['vmTrace'] is None
+        result = hex_to_integer(trace['output'])
+        assert result == 0
+
+    @pytest.mark.parametrize(
+        'raw_transaction',
+        [
+            (
+                # address 0x39EEed73fb1D3855E90Cbd42f348b3D7b340aAA6
+                '0xf8648085174876e8008252089439eeed73fb1d3855e90cbd42f348b3d7b340aaa601801ba0ec1295f00936acd0c2cb90ab2cdaacb8bf5e11b3d9957833595aca9ceedb7aada05dfc8937baec0e26029057abd3a1ef8c505dca2cdc07ffacb046d090d2bea06a'  # noqa: E501
+            ),
+        ]
+    )
+    def test_trace_raw_transaction(self,
+                                   web3,
+                                   raw_transaction,
+                                   funded_account_for_raw_txn):
+        trace = web3.parity.traceRawTransaction(raw_transaction)
+        assert trace['stateDiff'] is None
+        assert trace['vmTrace'] is None
+        print(trace['trace'][0]['action'])
+        assert trace['trace'][0]['action']['from'] == funded_account_for_raw_txn.lower()


### PR DESCRIPTION
### What was wrong?
Parity trace module was missing

### How was it fixed?
1. Added 4 trace functions in web3/parity.py based on: https://wiki.parity.io/JSONRPC-trace-module.html
2. Added a cute animal picture in pull request

### Question:
Is there a function which is equivalent to the converting from integer block_number or predefined_block_number to hex_block_number or predefined_block_number? It would clean up my code a little bit more. 

Code block in lines [43-48] or [57-62] of file parity.py
```
if is_integer(block_identifier):
    block = to_hex(block_identifier)
elif is_predefined_block_number or is_hex_encoded_block_hash:
    block = block_identifier
else:
    raise ValueError('The block identifier is not valid')
```

### Usage:

```
>>> w3.parity.traceTransaction(transaction_hash)
>>> w3.parity.traceReplayBlockTransactions(block_number, mode=['trace', 'stateDiff'])
```

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/236x/78/b8/a5/78b8a51098ef44932f2c459e23861b61.jpg)
