### PR TITLE
Require compatible setuptools version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ extras_require = {
         "pytest-pythonpath>=0.3",
         "pytest-watch==4.*",
         "pytest-xdist==1.*",
+        "setuptools>=36.2.0",
         "tox>=1.8.0",
         "tqdm",
         "when-changed"


### PR DESCRIPTION
### What was wrong?

see #1053 

### How was it fixed?

add `setuptools>=36.2.0` to the `dev` extra_requires.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8933231/45387832-2136de80-b5cc-11e8-9a91-3ec732c276dd.png)
