### PR TITLE
Fixing "Running the event loop in a separate thread" documentation - no need to use asyncio

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -80,7 +80,7 @@ Block and Transaction Filter Classes
 ------------------------------------
 
 .. py:class:: BlockFilter(...)
-    
+
 BlockFilter is a subclass of :class:``Filter``.
 
 You can setup a filter for new blocks using ``web3.eth.filter('latest')`` which
@@ -250,7 +250,6 @@ releasing the ``main`` function for other tasks.
             from web3.auto import w3
             from threading import Thread
             import time
-            import asyncio
 
 
             def handle_event(event):
@@ -258,7 +257,7 @@ releasing the ``main`` function for other tasks.
                 # and whatever
 
 
-            async def log_loop(event_filter, poll_interval):
+            def log_loop(event_filter, poll_interval):
                 while True:
                     for event in event_filter.get_new_entries():
                         handle_event(event)
@@ -266,7 +265,6 @@ releasing the ``main`` function for other tasks.
 
 
             def main():
-                loop = asyncio.new_event_loop()
                 block_filter = w3.eth.filter('latest')
                 worker = Thread(target=log_loop, args=(block_filter, 5), daemon=True)
                 worker.start()


### PR DESCRIPTION

### What was wrong?

The documentation for "Running the event loop in a separate thread" demonstrates the creation of a new event loop which is never used, and also defines a new thread's entry point as `async` without never using `await` and without adding it to an event loop.

### How was it fixed?

I removed the unneeded async references. This code was tested on my machine and after it was done I updated the documentation.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://s-media-cache-ak0.pinimg.com/originals/17/cd/52/17cd520ec99600fef8098d42192f9f95.jpg)
