### PR TITLE
memory leak fix

### DIFF
--- a/web3/contract.py
+++ b/web3/contract.py
@@ -101,14 +101,11 @@ class ContractFunctions:
     """Class containing contract function objects
     """
 
-    _function_names = []
-
     def __init__(self, abi, web3, address=None):
         if abi:
             self.abi = abi
             self._functions = filter_by_type('function', self.abi)
             for func in self._functions:
-                self._function_names.append(func['name'])
                 setattr(
                     self,
                     func['name'],
@@ -148,14 +145,11 @@ class ContractEvents:
     """Class containing contract event objects
     """
 
-    _event_names = []
-
     def __init__(self, abi, web3, address=None):
         if abi:
             self.abi = abi
             self._events = filter_by_type('event', self.abi)
             for event in self._events:
-                self._event_names.append(event['name'])
                 setattr(
                     self,
                     event['name'],


### PR DESCRIPTION
removed _function_names and _event_names

ContractEvents and ContractFunctions have not used lists _event_names / _function_names.
Each time a contract is created through the factory method, the _event_names list and the _function_names list are extended.
Creating many contract's results in high memory usage.

(cherry picked from commit 94b8b40d6df51730243a713c14cf174bcb14bb32)

### What was wrong?

Related to Issue #

### How was it fixed?



#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
