### PR TITLE
Restrict Python to >=3.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "pypiwin32>=223;platform_system=='Windows'",
     ],
     setup_requires=['setuptools-markdown'],
-    python_requires='>=3.5.2, <4',
+    python_requires='>=3.5.3,<4',
     extras_require=extras_require,
     py_modules=['web3', 'ens'],
     license="MIT",


### PR DESCRIPTION
### What was wrong?

Added this under #1096 (per @carver's comment here - https://github.com/ethereum/web3.py/issues/1094#issuecomment-428259232) as 3.5.2 was still allowed in the fix for #1094. I can log a separate issue if we want or we can rename 1096 to `Disallow Python < 3.5.3`.

### How was it fixed?

Restricted Python3 to >= 3.5.3.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://bucket.trending.com/trending/twitter/2017-10-08/cute-monkey.jpg)
