### PR TITLE
Bump websockets version to 7.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         "lru-dict>=1.1.6,<2.0.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "requests>=2.16.0,<3.0.0",
-        "websockets>=6.0.0,<7.0.0",
+        "websockets>=7.0.0,<8.0.0",
         "pypiwin32>=223;platform_system=='Windows'",
     ],
     setup_requires=['setuptools-markdown'],


### PR DESCRIPTION
### What was wrong?

websockets doesn't send pings to keep the connection open.

### How was it fixed?

Upgraded websockets to 7.0, which has keepalive support out of the box.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/138289/48978712-c2f4a480-f0c0-11e8-98a0-ab6071563c06.gif)

