### PR TITLE
Pin eth-abi version below 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     install_requires=[
         "toolz>=0.9.0,<1.0.0;implementation_name=='pypy'",
         "cytoolz>=0.9.0,<1.0.0;implementation_name=='cpython'",
-        "eth-abi>=1.2.0,<3",
+        "eth-abi>=1.2.0,<2.0.0",
         "eth-account>=0.2.1,<0.4.0",
         "eth-utils>=1.0.1,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",


### PR DESCRIPTION
### What was wrong?

eth-abi removed collapse_type from 2.0.0 (ref: [commit](https://github.com/ethereum/eth-abi/commit/3709dae913ccfb4ec51f2efa734993c80aa157da#diff-8571b2a70a70cacaa83996b7cdcc5d4e) ), but [web3.utils.abi](https://github.com/ethereum/web3.py/blob/e39518638682d02314e3f4700dea48ae95abf819/web3/utils/abi.py#L11) still use it. It will break if installed eth-abi is >= 2.0.0

### How was it fixed?

Pin eth-abi version below 2.0.0

#### Cute Animal Picture

![](https://images.pexels.com/photos/50577/hedgehog-animal-baby-cute-50577.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260)
