### PR TITLE
IPCProvider: Accept pathlib.Path in constructor.

### DIFF
--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import pytest
 import socket
 import tempfile
@@ -73,7 +74,7 @@ def serve_empty_result(simple_ipc_server):
 
 
 def test_sync_waits_for_full_result(jsonrpc_ipc_pipe_path, serve_empty_result):
-    provider = IPCProvider(jsonrpc_ipc_pipe_path, timeout=3)
+    provider = IPCProvider(pathlib.Path(jsonrpc_ipc_pipe_path), timeout=3)
     result = provider.make_request("method", [])
     assert result == {'id': 1, 'result': {}}
     provider._socket.sock.close()

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 import socket
 import sys
 import threading
@@ -188,6 +189,8 @@ class IPCProvider(JSONBaseProvider):
         if ipc_path is None:
             self.ipc_path = get_default_ipc_path(testnet)
         else:
+            if isinstance(ipc_path, pathlib.Path):
+                ipc_path = str(ipc_path.resolve())
             self.ipc_path = ipc_path
 
         self.timeout = timeout


### PR DESCRIPTION
### What was wrong?

IPCProvider accepted only str paths.

### How was it fixed?

If ipc_path is an instance of pathlib.Path, resolve the path
and cast to string. Modify IPCProvider sync test to use pathlib
Path.

#### Cute Animal Picture

![](https://i.imgflip.com/1srnz6.jpg)

Fixes: #867