### PR TITLE
Python version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "pypiwin32>=223;platform_system=='Windows'",
     ],
     setup_requires=['setuptools-markdown'],
-    python_requires='>=3.5, <4',
+    python_requires='>=3.5.2, <4',
     extras_require=extras_require,
     py_modules=['web3', 'ens'],
     license="MIT",


### PR DESCRIPTION
### What was wrong?

Related to Issue #1094

### How was it fixed?

According to https://docs.python.org/3/library/typing.html#typing.NewType `NewType` was introduced in Python 3.5.2, so I bumped version in setup.py to just such a version.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.mnn.com/assets/images/2017/04/puppy-smiling-bowtie.jpg.838x0_q80.jpg)
