### PR TITLE
Remove 3.5 support and update eth-abiV2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,112 +109,6 @@ geth_steps: &geth_steps
 
 jobs:
   #
-  # Python 3.5
-  #
-  py35-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35-core
-
-  py35-core-eth_abi2:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35-core-eth_abi2
-
-  py35-ens:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35-ens
-
-  py35-integration-goethereum-ipc-1.7.2:
-    <<: *geth_steps
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35-integration-goethereum-ipc
-      GETH_VERSION: v1.7.2
-
-  py35-integration-goethereum-http-1.7.2:
-    <<: *geth_steps
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35-integration-goethereum-http
-      GETH_VERSION: v1.7.2
-
-  py35-integration-goethereum-ws-1.7.2:
-    <<: *geth_steps
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35-integration-goethereum-ws
-      GETH_VERSION: v1.7.2
-
-  py35-integration-goethereum-ipc-1.8.1:
-    <<: *geth_steps
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35-integration-goethereum-ipc
-      GETH_VERSION: v1.8.1
-
-  py35-integration-goethereum-http-1.8.1:
-    <<: *geth_steps
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35-integration-goethereum-http
-      GETH_VERSION: v1.8.1
-
-  py35-integration-goethereum-ws-1.8.1:
-    <<: *geth_steps
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35-integration-goethereum-ws
-      GETH_VERSION: v1.8.1
-
-  py35-integration-parity-ipc:
-    <<: *parity_steps
-    docker:
-      - image: circleci/python:3.5-jessie
-    environment:
-      TOXENV: py35-integration-parity-ipc
-      PARITY_VERSION: v1.11.11
-      PARITY_OS: debian
-
-  py35-integration-parity-http:
-    <<: *parity_steps
-    docker:
-      - image: circleci/python:3.5-jessie
-    environment:
-      TOXENV: py35-integration-parity-http
-      PARITY_VERSION: v1.11.11
-      PARITY_OS: debian
-
-  py35-integration-parity-ws:
-    <<: *parity_steps
-    docker:
-      - image: circleci/python:3.5-jessie
-    environment:
-      TOXENV: py35-integration-parity-ws
-      PARITY_VERSION: v1.11.11
-      PARITY_OS: debian
-
-  py35-integration-ethtester-pyevm:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-    environment:
-      TOXENV: py35-integration-ethtester
-      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
-  #
   # Python 3.6
   #
   lint:
@@ -237,13 +131,6 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-core
-
-  py36-core-eth_abi2:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-    environment:
-      TOXENV: py36-core-eth_abi2
 
   py36-ens:
     <<: *common
@@ -344,13 +231,6 @@ jobs:
     environment:
       TOXENV: py37-core
 
-  py37-core-eth_abi2:
-    <<: *common
-    docker:
-      - image: circleci/python:3.7
-    environment:
-      TOXENV: py37-core-eth_abi2
-
   py37-ens:
     <<: *common
     docker:
@@ -447,20 +327,6 @@ workflows:
     jobs:
       - lint
       - doctest
-      - py35-core-eth_abi2
-      - py35-core
-      - py35-ens
-      - py35-integration-goethereum-ipc-1.7.2
-      - py35-integration-goethereum-http-1.7.2
-      - py35-integration-goethereum-ws-1.7.2
-      - py35-integration-goethereum-ipc-1.8.1
-      - py35-integration-goethereum-http-1.8.1
-      - py35-integration-goethereum-ws-1.8.1
-      - py35-integration-parity-ipc
-      - py35-integration-parity-http
-      - py35-integration-parity-ws
-      - py35-integration-ethtester-pyevm
-      - py36-core-eth_abi2
       - py36-core
       - py36-ens
       - py36-integration-goethereum-ipc-1.7.2
@@ -473,7 +339,6 @@ workflows:
       - py36-integration-parity-http
       - py36-integration-parity-ws
       - py36-integration-ethtester-pyevm
-      - py37-core-eth_abi2
       - py37-core
       - py37-ens
       - py37-integration-goethereum-ipc-1.7.2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Python implementation of [web3.js](https://github.com/ethereum/web3.js)
 
-* Python 3.5+ support
+* Python 3.6+ support
 
 Read more in the [documentation on ReadTheDocs](http://web3py.readthedocs.io/). [View the change log on Github](docs/releases.rst).
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     install_requires=[
         "toolz>=0.9.0,<1.0.0;implementation_name=='pypy'",
         "cytoolz>=0.9.0,<1.0.0;implementation_name=='cpython'",
-        "eth-abi>=1.2.0,<2.0.0",
+        "eth-abi>=2.0.0a1,<3.0.0",
         "eth-account>=0.2.1,<0.4.0",
         "eth-utils>=1.2.0,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
@@ -81,7 +81,7 @@ setup(
         "pypiwin32>=223;platform_system=='Windows'",
     ],
     setup_requires=['setuptools-markdown'],
-    python_requires='>=3.5.3,<4',
+    python_requires='>=3.6,<4',
     extras_require=extras_require,
     py_modules=['web3', 'ens'],
     license="MIT",
@@ -94,7 +94,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist=
-    py{35,36,37}-ens
-    py{35,36,37}-core
-    py{35,36,37}-core-eth_abi2
-    py{35,36,37}-integration-{goethereum,ethtester,parity}
+    py{36,37}-ens
+    py{36,37}-core
+    py{36,37}-integration-{goethereum,ethtester,parity}
     lint
     doctest
 
@@ -27,7 +26,6 @@ ignore=
 [testenv]
 usedevelop=True
 commands=
-    eth_abi2: pip install --upgrade --force-reinstall eth-abi~=2.0.0b1
     core: pytest {posargs:tests/core}
     ens: pytest {posargs:tests/ens}
     integration-goethereum-ipc: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py}
@@ -53,7 +51,6 @@ passenv =
     GOPATH
 basepython =
     doctest: python3.6
-    py35: python3.5
     py36: python3.6
     py37: python3.7
 


### PR DESCRIPTION
### What was wrong?
Updated to make some of the dependency changes I understood are happening in v5.
- Remove python 3.5 support
- Update to eth-abiV2 (and remove explicit eth-abiV2 environment tests)

If I'm mistaken, or forgot something, ping!

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/49994042-b8734f80-ff88-11e8-98a2-a9beaf092b6c.png)
