### PR TITLE
Add 'xyz' and 'luxe' to reconised TLDs

### DIFF
--- a/ens/constants.py
+++ b/ens/constants.py
@@ -9,6 +9,6 @@ EMPTY_ADDR_HEX = '0x' + '00' * 20
 
 MIN_ETH_LABEL_LENGTH = 7
 
-RECOGNIZED_TLDS = ['eth', 'reverse', 'test']
+RECOGNIZED_TLDS = ['eth', 'reverse', 'test', 'luxe', 'xyz']
 
 REVERSE_REGISTRAR_DOMAIN = 'addr.reverse'


### PR DESCRIPTION
web3 presently assumes all ENS names end with '.eth'. We're about to launch two new TLDs, with many more to follow.

This patch adds support for the two new TLDs, but ideally web3 should be modified to not care what TLD you enter (or to 'guess' and add extensions if you don't provide them).