### PR TITLE
Fix missing space in Contracts docs

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -117,7 +117,7 @@ example in :class:`ConciseContract` for specifying an alternate factory.
     recommended to use the classic ``Contract`` for those use cases.
     Just to be be clear, `ConciseContract` only exposes contract functions and all
     other `Contract` class methods and properties are not available with the `ConciseContract`
-    API. This includes but is not limited to ``contract.address``,``contract.abi``, and
+    API. This includes but is not limited to ``contract.address``, ``contract.abi``, and
     ``contract.deploy()``.
 
     Create this type of contract by passing a :py:class:`Contract` instance to


### PR DESCRIPTION
### What was wrong?

There was a missing space in Contracts docs, and the code formatting was failing to render correctly. You can observe the problem in the screenshot below.

![image](https://user-images.githubusercontent.com/553444/44273202-6e32c980-a247-11e8-8c48-6c63bf9bfef4.png)
From https://web3py.readthedocs.io/en/stable/contracts.html

Related to Issue #

### How was it fixed?

I added the space needed.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pbs.twimg.com/media/DaiaTzsX0AApUt6.jpg)
