### PR TITLE
added a method getUncleFromBlock to eth module

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -173,6 +173,22 @@ class Eth(Module):
             [block_identifier],
         )
 
+    def getUncleFromBlock(self, block_identifier, uncle_index):
+        """
+        `eth_getUncleByBlockHashAndIndex`
+        `eth_getUncleByBlockNumberAndIndex`
+        """
+        method = select_method_for_block_identifier(
+            block_identifier,
+            if_predefined='eth_getUncleByBlockNumberAndIndex',
+            if_hash='eth_getUncleByBlockHashAndIndex',
+            if_number='eth_getUncleByBlockNumberAndIndex',
+        )
+        return self.web3.manager.request_blocking(
+            method,
+            [block_identifier, uncle_index],
+        )
+
     def getTransaction(self, transaction_hash):
         return self.web3.manager.request_blocking(
             "eth_getTransactionByHash",

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -262,6 +262,11 @@ pythonic_middleware = construct_formatting_middleware(
         ),
         'eth_getTransactionCount': apply_formatter_at_index(block_number_formatter, 1),
         'eth_getUncleCountByBlockNumber': apply_formatter_at_index(block_number_formatter, 0),
+        'eth_getUncleByBlockNumberAndIndex': compose(
+            apply_formatter_at_index(block_number_formatter, 0),
+            apply_formatter_at_index(integer_to_hex, 1),
+        ),
+        'eth_getUncleByBlockHashAndIndex': apply_formatter_at_index(integer_to_hex, 1),
         'eth_newFilter': apply_formatter_at_index(filter_params_formatter, 0),
         'eth_getLogs': apply_formatter_at_index(filter_params_formatter, 0),
         'eth_call': combine_argument_formatters(


### PR DESCRIPTION
### What was wrong?

The method to get uncle data from a block was missing in the eth module.

### How was it fixed?

Added the method in eth module and added a middleware to convert blockNumber and uncleIndex into hex

### Issues:
How to write tests for creating uncles and then testing their data.

### Usage:
```
>>> w3.eth.getUncleFromBlock(block_number, uncle_index)
```

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://data.whicdn.com/images/129893488/large.jpg)
