### PR TITLE
Adding examples for specific operating systems

### DIFF
--- a/docs/README-linux.md
+++ b/docs/README-linux.md
@@ -16,3 +16,34 @@ sudo dnf install openssl-devel libffi-devel autoconf automake libtool
 ```
 
 2. Install `leveldb` (TODO)
+
+
+## Examples for specific operating systems
+
+### Ubuntu 16.04
+
+```sh
+#!/bin/bash
+
+sudo apt-get update
+sudo apt-get -y upgrade
+
+sudo apt-get -y install build-essential
+#RESOLVES ERROR:  unable to execute 'x86_64-linux-gnu-gcc': No such file or directory error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
+
+sudo apt-get -y install python3-dev
+#RESOLVES ERROR:  cytoolz/dicttoolz.c:17:20: fatal error: Python.h: No such file or directory compilation terminated. error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
+
+sudo apt-get -y install python3-venv
+#RESOLVES ERROR: The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package using the following command.
+
+cd ~
+git clone https://github.com/ethereum/web3.py.git
+cd web3.py
+python3 -m venv venv
+. venv/bin/activate
+pip install --upgrade pip
+pip install -e .[dev]
+
+```
+


### PR DESCRIPTION
This has been tested on fresh instance of Ubuntu 16.04

### What was wrong?
There were a few errors when installing web3 py on Ubuntu

### How was it fixed?
I just installed the dependencies and re-ran the installation a bunch of times until the installation worked from start to finish. The steps have all been placed in a linear fashion (so that the steps can be run as a bash script)

#### Cute Animal Picture

![](https://upload.wikimedia.org/wikipedia/commons/thumb/5/50/Curious_Quokka.jpg/320px-Curious_Quokka.jpg)
