### PR TITLE
Moar infura

### DIFF
--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -7,6 +7,8 @@ from eth_utils import (
 
 INFURA_MAINNET_DOMAIN = 'mainnet.infura.io'
 INFURA_ROPSTEN_DOMAIN = 'ropsten.infura.io'
+INFURA_RINKEBY_DOMAIN = 'rinkeby.infura.io'
+INFURA_KOVAN_DOMAIN = 'kovan.infura.io'
 
 WEBSOCKET_SCHEME = 'wss'
 HTTP_SCHEME = 'https'

--- a/web3/auto/infura/kovan.py
+++ b/web3/auto/infura/kovan.py
@@ -1,0 +1,13 @@
+from web3 import Web3
+from web3.providers.auto import (
+    load_provider_from_uri,
+)
+
+from .endpoints import (
+    INFURA_KOVAN_DOMAIN,
+    build_infura_url,
+)
+
+_infura_url = build_infura_url(INFURA_KOVAN_DOMAIN)
+
+w3 = Web3(load_provider_from_uri(_infura_url))

--- a/web3/auto/infura/mainnet.py
+++ b/web3/auto/infura/mainnet.py
@@ -1,0 +1,13 @@
+from web3 import Web3
+from web3.providers.auto import (
+    load_provider_from_uri,
+)
+
+from .endpoints import (
+    INFURA_MAINNET_DOMAIN,
+    build_infura_url,
+)
+
+_infura_url = build_infura_url(INFURA_MAINNET_DOMAIN)
+
+w3 = Web3(load_provider_from_uri(_infura_url))

--- a/web3/auto/infura/rinkeby.py
+++ b/web3/auto/infura/rinkeby.py
@@ -1,0 +1,13 @@
+from web3 import Web3
+from web3.providers.auto import (
+    load_provider_from_uri,
+)
+
+from .endpoints import (
+    INFURA_RINKEBY_DOMAIN,
+    build_infura_url,
+)
+
+_infura_url = build_infura_url(INFURA_RINKEBY_DOMAIN)
+
+w3 = Web3(load_provider_from_uri(_infura_url))


### PR DESCRIPTION
### What was wrong?
There was only two options for infura networks, and one (mainnet) was default without any suitable warnings.

### How was it fixed?
I added modules for the missing networks, rinkeby and kovan. I added a module for mainnet that warned you that you were on mainnet, and loaded that as the default w3 instance for the infura package.

Both seem to work fine with my dev account.

#### Cute Animal Picture
![Put a link to a cute animal picture inside the parenthesis-->](https://dogzone-tcwebsites.netdna-ssl.com/wp-content/uploads/2017/09/french-bulldog-names-2.jpg)