### PR TITLE
pin websockets version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "lru-dict>=1.1.6,<2.0.0",
         "eth-hash[pycryptodome]",
         "requests>=2.16.0,<3.0.0",
-        "websockets>=4.0.1",
+        "websockets>=4.0.1,<5.0.0",
         "pypiwin32>=223;platform_system=='Windows'",
     ],
     setup_requires=['setuptools-markdown'],


### PR DESCRIPTION
### What was wrong?
Tests on master are failing at the moment because a new version of `websockets` seems to incompatible with the existing code.

### How was it fixed?

Temporarily pin `websockets` until the existing code is made compatible with the [new version](https://github.com/aaugustin/websockets/releases/tag/5.0)


#### Cute Animal Picture

![](https://cdn.shopify.com/s/files/1/2011/8731/products/super-cute-animal-lamps-2192541351963_1024x1024@2x.jpg?v=1524423782)
