### PR TITLE
Fixed wrong import for event loop in separate thread

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -242,14 +242,15 @@ entries to a handler.
 Running the event loop in a separate thread
 """""""""""""""""""""""""""""""""""""""""""
 
-Here is an extended version of above example, where the event loop is run in a separate thread, 
+Here is an extended version of above example, where the event loop is run in a separate thread,
 releasing the ``main`` function for other tasks.
 
         .. code-block:: python
 
             from web3.auto import w3
-            import sleep
             from threading import Thread
+            import time
+            import asyncio
 
 
             def handle_event(event):
@@ -266,6 +267,7 @@ releasing the ``main`` function for other tasks.
 
             def main():
                 loop = asyncio.new_event_loop()
+                block_filter = w3.eth.filter('latest')
                 worker = Thread(target=log_loop, args=(block_filter, 5), daemon=True)
                 worker.start()
                     # .. do some other stuff


### PR DESCRIPTION
### What was wrong?
It looks like `import sleep` is used instead of `import time` in the filters.rst file for the event loop in a separate thread. 

### How was it fixed?

I changed to `import time`.
Moreover, while this example is an extended version of the previous one, I added the `import asyncio` and the `block_filter` to make it work. 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://duckduckgo.com/?q=cute+anumal&t=canonical&atb=v118-3&iax=images&ia=images&iai=http%3A%2F%2F4.bp.blogspot.com%2F-N0Mp-4V6xZM%2FUH_3rmZuNFI%2FAAAAAAAAlDI%2FwJNY9bNywGI%2Fs1600%2FCute%2BAnimal%2BPics%2B(10).jpg)
