### PR TITLE
WIP: No way to specify block number for eth_estimateGas 

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -632,7 +632,7 @@ The following methods are available on the ``web3.eth`` namespace.
     In most cases it is better to make contract function call through the :py:class:`web3.contract.Contract` interface.
 
 
-.. py:method:: Eth.estimateGas(transaction)
+.. py:method:: Eth.estimateGas(transaction, block_identifier=None)
 
     * Delegates to ``eth_estimateGas`` RPC Method
 
@@ -640,13 +640,19 @@ The following methods are available on the ``web3.eth`` namespace.
     on the blockchain.  Returns amount of gas consumed by execution which can
     be used as a gas estimate.
 
-    The ``transaction`` parameter is handled in the same manner as the
-    :meth:`~web3.eth.Eth.sendTransaction()` method.
+    The ``transaction`` and ``block_identifier`` parameters are handled in the
+    same manner as the :meth:`~web3.eth.call()` method.
 
     .. code-block:: python
 
         >>> web3.eth.estimateGas({'to': '0xd3cda913deb6f67967b99d67acdfa1712c293601', 'from': web3.eth.coinbase, 'value': 12345})
         21000
+
+    .. note::
+        The parameter ``block_identifier`` is not enabled in geth nodes,
+        hence passing a value of ``block_identifier`` when connected to a geth
+        nodes would result in an error like:  ``ValueError: {'code': -32602, 'message': 'too many arguments, want at most 1'}``
+
 
 .. py:method:: Eth.generateGasPrice(transaction_params=None)
 

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -60,6 +60,14 @@ class GoEthereumEthModuleTest(EthModuleTest):
         pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_modifyTransaction(web3, unlocked_account)
 
+    def test_eth_estimateGas_with_block(self,
+                                        web3,
+                                        unlocked_account_dual_type):
+        pytest.xfail('Block identifier has not been implemented in geth')
+        super().test_eth_estimateGas_with_block(
+            web3, unlocked_account_dual_type
+        )
+
 
 class GoEthereumVersionModuleTest(VersionModuleTest):
     pass

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -280,6 +280,14 @@ class TestEthereumTesterEthModule(EthModuleTest):
         pytest.xfail('json-rpc method is not implemented on eth-tester')
         super().test_eth_getStorageAt(web3, emitter_contract_address)
 
+    def test_eth_estimateGas_with_block(self,
+                                        web3,
+                                        unlocked_account_dual_type):
+        pytest.xfail('Block identifier has not been implemented in eth-tester')
+        super().test_eth_estimateGas_with_block(
+            web3, unlocked_account_dual_type
+        )
+
 
 class TestEthereumTesterVersionModule(VersionModuleTest):
     pass

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -356,6 +356,11 @@ def is_string_type(abi_type):
     return abi_type == 'string'
 
 
+@curry
+def is_length(target_length, value):
+    return len(value) == target_length
+
+
 def size_of_type(abi_type):
     """
     Returns size in bits of abi_type

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -469,6 +469,17 @@ class EthModuleTest:
         assert is_integer(gas_estimate)
         assert gas_estimate > 0
 
+    def test_eth_estimateGas_with_block(self,
+                                        web3,
+                                        unlocked_account_dual_type):
+        gas_estimate = web3.eth.estimateGas({
+            'from': unlocked_account_dual_type,
+            'to': unlocked_account_dual_type,
+            'value': 1,
+        }, 'latest')
+        assert is_integer(gas_estimate)
+        assert gas_estimate > 0
+
     def test_eth_getBlockByHash(self, web3, empty_block):
         block = web3.eth.getBlock(empty_block['hash'])
         assert block['hash'] == empty_block['hash']

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -294,15 +294,22 @@ class Eth(Module):
             [transaction, block_identifier],
         )
 
-    def estimateGas(self, transaction):
+    def estimateGas(self, transaction, block_identifier=None):
         # TODO: move to middleware
         if 'from' not in transaction and is_checksum_address(self.defaultAccount):
             transaction = assoc(transaction, 'from', self.defaultAccount)
 
-        return self.web3.manager.request_blocking(
-            "eth_estimateGas",
-            [transaction],
-        )
+        # TODO: move to middleware
+        if block_identifier is None:
+            return self.web3.manager.request_blocking(
+                "eth_estimateGas",
+                [transaction],
+            )
+        else:
+            return self.web3.manager.request_blocking(
+                "eth_estimateGas",
+                [transaction, block_identifier],
+            )
 
     def filter(self, filter_params=None, filter_id=None):
         if filter_id and filter_params:

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -299,17 +299,15 @@ class Eth(Module):
         if 'from' not in transaction and is_checksum_address(self.defaultAccount):
             transaction = assoc(transaction, 'from', self.defaultAccount)
 
-        # TODO: move to middleware
         if block_identifier is None:
-            return self.web3.manager.request_blocking(
-                "eth_estimateGas",
-                [transaction],
-            )
+            params = [transaction]
         else:
-            return self.web3.manager.request_blocking(
-                "eth_estimateGas",
-                [transaction, block_identifier],
-            )
+            params = [transaction, block_identifier]
+
+        return self.web3.manager.request_blocking(
+            "eth_estimateGas",
+            params,
+        )
 
     def filter(self, filter_params=None, filter_id=None):
         if filter_id and filter_params:


### PR DESCRIPTION
### What was wrong?

No way to specify block number for eth_estimateGas 

Related to Issue # https://github.com/ethereum/web3.py/issues/1011

### How was it fixed?
Added block_identifier as an input parameter in the estimateGas method(similar to web3.eth.call), this opens a can of worms because:
1. The `estimate_gas` method in the eth_tester library takes only 2 inputs while we now have an extra input (block_identifier). To enable the passing of all tests we need to also change the https://github.com/ethereum/eth-tester library
 ```
E       TypeError: estimate_gas() takes 2 positional arguments but 3 were given
 ```

2. A geth node does not accept block_identifier as a parameter and throws an error, this has been documented before https://github.com/ethereum/go-ethereum/issues/2586 

**Parity**
 ```
>>> w3 = Web3(Web3.HTTPProvider("https://kovan.infura.io/"))
>>> w3.eth.estimateGas(transaction)
method: eth_estimateGas, parameter: [{'data': '0xacabb9ed000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000039746869732d69732d7468652d66697273742d737472696e672d77686963682d657863656564732d33322d62797465732d696e2d6c656e67746800000000000000000000000000000000000000000000000000000000000000000000000000003a746869732d69732d7468652d7365636f6e642d737472696e672d77686963682d657863656564732d33322d62797465732d696e2d6c656e677468000000000000', 'from': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf', 'to': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b'}, 'latest']
response: {'jsonrpc': '2.0', 'id': 0, 'result': 29912}
29912
```

**Geth**
```
>>> w3 = Web3(Web3.HTTPProvider("https://mainnet.infura.io/"))
>>> w3.eth.estimateGas(transaction)
method: eth_estimateGas, parameter: [{'data': '0xacabb9ed000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000039746869732d69732d7468652d66697273742d737472696e672d77686963682d657863656564732d33322d62797465732d696e2d6c656e67746800000000000000000000000000000000000000000000000000000000000000000000000000003a746869732d69732d7468652d7365636f6e642d737472696e672d77686963682d657863656564732d33322d62797465732d696e2d6c656e677468000000000000', 'from': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf', 'to': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b'}, 'latest']
response: {'jsonrpc': '2.0', 'id': 0, 'error': {'code': -32602, 'message': 'too many arguments, want at most 1'}}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ankit/projects/web3.py/web3/eth.py", line 307, in estimateGas
    [transaction, block_identifier],
  File "/home/ankit/projects/web3.py/web3/manager.py", line 114, in request_blocking
    return response['result']
ValueError: {'code': -32602, 'message': 'too many arguments, want at most 1'}
```

Changing the two libraries would be a HUGE task. 
How do you (@Arachnid , @carver) propose that we should proceed?

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/fd/2b/47/fd2b4701180dc3c1d63ef35bd257ba46.jpg)
