### PR TITLE
Renamed getUncleFromBlock and added alias to getTransactionFromBlock

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -197,6 +197,13 @@ class Eth(Module):
 
     def getTransactionFromBlock(self, block_identifier, transaction_index):
         """
+        Alias for the method getTransactionByBlock
+        Depreceated to maintain naming consistency with the json-rpc API
+        """
+        return self.getTransactionByBlock(block_identifier, transaction_index)
+
+    def getTransactionByBlock(self, block_identifier, transaction_index):
+        """
         `eth_getTransactionByBlockHashAndIndex`
         `eth_getTransactionByBlockNumberAndIndex`
         """
@@ -210,13 +217,6 @@ class Eth(Module):
             method,
             [block_identifier, transaction_index],
         )
-
-    def getTransactionByBlock(self, block_identifier, transaction_index):
-        """
-        Alias for the method getTransactionFromBlock
-        More details here: https://github.com/ethereum/web3.py/pull/857
-        """
-        return self.getTransactionFromBlock(block_identifier, transaction_index)
 
     def waitForTransactionReceipt(self, transaction_hash, timeout=120):
         return wait_for_transaction_receipt(self.web3, transaction_hash, timeout)

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -173,7 +173,7 @@ class Eth(Module):
             [block_identifier],
         )
 
-    def getUncleFromBlock(self, block_identifier, uncle_index):
+    def getUncleByBlock(self, block_identifier, uncle_index):
         """
         `eth_getUncleByBlockHashAndIndex`
         `eth_getUncleByBlockNumberAndIndex`
@@ -210,6 +210,13 @@ class Eth(Module):
             method,
             [block_identifier, transaction_index],
         )
+
+    def getTransactionByBlock(self, block_identifier, transaction_index):
+        """
+        Alias for the method getTransactionFromBlock
+        More details here: https://github.com/ethereum/web3.py/pull/857
+        """
+        return self.getTransactionFromBlock(block_identifier, transaction_index)
 
     def waitForTransactionReceipt(self, transaction_hash, timeout=120):
         return wait_for_transaction_receipt(self.web3, transaction_hash, timeout)

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -511,6 +511,11 @@ class EthModuleTest:
         assert is_dict(transaction)
         assert transaction['hash'] == HexBytes(mined_txn_hash)
 
+    def test_eth_getTransactionByBlockHashAndIndex(self, web3, block_with_txn, mined_txn_hash):
+        transaction = web3.eth.getTransactionByBlock(block_with_txn['hash'], 0)
+        assert is_dict(transaction)
+        assert transaction['hash'] == HexBytes(mined_txn_hash)
+
     def test_eth_getTransactionByBlockNumberAndIndex(self, web3, block_with_txn, mined_txn_hash):
         transaction = web3.eth.getTransactionByBlock(block_with_txn['number'], 0)
         assert is_dict(transaction)

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -501,13 +501,18 @@ class EthModuleTest:
         assert is_dict(transaction)
         assert transaction['to'] is None, "to field is %r" % transaction['to']
 
-    def test_eth_getTransactionByBlockHashAndIndex(self, web3, block_with_txn, mined_txn_hash):
+    def test_eth_getTransactionFromBlockHashAndIndex(self, web3, block_with_txn, mined_txn_hash):
         transaction = web3.eth.getTransactionFromBlock(block_with_txn['hash'], 0)
         assert is_dict(transaction)
         assert transaction['hash'] == HexBytes(mined_txn_hash)
 
-    def test_eth_getTransactionByBlockNumberAndIndex(self, web3, block_with_txn, mined_txn_hash):
+    def test_eth_getTransactionFromBlockNumberAndIndex(self, web3, block_with_txn, mined_txn_hash):
         transaction = web3.eth.getTransactionFromBlock(block_with_txn['number'], 0)
+        assert is_dict(transaction)
+        assert transaction['hash'] == HexBytes(mined_txn_hash)
+
+    def test_eth_getTransactionByBlockNumberAndIndex(self, web3, block_with_txn, mined_txn_hash):
+        transaction = web3.eth.getTransactionByBlock(block_with_txn['number'], 0)
         assert is_dict(transaction)
         assert transaction['hash'] == HexBytes(mined_txn_hash)
 


### PR DESCRIPTION
### What was wrong?

The method names were not consistent with the JSON-RPC method names. 
For more details refer to this conversation: https://github.com/ethereum/web3.py/pull/857#pullrequestreview-121916432

### How was it fixed?
1. Changed the name of `getUncleFromBlock` method to `getUncleByBlock`
2. Added alias to the method `getTransactionFromBlock`
3. Added tests for the alias


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/a0/13/86/a013860470e3a76b171cd69bbd3db3bd.jpg)
