### PR TITLE
Add test to verify client consistency with None topic args

### DIFF
--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -97,6 +97,10 @@ class ParityEthModuleTest(EthModuleTest):
         assert receipt is not None
         assert receipt['blockHash'] is None
 
+    def test_eth_getLogs_with_logs_none_topic_args(self, web3):
+        pytest.xfail("Parity matches None to asbent values")
+        super().test_eth_getLogs_with_logs_none_topic_args(web3)
+
     @flaky(max_runs=MAX_FLAKY_RUNS)
     def test_eth_call_old_contract_state(self, web3, math_contract, unlocked_account):
         start_block = web3.eth.getBlock('latest')

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -718,8 +718,37 @@ class EthModuleTest:
             "fromBlock": 0,
             "address": emitter_contract_address,
         }
+        # Test with topic arguments
+
+        # Test with None event sig
+        filter_params = {
+            "fromBlock": 0,
+            "topics": [
+                None,
+                '0x000000000000000000000000000000000000000000000000000000000000d431'],
+        }
+
         result = web3.eth.getLogs(filter_params)
         assert_contains_log(result)
+
+        # Test with None indexed arg
+        filter_params = {
+            "fromBlock": 0,
+            "topics": [
+                '0x057bc32826fbe161da1c110afcdcae7c109a8b69149f727fc37a603c60ef94ca',
+                None],
+        }
+        result = web3.eth.getLogs(filter_params)
+        assert_contains_log(result)
+
+        # Test with None overflowing
+        filter_params = {
+            "fromBlock": 0,
+            "topics": [None, None, None],
+        }
+
+        result = web3.eth.getLogs(filter_params)
+        assert len(result) == 0
 
     def test_eth_call_old_contract_state(self, web3, math_contract, unlocked_account):
         start_block = web3.eth.getBlock('latest')

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -718,9 +718,25 @@ class EthModuleTest:
             "fromBlock": 0,
             "address": emitter_contract_address,
         }
-        # Test with topic arguments
+
+    def test_eth_getLogs_with_logs_topic_args(
+            self,
+            web3,
+            block_with_txn_with_log,
+            emitter_contract_address,
+            txn_hash_with_log):
+        def assert_contains_log(result):
+            assert len(result) == 1
+            log_entry = result[0]
+            assert log_entry['blockNumber'] == block_with_txn_with_log['number']
+            assert log_entry['blockHash'] == block_with_txn_with_log['hash']
+            assert log_entry['logIndex'] == 0
+            assert is_same_address(log_entry['address'], emitter_contract_address)
+            assert log_entry['transactionIndex'] == 0
+            assert log_entry['transactionHash'] == HexBytes(txn_hash_with_log)
 
         # Test with None event sig
+
         filter_params = {
             "fromBlock": 0,
             "topics": [
@@ -741,6 +757,9 @@ class EthModuleTest:
         result = web3.eth.getLogs(filter_params)
         assert_contains_log(result)
 
+    def test_eth_getLogs_with_logs_none_topic_args(
+            self,
+            web3):
         # Test with None overflowing
         filter_params = {
             "fromBlock": 0,


### PR DESCRIPTION
### What was wrong?
Want to verify client handling of None topic parameters yields consistent match results.

### How was it fixed?
Extended the getLogs test to try retrieving log matches using None values for topics.


#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8933231/43546515-b314194e-958d-11e8-9563-5ebceb51f7ad.png)

