### PR TITLE
Raise external timeout

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -386,7 +386,8 @@ The following methods are available on the ``web3.eth`` namespace.
     returns its transaction receipt.
 
     Optionally, specify a ``timeout`` in seconds. If timeout elapses before the transaction
-    is added to a block, then :meth:`~Eth.waitForTransactionReceipt` raises a `Timeout` exception.
+    is added to a block, then :meth:`~Eth.waitForTransactionReceipt` raises a
+    :class:`web3.exceptions.TimeExhausted` exception.
 
     .. code-block:: python
 

--- a/tests/generate_go_ethereum_fixture.py
+++ b/tests/generate_go_ethereum_fixture.py
@@ -297,17 +297,11 @@ def verify_chain_state(web3, chain_data):
 
 
 def mine_transaction_hash(web3, txn_hash):
-    start_time = time.time()
     web3.miner.start(1)
-    while time.time() < start_time + 60:
-        receipt = web3.eth.waitForTransactionReceipt(txn_hash)
-        if receipt is not None:
-            web3.miner.stop()
-            return receipt
-        else:
-            time.sleep(0.1)
-    else:
-        raise ValueError("Math contract deploy transaction not mined during wait period")
+    try:
+        return web3.eth.waitForTransactionReceipt(txn_hash, timeout=60)
+    finally:
+        web3.miner.stop()
 
 
 def mine_block(web3):

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -27,6 +27,9 @@ from web3._utils.filters import (
     LogFilter,
     TransactionFilter,
 )
+from web3._utils.threads import (
+    Timeout,
+)
 from web3._utils.toolz import (
     assoc,
     merge,
@@ -41,6 +44,9 @@ from web3._utils.transactions import (
 )
 from web3.contract import (
     Contract,
+)
+from web3.exceptions import (
+    TimeExhausted,
 )
 from web3.iban import (
     Iban,
@@ -220,7 +226,15 @@ class Eth(Module):
         )
 
     def waitForTransactionReceipt(self, transaction_hash, timeout=120):
-        return wait_for_transaction_receipt(self.web3, transaction_hash, timeout)
+        try:
+            return wait_for_transaction_receipt(self.web3, transaction_hash, timeout)
+        except Timeout:
+            raise TimeExhausted(
+                "Transaction {} is not in the chain, after {} seconds".format(
+                    transaction_hash,
+                    timeout,
+                )
+            )
 
     def getTransactionReceipt(self, transaction_hash):
         return self.web3.manager.request_blocking(

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -107,3 +107,10 @@ class InsufficientData(Exception):
     complete a calculation
     """
     pass
+
+
+class TimeExhausted(Exception):
+    """
+    Raised when a method has not retrieved the desired result within a specified timeout.
+    """
+    pass


### PR DESCRIPTION
### What was wrong?

We raise `Timeout` exception from `w3.eth.waitForTransactionReceipt()`, but the exception is in a private `_utils` module.

### How was it fixed?

- Add new `TimeExhausted` timeout.
- Update a few usages of `waitForTransactionReceipt`
- Explicitly test the timeout exception raised

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://bodyandsoulnourishmentblog.files.wordpress.com/2016/10/cute-animal-pictures-dog-kissing-young-owl.jpg)
