### PR TITLE
Add hack to make regex data filtering work

### DIFF
--- a/web3/utils/filters.py
+++ b/web3/utils/filters.py
@@ -127,7 +127,7 @@ class TransactionFilter(Filter):
     pass
 
 
-ZERO_32BYTES = '[a-f0-9]{64}'
+ANY_ABI_VALUE = '[a-f0-9]{16,512}'
 
 
 def construct_data_filter_regex(data_filter_set):
@@ -135,7 +135,7 @@ def construct_data_filter_regex(data_filter_set):
         '^' +
         '|'.join((
             '0x' + ''.join(
-                (ZERO_32BYTES if v is None else v[2:] for v in data_filter)
+                (ANY_ABI_VALUE if v is None else v[2:] for v in data_filter)
             )
             for data_filter in data_filter_set
         )) +


### PR DESCRIPTION
### What was wrong?

Related to Issue #943 
The regex data filters assume all values will be 32 bytes, which is a false assumption.

### How was it fixed?
I replaced the regex with one that will match any abi length value, which is a pretty bad idea. Maybe there is a better short term solution, or maybe this should be left alone pending the replacement for data filters.


#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8933231/42248909-fad4b972-7edc-11e8-98db-81d26ec4b836.png)

