### PR TITLE
Add a yaml file for Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,2 @@
+python:
+  version: 3.6

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,2 +1,2 @@
-python:
-  version: 3.6
+build:
+  image: latest


### PR DESCRIPTION
### What was wrong?
Read the Docs build is failing because it's running Python 3.5.2 and we specify that we need Python 3.5.3 or higher.


### How was it fixed?
Added a .readthedocs.yml file

#### Cute Animal Picture

![image7](https://user-images.githubusercontent.com/6540608/49971978-94aefb80-feed-11e8-8951-7be60971eab5.jpg)
