### PR TITLE
Add support for parity trace_filter calls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   sandbox:
     build:
       context: .
+    environment:
+      PARITY_VERSION: v1.11.7
     volumes:
       - .:/code
     command: tail -f /dev/null

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -205,3 +205,6 @@ class ParityTraceModuleTest(TraceModuleTest):
 
     def test_eth_call_with_0_result(self, web3, math_contract, math_contract_address):
         super().test_eth_call_with_0_result(web3, math_contract, math_contract_address)
+
+    def test_trace_filter(self, web3, txn_filter_params, parity_fixture_data):
+        super().test_trace_filter(web3, txn_filter_params, parity_fixture_data)

--- a/tests/integration/parity/conftest.py
+++ b/tests/integration/parity/conftest.py
@@ -214,3 +214,12 @@ def block_with_txn_with_log(web3, parity_fixture_data):
 @pytest.fixture(scope="module")
 def txn_hash_with_log(parity_fixture_data):
     return parity_fixture_data['txn_hash_with_log']
+
+
+@pytest.fixture(scope="module")
+def txn_filter_params(coinbase):
+    return {
+        "fromBlock": "earliest",
+        "toBlock": "latest",
+        "fromAddress": [coinbase],
+    }

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -46,6 +46,12 @@ class Parity(Module):
             [block_identifier]
         )
 
+    def traceFilter(self, params):
+        return self.web3.manager.request_blocking(
+            "trace_filter",
+            [params]
+        )
+
     def traceTransaction(self, transaction_hash):
         return self.web3.manager.request_blocking(
             "trace_transaction",

--- a/web3/utils/module_testing/parity_module.py
+++ b/web3/utils/module_testing/parity_module.py
@@ -82,3 +82,8 @@ class ParityModuleTest:
         assert trace['stateDiff'] is None
         assert trace['vmTrace'] is None
         assert trace['trace'][0]['action']['from'] == funded_account_for_raw_txn.lower()
+
+    def test_trace_filter(self, web3, txn_filter_params, parity_fixture_data):
+        trace = web3.parity.traceFilter(txn_filter_params)
+        assert isinstance(trace, list)
+        assert trace[0]['action']['from'] == add_0x_prefix(parity_fixture_data['coinbase'])


### PR DESCRIPTION
### What was wrong?
Currently, some parity trace calls are supported, but not trace_filter.

### How was it fixed?
I created the appropriate traceFilter method in the parity module and the corresponding test.
Also, the parity integration tests were failing in the docker container because the PARITY_VERSION environment variable was not set - I added that.

#### Cute Animal Picture
![Put a link to a cute animal picture inside the parenthesis-->](https://s-i.huffpost.com/gen/1841806/images/n-GREMLINS-628x314.jpg)
