### PR TITLE
Drop repeated RPC endpoints (V5 beta)

### DIFF
--- a/docs/web3.miner.rst
+++ b/docs/web3.miner.rst
@@ -9,26 +9,6 @@ The ``web3.miner`` object exposes methods to interact with the RPC APIs under
 the ``miner_`` namespace.
 
 
-Properties
-----------
-
-The following properties are available on the ``web3.miner`` namespace.
-
-.. py:attribute:: Miner.hashrate
-
-    * Delegates to ``eth_hashrate`` RPC Method
-
-    Returns the current number of hashes per second the node is mining with.
-
-    .. code-block:: python
-
-        >>> web3.eth.hashrate
-        906
-
-
-    .. note:: This property is an alias to ``web3.eth.hashrate``.
-
-
 Methods
 -------
 

--- a/docs/web3.version.rst
+++ b/docs/web3.version.rst
@@ -37,18 +37,6 @@ The following properties are available on the ``web3.eth`` namespace.
         'Geth/v1.4.11-stable-fed692f6/darwin/go1.7'
 
 
-.. py:method:: Version.network(self)
-
-    * Delegates to ``net_version`` RPC Method
-
-    Returns the current network protocol version.
-
-    .. code-block:: python
-
-        >>> web3.version.network
-        1
-
-
 .. py:method:: Version.ethereum(self)
 
     * Delegates to ``eth_protocolVersion`` RPC Method

--- a/tests/core/mining-module/conftest.py
+++ b/tests/core/mining-module/conftest.py
@@ -11,4 +11,3 @@ def always_wait_for_mining_start(web3,
 
     assert web3.eth.mining
     assert web3.eth.hashrate
-    assert web3.miner.hashrate

--- a/tests/core/mining-module/test_miner_hashrate.py
+++ b/tests/core/mining-module/test_miner_hashrate.py
@@ -7,5 +7,5 @@ from flaky import (
 def test_miner_hashrate(web3_empty, wait_for_miner_start):
     web3 = web3_empty
 
-    hashrate = web3.miner.hashrate
+    hashrate = web3.eth.hashrate
     assert hashrate > 0

--- a/tests/core/mining-module/test_miner_start.py
+++ b/tests/core/mining-module/test_miner_start.py
@@ -15,7 +15,7 @@ def test_miner_start(web3_empty, wait_for_miner_start):
 
     # sanity
     assert web3.eth.mining
-    assert web3.miner.hashrate
+    assert web3.eth.hashrate
 
     web3.miner.stop()
 
@@ -24,11 +24,11 @@ def test_miner_start(web3_empty, wait_for_miner_start):
             timeout.sleep(random.random())
 
     assert not web3.eth.mining
-    assert not web3.miner.hashrate
+    assert not web3.eth.hashrate
 
     web3.miner.start(1)
 
     wait_for_miner_start(web3)
 
     assert web3.eth.mining
-    assert web3.miner.hashrate
+    assert web3.eth.hashrate

--- a/tests/core/mining-module/test_miner_stop.py
+++ b/tests/core/mining-module/test_miner_stop.py
@@ -14,7 +14,7 @@ def test_miner_stop(web3_empty):
     web3 = web3_empty
 
     assert web3.eth.mining
-    assert web3.miner.hashrate
+    assert web3.eth.hashrate
 
     web3.miner.stop()
 
@@ -24,4 +24,4 @@ def test_miner_stop(web3_empty):
             timeout.check()
 
     assert not web3.eth.mining
-    assert not web3.miner.hashrate
+    assert not web3.eth.hashrate

--- a/tests/core/txpool-module/conftest.py
+++ b/tests/core/txpool-module/conftest.py
@@ -11,4 +11,3 @@ def skip_testrpc_and_wait_for_mining_start(web3,
 
     assert web3.eth.mining
     assert web3.eth.hashrate
-    assert web3.miner.hashrate

--- a/tests/core/txpool-module/test_txpool_content.py
+++ b/tests/core/txpool-module/test_txpool_content.py
@@ -11,7 +11,7 @@ def test_txpool_content(web3_empty):
     web3.miner.stop()
 
     with Timeout(60) as timeout:
-        while web3.miner.hashrate or web3.eth.mining:
+        while web3.eth.hashrate or web3.eth.mining:
             timeout.sleep(random.random())
 
     txn_1_hash = web3.eth.sendTransaction({

--- a/tests/core/txpool-module/test_txpool_inspect.py
+++ b/tests/core/txpool-module/test_txpool_inspect.py
@@ -11,7 +11,7 @@ def test_txpool_inspect(web3_empty):
     web3.miner.stop()
 
     with Timeout(60) as timeout:
-        while web3.miner.hashrate or web3.eth.mining:
+        while web3.eth.hashrate or web3.eth.mining:
             timeout.sleep(random.random())
 
     txn_1_hash = web3.eth.sendTransaction({

--- a/web3/_utils/module_testing/version_module.py
+++ b/web3/_utils/module_testing/version_module.py
@@ -4,12 +4,6 @@ from eth_utils import (
 
 
 class VersionModuleTest:
-    def test_net_version(self, web3):
-        version = web3.version.network
-
-        assert is_string(version)
-        assert version.isdigit()
-
     def test_eth_protocolVersion(self, web3):
         protocol_version = web3.version.ethereum
 

--- a/web3/miner.py
+++ b/web3/miner.py
@@ -4,10 +4,6 @@ from web3.module import (
 
 
 class Miner(Module):
-    @property
-    def hashrate(self):
-        return self.web3.manager.request_blocking("eth_hashrate", [])
-
     def makeDAG(self, number):
         return self.web3.manager.request_blocking("miner_makeDag", [number])
 

--- a/web3/version.py
+++ b/web3/version.py
@@ -14,9 +14,5 @@ class Version(Module):
         return self.web3.manager.request_blocking("web3_clientVersion", [])
 
     @property
-    def network(self):
-        return self.web3.manager.request_blocking("net_version", [])
-
-    @property
     def ethereum(self):
         return self.web3.manager.request_blocking("eth_protocolVersion", [])


### PR DESCRIPTION
### What was wrong?
Duplicate web3 endpoints for the same RPC endpoint

Fixes #1026 

### How was it fixed?
Removed...
- `web3.mining.hashrate` which was a duplicate for `web3.eth.hashrate` (RPC endpoint = `eth_hashrate`)
- `web3.version.network` which was a duplicate for `web3.net.version` (RPC endpoint = `net_version`)

These two were the only obvious conflicts I noticed

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/51034112-e2c72580-15a5-11e9-87cc-9df5063cb6c0.png)
