### PR TITLE
Freebsd support: cleanup and tox fix

### DIFF
--- a/docs/README-freebsd.md
+++ b/docs/README-freebsd.md
@@ -4,27 +4,46 @@
 
 ### Prerequisites
 
-Make sure you've UTF-8 defined for charset and lang in your [~/.login_conf](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/using-localization.html),
-otherwise almost every module will fail to install. Python 3 is very sensitive to that.
+Make sure you've UTF-8 defined for charset and lang in your [~/.login_conf](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/using-localization.html), 
+otherwise almost every Python 3 module will fail to install.
+
+`~/.login_conf`:
+```
+me:\
+	:charset=UTF-8:\
+	:lang=en_US.UTF-8:
+```
+
+Also make sure you've defined valid include and library paths in `~/.pydistutils.cfg`, otherwise native compilations fail.
+
+`~/.pydistutils.cfg`:
+```
+[build_ext]
+include_dirs=/usr/local/include
+library_dirs=/usr/local/lib
+```
 
 ```
-sudo pkg install python3 py36-virtualenv leveldb libxml2 libxslt pkgconf secp256k1 wget git
-sudo wget https://raw.githubusercontent.com/bitcoin/bitcoin/master/src/secp256k1/include/secp256k1_recovery.h -O /usr/local/include/secp256k1_recovery.h
-echo '#include "/usr/include/stdlib.h"' | sudo tee -a /usr/include/alloca.h > /dev/null
+sudo pkg install python3 py36-virtualenv git leveldb libxml2 libxslt pkgconf gmake secp256k1
+
+# hack around https://github.com/ethereum/ethash/pull/107#issuecomment-445072692
+sudo touch /usr/local/include/alloca.h
+
 mkdir -p /tmp/venv_python
 virtualenv-3.6 /tmp/venv_python/python3
 source /tmp/venv_python/python3/bin/activate.csh
 
-# these two modules fail to install natively
-pip install ptyprocess eth-account
+pip install coincurve
 
 cd /tmp
 git clone https://github.com/ethereum/web3.py.git
 cd web3.py
-pip install -e .\[dev\] --global-option=build_ext --global-option='-I/usr/local/include'
+
+# assuming you're using tcsh
+pip install -e .\[dev\]
 ```
 
-## Test
+### Test
 
 #### Prerequisites for integration tests:
 
@@ -44,7 +63,16 @@ BROKEN (build crashes on FreeBSD 11.2)
 ```
 
 ```
+cd web3.py
+tox -e py36-core
+tox -e py36-ens
+tox -e py36-integration
+etc
+
+or
+
 py.test tests/core
 py.test tests/ens
 py.test tests/integration
+etc
 ```

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -336,8 +336,8 @@ Fetch various data about the current state of the ERC20 contract.
     '🦄'
     >>> erc20.functions.decimals().call()
     0
-    >>> erc20.functions.totalSupply().call()
-    2040
+    >>> total_supply = erc20.functions.totalSupply().call()
+    >>> assert total_supply > 2040
 
 Get the balance of an account address. 
 


### PR DESCRIPTION
### What was wrong?
- tox fails to run because of additional include directories dependency
- unnecessary file manipulations and downloads

### How was it fixed?
- put paths into .pydistutils.cfg
- removed extra steps

