### PR TITLE
Add logging messages to Providers

### DIFF
--- a/web3/manager.py
+++ b/web3/manager.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 from eth_utils import (
@@ -32,6 +33,8 @@ from web3.utils.threads import (
 
 
 class RequestManager:
+    logger = logging.getLogger("web3.RequestManager")
+
     def __init__(self, web3, providers, middlewares=None):
         self.web3 = web3
         self.pending_requests = {}
@@ -82,6 +85,7 @@ class RequestManager:
     def _make_request(self, method, params):
         for provider in self.providers:
             request_func = provider.request_func(self.web3, tuple(self.middleware_stack))
+            self.logger.debug("Making request. Method: %s", method)
             try:
                 return request_func(method, params)
             except CannotHandleRequest:

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import socket
 import sys
@@ -136,6 +137,7 @@ def get_default_ipc_path(testnet=False):
 
 
 class IPCProvider(JSONBaseProvider):
+    logger = logging.getLogger("web3.providers.IPCProvider")
     _socket = None
 
     def __init__(self, ipc_path=None, testnet=False, timeout=10, *args, **kwargs):
@@ -150,6 +152,8 @@ class IPCProvider(JSONBaseProvider):
         super().__init__(*args, **kwargs)
 
     def make_request(self, method, params):
+        self.logger.debug("Making request IPC. Path: %s, Method: %s",
+                          self.ipc_path, method)
         request = self.encode_rpc_request(method, params)
 
         with self._lock, self._socket as sock:

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -22,14 +22,13 @@ from .base import (
     JSONBaseProvider,
 )
 
-logger = logging.getLogger(__name__)
-
 
 def get_default_endpoint():
     return os.environ.get('WEB3_HTTP_PROVIDER_URI', 'http://localhost:8545')
 
 
 class HTTPProvider(JSONBaseProvider):
+    logger = logging.getLogger("web3.providers.HTTPProvider")
     endpoint_uri = None
     _request_args = None
     _request_kwargs = None
@@ -60,6 +59,8 @@ class HTTPProvider(JSONBaseProvider):
         }
 
     def make_request(self, method, params):
+        self.logger.debug("Making request HTTP. URI: %s, Method: %s",
+                          self.endpoint_uri, method)
         request_data = self.encode_rpc_request(method, params)
         raw_response = make_post_request(
             self.endpoint_uri,
@@ -67,4 +68,7 @@ class HTTPProvider(JSONBaseProvider):
             **self.get_request_kwargs()
         )
         response = self.decode_rpc_response(raw_response)
+        self.logger.debug("Getting response HTTP. URI: %s, "
+                          "Method: %s, Response: %s",
+                          self.endpoint_uri, method, response)
         return response

--- a/web3/providers/websocket.py
+++ b/web3/providers/websocket.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 from threading import (
     Thread,
@@ -51,7 +52,7 @@ class PersistentWebSocket:
 
 
 class WebsocketProvider(JSONBaseProvider):
-
+    logger = logging.getLogger("web3.providers.WebsocketProvider")
     _loop = None
 
     def __init__(self, endpoint_uri=None):
@@ -72,6 +73,8 @@ class WebsocketProvider(JSONBaseProvider):
             return json.loads(await conn.recv())
 
     def make_request(self, method, params):
+        self.logger.debug("Making request WebSocket. URI: %s, "
+                          "Method: %s", self.endpoint_uri, method)
         request_data = self.encode_rpc_request(method, params)
         future = asyncio.run_coroutine_threadsafe(
             self.coro_make_request(request_data),


### PR DESCRIPTION
### What was wrong?

There are places where it would be useful for a user to enable logging on the `web3` namespace to get a better picture of what is happening.

Issue Reference: https://github.com/ethereum/web3.py/issues/854, https://github.com/ethereum/web3.py/issues/852#issuecomment-390247197

### How was it fixed?

- `web3.manager.RequestManager`
  - in `_make_request` prior to issuing the request to the provider with `provider/rpc-method-name/json-serialized-params`
- `web3.providers.rpc.HTTPProvider`
  - prior to making the http request with `uri/rpc-method-name/json-serialized-params`
  - after getting http response `uri/xrpc-method-name/status-code`
- `web3.providers.ipc.IPCProvider`
  - same as `HTTPProvider` but with `ipc_path` instead of `uri`
  - no response logging needed.
- `web3.providers.websocket.WebsocketProvider`
  - same as `HTTPProvider` but with the websocket `uri`
  - no response logging needed.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/236x/f3/67/11/f36711b0551ac8909ecdcb03da925fe3--toy-poodles-brown.jpg)
