### PR TITLE
Add support for https in WEB3_PROVIDER_URI environment variable #918

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -144,6 +144,7 @@ Valid formats for the this environment variable are:
 
 - ``file:///path/to/node/rpc-json/file.ipc``
 - ``http://192.168.1.2:8545``
+- ``https://node.ontheweb.com``
 
 
 Built In Providers

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -15,6 +15,7 @@ from web3.providers.auto import (
     (
         ('', type(None), {}),
         ('http://1.2.3.4:5678', HTTPProvider, {'endpoint_uri': 'http://1.2.3.4:5678'}),
+        ('https://node.ontheweb.com', HTTPProvider, {'endpoint_uri': 'https://node.ontheweb.com'}),
         ('file:///root/path/to/file.ipc', IPCProvider, {'ipc_path': '/root/path/to/file.ipc'}),
         ('ws://1.2.3.4:5679', WebsocketProvider, {'endpoint_uri': 'ws://1.2.3.4:5679'})
     ),

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -13,6 +13,8 @@ from web3.providers import (
     WebsocketProvider,
 )
 
+HTTP_SCHEMES = {'http', 'https'}
+
 
 def load_provider_from_environment():
     uri_string = os.environ.get('WEB3_PROVIDER_URI', '')
@@ -22,7 +24,7 @@ def load_provider_from_environment():
     uri = urlparse(uri_string)
     if uri.scheme == 'file':
         return IPCProvider(uri.path)
-    elif uri.scheme == 'http' or uri.scheme == 'https':
+    elif uri.scheme in HTTP_SCHEMES:
         return HTTPProvider(uri_string)
     elif uri.scheme == 'ws':
         return WebsocketProvider(uri_string)

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -22,7 +22,7 @@ def load_provider_from_environment():
     uri = urlparse(uri_string)
     if uri.scheme == 'file':
         return IPCProvider(uri.path)
-    elif uri.scheme == 'http':
+    elif uri.scheme == 'http' or uri.scheme == 'https':
         return HTTPProvider(uri_string)
     elif uri.scheme == 'ws':
         return WebsocketProvider(uri_string)


### PR DESCRIPTION
### What was wrong?

AutoProvider does not support https url in WEB3_PROVIDER_URI environment variable Issue #918 

### How was it fixed?

Modified ```load_provider_from_environment()``` function in ```web3/providers/auto.py``` to check for https scheme.

Added https test case in ```tests/core/providers/test_auto_provider.py```.

Updated ```docs/providers.rst``` section **Provider via Environment Variable** to include valid https example.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/m7vhu6i.jpg)
