### PR TITLE
removed _function_names and _event_names

### DIFF
--- a/web3/contract.py
+++ b/web3/contract.py
@@ -105,14 +105,11 @@ class ContractFunctions:
     """Class containing contract function objects
     """
 
-    _function_names = []
-
     def __init__(self, abi, web3, address=None):
         if abi:
             self.abi = abi
             self._functions = filter_by_type('function', self.abi)
             for func in self._functions:
-                self._function_names.append(func['name'])
                 setattr(
                     self,
                     func['name'],
@@ -152,14 +149,11 @@ class ContractEvents:
     """Class containing contract event objects
     """
 
-    _event_names = []
-
     def __init__(self, abi, web3, address=None):
         if abi:
             self.abi = abi
             self._events = filter_by_type('event', self.abi)
             for event in self._events:
-                self._event_names.append(event['name'])
                 setattr(
                     self,
                     event['name'],


### PR DESCRIPTION
### What was wrong?
ContractEvents and ContractFunctions have not used lists _event_names / _function_names.
Each time a contract is created through the factory method, the _event_names list and the _function_names list are extended.
Creating many contract's results in high memory usage.

### How was it fixed?
Removed unused class level lists. If they are really needed for some reason, a set would prevent the high memory usage. Especially in the case that a contract (with the same ABI) is created multiple times.

#### Cute Animal Picture
![Put a link to a cute animal picture inside the parenthesis-->](https://farm6.staticflickr.com/5718/23226510859_74363ecfc8_z_d.jpg)
