### PR TITLE
added poll_latency parameter to waitForTransactionReceipt() and finished testing

### DIFF
--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -10,8 +10,8 @@ from web3.middleware.simulate_unmined_transaction import (
 
 RECEIPT_TIMEOUT = 0.2
 RECEIPT_POLL_LATENCY = 0.1
-@pytest.mark.parametrize("timeout", [0.2, 120])
-@pytest.mark.parametrize("poll_latency", [0.1, 0.3, 110, 120, 130])
+@pytest.mark.parametrize("timeout",[0.2,120])
+@pytest.mark.parametrize("poll_latency",[0.1,0.3,110,120,130])
 
 @pytest.mark.parametrize(
     'make_chain_id, expect_success',
@@ -27,14 +27,14 @@ RECEIPT_POLL_LATENCY = 0.1
         ),
     ),
 )
-def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_success, timeout, poll_latency ):
+def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_success, timeout, poll_latency):
     transaction = {
         'to': web3.eth.accounts[1],
         'chainId': make_chain_id(web3),
     }
     if expect_success:
         txn_hash = web3.eth.sendTransaction(transaction)
-        receipt = web3.eth.waitForTransactionReceipt(txn_hash, timeout, poll_latency )
+        receipt = web3.eth.waitForTransactionReceipt(txn_hash, timeout, poll_latency)
         assert receipt.get('blockNumber') is not None
     else:
         with pytest.raises(ValidationError) as exc_info:
@@ -42,11 +42,12 @@ def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_succes
 
         assert 'chain ID' in str(exc_info.value)
 
+
 @pytest.mark.parametrize("timeout", [0.2])
 @pytest.mark.parametrize("poll_latency", [0.1, 0.3])
 def test_wait_for_missing_receipt(web3, timeout, poll_latency):
     with pytest.raises(TimeExhausted):
-        web3.eth.waitForTransactionReceipt(b'\0' * 32, timeout,poll_latency )
+        web3.eth.waitForTransactionReceipt(b'\0' * 32, timeout, poll_latency)
 
 
 def test_unmined_transaction_wait_for_receipt(web3):

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -10,9 +10,10 @@ from web3.middleware.simulate_unmined_transaction import (
 
 RECEIPT_TIMEOUT = 0.2
 RECEIPT_POLL_LATENCY = 0.1
-@pytest.mark.parametrize("timeout", [0.2,120])
-@pytest.mark.parametrize("poll_latency", [0.1, 0.3, 110, 120, 130])
 
+
+@pytest.mark.parametrize("timeout", [0.2, 120])
+@pytest.mark.parametrize("poll_latency", [0.1, 0.3, 110, 120, 130])
 @pytest.mark.parametrize(
     'make_chain_id, expect_success',
     (
@@ -27,7 +28,7 @@ RECEIPT_POLL_LATENCY = 0.1
         ),
     ),
 )
-def test_send_transaction_with_valid_chain_id(
+def test_send_transaction_with_valid_chain_id( \
 web3, make_chain_id, expect_success, timeout, poll_latency):
     transaction = {
         'to': web3.eth.accounts[1],

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -10,8 +10,8 @@ from web3.middleware.simulate_unmined_transaction import (
 
 RECEIPT_TIMEOUT = 0.2
 RECEIPT_POLL_LATENCY = 0.1
-@pytest.mark.parametrize("timeout",[0.2,120])
-@pytest.mark.parametrize("poll_latency",[0.1,0.3,110,120,130])
+@pytest.mark.parametrize("timeout", [0.2,120])
+@pytest.mark.parametrize("poll_latency", [0.1, 0.3, 110, 120, 130])
 
 @pytest.mark.parametrize(
     'make_chain_id, expect_success',
@@ -27,7 +27,8 @@ RECEIPT_POLL_LATENCY = 0.1
         ),
     ),
 )
-def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_success, timeout, poll_latency):
+def test_send_transaction_with_valid_chain_id(
+web3, make_chain_id, expect_success, timeout, poll_latency):
     transaction = {
         'to': web3.eth.accounts[1],
         'chainId': make_chain_id(web3),

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -28,8 +28,8 @@ RECEIPT_POLL_LATENCY = 0.1
         ),
     ),
 )
-def test_send_transaction_with_valid_chain_id( \
-web3, make_chain_id, expect_success, timeout, poll_latency):
+def test_send_transaction_with_valid_chain_id(web3, \
+    make_chain_id, expect_success, timeout, poll_latency):
     transaction = {
         'to': web3.eth.accounts[1],
         'chainId': make_chain_id(web3),

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -28,8 +28,8 @@ RECEIPT_POLL_LATENCY = 0.1
         ),
     ),
 )
-def test_send_transaction_with_valid_chain_id(web3, \
-    make_chain_id, expect_success, timeout, poll_latency):
+def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_success,
+    timeout, poll_latency):
     transaction = {
         'to': web3.eth.accounts[1],
         'chainId': make_chain_id(web3),

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -28,8 +28,8 @@ RECEIPT_POLL_LATENCY = 0.1
         ),
     ),
 )
-def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_success,
-    timeout, poll_latency):
+def test_send_transaction_with_valid_chain_id(
+        web3, make_chain_id, expect_success, timeout, poll_latency):
     transaction = {
         'to': web3.eth.accounts[1],
         'chainId': make_chain_id(web3),

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -9,7 +9,9 @@ from web3.middleware.simulate_unmined_transaction import (
 )
 
 RECEIPT_TIMEOUT = 0.2
-
+RECEIPT_POLL_LATENCY = 0.1
+@pytest.mark.parametrize("timeout", [0.2, 120])
+@pytest.mark.parametrize("poll_latency", [0.1, 0.3, 110, 120, 130])
 
 @pytest.mark.parametrize(
     'make_chain_id, expect_success',
@@ -25,14 +27,14 @@ RECEIPT_TIMEOUT = 0.2
         ),
     ),
 )
-def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_success):
+def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_success, timeout, poll_latency ):
     transaction = {
         'to': web3.eth.accounts[1],
         'chainId': make_chain_id(web3),
     }
     if expect_success:
         txn_hash = web3.eth.sendTransaction(transaction)
-        receipt = web3.eth.waitForTransactionReceipt(txn_hash, timeout=RECEIPT_TIMEOUT)
+        receipt = web3.eth.waitForTransactionReceipt(txn_hash, timeout, poll_latency )
         assert receipt.get('blockNumber') is not None
     else:
         with pytest.raises(ValidationError) as exc_info:
@@ -40,10 +42,11 @@ def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_succes
 
         assert 'chain ID' in str(exc_info.value)
 
-
-def test_wait_for_missing_receipt(web3):
+@pytest.mark.parametrize("timeout", [0.2])
+@pytest.mark.parametrize("poll_latency", [0.1, 0.3])
+def test_wait_for_missing_receipt(web3, timeout, poll_latency):
     with pytest.raises(TimeExhausted):
-        web3.eth.waitForTransactionReceipt(b'\0' * 32, timeout=RECEIPT_TIMEOUT)
+        web3.eth.waitForTransactionReceipt(b'\0' * 32, timeout,poll_latency )
 
 
 def test_unmined_transaction_wait_for_receipt(web3):

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -225,9 +225,9 @@ class Eth(Module):
             [block_identifier, transaction_index],
         )
 
-    def waitForTransactionReceipt(self, transaction_hash, timeout=120):
+    def waitForTransactionReceipt(self, transaction_hash, timeout=120, poll_latency=0.1):
         try:
-            return wait_for_transaction_receipt(self.web3, transaction_hash, timeout)
+            return wait_for_transaction_receipt(self.web3, transaction_hash, timeout, poll_latency)
         except Timeout:
             raise TimeExhausted(
                 "Transaction {} is not in the chain, after {} seconds".format(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -225,8 +225,10 @@ class Eth(Module):
             [block_identifier, transaction_index],
         )
 
-    def waitForTransactionReceipt(self, transaction_hash, timeout=120, poll_latency=0.1):
+    def waitForTransactionReceipt(self, transaction_hash, timeout=120, poll_latency = 0.2):
         try:
+            if poll_latency > timeout :
+                poll_latency = timeout
             return wait_for_transaction_receipt(self.web3, transaction_hash, timeout, poll_latency)
         except Timeout:
             raise TimeExhausted(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -225,9 +225,9 @@ class Eth(Module):
             [block_identifier, transaction_index],
         )
 
-    def waitForTransactionReceipt(self, transaction_hash, timeout=120, poll_latency = 0.2):
+    def waitForTransactionReceipt(self, transaction_hash, timeout=120, poll_latency=0.2):
         try:
-            if poll_latency > timeout :
+            if poll_latency > timeout:
                 poll_latency = timeout
             return wait_for_transaction_receipt(self.web3, transaction_hash, timeout, poll_latency)
         except Timeout:


### PR DESCRIPTION
### What was wrong?
Initially user cannot set polling interval between subsequent requests for getting transaction receipt

Related to Issue #1130 

### How was it fixed?
added polling_latency parameter to web3.eth.waitForTransactionReceipt() function. Still need to write test.


#### Cute Animal Picture

![cute coala](https://images.mentalfloss.com/sites/default/files/styles/mf_image_16x9/public/62012-istock-833768276.jpg?itok=AvAKdWF_&resize=1100x1100)
