### PR TITLE
4.7.0 release notes

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,27 @@
 Release Notes
 =============
 
+v4.7.0
+--------
+
+Released September 5th, 2018
+
+- Features
+
+  - Move :module:`~web3.utils.datastructures` to public namespace :module:`~web3.datastructures` 
+    to improve support for type checking.
+    - `#1038 <https://github.com/ethereum/web3.py/pull/1038>`_
+  - Optimization to contract calls
+    - `#944 <https://github.com/ethereum/web3.py/pull/944>`_
+- Bugfixes
+
+  - ENS name resolution only attempted on mainnet by default.
+    -  `#1037 <https://github.com/ethereum/web3.py/pull/1037>`_
+  - Fix attribute access error when attributedict middleware is not used.
+    - `#1040 <https://github.com/ethereum/web3.py/pull/1040>`_
+- Misc
+  - Upgrade eth-tester to 0.1.0-beta.32, and remove integration tests for py-ethereum.
+
 v4.6.0
 --------
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -8,6 +8,8 @@ Released September 5th, 2018
 
 - Features
 
+  - Add traceFilter method to the parity module.
+    - `#1051 <https://github.com/ethereum/web3.py/pull/1051>`_
   - Move :module:`~web3.utils.datastructures` to public namespace :module:`~web3.datastructures` 
     to improve support for type checking.
     - `#1038 <https://github.com/ethereum/web3.py/pull/1038>`_
@@ -21,6 +23,7 @@ Released September 5th, 2018
     - `#1040 <https://github.com/ethereum/web3.py/pull/1040>`_
 - Misc
   - Upgrade eth-tester to 0.1.0-beta.32, and remove integration tests for py-ethereum.
+  - Upgrade eth-hash to 0.2.0 with pycryptodome 3.6.6 which resolves a vulnerability.
 
 v4.6.0
 --------


### PR DESCRIPTION
Copy pasted here:

```
v4.7.0
--------

Released September 5th, 2018

- Features

  - ENS name resolution only attempted on mainnet by default.
    -  `#1037 <https://github.com/ethereum/web3.py/pull/1037>`_
  - Move :module:`~web3.utils.datastructures` to public namespace :module:`~web3.datastructures` 
    to improve support for type checking.
    - `#1038 <https://github.com/ethereum/web3.py/pull/1038>`_
  - Optimization to contract calls
    - `#944 <https://github.com/ethereum/web3.py/pull/944>`_
- Bugfixes

  - Fix attribute access error when attributedict middleware is not used.
    - `#1040 <https://github.com/ethereum/web3.py/pull/1040>`_
- Misc
  - Upgrade eth-tester to 0.1.0-beta.32, and remove integration tests for py-ethereum.
```

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8933231/45122889-04a52d00-b11a-11e8-8ee1-79a41cefe62b.png)
