### PR TITLE
Update parity binary for integration testing - libssl version differences

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,7 +288,7 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-integration-parity-ipc
-      PARITY_VERSION: v1.8.9
+      PARITY_VERSION: v1.10.4
 
   py36-integration-parity-http:
     <<: *parity_steps
@@ -296,7 +296,7 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-integration-parity-http
-      PARITY_VERSION: v1.8.9
+      PARITY_VERSION: v1.10.4
 
   py36-integration-parity-ws:
     <<: *parity_steps
@@ -304,7 +304,7 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-integration-parity-ws
-      PARITY_VERSION: v1.8.9
+      PARITY_VERSION: v1.10.4
 
   py36-integration-ethtester-pyethereum:
     <<: *common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
       - image: circleci/python:3.5
     environment:
       TOXENV: py35-integration-parity-ipc
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.8.9
 
   py35-integration-parity-http:
     <<: *parity_steps
@@ -178,7 +178,7 @@ jobs:
       - image: circleci/python:3.5
     environment:
       TOXENV: py35-integration-parity-http
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.8.9
 
   py35-integration-parity-ws:
     <<: *parity_steps
@@ -186,7 +186,7 @@ jobs:
       - image: circleci/python:3.5
     environment:
       TOXENV: py35-integration-parity-ws
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.8.9
 
   py35-integration-ethtester-pyethereum:
     <<: *common
@@ -288,7 +288,7 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-integration-parity-ipc
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.8.9
 
   py36-integration-parity-http:
     <<: *parity_steps
@@ -296,7 +296,7 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-integration-parity-http
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.8.9
 
   py36-integration-parity-ws:
     <<: *parity_steps
@@ -304,7 +304,7 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-integration-parity-ws
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.8.9
 
   py36-integration-ethtester-pyethereum:
     <<: *common

--- a/tests/integration/parity/install_parity.py
+++ b/tests/integration/parity/install_parity.py
@@ -16,9 +16,9 @@ from tqdm import tqdm
 URI_QUERY_URL = "https://vanity-service.parity.io/parity-binaries"
 BASE_BIN_PATH = "~/.parity-bin"
 VERSION_STRINGS = {
-    "v1.8.7": "1_8_7",
-    "v1.8.8": "1_8_8",
+    "v1.8.9": "1_8_9",
     "v1.9.1": "1_9_1"
+    "v1.10.4": "1_10_4"
 }
 ARCHITECTURE = 'x86_64'
 OS = 'debian'

--- a/tests/integration/parity/install_parity.py
+++ b/tests/integration/parity/install_parity.py
@@ -17,11 +17,11 @@ URI_QUERY_URL = "https://vanity-service.parity.io/parity-binaries"
 BASE_BIN_PATH = "~/.parity-bin"
 VERSION_STRINGS = {
     "v1.8.9": "1_8_9",
-    "v1.9.1": "1_9_1"
+    "v1.9.1": "1_9_1",
     "v1.10.4": "1_10_4"
 }
 ARCHITECTURE = 'x86_64'
-OS = 'debian'
+OS = 'linux'
 
 
 @toolz.curry

--- a/tests/integration/parity/install_parity.py
+++ b/tests/integration/parity/install_parity.py
@@ -21,7 +21,7 @@ VERSION_STRINGS = {
     "v1.9.1": "1_9_1"
 }
 ARCHITECTURE = 'x86_64'
-OS = 'linux'
+OS = 'debian'
 
 
 @toolz.curry


### PR DESCRIPTION
### What was wrong?

Related to https://github.com/ethereum/web3.py/pull/865


### How was it fixed?
debian package version is built with libssl1.1, changing to the "debian" build rather than the "linux" build will hopefully fix the issue.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://ichef.bbci.co.uk/wwfeatures/wm/live/1280_720/images/live/p0/2b/qv/p02bqv55.jpg)
