### PR TITLE
Replace min price with low percentile for gas price estimation

### DIFF
--- a/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
+++ b/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
@@ -108,21 +108,21 @@ def _get_block_by_something(method, params):
     'strategy_params,expected',
     (
         # 120 second wait times
-        (dict(max_wait_seconds=80, sample_size=5, probability=98), 53),
-        (dict(max_wait_seconds=80, sample_size=5, probability=90), 40),
-        (dict(max_wait_seconds=80, sample_size=5, probability=50), 35),
+        (dict(max_wait_seconds=80, sample_size=5, probability=98), 61),
+        (dict(max_wait_seconds=80, sample_size=5, probability=90), 46),
+        (dict(max_wait_seconds=80, sample_size=5, probability=50), 40),
         # 60 second wait times
-        (dict(max_wait_seconds=60, sample_size=5, probability=98), 57),
-        (dict(max_wait_seconds=60, sample_size=5, probability=90), 47),
-        (dict(max_wait_seconds=60, sample_size=5, probability=50), 35),
+        (dict(max_wait_seconds=60, sample_size=5, probability=98), 62),
+        (dict(max_wait_seconds=60, sample_size=5, probability=90), 55),
+        (dict(max_wait_seconds=60, sample_size=5, probability=50), 40),
         # 40 second wait times
-        (dict(max_wait_seconds=40, sample_size=5, probability=98), 59),
-        (dict(max_wait_seconds=40, sample_size=5, probability=90), 54),
-        (dict(max_wait_seconds=40, sample_size=5, probability=50), 35),
+        (dict(max_wait_seconds=40, sample_size=5, probability=98), 63),
+        (dict(max_wait_seconds=40, sample_size=5, probability=90), 61),
+        (dict(max_wait_seconds=40, sample_size=5, probability=50), 40),
         # 20 second wait times
-        (dict(max_wait_seconds=20, sample_size=5, probability=98), 60),
-        (dict(max_wait_seconds=20, sample_size=5, probability=90), 58),
-        (dict(max_wait_seconds=20, sample_size=5, probability=50), 43),
+        (dict(max_wait_seconds=20, sample_size=5, probability=98), 63),
+        (dict(max_wait_seconds=20, sample_size=5, probability=90), 62),
+        (dict(max_wait_seconds=20, sample_size=5, probability=50), 50),
     ),
 )
 def test_time_based_gas_price_strategy(strategy_params, expected):

--- a/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
+++ b/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
@@ -108,21 +108,21 @@ def _get_block_by_something(method, params):
     'strategy_params,expected',
     (
         # 120 second wait times
-        (dict(max_wait_seconds=80, sample_size=5, probability=98), 35),
-        (dict(max_wait_seconds=80, sample_size=5, probability=90), 27),
-        (dict(max_wait_seconds=80, sample_size=5, probability=50), 10),
+        (dict(max_wait_seconds=80, sample_size=5, probability=98), 53),
+        (dict(max_wait_seconds=80, sample_size=5, probability=90), 40),
+        (dict(max_wait_seconds=80, sample_size=5, probability=50), 35),
         # 60 second wait times
-        (dict(max_wait_seconds=60, sample_size=5, probability=98), 44),
-        (dict(max_wait_seconds=60, sample_size=5, probability=90), 29),
-        (dict(max_wait_seconds=60, sample_size=5, probability=50), 11),
+        (dict(max_wait_seconds=60, sample_size=5, probability=98), 57),
+        (dict(max_wait_seconds=60, sample_size=5, probability=90), 47),
+        (dict(max_wait_seconds=60, sample_size=5, probability=50), 35),
         # 40 second wait times
-        (dict(max_wait_seconds=40, sample_size=5, probability=98), 48),
-        (dict(max_wait_seconds=40, sample_size=5, probability=90), 38),
-        (dict(max_wait_seconds=40, sample_size=5, probability=50), 16),
+        (dict(max_wait_seconds=40, sample_size=5, probability=98), 59),
+        (dict(max_wait_seconds=40, sample_size=5, probability=90), 54),
+        (dict(max_wait_seconds=40, sample_size=5, probability=50), 35),
         # 20 second wait times
-        (dict(max_wait_seconds=20, sample_size=5, probability=98), 49),
-        (dict(max_wait_seconds=20, sample_size=5, probability=90), 45),
-        (dict(max_wait_seconds=20, sample_size=5, probability=50), 25),
+        (dict(max_wait_seconds=20, sample_size=5, probability=98), 60),
+        (dict(max_wait_seconds=20, sample_size=5, probability=90), 58),
+        (dict(max_wait_seconds=20, sample_size=5, probability=50), 43),
     ),
 )
 def test_time_based_gas_price_strategy(strategy_params, expected):

--- a/tests/core/utilities/test_math.py
+++ b/tests/core/utilities/test_math.py
@@ -1,0 +1,45 @@
+import pytest
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+from web3.utils.math import (
+    percentile,
+)
+
+values = range(100)
+
+
+@pytest.mark.parametrize(
+    "p,expected",
+    (
+        (0, 0),
+        (1, 0),
+        (2, 1),
+        (3, 2),
+        (4, 3),
+        (50, 49),
+        (50.5, 49.5),
+        (100, 99)
+    )
+)
+def test_percentiles_out_of_one_hundred(p, expected):
+    assert percentile(values, p) == expected
+
+
+def test_percentiles_with_single_values():
+    with pytest.raises(ValueError):
+        percentile([0], 1)
+
+
+@given(
+    values=st.lists(elements=st.integers(), min_size=3, max_size=200),
+    p=st.integers(max_value=100, min_value=0))
+def test_fuzz_test_percentiles(values, p):
+    if not values:
+        with pytest.raises(ValueError):
+            percentile(values, p)
+    else:
+        percentile(values, p)

--- a/web3/gas_strategies/time_based.py
+++ b/web3/gas_strategies/time_based.py
@@ -9,13 +9,19 @@ from eth_utils import (
 from web3.exceptions import (
     ValidationError,
 )
+from web3.utils.math import (
+    percentile,
+)
 from web3.utils.toolz import (
     curry,
     groupby,
     sliding_window,
 )
 
-MinerData = collections.namedtuple('MinerData', ['miner', 'num_blocks', 'min_gas_price'])
+MinerData = collections.namedtuple(
+    'MinerData',
+    ['miner', 'num_blocks', 'min_gas_price', 'low_percentile_gas_price'])
+
 Probability = collections.namedtuple('Probability', ['gas_price', 'prob'])
 
 
@@ -54,7 +60,11 @@ def _aggregate_miner_data(raw_data):
 
     for miner, miner_data in data_by_miner.items():
         _, block_hashes, gas_prices = map(set, zip(*miner_data))
-        yield MinerData(miner, len(set(block_hashes)), min(gas_prices))
+        yield MinerData(
+            miner,
+            len(set(block_hashes)),
+            min(gas_prices),
+            percentile(list(gas_prices), percentile=15))
 
 
 @to_tuple
@@ -65,15 +75,15 @@ def _compute_probabilities(miner_data, wait_blocks, sample_size):
     """
     miner_data_by_price = tuple(sorted(
         miner_data,
-        key=operator.attrgetter('min_gas_price'),
+        key=operator.attrgetter('low_percentile_gas_price'),
         reverse=True,
     ))
     for idx in range(len(miner_data_by_price)):
-        min_gas_price = miner_data_by_price[idx].min_gas_price
+        low_percentile_gas_price = miner_data_by_price[idx].low_percentile_gas_price
         num_blocks_accepting_price = sum(m.num_blocks for m in miner_data_by_price[idx:])
         inv_prob_per_block = (sample_size - num_blocks_accepting_price) / sample_size
         probability_accepted = 1 - inv_prob_per_block ** wait_blocks
-        yield Probability(min_gas_price, probability_accepted)
+        yield Probability(low_percentile_gas_price, probability_accepted)
 
 
 def _compute_gas_price(probabilities, desired_probability):

--- a/web3/gas_strategies/time_based.py
+++ b/web3/gas_strategies/time_based.py
@@ -64,7 +64,7 @@ def _aggregate_miner_data(raw_data):
             miner,
             len(set(block_hashes)),
             min(gas_prices),
-            percentile(list(gas_prices), percentile=15))
+            percentile(gas_prices, percentile=15))
 
 
 @to_tuple

--- a/web3/utils/math.py
+++ b/web3/utils/math.py
@@ -1,15 +1,24 @@
-import math
-
-
-def percentile(values, percentile):
-    if not values:
-        raise ValueError("Expected a sequence of values, got {0}".format(values))
-    if not percentile:
+def percentile(values=None, percentile=None):
+    """Calculates a simplified weighted average percentile
+    """
+    if values in [None, tuple(), []] or len(values) < 3:
+        raise ValueError("Expected a sequence of at least 3 integers, got {0}".format(values))
+    if percentile is None:
         raise ValueError("Expected a percentile choice, got {0}".format(percentile))
 
-    index = len(values) * percentile / 100
     sorted_values = sorted(values)
-    if index % 2 == 0:
-        return (sorted_values[index] + sorted_values[index + 1]) / 2
 
-    return sorted_values[math.ceil(index)]
+    rank = len(values) * percentile / 100
+    if rank > 0:
+        index = rank - 1
+    else:
+        index = rank
+
+    if index % 1 == 0:
+        return sorted_values[int(index)]
+    else:
+        fractional = index % 1
+        integer = int(index - fractional)
+        lower = sorted_values[integer]
+        higher = sorted_values[integer + 1]
+        return lower + fractional * (higher - lower)

--- a/web3/utils/math.py
+++ b/web3/utils/math.py
@@ -3,7 +3,10 @@ import math
 
 def percentile(values, percentile):
     if not values:
-        return None
+        raise ValueError("Expected a sequence of values, got {0}".format(values))
+    if not percentile:
+        raise ValueError("Expected a percentile choice, got {0}".format(percentile))
+
     index = len(values) * percentile / 100
     sorted_values = sorted(values)
     if index % 2 == 0:

--- a/web3/utils/math.py
+++ b/web3/utils/math.py
@@ -5,7 +5,8 @@ def percentile(values, percentile):
     if not values:
         return None
     index = len(values) * percentile / 100
+    sorted_values = sorted(values)
     if index % 2 == 0:
-        return (sorted(values)[index] + sorted(values)[index + 1]) / 2
+        return (sorted_values[index] + sorted_values[index + 1]) / 2
 
-    return sorted(values)[math.ceil(index)]
+    return sorted_values[math.ceil(index)]

--- a/web3/utils/math.py
+++ b/web3/utils/math.py
@@ -1,0 +1,11 @@
+import math
+
+
+def percentile(values, percentile):
+    if not values:
+        return None
+    index = len(values) * percentile / 100
+    if index % 2 == 0:
+        return (sorted(values)[index] + sorted(values)[index + 1]) / 2
+
+    return sorted(values)[math.ceil(index)]


### PR DESCRIPTION
### What was wrong?

Fixes https://github.com/ethereum/web3.py/issues/894

The current time based gas price estimation strategy uses the minimum gas price from a set of blocks from a particular miner.  Doing this makes the assumption that there is an equal chance for all transactions at or above the minimum price to have been accepted by the miner.  This isn't true, as the miners will accept higher priced transactions before those close to their set minimum.

### How was it fixed?

Using a low percentile instead of the minimum should give a better estimate.  We don't want to use the record minimum, we want the reasonable minimum price to make our estimate.  In lieu of divining a reasonable minimum, using a lower percentile should get us a bit closer.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://www.guineapighub.com/wp-content/uploads/2016/10/guinea7.jpg)
