### PR TITLE
Parity transactions methods

### DIFF
--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -253,6 +253,10 @@ estimate_gas_with_block_id = combine_argument_formatters(
     block_number_formatter,
 )
 
+parity_transactions_result_formatter = apply_one_of_formatters((
+    (apply_formatter_to_array(log_entry_formatter), is_array_of_dicts),
+    (apply_formatter_to_array(to_hexbytes(32)), is_array_of_strings),
+))
 
 pythonic_middleware = construct_formatting_middleware(
     request_formatters={
@@ -360,5 +364,10 @@ pythonic_middleware = construct_formatting_middleware(
         'evm_snapshot': hex_to_integer,
         # Net
         'net_peerCount': to_integer_if_hex,
+        # Parity
+        'parity_allTransactions': parity_transactions_result_formatter,
+        'parity_futureTransactions': parity_transactions_result_formatter,
+        'parity_pendingTransactions': parity_transactions_result_formatter,
+        'parity_pendingTransactionsStats': parity_transactions_result_formatter,
     },
 )

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -16,15 +16,33 @@ class Parity(Module):
     """
     defaultBlock = "latest"
 
+    def allTransactions(self):
+        return self.web3.manager.request_blocking(
+            "parity_allTransactions",
+            [],
+        )
+
     def enode(self):
         return self.web3.manager.request_blocking(
             "parity_enode",
             [],
         )
 
+    def futureTransactions(self):
+        return self.web3.manager.request_blocking(
+            "parity_futureTransactions",
+            [],
+        )
+
     def netPeers(self):
         return self.web3.manager.request_blocking(
             "parity_netPeers",
+            [],
+        )
+
+    def localTransactions(self):
+        return self.web3.manager.request_blocking(
+            "parity_localTransactions",
             [],
         )
 
@@ -75,4 +93,16 @@ class Parity(Module):
         return self.web3.manager.request_blocking(
             "trace_rawTransaction",
             [raw_transaction, mode],
+        )
+
+    def pendingTransactions(self):
+        return self.web3.manager.request_blocking(
+            "parity_pendingTransactions",
+            [],
+        )
+
+    def pendingTransactionsStats(self):
+        return self.web3.manager.request_blocking(
+            "parity_pendingTransactionsStats",
+            [],
         )


### PR DESCRIPTION
### What was wrong?

Parity methods were not implemented: parity_allTransactions, parity_futureTransactions, parity_pendingTransactions, parity_pendingTransactionsStats, parity_localTransactions

### How was it fixed?

Added methods, added formatters.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.pexels.com/photos/374906/pexels-photo-374906.jpeg?auto=compress&cs=tinysrgb&h=350)
