### PR TITLE
Create new list subclass for event topic management

### DIFF
--- a/tests/core/utilities/test_single_index_assignment_list.py
+++ b/tests/core/utilities/test_single_index_assignment_list.py
@@ -1,0 +1,94 @@
+import pytest
+
+from hypothesis import (
+    given,
+    strategies as s,
+)
+
+from web3.exceptions import (
+    ItemResetException,
+)
+from web3.utils.datastructures import (
+    SingleIndexAssignmentList,
+)
+from web3.utils.hypothesis import (
+    hexstr_strategy,
+)
+
+elements = s.one_of(
+    s.integers(),
+    s.booleans(),
+    s.floats(),
+    s.tuples(),
+    s.lists(),
+    s.sets(),
+    s.dictionaries(s.integers(), s.integers()),
+    s.characters(),
+    s.text(),
+    s.binary(),
+    hexstr_strategy()
+)
+
+
+@s.composite
+def values_indexes_resets(draw, elements=elements):
+    values = draw(s.lists(elements, min_size=1))
+    indexes = draw(
+        s.lists(
+            max_size=len(values),
+            min_size=len(values),
+            elements=s.integers(min_value=0, max_value=len(values) - 1), unique=True))
+
+    bools = draw(
+        s.lists(
+            max_size=len(values),
+            min_size=len(values),
+            elements=s.booleans()))
+    return (values, indexes, bools)
+
+
+@s.composite
+def filled_list_not_prohibited(draw):
+    values = draw(s.lists(elements, min_size=1))
+    not_prohibited_list = SingleIndexAssignmentList(values)
+    return not_prohibited_list
+
+
+@s.composite
+def filled_list_setting_prohibited(draw):
+    values = draw(s.lists(elements, min_size=1))
+    prohibited_list = SingleIndexAssignmentList(values)
+    prohibited_list.set_prohibited = [True for i in range(len(prohibited_list))]
+    return prohibited_list
+
+
+@given(values_indexes_resets())
+def test_SingleIndexAssignmentList(values_indexes_resets):
+    single_set = SingleIndexAssignmentList()
+    values, indexes, bools = values_indexes_resets
+    expected = [value for value, index in sorted(zip(values, indexes), key=lambda x: x[1])]
+    for value, index, reset in zip(values, indexes, bools):
+        single_set[index] = value
+        assert len(single_set) == len(single_set.set_prohibited)
+        if reset:
+            with pytest.raises(ItemResetException):
+                single_set[index] = value
+    assert single_set == expected
+
+
+@given(filled_list_not_prohibited())
+def test_filled_list_not_prohibited(not_prohibited):
+    for i in range(len(not_prohibited)):
+        not_prohibited[i] = "0x0"
+
+
+@given(filled_list_setting_prohibited())
+def test_pass_filled_list_to_constructor(prohibited_sets_list):
+    with pytest.raises(ItemResetException):
+        prohibited_sets_list[0] = "!!!!"
+    constructed_from_prohibited_set = SingleIndexAssignmentList(prohibited_sets_list)
+    for i in range(len(constructed_from_prohibited_set)):
+        constructed_from_prohibited_set[i] = "0x0"
+    copied_from_prohibited_set = SingleIndexAssignmentList(prohibited_sets_list)
+    for i in range(len(copied_from_prohibited_set)):
+        copied_from_prohibited_set[i] = "0x0"

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -99,3 +99,10 @@ class NoABIEventsFound(AttributeError):
     Raised when an ABI doesn't contain any events.
     """
     pass
+
+
+class ItemResetException(Exception):
+    """
+    Raised when resetting a value is prohibited.
+    """
+    pass


### PR DESCRIPTION
This this first piece of an improved event filter api.

Topics will be managed with a list like object that has some particular features:

1. The list prohibits repeat assignment
  e.g.:

```python
>>> from web3.utils.datastructures import SingleIndexAssignmentList
>>> test_list = SingleIndexAssignmentList()
>>> test_list.append("0x10101")
>>> test_list[0] = "0x11111"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dwilson/Develop/Projects/ethereum/web3.py/web3/utils/datastructures.py", line 255, in __setitem__
    raise ItemResetException("Values can't be reset.")
web3.exceptions.ItemResetException: Values can't be reset.
>>> 
```
2. Accepts out of range indexed assignments, filling in `None` for the preceding items.  For example:

```python
>>> from web3.utils.datastructures import SingleIndexAssignmentList
>>> test_list = SingleIndexAssignmentList()
>>> test_list[12] = "0x12345"
>>> test_list
[None, None, None, None, None, None, None, None, None, None, None, None, '0x12345']
>>> 
```

3.  The list can be copied, which does not carry over the state prohibiting repeat value setting.

```python
>>> from web3.utils.datastructures import SingleIndexAssignmentList
>>> test_list = SingleIndexAssignmentList()
>>> test_list.append("0x10101")
>>> test_list[0] = "0x11111"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dwilson/Develop/Projects/ethereum/web3.py/web3/utils/datastructures.py", line 255, in __setitem__
    raise ItemResetException("Values can't be reset.")
web3.exceptions.ItemResetException: Values can't be reset.
>>> new_test_list = test_list.copy()
>>> new_test_list
["0x10101"]
>>> new_test_list[0] = "0x11111
>>> new_test_list
["0x11111"]
>>> new_test_list[0] = "0x22222"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dwilson/Develop/Projects/ethereum/web3.py/web3/utils/datastructures.py", line 255, in __setitem__
    raise ItemResetException("Values can't be reset.")
```

These features will be leveraged to create a filter creation object that will (1) after having the initial parameters fed in, be essentially immutable, (2) allow setting only some topics in the topic argument list, while leaving those unfilled to match on all, and (3) allow existing filters to be used as templates to build new filters.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://hplusmagazine.com/sites/default/files/images/articles/nov09/making-a-smarter-rat.jpg)
