### PR TITLE
Remove unreachable code

### DIFF
--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -77,8 +77,8 @@ class JSONBaseProvider(BaseProvider):
             response = self.make_request('web3_clientVersion', [])
         except IOError:
             return False
-        else:
-            assert response['jsonrpc'] == '2.0'
-            assert 'error' not in response
-            return True
-        assert False
+
+        assert response['jsonrpc'] == '2.0'
+        assert 'error' not in response
+
+        return True


### PR DESCRIPTION
Also, remove unnecessary else clause that tends to obscure that problem.

### What was wrong?

There was an `assert False` statement which was unreachable.  It was clearly expected that this statement was not supposed to be reached in a "normal" situation.  However, I don't think it was realized that the statement could never be reach in *any* situation.

### How was it fixed?

Deleted it.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pixfeeds.com/images/2/181315/1200-454090919-panda-eating-bamboo.jpg)
