### PR TITLE
Add new autoproviders for geth --dev and Infura #797

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 bumpversion
 flaky>=3.3.0
 hypothesis>=3.31.2
-pytest==3.2.5
+pytest>=3.5.0,<4
 pytest-mock==1.*
 pytest-pythonpath>=0.3
 pytest-watch==4.*

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -1,11 +1,20 @@
 import pytest
 
+from web3.auto.gethdev import (
+    w3 as w3_gethdev,
+)
+from web3.auto.infura import (
+    w3 as w3_infura,
+)
 from web3.providers import (
     HTTPProvider,
     IPCProvider,
     WebsocketProvider,
 )
 from web3.providers.auto import (
+    INFURA_MAINNET_HTTP_URL,
+    load_gethdev_ipc_provider,
+    load_infura_mainnet_http_provider,
     load_provider_from_environment,
 )
 
@@ -25,3 +34,23 @@ def test_load_provider_from_env(monkeypatch, uri, expected_type, expected_attrs)
     assert isinstance(provider, expected_type)
     for attr, val in expected_attrs.items():
         assert getattr(provider, attr) == val
+
+
+def test_load_infura_provider():
+    provider = load_infura_mainnet_http_provider()
+    assert isinstance(provider, HTTPProvider)
+    assert getattr(provider, 'endpoint_uri') == INFURA_MAINNET_HTTP_URL
+
+
+def test_load_gethdev_provider():
+    provider = load_gethdev_ipc_provider()
+    assert isinstance(provider, IPCProvider)
+
+
+def test_web3_auto_infura():
+    assert isinstance(w3_infura.providers[0], HTTPProvider)
+    assert getattr(w3_infura.providers[0], 'endpoint_uri') == INFURA_MAINNET_HTTP_URL
+
+
+def test_web3_auto_gethdev():
+    assert isinstance(w3_gethdev.providers[0], IPCProvider)

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -1,8 +1,9 @@
+import importlib
+import logging
 import pytest
 
-from web3.auto.infura import (
-    INFURA_MAINNET_HTTP_URL,
-    w3,
+from web3.auto import (
+    infura,
 )
 from web3.providers import (
     HTTPProvider,
@@ -31,6 +32,42 @@ def test_load_provider_from_env(monkeypatch, uri, expected_type, expected_attrs)
         assert getattr(provider, attr) == val
 
 
-def test_web3_auto_infura():
+def test_web3_auto_infura_empty_key(monkeypatch, caplog):
+    monkeypatch.setenv('INFURA_API_KEY', '')
+
+    importlib.reload(infura)
+    assert len(caplog.record_tuples) == 1
+    logger, level, msg = caplog.record_tuples[0]
+    assert 'INFURA_API_KEY' in msg
+    assert level == logging.WARNING
+
+    w3 = infura.w3
     assert isinstance(w3.providers[0], HTTPProvider)
-    assert getattr(w3.providers[0], 'endpoint_uri') == INFURA_MAINNET_HTTP_URL
+    assert getattr(w3.providers[0], 'endpoint_uri') == infura.INFURA_MAINNET_BASE_URL
+
+
+def test_web3_auto_infura_missing_key(monkeypatch, caplog):
+    monkeypatch.delenv('INFURA_API_KEY', raising=False)
+
+    importlib.reload(infura)
+    assert len(caplog.record_tuples) == 1
+    logger, level, msg = caplog.record_tuples[0]
+    assert 'INFURA_API_KEY' in msg
+    assert level == logging.WARNING
+
+    w3 = infura.w3
+    assert isinstance(w3.providers[0], HTTPProvider)
+    assert getattr(w3.providers[0], 'endpoint_uri') == infura.INFURA_MAINNET_BASE_URL
+
+
+def test_web3_auto_infura(monkeypatch, caplog):
+    API_KEY = 'aoeuhtns'
+    monkeypatch.setenv('INFURA_API_KEY', API_KEY)
+    expected_url = '%s/%s' % (infura.INFURA_MAINNET_BASE_URL, API_KEY)
+
+    importlib.reload(infura)
+    assert len(caplog.record_tuples) == 0
+
+    w3 = infura.w3
+    assert isinstance(w3.providers[0], HTTPProvider)
+    assert getattr(w3.providers[0], 'endpoint_uri') == expected_url

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -1,10 +1,8 @@
 import pytest
 
-from web3.auto.gethdev import (
-    w3 as w3_gethdev,
-)
 from web3.auto.infura import (
-    w3 as w3_infura,
+    INFURA_MAINNET_HTTP_URL,
+    w3,
 )
 from web3.providers import (
     HTTPProvider,
@@ -12,9 +10,6 @@ from web3.providers import (
     WebsocketProvider,
 )
 from web3.providers.auto import (
-    INFURA_MAINNET_HTTP_URL,
-    load_gethdev_ipc_provider,
-    load_infura_mainnet_http_provider,
     load_provider_from_environment,
 )
 
@@ -36,21 +31,6 @@ def test_load_provider_from_env(monkeypatch, uri, expected_type, expected_attrs)
         assert getattr(provider, attr) == val
 
 
-def test_load_infura_provider():
-    provider = load_infura_mainnet_http_provider()
-    assert isinstance(provider, HTTPProvider)
-    assert getattr(provider, 'endpoint_uri') == INFURA_MAINNET_HTTP_URL
-
-
-def test_load_gethdev_provider():
-    provider = load_gethdev_ipc_provider()
-    assert isinstance(provider, IPCProvider)
-
-
 def test_web3_auto_infura():
-    assert isinstance(w3_infura.providers[0], HTTPProvider)
-    assert getattr(w3_infura.providers[0], 'endpoint_uri') == INFURA_MAINNET_HTTP_URL
-
-
-def test_web3_auto_gethdev():
-    assert isinstance(w3_gethdev.providers[0], IPCProvider)
+    assert isinstance(w3.providers[0], HTTPProvider)
+    assert getattr(w3.providers[0], 'endpoint_uri') == INFURA_MAINNET_HTTP_URL

--- a/web3/auto/gethdev.py
+++ b/web3/auto/gethdev.py
@@ -1,0 +1,9 @@
+from web3 import (
+    IPCProvider,
+    Web3,
+)
+from web3.providers.ipc import (
+    get_dev_ipc_path,
+)
+
+w3 = Web3(IPCProvider(get_dev_ipc_path()))

--- a/web3/auto/gethdev.py
+++ b/web3/auto/gethdev.py
@@ -2,8 +2,12 @@ from web3 import (
     IPCProvider,
     Web3,
 )
+from web3.middleware import (
+    geth_poa_middleware,
+)
 from web3.providers.ipc import (
     get_dev_ipc_path,
 )
 
 w3 = Web3(IPCProvider(get_dev_ipc_path()))
+w3.middleware_stack.inject(geth_poa_middleware, layer=0)

--- a/web3/auto/infura.py
+++ b/web3/auto/infura.py
@@ -1,8 +1,24 @@
+import logging
+import os
+
 from web3 import (
     HTTPProvider,
     Web3,
 )
 
-INFURA_MAINNET_HTTP_URL = 'https://mainnet.infura.io'
+INFURA_MAINNET_BASE_URL = 'https://mainnet.infura.io'
 
-w3 = Web3(HTTPProvider(INFURA_MAINNET_HTTP_URL))
+
+def load_infura_url():
+    key = os.environ.get('INFURA_API_KEY', '')
+    if key == '':
+        logging.getLogger('web3.auto.infura').warning(
+            "No Infura API Key found. Add environment variable INFURA_API_KEY to ensure continued "
+            "API access. New keys are available at https://infura.io/signup"
+        )
+        return INFURA_MAINNET_BASE_URL
+    else:
+        return "%s/%s" % (INFURA_MAINNET_BASE_URL, key)
+
+
+w3 = Web3(HTTPProvider(load_infura_url()))

--- a/web3/auto/infura.py
+++ b/web3/auto/infura.py
@@ -1,0 +1,9 @@
+from web3 import (
+    HTTPProvider,
+    Web3,
+)
+from web3.providers.auto import (
+    INFURA_MAINNET_HTTP_URL,
+)
+
+w3 = Web3(HTTPProvider(INFURA_MAINNET_HTTP_URL))

--- a/web3/auto/infura.py
+++ b/web3/auto/infura.py
@@ -2,8 +2,7 @@ from web3 import (
     HTTPProvider,
     Web3,
 )
-from web3.providers.auto import (
-    INFURA_MAINNET_HTTP_URL,
-)
+
+INFURA_MAINNET_HTTP_URL = 'https://mainnet.infura.io'
 
 w3 = Web3(HTTPProvider(INFURA_MAINNET_HTTP_URL))

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -12,6 +12,19 @@ from web3.providers import (
     IPCProvider,
     WebsocketProvider,
 )
+from web3.providers.ipc import (
+    get_dev_ipc_path,
+)
+
+INFURA_MAINNET_HTTP_URL = 'https://mainnet.infura.io'
+
+
+def load_infura_mainnet_http_provider():
+    return HTTPProvider(INFURA_MAINNET_HTTP_URL)
+
+
+def load_gethdev_ipc_provider():
+    return IPCProvider(get_dev_ipc_path())
 
 
 def load_provider_from_environment():
@@ -42,6 +55,8 @@ class AutoProvider(BaseProvider):
         IPCProvider,
         HTTPProvider,
         WebsocketProvider,
+        load_gethdev_ipc_provider,
+        load_infura_mainnet_http_provider,
     )
     _active_provider = None
 

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -12,19 +12,6 @@ from web3.providers import (
     IPCProvider,
     WebsocketProvider,
 )
-from web3.providers.ipc import (
-    get_dev_ipc_path,
-)
-
-INFURA_MAINNET_HTTP_URL = 'https://mainnet.infura.io'
-
-
-def load_infura_mainnet_http_provider():
-    return HTTPProvider(INFURA_MAINNET_HTTP_URL)
-
-
-def load_gethdev_ipc_provider():
-    return IPCProvider(get_dev_ipc_path())
 
 
 def load_provider_from_environment():
@@ -55,8 +42,6 @@ class AutoProvider(BaseProvider):
         IPCProvider,
         HTTPProvider,
         WebsocketProvider,
-        load_gethdev_ipc_provider,
-        load_infura_mainnet_http_provider,
     )
     _active_provider = None
 

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -136,6 +136,50 @@ def get_default_ipc_path(testnet=False):
         )
 
 
+def get_dev_ipc_path():
+    if sys.platform == 'darwin':
+        tmpdir = os.environ.get('TMPDIR', '')
+        ipc_path = os.path.expanduser(os.path.join(
+            tmpdir,
+            "geth.ipc"
+        ))
+        if os.path.exists(ipc_path):
+            return ipc_path
+
+    elif sys.platform.startswith('linux'):
+        ipc_path = os.path.expanduser(os.path.join(
+            "/tmp",
+            "geth.ipc"
+        ))
+        if os.path.exists(ipc_path):
+            return ipc_path
+
+    elif sys.platform == 'win32':
+        ipc_path = os.path.join(
+            "\\\\",
+            ".",
+            "pipe",
+            "geth.ipc"
+        )
+        if os.path.exists(ipc_path):
+            return ipc_path
+
+        ipc_path = os.path.join(
+            "\\\\",
+            ".",
+            "pipe",
+            "jsonrpc.ipc"
+        )
+        if os.path.exists(ipc_path):
+            return ipc_path
+
+    else:
+        raise ValueError(
+            "Unsupported platform '{0}'.  Only darwin/linux2/win32 are "
+            "supported.  You must specify the ipc_path".format(sys.platform)
+        )
+
+
 class IPCProvider(JSONBaseProvider):
     logger = logging.getLogger("web3.providers.IPCProvider")
     _socket = None


### PR DESCRIPTION
### What was wrong?

Added new autoproviders for ```geth --dev``` and Infura related to Issue #797 

### How was it fixed?

Users can now:
- [x] ```from web3.auto.gethdev import w3``` to connect to the default ```geth --dev``` location
- [x] ```from web3.auto.infura import w3``` to connect to Infura's Mainnet remote node

Also when users:
- [x] ```from web3.auto import w3``` the new ```geth --dev``` and Infura provider connections were added to the end of the default list of provider connections to try. The order the AutoProvider attempts to connect to is now:
1.  provider defined in environment variable
2.  IPCProvider
3.  HTTPProvider
4.  WebsocketProvider
5.  geth --dev IPCProvider
6.  Infura Mainnet HTTPProvider

This now means using ```from web3.auto import w3``` will always connect successfully, assuming either a local provider is found at the default locations or Infura's Mainnet remote node is operational.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/NyvWIEK.png)
