### PR TITLE
Move all used datastructures from utils module

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -343,7 +343,7 @@ Fetch various data about the current state of the ERC20 contract.
     >>> erc20.functions.decimals().call()
     0
     >>> erc20.functions.totalSupply().call()
-    2038
+    2039
 
 Get the balance of an account address. 
 

--- a/tests/core/middleware/test_stalecheck.py
+++ b/tests/core/middleware/test_stalecheck.py
@@ -5,15 +5,15 @@ from unittest.mock import (
     patch,
 )
 
+from web3.datastructures import (
+    AttributeDict,
+)
 from web3.middleware import (
     make_stalecheck_middleware,
 )
 from web3.middleware.stalecheck import (
     StaleBlockchain,
     _isfresh,
-)
-from web3.utils.datastructures import (
-    AttributeDict,
 )
 
 

--- a/tests/core/utilities/test_attributedict.py
+++ b/tests/core/utilities/test_attributedict.py
@@ -1,6 +1,6 @@
 import pytest
 
-from web3.utils.datastructures import (
+from web3.datastructures import (
     AttributeDict,
 )
 

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -1,4 +1,3 @@
-
 from collections import (
     Hashable,
     Mapping,

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -5,6 +5,9 @@ from eth_utils import (
     is_list_like,
 )
 
+from web3.datastructures import (
+    NamedElementOnion,
+)
 from web3.exceptions import (
     CannotHandleRequest,
     UnhandledRequest,
@@ -21,9 +24,6 @@ from web3.middleware import (
 )
 from web3.providers import (
     AutoProvider,
-)
-from web3.utils.datastructures import (
-    NamedElementOnion,
 )
 from web3.utils.empty import (
     empty,

--- a/web3/middleware/attrdict.py
+++ b/web3/middleware/attrdict.py
@@ -2,7 +2,7 @@ from eth_utils import (
     is_dict,
 )
 
-from web3.utils.datastructures import (
+from web3.datastructures import (
     AttributeDict,
 )
 from web3.utils.toolz import (

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -5,11 +5,11 @@ from eth_utils import (
     to_dict,
 )
 
+from web3.datastructures import (
+    NamedElementOnion,
+)
 from web3.middleware import (
     http_retry_request_middleware,
-)
-from web3.utils.datastructures import (
-    NamedElementOnion,
 )
 from web3.utils.http import (
     construct_user_agent,

--- a/web3/utils/events.py
+++ b/web3/utils/events.py
@@ -15,11 +15,11 @@ from eth_utils import (
     to_tuple,
 )
 
+from web3.datastructures import (
+    AttributeDict,
+)
 from web3.exceptions import (
     MismatchedABI,
-)
-from web3.utils.datastructures import (
-    AttributeDict,
 )
 from web3.utils.encoding import (
     hexstr_if_str,


### PR DESCRIPTION
### What was wrong?

As discussed in #1033, `web3.utils.datastructures` are used to type checks and shouldn't be treated as internal.

### How was it fixed?

I moved the datastructures.py from internal utils module to the public one. I wonder if I should be contained in a separate module instead of the top one.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/anb6vEe.jpg)
