### PR TITLE
bugfix: use custom Web3.RequestManager if set

### DIFF
--- a/web3/main.py
+++ b/web3/main.py
@@ -44,7 +44,7 @@ from web3.iban import (
     Iban,
 )
 from web3.manager import (
-    RequestManager,
+    RequestManager as DefaultRequestManager,
 )
 from web3.miner import (
     Miner,
@@ -107,7 +107,7 @@ class Web3:
     WebsocketProvider = WebsocketProvider
 
     # Managers
-    RequestManager = RequestManager
+    RequestManager = DefaultRequestManager
 
     # Iban
     Iban = Iban
@@ -128,7 +128,7 @@ class Web3:
     toChecksumAddress = staticmethod(to_checksum_address)
 
     def __init__(self, providers=empty, middlewares=None, modules=None, ens=empty):
-        self.manager = RequestManager(self, providers, middlewares)
+        self.manager = self.RequestManager(self, providers, middlewares)
 
         if modules is None:
             modules = get_default_modules()


### PR DESCRIPTION
### What was wrong?

If someone sets a custom `Web3.RequestManager`, it is ignored.

### How was it fixed?

@dylanjw found in #1088 which was just closed (unmerged)

I renamed the default `RequestManager` so that the current bug with naming reuse couldn't be reintroduced easily.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/1f/85/1c/1f851c59a5fe4d69daf73fef8fcd91a0.jpg)
