### PR TITLE
Removes depracated Contract.eventFilter. Fixes #1028.

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -282,51 +282,6 @@ Each Contract Factory exposes the following methods.
     ``argument_filters``, optional. Expects a dictionary of argument names and values. When provided event logs are filtered for the event argument values. Event arguments can be both indexed or unindexed. Indexed values with be translated to their corresponding topic arguments. Unindexed arguments will be filtered using a regular expression.
     ``topics`` optional, accepts the standard JSON-RPC topics argument.  See the JSON-RPC documentation for `eth_newFilter <https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter>`_ more information on the ``topics`` parameters.
 
-.. py:classmethod:: Contract.eventFilter(event_name, filter_params=None)
-
-        .. warning:: Contract.eventFilter() has been deprecated for :meth:`Contract.events.<event name>.createFilter()`
-
-    Creates a new :py:class:`web3.utils.filters.LogFilter` instance.
-
-    The ``event_name`` parameter should be the name of the contract event you
-    want to filter on.
-
-    If provided,  ``filter_params`` should be a dictionary specifying
-    additional filters for log entries.  The following keys are supported.
-
-    * ``filter``: ``dictionary`` - (optional) Dictionary keys should be
-      argument names for the Event arguments. Dictionary values should be the
-      value you want to filter on, or a list of values to be filtered on.
-      Lists of values will match log entries whose argument matches any value
-      in the list. Indexed and unindexed event arguments are accepted. The
-      processing of indexed argument values into hex encoded topics is handled
-      internally when using the ``filter`` parameter.
-    * ``fromBlock``: ``integer/tag`` - (optional, default: "latest") Integer
-      block number, or "latest" for the last mined block or "pending",
-      "earliest" for not yet mined transactions.
-    * ``toBlock``: ``integer/tag`` - (optional, default: "latest") Integer
-      block number, or "latest" for the last mined block or "pending",
-      "earliest" for not yet mined transactions.
-    * ``address``: ``string`` or list of ``strings``, each 20 Bytes -
-      (optional) Contract address or a list of addresses from which logs should
-      originate.
-    * ``topics``: list of 32 byte ``strings`` or ``null`` - (optional) Array of
-      topics that should be used for filtering, with the keccak hash of the event
-      signature as the first item, and the remaining items as hex encoded
-      argument values. Topics are order-dependent.  This parameter can also be a
-      list of topic lists in which case filtering will match any of the provided
-      topic arrays. This argument is useful when relying on the internally
-      generated topic lists via the ``filter`` argument is not desired. If
-      ``topics`` is included with the ``filter`` argument, the ``topics`` list
-      will be prepended to any topic lists inferred from the ``filter`` arguments.
-
-    The event topic for the event specified by ``event_name`` will be added to
-    the ``filter_params['topics']`` list.
-
-    If the :py:attr:`Contract.address` attribute for this contract is
-    non-null, the contract address will be added to the ``filter_params``.
-
-
 .. py:classmethod:: Contract.deploy(transaction=None, args=None)
 
     .. warning:: Deprecated: this method is deprecated in favor of
@@ -483,42 +438,6 @@ and the arguments are ambiguous.
         >>> identity_func(1, True).call()
         1
 
-
-
-.. _event-log-object:
-
-Event Log Object
-~~~~~~~~~~~~~~~~
-
-    The Event Log Object is a python dictionary with the following keys:
-
-    * ``args``: Dictionary - The arguments coming from the event.
-    * ``event``: String - The event name.
-    * ``logIndex``: Number - integer of the log index position in the block.
-    * ``transactionIndex``: Number - integer of the transactions index position
-      log was created from.
-    * ``transactionHash``: String, 32 Bytes - hash of the transactions this log
-      was created from.
-    * ``address``: String, 32 Bytes - address from which this log originated.
-    * ``blockHash``: String, 32 Bytes - hash of the block where this log was
-      in. null when its pending.
-    * ``blockNumber``: Number - the block number where this log was in. null
-      when its pending.
-
-
-    .. code-block:: python
-
-        >>> transfer_filter = my_token_contract.eventFilter('Transfer', {'filter': {'_from': '0xdc3a9db694bcdd55ebae4a89b22ac6d12b3f0c24'}})
-        >>> transfer_filter.get_new_entries()
-        [...]  # array of Event Log Objects that match the filter.
-
-        # wait a while...
-
-        >>> transfer_filter.get_new_entries()
-        [...]  # new events since the last call
-
-        >>> transfer_filter.get_all_entries()
-        [...]  # all events that match the filter.
 
 Contract Functions
 ------------------

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -133,20 +133,16 @@ def emitter_log_topics():
     return LogTopics
 
 
-def return_filter_by_api(
-        api_style=None,
+def return_filter(
         contract=None,
         args=[]):
-    if api_style == 'v4':
         event_name = args[0]
         kwargs = apply_key_map({'filter': 'argument_filters'}, args[1])
         if 'fromBlock' not in kwargs:
             kwargs['fromBlock'] = 'latest'
         return contract.events[event_name].createFilter(**kwargs)
-    else:
-        raise ValueError("api_style must be 'v3 or v4'")
 
 
-@pytest.fixture(params=['v3', 'v4'])
+@pytest.fixture()
 def create_filter(request):
-    return functools.partial(return_filter_by_api, request.param)
+    return functools.partial(return_filter)

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -137,10 +137,7 @@ def return_filter_by_api(
         api_style=None,
         contract=None,
         args=[]):
-    if api_style == 'v3':
-        with pytest.deprecated_call():
-            return contract.eventFilter(*args)
-    elif api_style == 'v4':
+    if api_style == 'v4':
         event_name = args[0]
         kwargs = apply_key_map({'filter': 'argument_filters'}, args[1])
         if 'fromBlock' not in kwargs:

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -366,39 +366,6 @@ class Contract:
 
         return encode_abi(cls.web3, fn_abi, fn_arguments, data)
 
-    @combomethod
-    @deprecated_for("contract.events.<event name>.createFilter")
-    def eventFilter(self, event_name, filter_params={}):
-        """
-        Create filter object that tracks events emitted by this contract.
-        :param event_name: the name of the event to track
-        :param filter_params: other parameters to limit the events
-        """
-        filter_meta_params = dict(filter_params)
-        argument_filters = filter_meta_params.pop('filter', {})
-
-        argument_filter_names = list(argument_filters.keys())
-        event_abi = self._find_matching_event_abi(
-            event_name,
-            argument_filter_names,
-        )
-
-        data_filter_set, event_filter_params = construct_event_filter_params(
-            event_abi,
-            contract_address=self.address,
-            argument_filters=argument_filters,
-            **filter_meta_params
-        )
-
-        log_data_extract_fn = functools.partial(get_event_data, event_abi)
-
-        log_filter = self.web3.eth.filter(event_filter_params)
-
-        log_filter.set_data_filters(data_filter_set)
-        log_filter.log_entry_formatter = log_data_extract_fn
-        log_filter.filter_params = event_filter_params
-
-        return log_filter
 
     @combomethod
     @deprecated_for("contract.functions.<method name>.estimateGas")

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -366,7 +366,6 @@ class Contract:
 
         return encode_abi(cls.web3, fn_abi, fn_arguments, data)
 
-
     @combomethod
     @deprecated_for("contract.functions.<method name>.estimateGas")
     def estimateGas(self, transaction=None):


### PR DESCRIPTION
### What was wrong?

Contract.eventFilter() method marked as deprecated and it should be removed in v5.
Related to Issue #1028 

### How was it fixed?

I removed the deprecated function, the test that used it and documentation about it.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://scontent-frt3-1.xx.fbcdn.net/v/t1.15752-9/s2048x2048/39698829_319599531949363_1773962265096093696_n.jpg?_nc_cat=0&oh=6b70b646b7bc7f6e3fe1f4ae12963550&oe=5C384C30)
