### PR TITLE
Function input decoder

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -768,11 +768,20 @@ Utils
 
 .. py:classmethod:: Contract.decode_function_input(data)
 
-    Decodes function input data and returns :py:class:`ContractFunction` and decoded parameters as :py:class:`dict`.
+    Decodes the transaction data used to invoke a smart contract function, and returns
+    :py:class:`ContractFunction` and decoded parameters as :py:class:`dict`.
 
     .. code-block:: python
 
-        >>> data = '338b5dea00000000000000000000000042d6622dece394b54999fbd73d108123806f6a180000000000000000000000000000000000000000000000000000000000000032'
-        >>> contract.decode_function_input(data)
-        (<Function depositToken(address,uint256)>,
-         {'token': '0x42d6622dece394b54999fbd73d108123806f6a18', 'amount': 50})
+        >>> transaction = w3.eth.getTransaction('0x5798fbc45e3b63832abc4984b0f3574a13545f415dd672cd8540cd71f735db56')
+        >>> transaction.input
+        '0x612e45a3000000000000000000000000b656b2a9c3b2416437a811e07466ca712f5a5b5a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000093a80000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000116c6f6e656c792c20736f206c6f6e656c7900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+        >>> contract.decode_function_input(transaction.input)
+        (<Function newProposal(address,uint256,string,bytes,uint256,bool)>,
+         {'_recipient': '0xb656b2a9c3b2416437a811e07466ca712f5a5b5a',
+          '_amount': 0,
+          '_description': b'lonely, so lonely',
+          '_transactionData': b'',
+          '_debatingPeriod': 604800,
+          '_newCurator': True})
+ 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -762,3 +762,17 @@ For example:
        >>> rich_logs = contract.events.myEvent().processReceipt(tx_receipt)
        >>> rich_logs[0]['args']
        {'myArg': 12345}
+
+Utils
+-----
+
+.. py:classmethod:: Contract.decode_function_input(data)
+
+    Decodes function input data and returns :py:class:`ContractFunction` and decoded parameters as :py:class:`dict`.
+
+    .. code-block:: python
+
+        >>> data = '338b5dea00000000000000000000000042d6622dece394b54999fbd73d108123806f6a180000000000000000000000000000000000000000000000000000000000000032'
+        >>> contract.decode_function_input(data)
+        (<Function depositToken(address,uint256)>,
+         {'token': '0x42d6622dece394b54999fbd73d108123806f6a18', 'amount': 50})

--- a/tests/core/contracts/test_contract_method_abi_decoding.py
+++ b/tests/core/contracts/test_contract_method_abi_decoding.py
@@ -4,9 +4,9 @@ from binascii import (
 import json
 import pytest
 
-ABI_A = json.loads('[{"constant":false,"inputs":[],"name":"a","outputs":[],"type":"function"}]')
-ABI_B = json.loads('[{"constant":false,"inputs":[{"name":"","type":"uint256"}],"name":"a","outputs":[],"type":"function"}]')  # noqa: E501
-ABI_C = json.loads('[{"constant":false,"inputs":[],"name":"a","outputs":[],"type":"function"},{"constant":false,"inputs":[{"name":"","type":"bytes32"}],"name":"a","outputs":[],"type":"function"},{"constant":false,"inputs":[{"name":"","type":"uint256"}],"name":"a","outputs":[],"type":"function"}]')  # noqa: E501
+ABI_A = json.loads('[{"constant":false,"inputs":[],"name":"noargfunc","outputs":[],"type":"function"}]')  # noqa: E501
+ABI_B = json.loads('[{"constant":false,"inputs":[{"name":"uintarg","type":"uint256"}],"name":"uintfunc","outputs":[],"type":"function"}]')  # noqa: E501
+ABI_C = json.loads('[{"constant":false,"inputs":[],"name":"namesakefunc","outputs":[],"type":"function"},{"constant":false,"inputs":[{"name":"bytesarg","type":"bytes32"}],"name":"namesakefunc","outputs":[],"type":"function"},{"constant":false,"inputs":[{"name":"uintarg","type":"uint256"}],"name":"namesakefunc","outputs":[],"type":"function"}]')  # noqa: E501
 ABI_D = json.loads('[{ "constant": false, "inputs": [ { "name": "b", "type": "bytes32[]" } ], "name": "byte_array", "outputs": [], "payable": false, "type": "function" }]')  # noqa: E501
 ABI_BYTES = json.loads('[{"constant":false,"inputs":[{"name":"bytesarg","type":"bytes"}],"name":"bytesfunc","outputs":[],"type":"function"}]')  # noqa: E501
 ABI_STRING = json.loads('[{"constant":false,"inputs":[{"name":"stringarg","type":"string"}],"name":"stringfunc","outputs":[],"type":"function"}]')  # noqa: E501
@@ -15,81 +15,59 @@ a32bytes = b'a'.ljust(32, b'\x00')
 
 
 @pytest.mark.parametrize(
-    'abi,data,method,arguments,expected',
+    'abi,data,method,expected',
     (
         (
             ABI_A,
-            '0x0dbe671f',
-            'a',
-            [],
+            '0xc4c1a40b',
+            'noargfunc',
             {},
         ),
         (
             ABI_B,
-            '0xf0fdf8340000000000000000000000000000000000000000000000000000000000000001',
-            'a',
-            [1],
-            {'': 1},
+            '0xcc6820de0000000000000000000000000000000000000000000000000000000000000001',
+            'uintfunc',
+            {'uintarg': 1},
         ),
         (
             ABI_C,
-            '0xf0fdf8340000000000000000000000000000000000000000000000000000000000000001',
-            'a',
-            [1],
-            {'': 1},
+            '0x22d86fa3',
+            'namesakefunc',
+            {},
         ),
         (
             ABI_C,
-            '0x9f3fab586100000000000000000000000000000000000000000000000000000000000000',
-            'a',
-            [b'a'],
-            {'': a32bytes},
+            '0x40c05b2f0000000000000000000000000000000000000000000000000000000000000001',
+            'namesakefunc',
+            {'uintarg': 1},
         ),
         (
             ABI_C,
-            '0x9f3fab586100000000000000000000000000000000000000000000000000000000000000',
-            'a',
-            ['0x61'],
-            {'': a32bytes},
-        ),
-        (
-            ABI_C,
-            '0x9f3fab586100000000000000000000000000000000000000000000000000000000000000',
-            'a',
-            ['61'],
-            {'': a32bytes},
-        ),
-        (
-            ABI_C,
-            '0xf0fdf834000000000000000000000000000000000000000000000000000000000000007f',
-            'a',
-            [127],
-            {'': 127},
+            '0xf931d77c6100000000000000000000000000000000000000000000000000000000000000',
+            'namesakefunc',
+            {'bytesarg': a32bytes},
         ),
         (
             ABI_BYTES,
             '0xb606a9f6000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000016100000000000000000000000000000000000000000000000000000000000000',  # noqa: E501
             'bytesfunc',
-            [],
             {'bytesarg': b'a'},
         ),
         (
             ABI_STRING,
             '0x33b4005f000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000016100000000000000000000000000000000000000000000000000000000000000',  # noqa: E501
             'stringfunc',
-            [],
             {'stringarg': 'a'},
         ),
         (
             ABI_ADDRESS,
             '0x4767be6c000000000000000000000000ffffffffffffffffffffffffffffffffffffffff',
             'addressfunc',
-            [],
             {'addressarg': '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'},
         ),
     ),
 )
-def test_contract_abi_decoding(web3, abi, data, method, arguments, expected):
+def test_contract_abi_decoding(web3, abi, data, method, expected):
     contract = web3.eth.contract(abi=abi)
     func, params = contract.decode_function_input(data)
     assert func.fn_name == method
@@ -107,10 +85,10 @@ def test_contract_abi_decoding(web3, abi, data, method, arguments, expected):
             ABI_D,
             'byte_array',
             {
-                'b': (
+                'b': [
                     unhexlify('5595c210956e7721f9b692e702708556aa9aabb14ea163e96afa56ffbe9fa809'),
                     unhexlify('6f8d2fa18448afbfe4f82143c384484ad09a0271f3a3c0eb9f629e703f883125'),
-                ),
+                ],
             },
             '0xf166d6f8000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000025595c210956e7721f9b692e702708556aa9aabb14ea163e96afa56ffbe9fa8096f8d2fa18448afbfe4f82143c384484ad09a0271f3a3c0eb9f629e703f883125',  # noqa: E501
         ),

--- a/tests/core/contracts/test_contract_method_abi_decoding.py
+++ b/tests/core/contracts/test_contract_method_abi_decoding.py
@@ -1,0 +1,94 @@
+import json
+import pytest
+from eth_abi import encode_single
+from binascii import unhexlify
+
+ABI_A = json.loads('[{"constant":false,"inputs":[],"name":"a","outputs":[],"type":"function"}]')
+ABI_B = json.loads('[{"constant":false,"inputs":[{"name":"","type":"uint256"}],"name":"a","outputs":[],"type":"function"}]')  # noqa: E501
+ABI_C = json.loads('[{"constant":false,"inputs":[],"name":"a","outputs":[],"type":"function"},{"constant":false,"inputs":[{"name":"","type":"bytes32"}],"name":"a","outputs":[],"type":"function"},{"constant":false,"inputs":[{"name":"","type":"uint256"}],"name":"a","outputs":[],"type":"function"}]')  # noqa: E501
+ABI_D = json.loads('[{ "constant": false, "inputs": [ { "name": "b", "type": "bytes32[]" } ], "name": "byte_array", "outputs": [], "payable": false, "type": "function" }]')  # noqa: E501
+A = encode_single('bytes32', b'a')
+
+
+@pytest.mark.parametrize(
+    'abi,data,method,arguments,expected',
+    (
+        (
+            ABI_A,
+            '0x0dbe671f',
+            'a',
+            [],
+            {},
+        ),
+        (
+            ABI_B,
+            '0xf0fdf8340000000000000000000000000000000000000000000000000000000000000001',
+            'a',
+            [1],
+            {'': 1},
+        ),
+        (
+            ABI_C,
+            '0xf0fdf8340000000000000000000000000000000000000000000000000000000000000001',
+            'a',
+            [1],
+            {'': 1},
+        ),
+        (
+            ABI_C,
+            '0x9f3fab586100000000000000000000000000000000000000000000000000000000000000',
+            'a',
+            [b'a'],
+            {'': A},
+        ),
+        (
+            ABI_C,
+            '0x9f3fab586100000000000000000000000000000000000000000000000000000000000000',
+            'a',
+            ['0x61'],
+            {'': A},
+        ),
+        (
+            ABI_C,
+            '0x9f3fab586100000000000000000000000000000000000000000000000000000000000000',
+            'a',
+            ['61'],
+            {'': A},
+        ),
+        (
+            ABI_C,
+            '0xf0fdf834000000000000000000000000000000000000000000000000000000000000007f',
+            'a',
+            [127],
+            {'': 127},
+        ),
+    ),
+)
+def test_contract_abi_decoding(web3, abi, data, method, arguments, expected):
+    contract = web3.eth.contract(abi=abi)
+    func, params = contract.decode_function_input(data)
+    assert func.fn_name == method
+    assert params == expected
+
+
+@pytest.mark.parametrize(
+    'abi,method,expected,data',
+    (
+        (
+            ABI_D,
+            'byte_array',
+            {
+                'b': (
+                    unhexlify('5595c210956e7721f9b692e702708556aa9aabb14ea163e96afa56ffbe9fa809'),
+                    unhexlify('6f8d2fa18448afbfe4f82143c384484ad09a0271f3a3c0eb9f629e703f883125'),
+                ),
+            },
+            '0xf166d6f8000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000025595c210956e7721f9b692e702708556aa9aabb14ea163e96afa56ffbe9fa8096f8d2fa18448afbfe4f82143c384484ad09a0271f3a3c0eb9f629e703f883125',  # noqa: E501
+        ),
+    ),
+)
+def test_contract_abi_encoding_kwargs(web3, abi, method, expected, data):
+    contract = web3.eth.contract(abi=abi)
+    func, params = contract.decode_function_input(data)
+    assert func.fn_name == method
+    assert params == expected

--- a/tests/core/contracts/test_contract_method_abi_decoding.py
+++ b/tests/core/contracts/test_contract_method_abi_decoding.py
@@ -1,7 +1,12 @@
+from binascii import (
+    unhexlify,
+)
 import json
 import pytest
-from eth_abi import encode_single
-from binascii import unhexlify
+
+from eth_abi import (
+    encode_single,
+)
 
 ABI_A = json.loads('[{"constant":false,"inputs":[],"name":"a","outputs":[],"type":"function"}]')
 ABI_B = json.loads('[{"constant":false,"inputs":[{"name":"","type":"uint256"}],"name":"a","outputs":[],"type":"function"}]')  # noqa: E501

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1207,7 +1207,7 @@ class ContractFunction:
 
         if not self.address and 'to' not in built_transaction:
             raise ValueError(
-                "When using `ContractFunction.buildTransaction` from a Contract factory"
+                "When using `ContractFunction.buildTransaction` from a contract factory "
                 "you must provide a `to` address with the transaction"
             )
         if self.address and 'to' in built_transaction:

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -18,6 +18,9 @@ from eth_utils import (
     is_text,
     to_tuple,
 )
+from hexbytes import (
+    HexBytes,
+)
 
 from web3.exceptions import (
     BadFunctionCallOutput,
@@ -83,7 +86,6 @@ from web3.utils.toolz import (
 from web3.utils.transactions import (
     fill_transaction_defaults,
 )
-from hexbytes import HexBytes
 
 DEPRECATED_SIGNATURE_MESSAGE = (
     "The constructor signature for the `Contract` object has changed. "

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -83,6 +83,7 @@ from web3.utils.toolz import (
 from web3.utils.transactions import (
     fill_transaction_defaults,
 )
+from hexbytes import HexBytes
 
 DEPRECATED_SIGNATURE_MESSAGE = (
     "The constructor signature for the `Contract` object has changed. "
@@ -687,6 +688,16 @@ class Contract:
 
         fns = find_functions_by_identifier(self.abi, self.web3, self.address, callable_check)
         return get_function_by_identifier(fns, 'selector')
+
+    @combomethod
+    def decode_function_input(self, data):
+        data = HexBytes(data)
+        selector, params = data[:4], data[4:]
+        func = self.get_function_by_selector(selector)
+        names = [x['name'] for x in func.abi['inputs']]
+        types = [x['type'] for x in func.abi['inputs']]
+        decoded = decode_abi(types, params)
+        return func, dict(zip(names, decoded))
 
     @combomethod
     def find_functions_by_args(self, *args):

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -699,7 +699,8 @@ class Contract:
         names = [x['name'] for x in func.abi['inputs']]
         types = [x['type'] for x in func.abi['inputs']]
         decoded = decode_abi(types, params)
-        return func, dict(zip(names, decoded))
+        normalized = map_abi_data(BASE_RETURN_NORMALIZERS, types, decoded)
+        return func, dict(zip(names, normalized))
 
     @combomethod
     def find_functions_by_args(self, *args):


### PR DESCRIPTION
### What was wrong?

There was no trivial method to decode function input parameters.

### How was it fixed?

This adds `Contract.decode_function_input` which is a counterpart to `Contract.encodeABI`.

```python
>>> data = '338b5dea00000000000000000000000042d6622dece394b54999fbd73d108123806f6a180000000000000000000000000000000000000000000000000000000000000032'
>>> contract.decode_function_input(data)
(<Function depositToken(address,uint256)>,
 {'token': '0x42d6622dece394b54999fbd73d108123806f6a18', 'amount': 50})
```

Works like a charm ✨ 

#### Cute Animal Picture

![My bunny loves Ethereum](https://user-images.githubusercontent.com/4562643/43736314-5b228168-99e7-11e8-9f75-b16ec43d668d.jpg)