### PR TITLE
Close evicted sessions

### DIFF
--- a/web3/utils/request.py
+++ b/web3/utils/request.py
@@ -5,7 +5,12 @@ from web3.utils.caching import (
     generate_cache_key,
 )
 
-_session_cache = lru.LRU(8)
+
+def _remove_session(key, session):
+    session.close()
+
+
+_session_cache = lru.LRU(8, callback=_remove_session)
 
 
 def _get_session(*args, **kwargs):


### PR DESCRIPTION
### What was wrong?

Related to Issue #874 

### How was it fixed?

Add a callback the the `LRU` that closes the session when it's evicted from the cache.

This fixes the warnings: https://travis-ci.org/palango/raiden/jobs/386300304#L1029



#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redditmedia.com/K34UbwACP2UEF-Y5HiXlktKWTc9P9RkKx5U_OG--3S4.jpg?w=557&s=fcc652e39e86447fd474873726beb30b)
