### PR TITLE
Restrict Python to >=3.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         "pypiwin32>=223;platform_system=='Windows'",
     ],
     setup_requires=['setuptools-markdown'],
-    python_requires='>=3.5, <4',
+    python_requires='>=3.5.3,<4',
     extras_require=extras_require,
     py_modules=['web3', 'ens'],
     license="MIT",


### PR DESCRIPTION
### What was wrong?

Fixes #1096 (per @carver's comment here - https://github.com/ethereum/web3.py/issues/1094#issuecomment-428259232)

### How was it fixed?

Restricted the Python3 version to >=3.5.3.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.shopify.com/s/files/1/0025/2618/3476/files/CuteElephant13_fcc80981-fb6f-432a-a8d6-36a4b3f7b9ba_large.jpg?v=1528492456)
