### PR TITLE
Fix CircleCI Parity integration failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
       - image: circleci/python:3.5
     environment:
       TOXENV: py35-integration-parity-ipc
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.9.7
 
   py35-integration-parity-http:
     <<: *parity_steps
@@ -178,7 +178,7 @@ jobs:
       - image: circleci/python:3.5
     environment:
       TOXENV: py35-integration-parity-http
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.9.7
 
   py35-integration-parity-ws:
     <<: *parity_steps
@@ -186,7 +186,7 @@ jobs:
       - image: circleci/python:3.5
     environment:
       TOXENV: py35-integration-parity-ws
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.9.7
 
   py35-integration-ethtester-pyethereum:
     <<: *common
@@ -288,7 +288,7 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-integration-parity-ipc
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.9.7
 
   py36-integration-parity-http:
     <<: *parity_steps
@@ -296,7 +296,7 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-integration-parity-http
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.9.7
 
   py36-integration-parity-ws:
     <<: *parity_steps
@@ -304,7 +304,7 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-integration-parity-ws
-      PARITY_VERSION: v1.8.8
+      PARITY_VERSION: v1.9.7
 
   py36-integration-ethtester-pyethereum:
     <<: *common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,16 @@ parity_steps: &parity_steps
         name: install parity if needed
         command: |
           pip install --user requests eth_utils tqdm eth-hash[pycryptodome]
-          echo $PARITY_VERSION
+          echo "Job specifies Parity version $PARITY_VERSION"
           python tests/integration/parity/install_parity.py $PARITY_VERSION
+    - run:
+        name: update parity deps from testing repo if needed
+        command: |
+          [ "`cat /etc/*release | grep jessie`" != "" ] && echo "On Jessie - installing missing deps..." || echo "Not on Jessie - doing nothing."
+          [ "`cat /etc/*release | grep jessie`" != "" ] || exit 0
+          echo "deb http://ftp.debian.org/debian testing main" > testing.list && sudo mv testing.list /etc/apt/sources.list.d/
+          sudo apt update
+          sudo apt-get -t testing install libstdc++6
     - run:
         name: run tox
         command: ~/.local/bin/tox -r
@@ -167,26 +175,26 @@ jobs:
   py35-integration-parity-ipc:
     <<: *parity_steps
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.5-jessie
     environment:
       TOXENV: py35-integration-parity-ipc
-      PARITY_VERSION: v1.9.7
+      PARITY_VERSION: v1.10.4
 
   py35-integration-parity-http:
     <<: *parity_steps
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.5-jessie
     environment:
       TOXENV: py35-integration-parity-http
-      PARITY_VERSION: v1.9.7
+      PARITY_VERSION: v1.10.4
 
   py35-integration-parity-ws:
     <<: *parity_steps
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.5-jessie
     environment:
       TOXENV: py35-integration-parity-ws
-      PARITY_VERSION: v1.9.7
+      PARITY_VERSION: v1.10.4
 
   py35-integration-ethtester-pyethereum:
     <<: *common
@@ -285,26 +293,26 @@ jobs:
   py36-integration-parity-ipc:
     <<: *parity_steps
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.6-stretch
     environment:
       TOXENV: py36-integration-parity-ipc
-      PARITY_VERSION: v1.9.7
+      PARITY_VERSION: v1.10.4
 
   py36-integration-parity-http:
     <<: *parity_steps
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.6-stretch
     environment:
       TOXENV: py36-integration-parity-http
-      PARITY_VERSION: v1.9.7
+      PARITY_VERSION: v1.10.4
 
   py36-integration-parity-ws:
     <<: *parity_steps
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.6-stretch
     environment:
       TOXENV: py36-integration-parity-ws
-      PARITY_VERSION: v1.9.7
+      PARITY_VERSION: v1.10.4
 
   py36-integration-ethtester-pyethereum:
     <<: *common

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,13 @@ matrix:
       env: TOX_POSARGS="-e py35-integration-goethereum-ws" GETH_VERSION=v1.8.1
     # parity-ipc
     - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-parity-ipc" PARITY_VERSION=v1.8.8
+      env: TOX_POSARGS="-e py35-integration-parity-ipc" PARITY_VERSION=v1.9.7
     # parity-http
     - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-parity-http" PARITY_VERSION=v1.8.8
+      env: TOX_POSARGS="-e py35-integration-parity-http" PARITY_VERSION=v1.9.7
     # parity-ws
     - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-parity-ws" PARITY_VERSION=v1.8.8
+      env: TOX_POSARGS="-e py35-integration-parity-ws" PARITY_VERSION=v1.9.7
     # ENS
     - python: "3.5"
       env: TOX_POSARGS="-e py35-ens"
@@ -72,13 +72,13 @@ matrix:
       env: TOX_POSARGS="-e py36-integration-goethereum-ws" GETH_VERSION=v1.8.1
     # parity-ipc
     - python: "3.6"
-      env: TOX_POSARGS="-e py36-integration-parity-ipc" PARITY_VERSION=v1.8.8
+      env: TOX_POSARGS="-e py36-integration-parity-ipc" PARITY_VERSION=v1.9.7
     # parity-http
     - python: "3.6"
-      env: TOX_POSARGS="-e py36-integration-parity-http" PARITY_VERSION=v1.8.8
+      env: TOX_POSARGS="-e py36-integration-parity-http" PARITY_VERSION=v1.9.7
     # parity-ws
     - python: "3.6"
-      env: TOX_POSARGS="-e py36-integration-parity-ws" PARITY_VERSION=v1.8.8
+      env: TOX_POSARGS="-e py36-integration-parity-ws" PARITY_VERSION=v1.9.7
     # ENS
     - python: "3.6"
       env: TOX_POSARGS="-e py36-ens"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,13 @@ matrix:
       env: TOX_POSARGS="-e py35-integration-goethereum-ws" GETH_VERSION=v1.8.1
     # parity-ipc
     - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-parity-ipc" PARITY_VERSION=v1.9.7
+      env: TOX_POSARGS="-e py35-integration-parity-ipc" PARITY_VERSION=v1.10.4
     # parity-http
     - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-parity-http" PARITY_VERSION=v1.9.7
+      env: TOX_POSARGS="-e py35-integration-parity-http" PARITY_VERSION=v1.10.4
     # parity-ws
     - python: "3.5"
-      env: TOX_POSARGS="-e py35-integration-parity-ws" PARITY_VERSION=v1.9.7
+      env: TOX_POSARGS="-e py35-integration-parity-ws" PARITY_VERSION=v1.10.4
     # ENS
     - python: "3.5"
       env: TOX_POSARGS="-e py35-ens"
@@ -72,13 +72,13 @@ matrix:
       env: TOX_POSARGS="-e py36-integration-goethereum-ws" GETH_VERSION=v1.8.1
     # parity-ipc
     - python: "3.6"
-      env: TOX_POSARGS="-e py36-integration-parity-ipc" PARITY_VERSION=v1.9.7
+      env: TOX_POSARGS="-e py36-integration-parity-ipc" PARITY_VERSION=v1.10.4
     # parity-http
     - python: "3.6"
-      env: TOX_POSARGS="-e py36-integration-parity-http" PARITY_VERSION=v1.9.7
+      env: TOX_POSARGS="-e py36-integration-parity-http" PARITY_VERSION=v1.10.4
     # parity-ws
     - python: "3.6"
-      env: TOX_POSARGS="-e py36-integration-parity-ws" PARITY_VERSION=v1.9.7
+      env: TOX_POSARGS="-e py36-integration-parity-ws" PARITY_VERSION=v1.10.4
     # ENS
     - python: "3.6"
       env: TOX_POSARGS="-e py36-ens"

--- a/tests/integration/parity/install_parity.py
+++ b/tests/integration/parity/install_parity.py
@@ -18,7 +18,8 @@ BASE_BIN_PATH = "~/.parity-bin"
 VERSION_STRINGS = {
     "v1.8.7": "1_8_7",
     "v1.8.8": "1_8_8",
-    "v1.9.1": "1_9_1"
+    "v1.9.1": "1_9_1",
+    "v1.9.7": "1_9_7",
 }
 ARCHITECTURE = 'x86_64'
 OS = 'linux'

--- a/tests/integration/parity/install_parity.py
+++ b/tests/integration/parity/install_parity.py
@@ -19,10 +19,10 @@ VERSION_STRINGS = {
     "v1.8.7": "1_8_7",
     "v1.8.8": "1_8_8",
     "v1.9.1": "1_9_1",
-    "v1.9.7": "1_9_7",
+    "v1.10.4": "1_10_4",
 }
 ARCHITECTURE = 'x86_64'
-OS = 'linux'
+OS = 'debian'
 
 
 @toolz.curry


### PR DESCRIPTION
### What was wrong?

Parity integration tests are failing due to the used (dynamically-linked!) Parity binary not finding its dependencies.

Conflicts with PR #873.

### How was it fixed?

(There were 42 (or so) commits in the "debug" branch. It was a messy tangle, so I squashed them. Sorry for that, but I really think it's better this way.)

There are four main changes.

#### First

Debian version (Jessie, 8; or Stretch, 9) is specified excplicitly to CircleCI for Parity integration jobs.

Before this commit, Python 3.6 jobs might get run on either, which introduces a heisenbug (see "Second" point below).

(Python 3.5 jobs were always run on Jessie, since CircleCI doesn't have a Debian 9 + Python 3.5 docker image.)

After this commit, Python 3.5 jobs are _explicitly_ run on Jessie, and Python 3.6 jobs are _always_ run on Stretch.

#### Second and third

The Parity node/client version has been updated to v1.10.4.

(Note that this is a pre-compiled, _dynamically linked_ executable, downloaded from vanity-service.parity.io.)

Before this commit, when testing Parity integration on Jessie, the pre-compiled `parity` binary may have failed to start, due to the `openssl` or `libstdc++6` dependencies being too old.

Updating from v1.8.x to v1.10.y helps avoid the `openssl` dependency, as this version is no longer built against `openssl`.

After this commit, tTo work around the remaining `libstdc++6` incompatibility, Jessie builds enable the Debian 'testing' repository, and update the package from there.

#### Fourth

Some tests are marked flaky.

It seems that the Parity v1.10.x release family do things faster or in a more asynchronous way than v1.{8,9}.

Before this commit, two tests in the 'eth' module would sporadically fail:

* `test_eth_call_old_contract_state(...)` - about 1 in 3 times;
* `test_eth_getTransactionReceipt_unmined(...)` - about 1 in 10 times.

After this commit, the tests are allowed to succeed just once in 3 runs.

#### Cute Animal Picture

Squash!

![Put a link to a cute animal picture inside the parenthesis-->](http://i.imgur.com/nNWmq5V.jpg)

Source: [/r/aww](https://www.reddit.com/r/aww/comments/18lc91/my_guinea_pigs_stunt_double_is_this_butternut/)