### PR TITLE
Allowed passing websockets connection kwargs

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -224,15 +224,30 @@ IPCProvider
 WebsocketProvider
 ~~~~~~~~~~~~~~~~~
 
-.. py:class:: web3.providers.websocket.WebsocketProvider(endpoint_uri)
+.. py:class:: web3.providers.websocket.WebsocketProvider(endpoint_uri[, websocket_kwargs])
 
     This provider handles interactions with an WS or WSS based JSON-RPC server.
+
+    * ``endpoint_uri`` should be the full URI to the RPC endpoint such as
+      ``'ws://localhost:8546'``.
+    * ``websocket_kwargs`` this should be a dictionary of keyword arguments which
+      will be passed onto the ws/wss websocket connection.
 
     .. code-block:: python
 
         >>> from web3 import Web3
         >>> web3 = Web3(Web3.WebsocketProvider("ws://127.0.0.1:8546")
 
+    Under the hood, the ``WebsocketProvider`` uses the python websockets library for
+    making requests.  If you would like to modify how requests are made, you can
+    use the ``websocket_kwargs`` to do so.  A common use case for this is increasing
+    the timeout for each request.
+
+
+    .. code-block:: python
+
+        >>> from web3 import Web3
+        >>> web3 = Web3(Web3.WebsocketProvider("http://127.0.0.1:8546", websocket_kwargs={'timeout': 60}))
 
 .. py:currentmodule:: web3.providers.eth_tester
 

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -1,0 +1,15 @@
+import pytest
+
+from web3.exceptions import (
+    ValidationError,
+)
+from web3.providers.websocket import (
+    WebsocketProvider,
+)
+
+
+def test_restricted_websocket_kwargs():
+    invalid_kwargs = {'uri': 'ws://127.0.0.1:8546'}
+    re_exc_message = r'.*found: {0}*'.format(set(invalid_kwargs.keys()))
+    with pytest.raises(ValidationError, match=re_exc_message):
+        WebsocketProvider(websocket_kwargs=invalid_kwargs)

--- a/tests/integration/common.py
+++ b/tests/integration/common.py
@@ -1,0 +1,17 @@
+import pytest
+
+from websockets.exceptions import (
+    ConnectionClosed,
+)
+
+from web3 import Web3
+
+
+class MiscWebsocketTest:
+
+    def test_websocket_max_size_error(self, web3, endpoint_uri):
+        w3 = Web3(Web3.WebsocketProvider(
+            endpoint_uri=endpoint_uri, websocket_kwargs={'max_size': 1})
+        )
+        with pytest.raises(ConnectionClosed):
+            w3.eth.getBlock(0)

--- a/tests/integration/go_ethereum/test_goethereum_ws.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws.py
@@ -1,5 +1,8 @@
 import pytest
 
+from tests.integration.common import (
+    MiscWebsocketTest,
+)
 from tests.integration.utils import (
     wait_for_ws,
 )
@@ -64,4 +67,8 @@ class TestGoEthereumNetModuleTest(GoEthereumNetModuleTest):
 
 
 class TestGoEthereumPersonalModuleTest(GoEthereumPersonalModuleTest):
+    pass
+
+
+class TestMiscWebsocketTest(MiscWebsocketTest):
     pass

--- a/tests/integration/parity/test_parity_ws.py
+++ b/tests/integration/parity/test_parity_ws.py
@@ -1,6 +1,9 @@
 import os
 import pytest
 
+from tests.integration.common import (
+    MiscWebsocketTest,
+)
 from tests.integration.utils import (
     wait_for_ws,
 )
@@ -95,4 +98,8 @@ class TestParityPersonalModuleTest(ParityPersonalModuleTest):
 
 
 class TestParityTraceModuleTest(ParityTraceModuleTest):
+    pass
+
+
+class TestMiscWebsocketTest(MiscWebsocketTest):
     pass


### PR DESCRIPTION
### What was wrong?
The current implementation of `WebsocketProvider` did not allow configuring extra configurations that a `websockets` connection takes
fixes #913

### How was it fixed?
Allowed passing websockets connection kwargs


#### Cute Animal Picture

![](https://i.redditmedia.com/Cv9N2ZppSiHVL0Zpjok89laK_bCx4F8lpj32-mhlD-M.jpg?fit=crop&crop=faces%2Centropy&arh=2&w=640&s=d71074699c5976feb5d1d201c6163bc2)
