### PR TITLE
Doc update: addresses must be checksummed

### DIFF
--- a/docs/conventions.rst
+++ b/docs/conventions.rst
@@ -18,4 +18,8 @@ Hexidecimal Representations
 Addresses
 ---------
 
-* Any hexidecimal address with at least one capitalized letter will be validated using the EIP55 checksum spec.
+All addresses must be supplied in one of two ways:
+
+* A 20-byte hexidecimal that is checksummed using the `EIP-55
+  <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md>`_ spec.
+* An Ethereum Name Service name (often in the form ``myname.eth``)

--- a/docs/conventions.rst
+++ b/docs/conventions.rst
@@ -22,4 +22,4 @@ All addresses must be supplied in one of two ways:
 
 * A 20-byte hexadecimal that is checksummed using the `EIP-55
   <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md>`_ spec.
-* An Ethereum Name Service name (often in the form ``myname.eth``)
+* While connected to mainnet, an Ethereum Name Service name (often in the form ``myname.eth``)

--- a/docs/conventions.rst
+++ b/docs/conventions.rst
@@ -9,17 +9,17 @@ Bytes vs Text
 * The term *bytes* is used to refer to the binary representation of a string.
 * The term *text* is used to refer to unicode representations of strings.
 
-Hexidecimal Representations
+Hexadecimal Representations
 ---------------------------
 
-* All hexidecimal values will be returned as text.
-* All hexidecimal values will be ``0x`` prefixed.
+* All hexadecimal values will be returned as text.
+* All hexadecimal values will be ``0x`` prefixed.
 
 Addresses
 ---------
 
 All addresses must be supplied in one of two ways:
 
-* A 20-byte hexidecimal that is checksummed using the `EIP-55
+* A 20-byte hexadecimal that is checksummed using the `EIP-55
   <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md>`_ spec.
 * An Ethereum Name Service name (often in the form ``myname.eth``)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -9,7 +9,7 @@ Looking up blocks
 -----------------
 
 Blocks can be looked up by either their number or hash using the
-``web3.eth.getBlock`` API.  Block hashes should be in their hexidecimal
+``web3.eth.getBlock`` API.  Block hashes should be in their hexadecimal
 representation.  Block numbers
 
 .. code-block:: python

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -22,7 +22,7 @@ Here are some common things you might want to do with these APIs.
 * Transparently intercept transactions sent over ``eth_sendTransaction``, sign
   them locally, and then send them through ``eth_sendRawTransaction``.
 * Modify the response from an RPC request so that it is returned in different
-  format such as converting all integer values to their hexidecimal
+  format such as converting all integer values to their hexadecimal
   representation.
 * Validate the inputs to RPC requests
 
@@ -193,8 +193,8 @@ responses for certain methods your middleware would likely not call the
 By default, Web3 will use the ``web3.middleware.pythonic_middleware``.  This
 middleware performs the following translations for requests and responses.
 
-* Numeric request parameters will be converted to their hexidecimal representation
-* Numeric responses will be converted from their hexidecimal representations to
+* Numeric request parameters will be converted to their hexadecimal representation
+* Numeric responses will be converted from their hexadecimal representations to
   their integer representations.
 
 The ``RequestManager`` object exposes the ``middleware_stack`` object to manage middlewares. It

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -58,7 +58,7 @@ Type Conversions
 
 .. py:method:: Web3.toHex(primitive=None, hexstr=None, text=None)
 
-    Takes a variety of inputs and returns it in its hexidecimal representation.
+    Takes a variety of inputs and returns it in its hexadecimal representation.
     It follows the rules for converting to hex in the
     `JSON-RPC spec`_
 


### PR DESCRIPTION
### What was wrong?

The conventions section of the docs said that non-checksummed addresses might be allowed, which is incorrect.

### How was it fixed?

* docs fixed to say that must be checksummed (or ENS)
* also fixed hexadecimal spelling in several places

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://paperlief.com/images/cute-baby-lizard-wallpaper-4.jpg)
