### PR TITLE
Fix contract doc typos

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -491,7 +491,7 @@ Contract Functions
 .. py:class:: ContractFunction
 
 The named functions exposed through the :py:attr:`Contract.functions` property are
-of the ContractFunction type. This class it not to be used directly,
+of the ContractFunction type. This class is not to be used directly,
 but instead through :py:attr:`Contract.functions`.
 
 For example:
@@ -700,7 +700,7 @@ Events
 
 .. py:class:: ContractEvents
 
-The named events exposed through the :py:attr:`Contract.events` property are of the ContractEvents type. This class it not to be used directly, but instead through :py:attr:`Contract.events`.
+The named events exposed through the :py:attr:`Contract.events` property are of the ContractEvents type. This class is not to be used directly, but instead through :py:attr:`Contract.events`.
 
 For example:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -337,7 +337,7 @@ Fetch various data about the current state of the ERC20 contract.
     >>> erc20.functions.decimals().call()
     0
     >>> erc20.functions.totalSupply().call()
-    2039
+    2040
 
 Get the balance of an account address. 
 


### PR DESCRIPTION
### What was wrong?
Just a few typos I noticed while reading docs. `it` should be `is`

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://i.imgur.com/PHrdd.jpg)
