### PR TITLE
Upgrade eth-utils to 1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "cytoolz>=0.9.0,<1.0.0;implementation_name=='cpython'",
         "eth-abi>=1.2.0,<2.0.0",
         "eth-account>=0.2.1,<0.4.0",
-        "eth-utils>=1.0.1,<2.0.0",
+        "eth-utils>=1.2.0,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "lru-dict>=1.1.6,<2.0.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",


### PR DESCRIPTION
### What was wrong?

Related to Issue #1102

### How was it fixed?

Upgraded minimum eth-utils  version to 1.2.0

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/6519792/46826051-ad8c1b00-cd9d-11e8-815c-b054d486c9f6.png)

