### PR TITLE
middleware/pythonic: only apply formatter to 'publicKey' if not null.

### DIFF
--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -92,7 +92,7 @@ TRANSACTION_FORMATTERS = {
     'gasPrice': to_integer_if_hex,
     'value': to_integer_if_hex,
     'from': to_checksum_address,
-    'publicKey': to_hexbytes(64),
+    'publicKey': apply_formatter_if(is_not_null, to_hexbytes(64)),
     'r': to_hexbytes(32, variable_length=True),
     'raw': HexBytes,
     's': to_hexbytes(32, variable_length=True),


### PR DESCRIPTION
### What was wrong?

While figuring out y-days `geth`/`parity` consensus failure on Ropsten, I couldn't retrieve the "malformed" block from the Parity node via `web3.py`; here's a gist of the traceback (the last line is 128 KiB long):

https://gist.github.com/veox/8a24b90b0abe4efc89e7b37c06b6bcb1#file-trace-py

(The gist also includes system info - scroll up if needed.)

The error happens with `full_transactions=True` (through `TypeError: Could not format value None as field 'publicKey'`).

### How was it fixed?

Via @carver on https://gitter.im/ethereum/web3.py?at=5b17eb9916f649612410092f:

> `publicKey` will not be `None` in correctly formed mainnet blocks (for now), since every transaction requires a signer. But, `publicKey` also isn't a standardized (consensus-critical) piece of info that's reported -- I don't think `geth` reports it at all.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://peepeth.s3-us-west-1.amazonaws.com/images/peep_pics/tCrXy9vk/large.jpg?1527850034)

Source: [d2r2 on peepeth](https://peepeth.com/d2r2/peeps/QmX6yu32aFyHGyXCN8YX2P2ckX4UfZuvmZDSp5WZoS1Uyb)