### PR TITLE
Cache parity bin during circleci run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ parity_steps: &parity_steps
           - ./eggs
           - ~/.ethash
           - ~/.py-geth
+          - ~/.parity-bin
         key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 geth_steps: &geth_steps


### PR DESCRIPTION
### What was wrong?

Related to Issue #882

### How was it fixed?

Add parity binary install path to circleci `save_cache` command arguments.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/a0/3a/b2/a03ab29575cf05539875999b65fb1d50.jpg)
