### PR TITLE
bumped websockets version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "lru-dict>=1.1.6,<2.0.0",
         "eth-hash[pycryptodome]",
         "requests>=2.16.0,<3.0.0",
-        "websockets>=4.0.1,<5.0.0",
+        "websockets>=5.0.1,<6.0.0",
         "pypiwin32>=223;platform_system=='Windows'",
     ],
     setup_requires=['setuptools-markdown'],


### PR DESCRIPTION
### What was wrong?
Web3 was pinned to `websockets` version `<v5`
fixes #910

### How was it fixed?
upgraded websockets. version to `5.0.1`
version 5.0.0 had a breaking change. It would give the following error:
```    async def __aenter__(self):
        if self.ws is None:
>           self.ws = await websockets.connect(uri=self.endpoint_uri, loop=self.loop)
E           TypeError: __await__() returned a coroutine
```
This is because of this [commit ](https://github.com/aaugustin/websockets/commit/7da5f40a65fc6003b3d2457d042c07443a8256d1). The author has [accepted that it was mistake](https://github.com/aaugustin/websockets/issues/411#issuecomment-391416957). This was [reverted](https://github.com/aaugustin/websockets/commit/5b991fb441fc7626d783a813609022e670397132) back in `5.0.1`.

`v5` has some security fixes, so I'm skeptical about supporting `v4`.


#### Cute Animal Picture

![](https://media.mnn.com/assets/images/2016/05/01-slothlove-keychain-in-a-cup.jpg.653x0_q80_crop-smart.jpg)
