### PR TITLE
Adds Web3.toJSON per #782

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -163,6 +163,18 @@ Type Conversions
         >>> Web3.toInt(hexstr='000F')
         15
 
+.. py:method:: Web3.toJSON(obj)
+
+    Takes a variety of inputs and returns its JSON equivalent.
+
+
+    .. code-block:: python
+
+        >>> Web3.toJSON(3)
+        '3'
+        >>> Web3.toJSON({'one': 1})
+        '{"one": 1}'
+
 .. _overview_currency_conversions:
 
 Currency Conversions

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -201,7 +201,11 @@ def test_to_hex_cleanup_only(val, expected):
     (
         (AttributeDict({'one': HexBytes('0x1')}), '{"one": "0x01"}'),
         (AttributeDict({'two': HexBytes(2)}), '{"two": "0x02"}'),
-        (AttributeDict({'three': AttributeDict({ 'four': 4 })}), '{"three": {"four": 4}}'),
+        (AttributeDict({
+            'three': AttributeDict({
+                'four': 4
+            })
+        }), '{"three": {"four": 4}}'),
         ({'three': 3}, '{"three": 3}'),
     ),
 )
@@ -214,12 +218,16 @@ def test_to_json(val, expected):
     (
         (
             AttributeDict({
-                'blockHash': HexBytes('0x849044202a39ae36888481f90d62c3826bca8269c2716d7a38696b4f45e61d83'),
+                'blockHash': HexBytes(
+                    '0x849044202a39ae36888481f90d62c3826bca8269c2716d7a38696b4f45e61d83'
+                ),
                 'blockNumber': 6928809,
                 'from': '0xDEA141eF43A2fdF4e795adA55958DAf8ef5FA619',
                 'gas': 21000,
                 'gasPrice': 19110000000,
-                'hash': HexBytes('0x1ccddd19830e998d7cf4d921b19fafd5021c9d4c4ba29680b66fb535624940fc'),
+                'hash': HexBytes(
+                    '0x1ccddd19830e998d7cf4d921b19fafd5021c9d4c4ba29680b66fb535624940fc'
+                ),
                 'input': '0x',
                 'nonce': 5522,
                 'r': HexBytes('0x71ef3eed6242230a219d9dc7737cb5a3a16059708ee322e96b8c5774105b9b00'),
@@ -229,7 +237,7 @@ def test_to_json(val, expected):
                 'v': 27,
                 'value': 2907000000000000
             }),
-            '{"blockHash": "0x849044202a39ae36888481f90d62c3826bca8269c2716d7a38696b4f45e61d83", "blockNumber": 6928809, "from": "0xDEA141eF43A2fdF4e795adA55958DAf8ef5FA619", "gas": 21000, "gasPrice": 19110000000, "hash": "0x1ccddd19830e998d7cf4d921b19fafd5021c9d4c4ba29680b66fb535624940fc", "input": "0x", "nonce": 5522, "r": "0x71ef3eed6242230a219d9dc7737cb5a3a16059708ee322e96b8c5774105b9b00", "s": "0x48a076afe10b4e1ae82ef82b747e9be64e0bbb1cc90e173db8d53e7baba8ac46", "to": "0x3a84E09D30476305Eda6b2DA2a4e199E2Dd1bf79", "transactionIndex": 8, "v": 27, "value": 2907000000000000}'
+            '{"blockHash": "0x849044202a39ae36888481f90d62c3826bca8269c2716d7a38696b4f45e61d83", "blockNumber": 6928809, "from": "0xDEA141eF43A2fdF4e795adA55958DAf8ef5FA619", "gas": 21000, "gasPrice": 19110000000, "hash": "0x1ccddd19830e998d7cf4d921b19fafd5021c9d4c4ba29680b66fb535624940fc", "input": "0x", "nonce": 5522, "r": "0x71ef3eed6242230a219d9dc7737cb5a3a16059708ee322e96b8c5774105b9b00", "s": "0x48a076afe10b4e1ae82ef82b747e9be64e0bbb1cc90e173db8d53e7baba8ac46", "to": "0x3a84E09D30476305Eda6b2DA2a4e199E2Dd1bf79", "transactionIndex": 8, "v": 27, "value": 2907000000000000}'  # noqa: E501
         ),
     ),
 )

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -195,22 +195,39 @@ def test_to_hex_text(val, expected):
 def test_to_hex_cleanup_only(val, expected):
     assert Web3.toHex(hexstr=val) == expected
 
+
 @pytest.mark.parametrize(
     'val, expected',
     (
-        (AttributeDict({ 'one': HexBytes('0x1') }), '{"one": "0x01"}'),
-        (AttributeDict({ 'two': HexBytes(2) }), '{"two": "0x02"}'),
-        ({ 'three': 3 }, '{"three": 3}'),
+        (AttributeDict({'one': HexBytes('0x1')}), '{"one": "0x01"}'),
+        (AttributeDict({'two': HexBytes(2)}), '{"two": "0x02"}'),
+        ({'three': 3}, '{"three": 3}'),
     ),
 )
 def test_to_json(val, expected):
     assert Web3.toJSON(val) == expected
 
+
 @pytest.mark.parametrize(
     'tx, expected',
     (
         (
-            AttributeDict({'blockHash': HexBytes('0x849044202a39ae36888481f90d62c3826bca8269c2716d7a38696b4f45e61d83'), 'blockNumber': 6928809, 'from': '0xDEA141eF43A2fdF4e795adA55958DAf8ef5FA619', 'gas': 21000, 'gasPrice': 19110000000, 'hash': HexBytes('0x1ccddd19830e998d7cf4d921b19fafd5021c9d4c4ba29680b66fb535624940fc'), 'input': '0x', 'nonce': 5522, 'r': HexBytes('0x71ef3eed6242230a219d9dc7737cb5a3a16059708ee322e96b8c5774105b9b00'), 's': HexBytes('0x48a076afe10b4e1ae82ef82b747e9be64e0bbb1cc90e173db8d53e7baba8ac46'), 'to': '0x3a84E09D30476305Eda6b2DA2a4e199E2Dd1bf79', 'transactionIndex': 8, 'v': 27, 'value': 2907000000000000}),
+            AttributeDict({
+                'blockHash': HexBytes('0x849044202a39ae36888481f90d62c3826bca8269c2716d7a38696b4f45e61d83'),
+                'blockNumber': 6928809,
+                'from': '0xDEA141eF43A2fdF4e795adA55958DAf8ef5FA619',
+                'gas': 21000,
+                'gasPrice': 19110000000,
+                'hash': HexBytes('0x1ccddd19830e998d7cf4d921b19fafd5021c9d4c4ba29680b66fb535624940fc'),
+                'input': '0x',
+                'nonce': 5522,
+                'r': HexBytes('0x71ef3eed6242230a219d9dc7737cb5a3a16059708ee322e96b8c5774105b9b00'),
+                's': HexBytes('0x48a076afe10b4e1ae82ef82b747e9be64e0bbb1cc90e173db8d53e7baba8ac46'),
+                'to': '0x3a84E09D30476305Eda6b2DA2a4e199E2Dd1bf79',
+                'transactionIndex': 8,
+                'v': 27,
+                'value': 2907000000000000
+            }),
             '{"blockHash": "0x849044202a39ae36888481f90d62c3826bca8269c2716d7a38696b4f45e61d83", "blockNumber": 6928809, "from": "0xDEA141eF43A2fdF4e795adA55958DAf8ef5FA619", "gas": 21000, "gasPrice": 19110000000, "hash": "0x1ccddd19830e998d7cf4d921b19fafd5021c9d4c4ba29680b66fb535624940fc", "input": "0x", "nonce": 5522, "r": "0x71ef3eed6242230a219d9dc7737cb5a3a16059708ee322e96b8c5774105b9b00", "s": "0x48a076afe10b4e1ae82ef82b747e9be64e0bbb1cc90e173db8d53e7baba8ac46", "to": "0x3a84E09D30476305Eda6b2DA2a4e199E2Dd1bf79", "transactionIndex": 8, "v": 27, "value": 2907000000000000}'
         ),
     ),

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -201,6 +201,7 @@ def test_to_hex_cleanup_only(val, expected):
     (
         (AttributeDict({'one': HexBytes('0x1')}), '{"one": "0x01"}'),
         (AttributeDict({'two': HexBytes(2)}), '{"two": "0x02"}'),
+        (AttributeDict({'three': AttributeDict({ 'four': 4 })}), '{"three": {"four": 4}}'),
         ({'three': 3}, '{"three": 3}'),
     ),
 )

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -3,6 +3,8 @@
 import pytest
 
 from web3 import Web3
+from web3.datastructures import AttributeDict
+from hexbytes import HexBytes
 
 
 @pytest.mark.parametrize(
@@ -192,3 +194,26 @@ def test_to_hex_text(val, expected):
 )
 def test_to_hex_cleanup_only(val, expected):
     assert Web3.toHex(hexstr=val) == expected
+
+@pytest.mark.parametrize(
+    'val, expected',
+    (
+        (AttributeDict({ 'one': HexBytes('0x1') }), '{"one": "0x01"}'),
+        (AttributeDict({ 'two': HexBytes(2) }), '{"two": "0x02"}'),
+        ({ 'three': 3 }, '{"three": 3}'),
+    ),
+)
+def test_to_json(val, expected):
+    assert Web3.toJSON(val) == expected
+
+@pytest.mark.parametrize(
+    'tx, expected',
+    (
+        (
+            AttributeDict({'blockHash': HexBytes('0x849044202a39ae36888481f90d62c3826bca8269c2716d7a38696b4f45e61d83'), 'blockNumber': 6928809, 'from': '0xDEA141eF43A2fdF4e795adA55958DAf8ef5FA619', 'gas': 21000, 'gasPrice': 19110000000, 'hash': HexBytes('0x1ccddd19830e998d7cf4d921b19fafd5021c9d4c4ba29680b66fb535624940fc'), 'input': '0x', 'nonce': 5522, 'r': HexBytes('0x71ef3eed6242230a219d9dc7737cb5a3a16059708ee322e96b8c5774105b9b00'), 's': HexBytes('0x48a076afe10b4e1ae82ef82b747e9be64e0bbb1cc90e173db8d53e7baba8ac46'), 'to': '0x3a84E09D30476305Eda6b2DA2a4e199E2Dd1bf79', 'transactionIndex': 8, 'v': 27, 'value': 2907000000000000}),
+            '{"blockHash": "0x849044202a39ae36888481f90d62c3826bca8269c2716d7a38696b4f45e61d83", "blockNumber": 6928809, "from": "0xDEA141eF43A2fdF4e795adA55958DAf8ef5FA619", "gas": 21000, "gasPrice": 19110000000, "hash": "0x1ccddd19830e998d7cf4d921b19fafd5021c9d4c4ba29680b66fb535624940fc", "input": "0x", "nonce": 5522, "r": "0x71ef3eed6242230a219d9dc7737cb5a3a16059708ee322e96b8c5774105b9b00", "s": "0x48a076afe10b4e1ae82ef82b747e9be64e0bbb1cc90e173db8d53e7baba8ac46", "to": "0x3a84E09D30476305Eda6b2DA2a4e199E2Dd1bf79", "transactionIndex": 8, "v": 27, "value": 2907000000000000}'
+        ),
+    ),
+)
+def test_to_json_with_transaction(tx, expected):
+    assert Web3.toJSON(tx) == expected

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -2,9 +2,14 @@
 
 import pytest
 
+from hexbytes import (
+    HexBytes,
+)
+
 from web3 import Web3
-from web3.datastructures import AttributeDict
-from hexbytes import HexBytes
+from web3.datastructures import (
+    AttributeDict,
+)
 
 
 @pytest.mark.parametrize(

--- a/web3/_utils/encoding.py
+++ b/web3/_utils/encoding.py
@@ -2,8 +2,6 @@
 import json
 import re
 
-from hexbytes import HexBytes
-
 from eth_abi.encoding import (
     BaseArrayEncoder,
 )
@@ -21,8 +19,9 @@ from eth_utils import (
     remove_0x_prefix,
     to_hex,
 )
-
-from web3.datastructures import AttributeDict
+from hexbytes import (
+    HexBytes,
+)
 
 from web3._utils.abi import (
     is_address_type,
@@ -42,6 +41,9 @@ from web3._utils.validation import (
     assert_one_val,
     validate_abi_type,
     validate_abi_value,
+)
+from web3.datastructures import (
+    AttributeDict,
 )
 
 

--- a/web3/_utils/encoding.py
+++ b/web3/_utils/encoding.py
@@ -318,7 +318,7 @@ def encode_single_packed(_type, value):
 class Web3JsonEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, AttributeDict):
-            return { k: v for k,v in obj.items() }
+            return {k: v for k, v in obj.items()}
         if isinstance(obj, HexBytes):
             return obj.hex()
         return json.JSONEncoder.default(self, obj)

--- a/web3/main.py
+++ b/web3/main.py
@@ -30,6 +30,7 @@ from web3._utils.encoding import (
     to_hex,
     to_int,
     to_text,
+    to_json,
 )
 from web3._utils.normalizers import (
     abi_ens_resolver,
@@ -117,6 +118,7 @@ class Web3:
     toInt = staticmethod(to_int)
     toHex = staticmethod(to_hex)
     toText = staticmethod(to_text)
+    toJSON = staticmethod(to_json)
 
     # Currency Utility
     toWei = staticmethod(to_wei)


### PR DESCRIPTION
### What was wrong?

Related to Issue #782

### How was it fixed?

Added `Web3.toJSON()` and accompanying tests.  Basically, this extends the standard `json.JSONEncoder` to support `HexBytes` and `web3.datastructures.AttributeDict` and adds a static method to the `Web3` object that utilizes it.

This is my first PR for this project, so please tear it apart. 

It would probably be good to get some more test cases, as well.  In what other ways might a user use `Web3.toJSON()`?  Should there be more supported types?  In what ways should it *not* work?

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.vyperlook.com/wp-content/uploads/2012/03/Ugliest-animal-in-the-world.jpg)
