### PR TITLE
Fix 'pmp' typo in docs

### DIFF
--- a/docs/web3.pm.rst
+++ b/docs/web3.pm.rst
@@ -16,7 +16,7 @@ To use ``web3.pm``, attach it to your ``web3`` instance.
 .. code-block:: python
 
    from web3.pm import PM
-   PM.attach(web3, 'pmp')
+   PM.attach(web3, 'pm')
 
 
 Methods


### PR DESCRIPTION
### What was wrong?
Typo in `pm` docs

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/41993988-3b4c85a2-7a0a-11e8-9239-d038ed0c07e8.png)
