### PR TITLE
Migrate tester provider results from middleware to defaults

### DIFF
--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -157,20 +157,20 @@ API_ENDPOINTS = {
         ),
     },
     'net': {
-        'version': not_implemented,
-        'peerCount': not_implemented,
-        'listening': not_implemented,
+        'version': static_return('1'),
+        'peerCount': static_return(0),
+        'listening': static_return(False),
     },
     'eth': {
-        'protocolVersion': not_implemented,
-        'syncing': not_implemented,
+        'protocolVersion': static_return('63'),
+        'syncing': static_return(False),
         'coinbase': compose(
             operator.itemgetter(0),
             call_eth_tester('get_accounts'),
         ),
-        'mining': not_implemented,
-        'hashrate': not_implemented,
-        'gasPrice': not_implemented,
+        'mining': static_return(False),
+        'hashrate': static_return(0),
+        'gasPrice': static_return(1),
         'accounts': call_eth_tester('get_accounts'),
         'blockNumber': compose(
             operator.itemgetter('number'),

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -4,7 +4,6 @@ from web3.providers import (
 
 from .middleware import (
     default_transaction_fields_middleware,
-    ethereum_tester_fixture_middleware,
     ethereum_tester_middleware,
 )
 
@@ -12,7 +11,6 @@ from .middleware import (
 class EthereumTesterProvider(BaseProvider):
     middlewares = [
         default_transaction_fields_middleware,
-        ethereum_tester_fixture_middleware,
         ethereum_tester_middleware,
     ]
     ethereum_tester = None

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -28,7 +28,6 @@ from web3._utils.toolz import (
     pipe,
 )
 from web3.middleware import (
-    construct_fixture_middleware,
     construct_formatting_middleware,
 )
 
@@ -257,20 +256,6 @@ ethereum_tester_middleware = construct_formatting_middleware(
         'evm_snapshot': integer_to_hex,
     },
 )
-
-
-ethereum_tester_fixture_middleware = construct_fixture_middleware({
-    # Eth
-    'eth_protocolVersion': '63',
-    'eth_hashrate': 0,
-    'eth_gasPrice': 1,
-    'eth_syncing': False,
-    'eth_mining': False,
-    # Net
-    'net_version': '1',
-    'net_listening': False,
-    'net_peerCount': 0,
-})
 
 
 def guess_from(web3, transaction):


### PR DESCRIPTION
### What was wrong?
Many of default results for the EthereumTesterProvider come from a set of special middlewares. Eliminating these middlewares will reduce the number of middlewares that need to be duplicated for async support. Having these middlewares eliminated will also help with testing the early stages of the async api, which implements no middlewares.

Before I get too far with this, does this seem like an acceptable way forward? Should I continue eliminating the rest of the eth_tester middlewares? is there any reason that these results and formatters need the middleware pattern?  Removing them does not preclude using custom middlewares to alter the EthereumTesterProvider defaults. 

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/8933231/50797751-b308dc80-128a-11e9-88a4-6577597009ca.png)

