### PR TITLE
[WIP] Replace ConciseContract with ContractCaller. 

### DIFF
--- a/tests/core/contracts/test_concise_contract.py
+++ b/tests/core/contracts/test_concise_contract.py
@@ -8,7 +8,7 @@ from eth_utils import (
 )
 
 from web3.contract import (
-    CONCISE_NORMALIZERS,
+    CALLER_NORMALIZERS,
     ConciseContract,
     ConciseMethod,
 )
@@ -109,7 +109,7 @@ def test_conciscecontract_keeps_custom_normalizers_on_base(web3):
 
     # check that concise contract includes the new normalizers
     concise_normalizers_size = len(concise._classic_contract._return_data_normalizers)
-    assert concise_normalizers_size == new_normalizers_size + len(CONCISE_NORMALIZERS)
+    assert concise_normalizers_size == new_normalizers_size + len(CALLER_NORMALIZERS)
     assert concise._classic_contract._return_data_normalizers[0] is None
 
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #1025 

### How was it fixed?

I renamed ConciceContract to ContractReader and ConciseMethod to ReaderMethod. Also removed all unwanted methods allowance from ReaderMethod.

TODO:
- [ ] Write documentation to the ContractCaller
- [ ] Write test for the ContractCaller
- [ ] Write test for deprecation message for ConciseContract and ImplicitContract

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/o7xFIkC.jpg)
