### PR TITLE
Pacify Python `DeprecationWarning`s + add solidityKeccak() and deprecate soliditySha3()

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -242,44 +242,44 @@ Addresses
 Cryptographic Hashing
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. py:classmethod:: Web3.sha3(primitive=None, hexstr=None, text=None)
+.. py:classmethod:: Web3.keccak(primitive=None, hexstr=None, text=None)
 
-    Returns the Keccak SHA256 of the given value. Text is encoded to UTF-8 before
+    Returns the Keccak-256 of the given value. Text is encoded to UTF-8 before
     computing the hash, just like Solidity. Any of the following are
     valid and equivalent:
 
     .. code-block:: python
 
-        >>> Web3.sha3(0x747874)
-        >>> Web3.sha3(b'\x74\x78\x74')
-        >>> Web3.sha3(hexstr='0x747874')
-        >>> Web3.sha3(hexstr='747874')
-        >>> Web3.sha3(text='txt')
+        >>> Web3.keccak(0x747874)
+        >>> Web3.keccak(b'\x74\x78\x74')
+        >>> Web3.keccak(hexstr='0x747874')
+        >>> Web3.keccak(hexstr='747874')
+        >>> Web3.keccak(text='txt')
         HexBytes('0xd7278090a36507640ea6b7a0034b69b0d240766fa3f98e3722be93c613b29d2e')
 
-.. py:classmethod:: Web3.soliditySha3(abi_types, value)
+.. py:classmethod:: Web3.solidityKeccak(abi_types, value)
 
-    Returns the sha3 as it would be computed by the solidity ``sha3`` function
-    on the provided ``value`` and ``abi_types``.  The ``abi_types`` value
-    should be a list of solidity type strings which correspond to each of the
-    provided values.
+    Returns the Keccak-256 as it would be computed by the solidity ``keccak``
+    function on the provided ``value`` and ``abi_types``.  The ``abi_types``
+    value should be a list of solidity type strings which correspond to each
+    of the provided values.
 
 
     .. code-block:: python
 
-        >>> Web3.soliditySha3(['bool'], [True])
+        >>> Web3.solidityKeccak(['bool'], [True])
         HexBytes("0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2")
 
-        >>> Web3.soliditySha3(['uint8', 'uint8', 'uint8'], [97, 98, 99])
+        >>> Web3.solidityKeccak(['uint8', 'uint8', 'uint8'], [97, 98, 99])
         HexBytes("0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45")
 
-        >>> Web3.soliditySha3(['uint8[]'], [[97, 98, 99]])
+        >>> Web3.solidityKeccak(['uint8[]'], [[97, 98, 99]])
         HexBytes("0x233002c671295529bcc50b76a2ef2b0de2dac2d93945fca745255de1a9e4017e")
 
-        >>> Web3.soliditySha3(['address'], ["0x49eddd3769c0712032808d86597b84ac5c2f5614"])
+        >>> Web3.solidityKeccak(['address'], ["0x49eddd3769c0712032808d86597b84ac5c2f5614"])
         HexBytes("0x2ff37b5607484cd4eecf6d13292e22bd6e5401eaffcc07e279583bc742c68882")
 
-        >>> Web3.soliditySha3(['address'], ["ethereumfoundation.eth"])
+        >>> Web3.solidityKeccak(['address'], ["ethereumfoundation.eth"])
         HexBytes("0x913c99ea930c78868f1535d34cd705ab85929b2eaaf70fcd09677ecd6e5d75e9")
 
 Modules

--- a/tests/core/middleware/test_name_to_address_middleware.py
+++ b/tests/core/middleware/test_name_to_address_middleware.py
@@ -52,5 +52,5 @@ def test_fail_name_resolver(w3):
         'net_version': '2',
     })
     w3.middleware_stack.inject(return_chain_on_mainnet, layer=0)
-    with pytest.raises(InvalidAddress, match='.*ethereum\.eth.*'):
+    with pytest.raises(InvalidAddress, match=r'.*ethereum\.eth.*'):
         w3.eth.getBalance("ethereum.eth")

--- a/web3/_utils/caching.py
+++ b/web3/_utils/caching.py
@@ -29,7 +29,7 @@ def generate_cache_key(value):
             for key
             in sorted(value.keys())
         ))
-    elif is_list_like(value) or isinstance(value, collections.Generator):
+    elif is_list_like(value) or isinstance(value, collections.abc.Generator):
         return generate_cache_key("".join((
             generate_cache_key(item)
             for item

--- a/web3/_utils/hypothesis.py
+++ b/web3/_utils/hypothesis.py
@@ -4,4 +4,4 @@ from hypothesis import (
 
 
 def hexstr_strategy():
-    return st.from_regex('\A(0[xX])?[0-9a-fA-F]*\Z')
+    return st.from_regex(r'\A(0[xX])?[0-9a-fA-F]*\Z')

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -164,13 +164,13 @@ class Web3ModuleTest:
             ),
         ),
     )
-    def test_soliditySha3(self, web3, types, values, expected):
+    def test_solidityKeccak(self, web3, types, values, expected):
         if isinstance(expected, type) and issubclass(expected, Exception):
             with pytest.raises(expected):
-                web3.soliditySha3(types, values)
+                web3.solidityKeccak(types, values)
             return
 
-        actual = web3.soliditySha3(types, values)
+        actual = web3.solidityKeccak(types, values)
         assert actual == expected
 
     @pytest.mark.parametrize(
@@ -188,17 +188,17 @@ class Web3ModuleTest:
             ),
         ),
     )
-    def test_soliditySha3_ens(self, web3, types, values, expected):
+    def test_solidityKeccak_ens(self, web3, types, values, expected):
         with ens_addresses(web3, {
             'one.eth': "0x49EdDD3769c0712032808D86597B84ac5c2F5614",
             'two.eth': "0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5",
         }):
             # when called as class method, any name lookup attempt will fail
             with pytest.raises(InvalidAddress):
-                Web3.soliditySha3(types, values)
+                Web3.solidityKeccak(types, values)
 
-            # when called as instance method method, ens lookups can succeed
-            actual = web3.soliditySha3(types, values)
+            # when called as instance method, ens lookups can succeed
+            actual = web3.solidityKeccak(types, values)
             assert actual == expected
 
     @pytest.mark.parametrize(
@@ -209,9 +209,9 @@ class Web3ModuleTest:
             ([], ['0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5']),
         )
     )
-    def test_soliditySha3_same_number_of_types_and_values(self, web3, types, values):
+    def test_solidityKeccak_same_number_of_types_and_values(self, web3, types, values):
         with pytest.raises(ValueError):
-            web3.soliditySha3(types, values)
+            web3.solidityKeccak(types, values)
 
     def test_is_connected(self, web3):
         assert web3.isConnected()

--- a/web3/main.py
+++ b/web3/main.py
@@ -151,7 +151,7 @@ class Web3:
         self.manager.providers = providers
 
     @staticmethod
-    @deprecated_for("This method has been renamed to keccak")
+    @deprecated_for("keccak")
     @apply_to_return_value(HexBytes)
     def sha3(primitive=None, text=None, hexstr=None):
         return Web3.keccak(primitive, text, hexstr)
@@ -173,9 +173,15 @@ class Web3:
         )
 
     @combomethod
+    @deprecated_for("solidityKeccak")
     def soliditySha3(cls, abi_types, values):
+        # just call it as a class method
+        return Web3.solidityKeccak(abi_types, values)
+
+    @combomethod
+    def solidityKeccak(cls, abi_types, values):
         """
-        Executes sha3 (keccak256) exactly as Solidity does.
+        Executes keccak256 exactly as Solidity does.
         Takes list of abi_types as inputs -- `[uint24, int8[], bool]`
         and list of corresponding values  -- `[20, [-1, 5, 0], True]`
         """
@@ -196,7 +202,7 @@ class Web3:
             for abi_type, value
             in zip(abi_types, normalized_values)
         ))
-        return cls.sha3(hexstr=hex_string)
+        return cls.keccak(hexstr=hex_string)
 
     def isConnected(self):
         for provider in self.providers:

--- a/web3/main.py
+++ b/web3/main.py
@@ -175,8 +175,7 @@ class Web3:
     @combomethod
     @deprecated_for("solidityKeccak")
     def soliditySha3(cls, abi_types, values):
-        # just call it as a class method
-        return Web3.solidityKeccak(abi_types, values)
+        return cls.solidityKeccak(abi_types, values)
 
     @combomethod
     def solidityKeccak(cls, abi_types, values):


### PR DESCRIPTION
### What was wrong?

Without `export PYTHONWARNINGS=ignore`, many programs are now overly noisy.

### How was it fixed?

Collecting and squashing these warnings here.

### Snippet for `releases.rst`

```
* `Web3.soliditySha3` has been deprecated; use `Web3.solidityKeccak` instead.
```

### Cute Animal Picture

"Whistle if you see 'em!.."

![Put a link to a cute animal picture inside the parenthesis-->](https://3c1703fe8d.site.internapcdn.net/newman/gfx/news/hires/2011/groundhog.jpg)

Source: [Wikipedia](https://commons.wikimedia.org/wiki/File:Groundhog-Standing2.jpg); by [April King](https://pokeinthe.io/)