### PR TITLE
added Python3.7 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,6 +336,113 @@ jobs:
     environment:
       TOXENV: py36-integration-ethtester
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
+  #
+  # Python 3.7
+  #
+  py37-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      TOXENV: py37-core
+
+  py37-ens:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      TOXENV: py37-ens
+
+  py37-integration-goethereum-ipc-1.7.2:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      TOXENV: py37-integration-goethereum-ipc
+      GETH_VERSION: v1.7.2
+
+  py37-integration-goethereum-http-1.7.2:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      TOXENV: py37-integration-goethereum-http
+      GETH_VERSION: v1.7.2
+
+  py37-integration-goethereum-ws-1.7.2:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      TOXENV: py37-integration-goethereum-ws
+      GETH_VERSION: v1.7.2
+
+  py37-integration-goethereum-ipc-1.8.1:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      TOXENV: py37-integration-goethereum-ipc
+      GETH_VERSION: v1.8.1
+
+  py37-integration-goethereum-http-1.8.1:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      TOXENV: py37-integration-goethereum-http
+      GETH_VERSION: v1.8.1
+
+  py37-integration-goethereum-ws-1.8.1:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      TOXENV: py37-integration-goethereum-ws
+      GETH_VERSION: v1.8.1
+
+  py37-integration-parity-ipc:
+    <<: *parity_steps
+    docker:
+      - image: circleci/python:3.7-stretch
+    environment:
+      TOXENV: py37-integration-parity-ipc
+      PARITY_VERSION: v1.11.7
+      PARITY_OS: debian
+
+  py37-integration-parity-http:
+    <<: *parity_steps
+    docker:
+      - image: circleci/python:3.7-stretch
+    environment:
+      TOXENV: py37-integration-parity-http
+      PARITY_VERSION: v1.11.7
+      PARITY_OS: debian
+
+  py37-integration-parity-ws:
+    <<: *parity_steps
+    docker:
+      - image: circleci/python:3.7-stretch
+    environment:
+      TOXENV: py37-integration-parity-ws
+      PARITY_VERSION: v1.11.7
+      PARITY_OS: debian
+
+  py37-integration-ethtester-pyethereum:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      TOXENV: py37-integration-ethtester
+      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEthereum16Backend
+
+  py37-integration-ethtester-pyevm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      TOXENV: py37-integration-ethtester
+      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
 
 workflows:
   version: 2
@@ -369,3 +476,16 @@ workflows:
       - py36-integration-parity-ws
       - py36-integration-ethtester-pyethereum
       - py36-integration-ethtester-pyevm
+      - py37-core
+      - py37-ens
+      - py37-integration-goethereum-ipc-1.7.2
+      - py37-integration-goethereum-http-1.7.2
+      - py37-integration-goethereum-ws-1.7.2
+      - py37-integration-goethereum-ipc-1.8.1
+      - py37-integration-goethereum-http-1.8.1
+      - py37-integration-goethereum-ws-1.8.1
+      - py37-integration-parity-ipc
+      - py37-integration-parity-http
+      - py37-integration-parity-ws
+      - py37-integration-ethtester-pyethereum
+      - py37-integration-ethtester-pyevm

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires='>=3.5, <4',
     extras_require={
         'tester': [
-            "eth-tester[py-evm]==0.1.0-beta.30",
+            "eth-tester[py-evm]==0.1.0-beta.31",
             "py-geth>=2.0.1,<3.0.0",
         ],
         'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "lru-dict>=1.1.6,<2.0.0",
         "eth-hash[pycryptodome]",
         "requests>=2.16.0,<3.0.0",
-        "websockets>=5.0.1,<6.0.0",
+        "websockets>=6.0.0,<7.0.0",
         "pypiwin32>=223;platform_system=='Windows'",
     ],
     setup_requires=['setuptools-markdown'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{35,36}-ens
-    py{35,36}-core
-    py{35,36}-integration-{goethereum,ethtester,parity}
+    py{35,36,37}-ens
+    py{35,36,37}-core
+    py{35,36,37}-integration-{goethereum,ethtester,parity}
     lint
     doctest
 
@@ -53,6 +53,7 @@ basepython =
     doctest: python3.6
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 extras =
     tester
 


### PR DESCRIPTION
### What was wrong?
web3.py was not compatible with python3.7.

Related to Issue #
closes #968

### How was it fixed?
- Added tests for python3.7 
- bumped version of `websockets` to `6.0.0`
- pinned `eth-tester` version to `0.1.0-beta.31` 


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/fbs5mdgxfj911.jpg)
