### PR TITLE
Raise helpful exception in pm module

### DIFF
--- a/tests/core/pm-module/test_pm_init.py
+++ b/tests/core/pm-module/test_pm_init.py
@@ -5,15 +5,11 @@ from pathlib import (
 import pytest
 
 from web3 import Web3
-from web3.pm import (
-    PM,
-)
 
 try:
-    from ethpm.exceptions import (
-        InsufficientAssetsError,
-    )
-except ImportError as exc:
+    from web3.pm import PM
+    from ethpm.exceptions import InsufficientAssetsError
+except ImportError:
     ethpm_installed = False
 else:
     ethpm_installed = True

--- a/web3/pm.py
+++ b/web3/pm.py
@@ -7,7 +7,10 @@ try:
         Package,
     )
 except ImportError as exc:
-    pass
+    raise ImportError(
+        "To use web3's alpha package management features, you must install the "
+        "`ethpm` dependency manually: pip install --upgrade ethpm"
+    ) from exc
 
 
 # Package Management is currently still in alpha


### PR DESCRIPTION
### What was wrong?

If someone tries to use the alpha PM features in web3.py, they will get some confusing errors since the ethpm imports just fail silently.

### How was it fixed?

Re-introduced exception raising for when ethpm is not installed.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://4.bp.blogspot.com/-cetV3ZyTDY0/U8gT2H1ZF_I/AAAAAAABBDY/7EZuoVZCzAc/s1600/cute-red-panda-31.jpg)
