### PR TITLE
Contract call optimization - remove round trip

### DIFF
--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -392,9 +392,6 @@ def test_call_fallback_function(fallback_function_contract):
 def test_throws_error_if_block_out_of_range(web3, math_contract):
     web3.providers[0].make_request(method='evm_mine', params=[20])
     with pytest.raises(BlockNumberOutofRange):
-        math_contract.functions.counter().call(block_identifier=50)
-
-    with pytest.raises(BlockNumberOutofRange):
         math_contract.functions.counter().call(block_identifier=-50)
 
 

--- a/tests/core/contracts/test_contract_util_functions.py
+++ b/tests/core/contracts/test_contract_util_functions.py
@@ -1,3 +1,8 @@
+from web3.contract import (
+    parse_block_identifier_int,
+)
+
+
 def test_parse_block_identifier_int(web3):
     last_num = web3.eth.getBlock('latest').number
-    assert web3.eth.getBlock(0) == web3.eth.getBlock(-1 - last_num)
+    assert 0 == parse_block_identifier_int(web3, -1 - last_num)

--- a/tests/core/contracts/test_contract_util_functions.py
+++ b/tests/core/contracts/test_contract_util_functions.py
@@ -3,6 +3,11 @@ from web3.contract import (
 )
 
 
+#  This tests negative block number identifiers, which behave like python
+#  list slices, with -1 being the latest block and -2 being the block before that.
+#  This test is necessary because transaction calls allow negative block indexes, although
+#  getBlock() does not allow negative block identifiers. Support for negative block identifier
+#  will likely be removed in v5.
 def test_parse_block_identifier_int(web3):
     last_num = web3.eth.getBlock('latest').number
     assert 0 == parse_block_identifier_int(web3, -1 - last_num)

--- a/tests/core/contracts/test_contract_util_functions.py
+++ b/tests/core/contracts/test_contract_util_functions.py
@@ -1,0 +1,3 @@
+def test_parse_block_identifier_int(web3):
+    last_num = web3.eth.getBlock('latest').number
+    assert web3.eth.getBlock(0) == web3.eth.getBlock(-1 - last_num)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1398,18 +1398,25 @@ def call_contract_function(
 
 def parse_block_identifier(web3, block_identifier):
     if isinstance(block_identifier, int):
-        last_block = web3.eth.getBlock('latest').number
-        if abs(block_identifier) <= last_block:
-            if block_identifier >= 0:
-                return block_identifier
-            else:
-                return last_block + block_identifier + 1
-        else:
-            raise BlockNumberOutofRange
+        return parse_block_identifier_int(web3, block_identifier)
     elif block_identifier in ['latest', 'earliest', 'pending']:
         return block_identifier
     elif isinstance(block_identifier, bytes) or is_hex_encoded_block_hash(block_identifier):
         return web3.eth.getBlock(block_identifier).number
+    else:
+        raise BlockNumberOutofRange
+
+
+def parse_block_identifier_int(web3, block_identifier_int):
+    last_block = web3.eth.getBlock('latest').number
+
+    if block_identifier_int >= 0:
+        block_num = block_identifier_int
+    else:
+        block_num = last_block + block_identifier_int + 1
+
+    if 0 <= block_num <= last_block:
+        return block_num
     else:
         raise BlockNumberOutofRange
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1397,12 +1397,15 @@ def call_contract_function(
 
 
 def parse_block_identifier(web3, block_identifier):
-    last_block = web3.eth.getBlock('latest').number
-    if isinstance(block_identifier, int) and abs(block_identifier) <= last_block:
-        if block_identifier >= 0:
-            return block_identifier
+    if isinstance(block_identifier, int):
+        last_block = web3.eth.getBlock('latest').number
+        if abs(block_identifier) <= last_block:
+            if block_identifier >= 0:
+                return block_identifier
+            else:
+                return last_block + block_identifier + 1
         else:
-            return last_block + block_identifier + 1
+            raise BlockNumberOutofRange
     elif block_identifier in ['latest', 'earliest', 'pending']:
         return block_identifier
     elif isinstance(block_identifier, bytes) or is_hex_encoded_block_hash(block_identifier):

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1408,17 +1408,14 @@ def parse_block_identifier(web3, block_identifier):
 
 
 def parse_block_identifier_int(web3, block_identifier_int):
-    last_block = web3.eth.getBlock('latest').number
-
     if block_identifier_int >= 0:
         block_num = block_identifier_int
     else:
+        last_block = web3.eth.getBlock('latest').number
         block_num = last_block + block_identifier_int + 1
-
-    if 0 <= block_num <= last_block:
-        return block_num
-    else:
-        raise BlockNumberOutofRange
+        if block_num < 0:
+            raise BlockNumberOutofRange
+    return block_num
 
 
 def transact_with_contract_function(


### PR DESCRIPTION
### What was wrong?

When calling a contract function on latest block, the lib unnecessarily calls getBlock('latest')

### How was it fixed?

Remove a round trip when block number is latest, earliest or pending when calling a contract function.
