### PR TITLE
Added eth_getCode to ethereum_tester_middleware to appease eth-tester

### DIFF
--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -201,6 +201,10 @@ ethereum_tester_middleware = construct_formatting_middleware(
             apply_formatter_if(is_not_named_block, to_integer_if_hex),
         ),
         'eth_uninstallFilter': apply_formatters_to_args(hex_to_integer),
+        'eth_getCode': apply_formatters_to_args(
+            identity,
+            apply_formatter_if(is_not_named_block, to_integer_if_hex),
+        ),
         # EVM
         'evm_revert': apply_formatters_to_args(hex_to_integer),
         # Personal

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -152,12 +152,17 @@ class EthModuleTest:
 
     def test_eth_getCode(self, web3, math_contract_address):
         code = web3.eth.getCode(math_contract_address)
-        assert is_string(code)
-        assert len(code) > 2
+        assert isinstance(code, HexBytes)
+        assert len(code) > 0
 
     def test_eth_getCode_invalid_address(self, web3, math_contract):
         with pytest.raises(InvalidAddress):
             web3.eth.getCode(math_contract.address.lower())
+
+    def test_eth_getCode_with_block_identifier(self, web3, emitter_contract):
+        code = web3.eth.getCode(emitter_contract.address, block_identifier=web3.eth.blockNumber)
+        assert isinstance(code, HexBytes)
+        assert len(code) > 0
 
     def test_eth_sign(self, web3, unlocked_account_dual_type):
         signature = web3.eth.sign(


### PR DESCRIPTION
### What was wrong?
While porting `populus` for `compatibilty` with `web3 4.x`, I found the following problem with `eth-tester`:
```python
web3.eth.getCode(emitter_contract.address, block_identifier=web3.eth.blockNumber)
```
The above lines gives the following error 
```
.tox/py36-integration-ethtester/lib/python3.6/site-packages/eth_tester/main.py:272: in get_code
    self.validator.validate_inbound_block_number(block_number)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

value = '0x1'

    def validate_block_number(value):
        error_message = (
            "Block number must be a positive integer or one of the strings "
            "'latest', 'earliest', or 'pending'.  Got: {0}".format(value)
        )
        if is_string(value):
            validate_text(value)
            if value not in BLOCK_NUMBER_META_VALUES:
>               raise ValidationError(error_message)
E               eth_tester.exceptions.ValidationError: Block number must be a positive integer or one of the strings 'latest', 'earliest', or 'pending'.  Got: 0x1

error_message = "Block number must be a positive integer or one of the strings 'latest', 'earliest', or 'pending'.  Got: 0x1"
value      = '0x1'

```
Related to Issue #

### How was it fixed?

added `eth_getCode` to `ethereum_tester_middleware` to appease eth-tester

#### Cute Animal Picture

![](https://bornrealist.com/wp-content/uploads/2017/11/Here-Are-Top-10-Cute-Animals-That-Might-Actually-Kill-You-1024x538.jpg)
