### PR TITLE
Add `PM.get_package_from_uri` method

### DIFF
--- a/docs/web3.pm.rst
+++ b/docs/web3.pm.rst
@@ -32,10 +32,14 @@ To use ``web3.pm``, attach it to your ``web3`` instance.
 Methods
 -------
 
-The follwing methods are available on the ``web3.pm`` namespace.
+The following methods are available on the ``web3.pm`` namespace.
 
 .. py:method:: PM.get_package_from_manifest(self, manifest)
     
-    * Manifest must currently be a dict representing a valid manifest
-    * Returns a Package instance representing the Manifest
+    * :manifest: must be a dict representing a valid manifest
+    * Returns a ``Package`` instance representing the Manifest
 
+.. py:method:: PM.get_package_from_uri(self, uri)
+
+    * :uri: *must* be a valid content-addressed URI, as defined in the `Py-EthPM Documentation <https://py-ethpm.readthedocs.io/en/latest/uri_backends.html>`_.
+    * Returns a ``Package`` isntance representing the Manifest stored at the URI.

--- a/web3/pm.py
+++ b/web3/pm.py
@@ -21,3 +21,7 @@ class PM(Module):
     def get_package_from_manifest(self, manifest):
         pkg = Package(manifest, self.web3)
         return pkg
+
+    def get_package_from_uri(self, uri):
+        pkg = Package.from_uri(uri, self.web3)
+        return pkg


### PR DESCRIPTION
### What was wrong?
PM module needs a method to create a `Package` instance from a content addressed uri.

Related to Issue #

### How was it fixed?
Wrote wrapper method around `Package.from_uri(uri)`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/44501585-1501d600-a64b-11e8-9f37-62ac58ab97c0.png)