### PR TITLE
Add parity-specific listStorageKeys RPC.

### DIFF
--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -169,6 +169,9 @@ class ParityPersonalModuleTest(PersonalModuleTest):
 
 
 class ParityTraceModuleTest(TraceModuleTest):
+    def test_list_storage_keys_no_support(self, web3, emitter_contract_address):
+        super().test_list_storage_keys_no_support(web3, emitter_contract_address)
+
     def test_trace_replay_transaction(self, web3, parity_fixture_data):
         super().test_trace_replay_transaction(web3, parity_fixture_data)
 

--- a/web3/_utils/module_testing/parity_module.py
+++ b/web3/_utils/module_testing/parity_module.py
@@ -11,6 +11,10 @@ from web3._utils.formatters import (
 
 class ParityModuleTest:
 
+    def test_list_storage_keys_no_support(self, web3, emitter_contract_address):
+        keys = web3.parity.listStorageKeys(emitter_contract_address, 10, None)
+        assert keys is None
+
     def test_trace_replay_transaction(self, web3, parity_fixture_data):
         trace = web3.parity.traceReplayTransaction(parity_fixture_data['mined_txn_hash'])
 

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -57,6 +57,8 @@ RPC_ABIS = {
     'personal_unlockAccount': ['address', None, None],
     'personal_sign': [None, 'address', None],
     'trace_call': TRACE_PARAMS_ABIS,
+    # parity
+    'parity_listStorageKeys': ['address', None, None, None],
 }
 
 

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -22,6 +22,14 @@ class Parity(Module):
             [],
         )
 
+    def listStorageKeys(self, address, quantity, hash_, block_identifier=None):
+        if block_identifier is None:
+            block_identifier = self.defaultBlock
+        return self.web3.manager.request_blocking(
+            "parity_listStorageKeys",
+            [address, quantity, hash_, block_identifier],
+        )
+
     def netPeers(self):
         return self.web3.manager.request_blocking(
             "parity_netPeers",


### PR DESCRIPTION
### What was wrong?

There was no support for the parity_listStorageKeys RPC:
https://wiki.parity.io/JSONRPC-parity-module#parity_liststoragekeys

### How was it fixed?

I added a function to implement it in the parity module.

### How was it tested?

I tested locally, and also ran the parity integration tests.
I added a test, but because the current integration tests doesn't seem to use "--fat-db", parity returns None. I make sure it does.

However, the test is run in two variants, and one fails:
`tests/integration/parity/test_parity_http.py::TestParityTraceModuleTest::test_list_storage_keys_no_support[<lambda>]`

Where this one passes:
`tests/integration/parity/test_parity_http.py::TestParityTraceModuleTest::test_list_storage_keys_no_support[address_conversion_func1]`

The failure is because the address seems to be passed as raw bytes, and cannot be serialized to json. That's supposed to be allowed? How to handle that? I don't see code to handle it in the other RPCs.

#### Cute Animal Picture

```
   \
    \ /\
    ( )
  .( o ).
```
(that's an ASCII Bunny viewed from behind)