### PR TITLE
Removed web3._utils.six support

### DIFF
--- a/web3/_utils/caching.py
+++ b/web3/_utils/caching.py
@@ -1,3 +1,4 @@
+import collections
 import hashlib
 
 from eth_utils import (
@@ -9,10 +10,6 @@ from eth_utils import (
     is_number,
     is_text,
     to_bytes,
-)
-
-from .six import (
-    Generator,
 )
 
 
@@ -32,7 +29,7 @@ def generate_cache_key(value):
             for key
             in sorted(value.keys())
         ))
-    elif is_list_like(value) or isinstance(value, Generator):
+    elif is_list_like(value) or isinstance(value, collections.Generator):
         return generate_cache_key("".join((
             generate_cache_key(item)
             for item

--- a/web3/_utils/six/__init__.py
+++ b/web3/_utils/six/__init__.py
@@ -1,5 +1,0 @@
-from .six import (  # noqa: #401
-    urlparse,
-    urlunparse,
-    Generator,
-)

--- a/web3/_utils/six/six.py
+++ b/web3/_utils/six/six.py
@@ -1,7 +1,0 @@
-import collections
-from urllib.parse import (  # noqa: F401
-    urlparse,
-    urlunparse,
-)
-
-Generator = collections.Generator

--- a/web3/utils/__init__.py
+++ b/web3/utils/__init__.py
@@ -20,7 +20,6 @@ from web3._utils import (  # noqa: F401
     normalizers,
     request,
     rpc_abi,
-    six,
     threads,
     toolz,
     transactions,


### PR DESCRIPTION
### What was wrong?
Fixed https://github.com/ethereum/web3.py/issues/1111 (cool number)

### How was it fixed?
1. Removed `six` module
2. Updated the `web3._utils.caching` module
3. Updated `web3.utils.__init__.py` module



#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://photos1.blogger.com/hello/258/4294/640/hippy%20chick%20looking%20cute.jpg)
