### PR TITLE
Fix raw transaction signing middleware with byte addresses

### DIFF
--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -19,12 +19,20 @@ from eth_utils import (
 from web3._utils.formatters import (
     apply_formatter_if,
 )
+from web3._utils.rpc_abi import (
+    TRANSACTION_PARAMS_ABIS,
+    apply_abi_formatters_to_dict,
+)
 from web3._utils.toolz import (
     compose,
 )
 from web3._utils.transactions import (
     fill_nonce,
     fill_transaction_defaults,
+)
+
+from .abi import (
+    STANDARD_NORMALIZERS,
 )
 
 to_hexstr_from_eth_key = operator.methodcaller('to_hex')
@@ -75,6 +83,15 @@ to_account.register(str, private_key_to_account)
 to_account.register(bytes, private_key_to_account)
 
 
+def format_transaction(transaction):
+    """Format transaction so that it can be used correctly in the signing middleware.
+
+    Converts bytes to hex strings and other types that can be passed to the underlying layers.
+    Also has the effect of normalizing 'from' for easier comparisons.
+    """
+    return apply_abi_formatters_to_dict(STANDARD_NORMALIZERS, TRANSACTION_PARAMS_ABIS, transaction)
+
+
 def construct_sign_and_send_raw_middleware(private_key_or_account):
     """Capture transactions sign and send as raw transactions
 
@@ -91,7 +108,8 @@ def construct_sign_and_send_raw_middleware(private_key_or_account):
 
     def sign_and_send_raw_middleware(make_request, w3):
 
-        fill_tx = compose(
+        format_and_fill_tx = compose(
+            format_transaction,
             fill_transaction_defaults(w3),
             fill_nonce(w3))
 
@@ -99,7 +117,7 @@ def construct_sign_and_send_raw_middleware(private_key_or_account):
             if method != "eth_sendTransaction":
                 return make_request(method, params)
             else:
-                transaction = fill_tx(params[0])
+                transaction = format_and_fill_tx(params[0])
 
             if 'from' not in transaction:
                 return make_request(method, params)


### PR DESCRIPTION
### What was wrong?

Using `web3.middleware.construct_sign_and_send_raw_middleware` with `bytes` typed addresses  caused improper behaviour in at least the following cases:

1. Passing a `bytes` typed address as the `from` address, in which case the middleware got never executed because the check `transaction.get('from') not in accounts` always evaluated as `True`
2. Passing a `bytes` typed address as the `to` address (for an instance, when doing `web3.eth.contract(address=bytes(...), ...)`), which resulted in an exception.

### How was it fixed?

The transaction is now formatted according to the transaction abi types in `sign_and_send_raw_middleware` (similar to what's done with `abi_middleware`).

I'm not totally sure about the fix, since I don't know web3.py internals that well. I discussed this issue with @voith and he encouraged me to submit a fix though. Any feedback is appreciated :) .

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://drscdn.500px.org/photo/61759777/m%3D900/v2?webp=true&sig=fd506c02747cdd46b45a9b09e22c3d227543e98a38091d81ba621d482ee7af17)
