### PR TITLE
Use Twine for release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ release: clean
 	git config commit.gpgSign true
 	bumpversion $(bump)
 	git push upstream && git push upstream --tags
-	python setup.py sdist bdist_wheel upload
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
 dist: clean

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ extras_require = {
         "setuptools>=36.2.0",
         "tox>=1.8.0",
         "tqdm",
+        "twine",
         "when-changed"
     ]
 }


### PR DESCRIPTION
### What was wrong?
I kept running into problems with my password without using Twine, but with Twine, it would work fine. 

### How was it fixed?
Added twine dependency and updated release script to use Twine

#### Cute Animal Picture
![cea47948781ca0ae95635c512a8a85c2](https://user-images.githubusercontent.com/6540608/50017663-0046a680-ff8a-11e8-8078-f814c006073d.jpg)

