### PR TITLE
Drop auto detect testnets for IPCProvider

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -95,7 +95,10 @@ Web3 attempts to connect to nodes in the following order, using the first
 succesful connection it can make:
 
 1. The connection specified by an environment variable, see :ref:`provider_uri`
-2. :class:`~web3.providers.ipc.IPCProvider`, which looks for several IPC file locations
+2. :class:`~web3.providers.ipc.IPCProvider`, which looks for several IPC file locations.
+   `IPCProvider` will not automatically detect a testnet connection, it is suggested that the
+    user instead uses a `w3` instance from `web3.auto.infura` (eg.
+    `from web3.auto.infura.ropsten import w3`) if they want to auto-detect a testnet.
 3. :class:`~web3.providers.rpc.HTTPProvider`, which attempts to connect to "http://localhost:8545"
 4. None - if no providers are successful, you can still use Web3 APIs
    that do not require a connection, like:

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -66,18 +66,12 @@ class PersistantSocket:
         return self.sock
 
 
-def get_default_ipc_path(testnet=False):
-    if testnet:
-        testnet = "testnet"
-    else:
-        testnet = ""
-
+def get_default_ipc_path():
     if sys.platform == 'darwin':
         ipc_path = os.path.expanduser(os.path.join(
             "~",
             "Library",
             "Ethereum",
-            testnet,
             "geth.ipc"
         ))
         if os.path.exists(ipc_path):
@@ -94,16 +88,14 @@ def get_default_ipc_path(testnet=False):
             return ipc_path
 
         base_trinity_path = Path('~').expanduser() / '.local' / 'share' / 'trinity'
-        if not testnet:
-            ipc_path = base_trinity_path / 'mainnet' / 'jsonrpc.ipc'
-            if ipc_path.exists():
-                return str(ipc_path)
+        ipc_path = base_trinity_path / 'mainnet' / 'jsonrpc.ipc'
+        if ipc_path.exists():
+            return str(ipc_path)
 
     elif sys.platform.startswith('linux') or sys.platform.startswith('freebsd'):
         ipc_path = os.path.expanduser(os.path.join(
             "~",
             ".ethereum",
-            testnet,
             "geth.ipc"
         ))
         if os.path.exists(ipc_path):
@@ -120,10 +112,9 @@ def get_default_ipc_path(testnet=False):
             return ipc_path
 
         base_trinity_path = Path('~').expanduser() / '.local' / 'share' / 'trinity'
-        if not testnet:
-            ipc_path = base_trinity_path / 'mainnet' / 'jsonrpc.ipc'
-            if ipc_path.exists():
-                return str(ipc_path)
+        ipc_path = base_trinity_path / 'mainnet' / 'jsonrpc.ipc'
+        if ipc_path.exists():
+            return str(ipc_path)
 
     elif sys.platform == 'win32':
         ipc_path = os.path.join(
@@ -199,9 +190,9 @@ class IPCProvider(JSONBaseProvider):
     logger = logging.getLogger("web3.providers.IPCProvider")
     _socket = None
 
-    def __init__(self, ipc_path=None, testnet=False, timeout=10, *args, **kwargs):
+    def __init__(self, ipc_path=None, timeout=10, *args, **kwargs):
         if ipc_path is None:
-            self.ipc_path = get_default_ipc_path(testnet)
+            self.ipc_path = get_default_ipc_path()
         else:
             if isinstance(ipc_path, Path):
                 ipc_path = str(ipc_path.resolve())


### PR DESCRIPTION
### What was wrong?
From `Planned v5 changes` issue

> Stop automatically looking up a testnet connection in IPCProvider. Indicate that users should use something like from web3.auto.ropsten import w3 instead, if they want to auto-detect a testnet.

Related to Issue #722 

### How was it fixed?
Removed the `testnet` flag from `get_default_ipc_path`, and added a comment in the docs

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/51115304-2caf4600-1808-11e9-9568-cf82de0e019d.png)

