### PR TITLE
providers/ipc: make `ipc_path` a `str` when getting socket

### DIFF
--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -19,6 +19,9 @@ except ImportError:
 
 
 def get_ipc_socket(ipc_path, timeout=0.1):
+    # in case it's a `pathlib.Path` or similar
+    ipc_path = str(ipc_path)
+
     if sys.platform == 'win32':
         # On Windows named pipe is used. Simulate socket with it.
         from web3.utils.windows import NamedPipe


### PR DESCRIPTION
Implements #867 in a "hotfix" manner.

### What was wrong?

Trinity (py-evm node impl-n) passes in a `PosixPath` (`pathlib.Path`), which `socket` doesn't like. This makes `trinity console` unusable, since the underlying `web3` IPC provider can't connect to the socket.

``` py
...
/mnt/data/veox/src/py-evm/.virtualenv/py-evm/lib/python3.6/site-packages/web3/providers/ipc.py in get_ipc_socket(ipc_path, timeout)
     28     else:
     29         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
---> 30         sock.connect(ipc_path)
     31         sock.settimeout(timeout)
     32         return sock

TypeError: a bytes-like object is required, not 'PosixPath'
```

### How was it fixed?

Unconditionally cast `ipc_path` to `str`.

Whether `get_ipc_socket()` should accept just `str` arguments for the path, just `pathlib` objects, or try to handle several types depends on design decisions I'm not sufficiently in-the-loop to make.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/H1sPRwP.jpg)

Source: [/r/aww](https://www.reddit.com/r/aww/comments/79jta5/squirrel_friend/)