### PR TITLE
Drop deprecated `web3.sha3` method

### DIFF
--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -302,5 +302,5 @@ To sign a transaction locally that will invoke a smart contract:
     >>> w3.eth.sendRawTransaction(signed_txn.rawTransaction)  # doctest: +SKIP
 
     # When you run sendRawTransaction, you get the same result as the hash of the transaction:
-    >>> w3.toHex(w3.sha3(signed_txn.rawTransaction))
+    >>> w3.toHex(w3.keccak(signed_txn.rawTransaction))
     '0x4795adc6a719fa64fa21822630c0218c04996e2689ded114b6553cef1ae36618'

--- a/tests/core/web3-module/test_keccak.py
+++ b/tests/core/web3-module/test_keccak.py
@@ -21,18 +21,6 @@ def test_keccak_text(message, digest):
 
 
 @pytest.mark.parametrize(
-    'message, digest',
-    [
-        ('cowmö', HexBytes('0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8')),
-        ('', HexBytes('0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')),
-    ],
-)
-def test_sha3_text(message, digest):
-    with pytest.deprecated_call():
-        assert Web3.sha3(text=message) == digest
-
-
-@pytest.mark.parametrize(
     'hexstr, digest',
     [
         (
@@ -55,32 +43,6 @@ def test_sha3_text(message, digest):
 )
 def test_keccak_hexstr(hexstr, digest):
     assert Web3.keccak(hexstr=hexstr) == digest
-
-
-@pytest.mark.parametrize(
-    'hexstr, digest',
-    [
-        (
-            '0x636f776dc3b6',
-            HexBytes('0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8')
-        ),
-        (
-            '636f776dc3b6',
-            HexBytes('0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8')
-        ),
-        (
-            '0x',
-            HexBytes('0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
-        ),
-        (
-            '',
-            HexBytes('0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470')
-        ),
-    ],
-)
-def test_sha3_hexstr(hexstr, digest):
-    with pytest.deprecated_call():
-        assert Web3.sha3(hexstr=hexstr) == digest
 
 
 @pytest.mark.parametrize(

--- a/web3/main.py
+++ b/web3/main.py
@@ -147,12 +147,6 @@ class Web3:
         self.manager.provider = provider
 
     @staticmethod
-    @deprecated_for("keccak")
-    @apply_to_return_value(HexBytes)
-    def sha3(primitive=None, text=None, hexstr=None):
-        return Web3.keccak(primitive, text, hexstr)
-
-    @staticmethod
     @apply_to_return_value(HexBytes)
     def keccak(primitive=None, text=None, hexstr=None):
         if isinstance(primitive, (bytes, int, type(None))):


### PR DESCRIPTION
### What was wrong?
From `Planned v5 changes` issue...
> rename Web3.sha3 to Web3.keccak

Related to Issue #722

### How was it fixed?
Dropped the already deprecated `web3.sha3` method.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/51116069-50738b80-180a-11e9-8de4-b3ebb7589b88.png)

