### PR TITLE
Rename middleware_stack to middleware_onion

### DIFF
--- a/docs/gas_price.rst
+++ b/docs/gas_price.rst
@@ -112,6 +112,6 @@ Available gas price strategies
         w3 = Web3()
         w3.eth.setGasPriceStrategy(medium_gas_price_strategy)
 
-        w3.middleware_stack.add(middleware.time_based_cache_middleware)
-        w3.middleware_stack.add(middleware.latest_block_based_cache_middleware)
-        w3.middleware_stack.add(middleware.simple_cache_middleware)
+        w3.middleware_onion.add(middleware.time_based_cache_middleware)
+        w3.middleware_onion.add(middleware.latest_block_based_cache_middleware)
+        w3.middleware_onion.add(middleware.simple_cache_middleware)

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -197,7 +197,7 @@ middleware performs the following translations for requests and responses.
 * Numeric responses will be converted from their hexadecimal representations to
   their integer representations.
 
-The ``RequestManager`` object exposes the ``middleware_stack`` object to manage middlewares. It
+The ``RequestManager`` object exposes the ``middleware_onion`` object to manage middlewares. It
 is also exposed on the ``Web3`` object for convenience. That API is detailed in
 :ref:`Modifying_Middleware`.
 

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -142,12 +142,12 @@ to the request inside the innermost layer of the onion. Here is a (simplified) d
                                           Returned value in Web3.py
 
 
-The middlewares are maintained in ``Web3.middleware_stack``. See
+The middlewares are maintained in ``Web3.middleware_onion``. See
 below for the API.
 
 When specifying middlewares in a list, or retrieving the list of middlewares, they will
 be returned in the order of outermost layer first and innermost layer last. In the above
-example, that means that ``list(w3.middleware_stack)`` would return the middlewares in
+example, that means that ``list(w3.middleware_onion)`` would return the middlewares in
 the order of: ``[2, 1, 0]``.
 
 See "Internals: :ref:`internals__middlewares`" for a deeper dive to how middlewares work.
@@ -157,7 +157,7 @@ Middleware Stack API
 
 To add or remove items in different layers, use the following API:
 
-.. py:method:: Web3.middleware_stack.add(middleware, name=None)
+.. py:method:: Web3.middleware_onion.add(middleware, name=None)
 
     Middleware will be added to the outermost layer. That means the new middleware will modify the
     request first, and the response last. You can optionally name it with any hashable object,
@@ -166,27 +166,27 @@ To add or remove items in different layers, use the following API:
     .. code-block:: python
 
         >>> w3 = Web3(...)
-        >>> w3.middleware_stack.add(web3.middleware.pythonic_middleware)
+        >>> w3.middleware_onion.add(web3.middleware.pythonic_middleware)
         # or
-        >>> w3.middleware_stack.add(web3.middleware.pythonic_middleware, 'pythonic')
+        >>> w3.middleware_onion.add(web3.middleware.pythonic_middleware, 'pythonic')
 
-.. py:method:: Web3.middleware_stack.inject(middleware, name=None, layer=None)
+.. py:method:: Web3.middleware_onion.inject(middleware, name=None, layer=None)
 
     Inject a named middleware to an arbitrary layer.
 
     The current implementation only supports injection at the innermost or
     outermost layers. Note that injecting to the outermost layer is equivalent to calling
-    :meth:`Web3.middleware_stack.add` .
+    :meth:`Web3.middleware_onion.add` .
 
     .. code-block:: python
 
         # Either of these will put the pythonic middleware at the innermost layer
         >>> w3 = Web3(...)
-        >>> w3.middleware_stack.inject(web3.middleware.pythonic_middleware, layer=0)
+        >>> w3.middleware_onion.inject(web3.middleware.pythonic_middleware, layer=0)
         # or
-        >>> w3.middleware_stack.inject(web3.middleware.pythonic_middleware, 'pythonic', layer=0)
+        >>> w3.middleware_onion.inject(web3.middleware.pythonic_middleware, 'pythonic', layer=0)
 
-.. py:method:: Web3.middleware_stack.remove(middleware)
+.. py:method:: Web3.middleware_onion.remove(middleware)
 
     Middleware will be removed from whatever layer it was in. If you added the middleware with
     a name, use the name to remove it. If you added the middleware as an object, use the object
@@ -195,11 +195,11 @@ To add or remove items in different layers, use the following API:
     .. code-block:: python
 
         >>> w3 = Web3(...)
-        >>> w3.middleware_stack.remove(web3.middleware.pythonic_middleware)
+        >>> w3.middleware_onion.remove(web3.middleware.pythonic_middleware)
         # or
-        >>> w3.middleware_stack.remove('pythonic')
+        >>> w3.middleware_onion.remove('pythonic')
 
-.. py:method:: Web3.middleware_stack.replace(old_middleware, new_middleware)
+.. py:method:: Web3.middleware_onion.replace(old_middleware, new_middleware)
 
     Middleware will be replaced from whatever layer it was in. If the middleware was named, it will
     continue to have the same name. If it was un-named, then you will now reference it with the new
@@ -210,25 +210,25 @@ To add or remove items in different layers, use the following API:
         >>> from web3.middleware import pythonic_middleware, attrdict_middleware
         >>> w3 = Web3(...)
 
-        >>> w3.middleware_stack.replace(pythonic_middleware, attrdict_middleware)
+        >>> w3.middleware_onion.replace(pythonic_middleware, attrdict_middleware)
         # this is now referenced by the new middleware object, so to remove it:
-        >>> w3.middleware_stack.remove(attrdict_middleware)
+        >>> w3.middleware_onion.remove(attrdict_middleware)
 
         # or, if it was named
 
-        >>> w3.middleware_stack.replace('pythonic', attrdict_middleware)
+        >>> w3.middleware_onion.replace('pythonic', attrdict_middleware)
         # this is still referenced by the original name, so to remove it:
-        >>> w3.middleware_stack.remove('pythonic')
+        >>> w3.middleware_onion.remove('pythonic')
 
-.. py:method:: Web3.middleware_stack.clear()
+.. py:method:: Web3.middleware_onion.clear()
 
     Empty all the middlewares, including the default ones.
 
     .. code-block:: python
 
         >>> w3 = Web3(...)
-        >>> w3.middleware_stack.clear()
-        >>> assert len(w3.middleware_stack) == 0
+        >>> w3.middleware_onion.clear()
+        >>> assert len(w3.middleware_onion) == 0
 
 
 Optional Middleware
@@ -244,7 +244,7 @@ Web3 ships with non-default middleware, for your custom use. In addition to the 
 .. warning::
   This will
   *replace* the default middlewares. To keep the default functionality,
-  either use ``middleware_stack.add()`` from above, or add the default middlewares to your list of
+  either use ``middleware_onion.add()`` from above, or add the default middlewares to your list of
   new middlewares.
 
 Below is a list of built-in middleware, which is not enabled by default.
@@ -266,7 +266,7 @@ Stalecheck
     .. code-block:: python
 
         two_day_stalecheck = make_stalecheck_middleware(60 * 60 * 24 * 2)
-        web3.middleware_stack.add(two_day_stalecheck)
+        web3.middleware_onion.add(two_day_stalecheck)
 
     If the latest block in the blockchain is older than 2 days in this example, then the
     middleware will raise a ``StaleBlockchain`` exception on every call except
@@ -352,7 +352,7 @@ unique IPC location and loads the middleware:
     >>> from web3.middleware import geth_poa_middleware
 
     # inject the poa compatibility middleware to the innermost layer
-    >>> w3.middleware_stack.inject(geth_poa_middleware, layer=0)
+    >>> w3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     # confirm that the connection succeeded
     >>> w3.version.node
@@ -383,7 +383,7 @@ retrieved using JSON-RPC endpoints that don't rely on server state.
     >>> from web3 import Web3, EthereumTesterProvider
     >>> w3 = Web3(EthereumTesterProvider)
     >>> from web3.middleware import local_filter_middleware
-    >>> w3.middleware_stack.add(local_filter_middleware())
+    >>> w3.middleware_onion.add(local_filter_middleware())
 
     #  Normal block and log filter apis behave as before.
     >>> block_filter = w3.eth.filter("latest")
@@ -412,6 +412,6 @@ This middleware automatically captures transactions, signs them, and sends them 
    >>> from web3.middleware import construct_sign_and_send_raw_middleware
    >>> from eth_account import Account
    >>> acct = Account.create('KEYSMASH FJAFJKLDSKF7JKFDJ 1530')
-   >>> w3.middleware_stack.add(construct_sign_and_send_raw_middleware(acct))
+   >>> w3.middleware_onion.add(construct_sign_and_send_raw_middleware(acct))
    >>> w3.eth.defaultAccount = acct.address
    # Now you can send a tx from acct.address without having to build and sign each raw transaction

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -62,8 +62,8 @@ def customize_web3(w3):
     from web3.contract import ConciseContract
     from web3.middleware import make_stalecheck_middleware
 
-    w3.middleware_stack.remove('name_to_address')
-    w3.middleware_stack.add(
+    w3.middleware_onion.remove('name_to_address')
+    w3.middleware_onion.add(
         make_stalecheck_middleware(ACCEPTABLE_STALE_HOURS * 3600),
         name='stalecheck',
     )

--- a/tests/core/eth-module/test_poa.py
+++ b/tests/core/eth-module/test_poa.py
@@ -14,7 +14,7 @@ def test_long_extra_data(web3):
     return_block_with_long_extra_data = construct_fixture_middleware({
         'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 33},
     })
-    web3.middleware_stack.inject(return_block_with_long_extra_data, layer=0)
+    web3.middleware_onion.inject(return_block_with_long_extra_data, layer=0)
     with pytest.raises(ValidationError):
         web3.eth.getBlock('latest')
 
@@ -23,7 +23,7 @@ def test_full_extra_data(web3):
     return_block_with_long_extra_data = construct_fixture_middleware({
         'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 32},
     })
-    web3.middleware_stack.inject(return_block_with_long_extra_data, layer=0)
+    web3.middleware_onion.inject(return_block_with_long_extra_data, layer=0)
     block = web3.eth.getBlock('latest')
     assert block.extraData == b'\xff' * 32
 
@@ -32,8 +32,8 @@ def test_geth_proof_of_authority(web3):
     return_block_with_long_extra_data = construct_fixture_middleware({
         'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 33},
     })
-    web3.middleware_stack.inject(geth_poa_middleware, layer=0)
-    web3.middleware_stack.inject(return_block_with_long_extra_data, layer=0)
+    web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+    web3.middleware_onion.inject(return_block_with_long_extra_data, layer=0)
     block = web3.eth.getBlock('latest')
     assert 'extraData' not in block
     assert block.proofOfAuthorityData == b'\xff' * 33

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -47,7 +47,7 @@ def test_wait_for_missing_receipt(web3):
 
 
 def test_unmined_transaction_wait_for_receipt(web3):
-    web3.middleware_stack.add(unmined_receipt_simulator_middleware)
+    web3.middleware_onion.add(unmined_receipt_simulator_middleware)
     txn_hash = web3.eth.sendTransaction({
         'from': web3.eth.coinbase,
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -31,7 +31,7 @@ def web3(request):
     provider = EthereumTesterProvider()
     w3 = Web3(provider)
     if use_filter_middleware:
-        w3.middleware_stack.add(local_filter_middleware)
+        w3.middleware_onion.add(local_filter_middleware)
     return w3
 
 

--- a/tests/core/manager/test_middleware_add_and_clear_api.py
+++ b/tests/core/manager/test_middleware_add_and_clear_api.py
@@ -19,23 +19,23 @@ def test_provider_property_setter_and_getter(middleware_factory):
 
     manager = RequestManager(None, provider, middlewares=[])
 
-    assert tuple(manager.middleware_stack) == tuple()
+    assert tuple(manager.middleware_onion) == tuple()
 
-    manager.middleware_stack.add(middleware_a)
-    manager.middleware_stack.add(middleware_b)
+    manager.middleware_onion.add(middleware_a)
+    manager.middleware_onion.add(middleware_b)
 
-    manager.middleware_stack.clear()
+    manager.middleware_onion.clear()
 
-    assert tuple(manager.middleware_stack) == tuple()
+    assert tuple(manager.middleware_onion) == tuple()
 
-    manager.middleware_stack.add(middleware_c)
-    manager.middleware_stack.add(middleware_b)
-    manager.middleware_stack.add(middleware_a)
+    manager.middleware_onion.add(middleware_c)
+    manager.middleware_onion.add(middleware_b)
+    manager.middleware_onion.add(middleware_a)
 
     with pytest.raises(ValueError):
-        manager.middleware_stack.add(middleware_b)
+        manager.middleware_onion.add(middleware_b)
 
-    assert tuple(manager.middleware_stack) == (
+    assert tuple(manager.middleware_onion) == (
         middleware_a,
         middleware_b,
         middleware_c,
@@ -45,22 +45,22 @@ def test_provider_property_setter_and_getter(middleware_factory):
 def test_add_named_middleware(middleware_factory):
     mw = middleware_factory()
     manager = RequestManager(None, BaseProvider(), middlewares=[(mw, 'the-name')])
-    assert len(manager.middleware_stack) == 1
+    assert len(manager.middleware_onion) == 1
 
-    assert tuple(manager.middleware_stack) == (mw, )
+    assert tuple(manager.middleware_onion) == (mw, )
 
 
 def test_add_named_duplicate_middleware(middleware_factory):
     mw = middleware_factory()
     manager = RequestManager(None, BaseProvider(), middlewares=[(mw, 'the-name'), (mw, 'name2')])
-    assert tuple(manager.middleware_stack) == (mw, mw)
+    assert tuple(manager.middleware_onion) == (mw, mw)
 
-    manager.middleware_stack.clear()
-    assert len(manager.middleware_stack) == 0
+    manager.middleware_onion.clear()
+    assert len(manager.middleware_onion) == 0
 
-    manager.middleware_stack.add(mw, 'name1')
-    manager.middleware_stack.add(mw, 'name2')
-    assert tuple(manager.middleware_stack) == (mw, mw)
+    manager.middleware_onion.add(mw, 'name1')
+    manager.middleware_onion.add(mw, 'name2')
+    assert tuple(manager.middleware_onion) == (mw, mw)
 
 
 def test_add_duplicate_middleware(middleware_factory):
@@ -69,11 +69,11 @@ def test_add_duplicate_middleware(middleware_factory):
         manager = RequestManager(None, BaseProvider(), middlewares=[mw, mw])
 
     manager = RequestManager(None, BaseProvider(), middlewares=[])
-    manager.middleware_stack.add(mw)
+    manager.middleware_onion.add(mw)
 
     with pytest.raises(ValueError):
-        manager.middleware_stack.add(mw)
-    assert tuple(manager.middleware_stack) == (mw, )
+        manager.middleware_onion.add(mw)
+    assert tuple(manager.middleware_onion) == (mw, )
 
 
 def test_replace_middleware(middleware_factory):
@@ -83,16 +83,16 @@ def test_replace_middleware(middleware_factory):
 
     manager = RequestManager(None, BaseProvider(), middlewares=[mw1, (mw2, '2nd'), mw3])
 
-    assert tuple(manager.middleware_stack) == (mw1, mw2, mw3)
+    assert tuple(manager.middleware_onion) == (mw1, mw2, mw3)
 
     mw_replacement = middleware_factory()
-    manager.middleware_stack.replace('2nd', mw_replacement)
+    manager.middleware_onion.replace('2nd', mw_replacement)
 
-    assert tuple(manager.middleware_stack) == (mw1, mw_replacement, mw3)
+    assert tuple(manager.middleware_onion) == (mw1, mw_replacement, mw3)
 
-    manager.middleware_stack.remove('2nd')
+    manager.middleware_onion.remove('2nd')
 
-    assert tuple(manager.middleware_stack) == (mw1, mw3)
+    assert tuple(manager.middleware_onion) == (mw1, mw3)
 
 
 def test_replace_middleware_without_name(middleware_factory):
@@ -102,16 +102,16 @@ def test_replace_middleware_without_name(middleware_factory):
 
     manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2, mw3])
 
-    assert tuple(manager.middleware_stack) == (mw1, mw2, mw3)
+    assert tuple(manager.middleware_onion) == (mw1, mw2, mw3)
 
     mw_replacement = middleware_factory()
-    manager.middleware_stack.replace(mw2, mw_replacement)
+    manager.middleware_onion.replace(mw2, mw_replacement)
 
-    assert tuple(manager.middleware_stack) == (mw1, mw_replacement, mw3)
+    assert tuple(manager.middleware_onion) == (mw1, mw_replacement, mw3)
 
-    manager.middleware_stack.remove(mw_replacement)
+    manager.middleware_onion.remove(mw_replacement)
 
-    assert tuple(manager.middleware_stack) == (mw1, mw3)
+    assert tuple(manager.middleware_onion) == (mw1, mw3)
 
 
 def test_add_middleware(middleware_factory):
@@ -121,9 +121,9 @@ def test_add_middleware(middleware_factory):
 
     manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2])
 
-    manager.middleware_stack.add(mw3)
+    manager.middleware_onion.add(mw3)
 
-    assert tuple(manager.middleware_stack) == (mw3, mw1, mw2)
+    assert tuple(manager.middleware_onion) == (mw3, mw1, mw2)
 
 
 def test_bury_middleware(middleware_factory):
@@ -133,9 +133,9 @@ def test_bury_middleware(middleware_factory):
 
     manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2])
 
-    manager.middleware_stack.inject(mw3, layer=0)
+    manager.middleware_onion.inject(mw3, layer=0)
 
-    assert tuple(manager.middleware_stack) == (mw1, mw2, mw3)
+    assert tuple(manager.middleware_onion) == (mw1, mw2, mw3)
 
 
 def test_bury_named_middleware(middleware_factory):
@@ -145,15 +145,15 @@ def test_bury_named_middleware(middleware_factory):
 
     manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2])
 
-    manager.middleware_stack.inject(mw3, name='middleware3', layer=0)
+    manager.middleware_onion.inject(mw3, name='middleware3', layer=0)
 
-    assert tuple(manager.middleware_stack) == (mw1, mw2, mw3)
+    assert tuple(manager.middleware_onion) == (mw1, mw2, mw3)
 
     # make sure middleware was injected with correct name, by trying to remove
     # it by name.
-    manager.middleware_stack.remove('middleware3')
+    manager.middleware_onion.remove('middleware3')
 
-    assert tuple(manager.middleware_stack) == (mw1, mw2)
+    assert tuple(manager.middleware_onion) == (mw1, mw2)
 
 
 def test_remove_middleware(middleware_factory):
@@ -163,8 +163,8 @@ def test_remove_middleware(middleware_factory):
 
     manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2, mw3])
 
-    assert tuple(manager.middleware_stack) == (mw1, mw2, mw3)
+    assert tuple(manager.middleware_onion) == (mw1, mw2, mw3)
 
-    manager.middleware_stack.remove(mw2)
+    manager.middleware_onion.remove(mw2)
 
-    assert tuple(manager.middleware_stack) == (mw1, mw3)
+    assert tuple(manager.middleware_onion) == (mw1, mw3)

--- a/tests/core/middleware/test_filter_middleware.py
+++ b/tests/core/middleware/test_filter_middleware.py
@@ -52,8 +52,8 @@ def w3_base():
 
 @pytest.fixture(scope='function')
 def w3(w3_base, result_generator_middleware):
-    w3_base.middleware_stack.add(result_generator_middleware)
-    w3_base.middleware_stack.add(local_filter_middleware)
+    w3_base.middleware_onion.add(result_generator_middleware)
+    w3_base.middleware_onion.add(local_filter_middleware)
     return w3_base
 
 

--- a/tests/core/middleware/test_fixture_middleware.py
+++ b/tests/core/middleware/test_fixture_middleware.py
@@ -32,7 +32,7 @@ def w3():
     )
 )
 def test_fixture_middleware(w3, method, expected):
-    w3.middleware_stack.add(construct_fixture_middleware({'test_endpoint': 'value-a'}))
+    w3.middleware_onion.add(construct_fixture_middleware({'test_endpoint': 'value-a'}))
 
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(expected):
@@ -53,7 +53,7 @@ def test_result_middleware(w3, method, expected):
     def _callback(method, params):
         return params[0]
 
-    w3.middleware_stack.add(construct_result_generator_middleware({
+    w3.middleware_onion.add(construct_result_generator_middleware({
         'test_endpoint': _callback,
     }))
 
@@ -76,7 +76,7 @@ def test_error_middleware(w3, method, expected):
     def _callback(method, params):
         return params[0]
 
-    w3.middleware_stack.add(construct_error_generator_middleware({
+    w3.middleware_onion.add(construct_error_generator_middleware({
         'test_endpoint': _callback,
     }))
 

--- a/tests/core/middleware/test_latest_block_based_cache_middleware.py
+++ b/tests/core/middleware/test_latest_block_based_cache_middleware.py
@@ -140,9 +140,9 @@ def w3(w3_base,
        result_generator_middleware,
        block_data_middleware,
        latest_block_based_cache_middleware):
-    w3_base.middleware_stack.add(block_data_middleware)
-    w3_base.middleware_stack.add(result_generator_middleware)
-    w3_base.middleware_stack.add(latest_block_based_cache_middleware)
+    w3_base.middleware_onion.add(block_data_middleware)
+    w3_base.middleware_onion.add(result_generator_middleware)
+    w3_base.middleware_onion.add(latest_block_based_cache_middleware)
     return w3_base
 
 
@@ -151,8 +151,8 @@ def test_latest_block_based_cache_middleware_pulls_from_cache(
         block_data_middleware,
         result_generator_middleware):
     w3 = w3_base
-    w3.middleware_stack.add(block_data_middleware)
-    w3.middleware_stack.add(result_generator_middleware)
+    w3.middleware_onion.add(block_data_middleware)
+    w3.middleware_onion.add(result_generator_middleware)
 
     current_block_hash = w3.eth.getBlock('latest')['hash']
 
@@ -163,7 +163,7 @@ def test_latest_block_based_cache_middleware_pulls_from_cache(
             ): {'result': 'value-a'},
         }
 
-    w3.middleware_stack.add(construct_latest_block_based_cache_middleware(
+    w3.middleware_onion.add(construct_latest_block_based_cache_middleware(
         cache_class=cache_class,
         rpc_whitelist={'fake_endpoint'},
     ))
@@ -205,11 +205,11 @@ def test_latest_block_cache_middleware_does_not_cache_bad_responses(
         return None
 
     w3 = w3_base
-    w3.middleware_stack.add(block_data_middleware)
-    w3.middleware_stack.add(construct_result_generator_middleware({
+    w3.middleware_onion.add(block_data_middleware)
+    w3.middleware_onion.add(construct_result_generator_middleware({
         'fake_endpoint': result_cb,
     }))
-    w3.middleware_stack.add(latest_block_based_cache_middleware)
+    w3.middleware_onion.add(latest_block_based_cache_middleware)
 
     w3.manager.request_blocking('fake_endpoint', [])
     w3.manager.request_blocking('fake_endpoint', [])
@@ -228,11 +228,11 @@ def test_latest_block_cache_middleware_does_not_cache_error_response(
         next(counter)
         return "the error message"
 
-    w3.middleware_stack.add(block_data_middleware)
-    w3.middleware_stack.add(construct_error_generator_middleware({
+    w3.middleware_onion.add(block_data_middleware)
+    w3.middleware_onion.add(construct_error_generator_middleware({
         'fake_endpoint': error_cb,
     }))
-    w3.middleware_stack.add(latest_block_based_cache_middleware)
+    w3.middleware_onion.add(latest_block_based_cache_middleware)
 
     with pytest.raises(ValueError):
         w3.manager.request_blocking('fake_endpoint', [])

--- a/tests/core/middleware/test_name_to_address_middleware.py
+++ b/tests/core/middleware/test_name_to_address_middleware.py
@@ -31,7 +31,7 @@ class TempENS():
 def w3():
     w3 = Web3(provider=BaseProvider(), middlewares=[])
     w3.ens = TempENS({NAME: ADDRESS})
-    w3.middleware_stack.add(name_to_address_middleware(w3))
+    w3.middleware_onion.add(name_to_address_middleware(w3))
     return w3
 
 
@@ -42,8 +42,8 @@ def test_pass_name_resolver(w3):
     return_balance = construct_fixture_middleware({
         'eth_getBalance': BALANCE
     })
-    w3.middleware_stack.inject(return_chain_on_mainnet, layer=0)
-    w3.middleware_stack.inject(return_balance, layer=0)
+    w3.middleware_onion.inject(return_chain_on_mainnet, layer=0)
+    w3.middleware_onion.inject(return_balance, layer=0)
     assert w3.eth.getBalance(NAME) == BALANCE
 
 
@@ -51,6 +51,6 @@ def test_fail_name_resolver(w3):
     return_chain_on_mainnet = construct_fixture_middleware({
         'net_version': '2',
     })
-    w3.middleware_stack.inject(return_chain_on_mainnet, layer=0)
+    w3.middleware_onion.inject(return_chain_on_mainnet, layer=0)
     with pytest.raises(InvalidAddress, match=r'.*ethereum\.eth.*'):
         w3.eth.getBalance("ethereum.eth")

--- a/tests/core/middleware/test_request_param_normalizer.py
+++ b/tests/core/middleware/test_request_param_normalizer.py
@@ -24,8 +24,8 @@ def result_generator_middleware():
 
 @pytest.fixture
 def w3(w3_base, result_generator_middleware):
-    w3_base.middleware_stack.add(result_generator_middleware)
-    w3_base.middleware_stack.add(request_parameter_normalizer)
+    w3_base.middleware_onion.add(result_generator_middleware)
+    w3_base.middleware_onion.add(request_parameter_normalizer)
     return w3_base
 
 

--- a/tests/core/middleware/test_simple_cache_middleware.py
+++ b/tests/core/middleware/test_simple_cache_middleware.py
@@ -31,7 +31,7 @@ def result_generator_middleware():
 
 @pytest.fixture
 def w3(w3_base, result_generator_middleware):
-    w3_base.middleware_stack.add(result_generator_middleware)
+    w3_base.middleware_onion.add(result_generator_middleware)
     return w3_base
 
 
@@ -41,7 +41,7 @@ def test_simple_cache_middleware_pulls_from_cache(w3):
             generate_cache_key(('fake_endpoint', [1])): {'result': 'value-a'},
         }
 
-    w3.middleware_stack.add(construct_simple_cache_middleware(
+    w3.middleware_onion.add(construct_simple_cache_middleware(
         cache_class=cache_class,
         rpc_whitelist={'fake_endpoint'},
     ))
@@ -50,7 +50,7 @@ def test_simple_cache_middleware_pulls_from_cache(w3):
 
 
 def test_simple_cache_middleware_populates_cache(w3):
-    w3.middleware_stack.add(construct_simple_cache_middleware(
+    w3.middleware_onion.add(construct_simple_cache_middleware(
         cache_class=dict,
         rpc_whitelist={'fake_endpoint'},
     ))
@@ -69,11 +69,11 @@ def test_simple_cache_middleware_does_not_cache_none_responses(w3_base):
         next(counter)
         return None
 
-    w3.middleware_stack.add(construct_result_generator_middleware({
+    w3.middleware_onion.add(construct_result_generator_middleware({
         'fake_endpoint': result_cb,
     }))
 
-    w3.middleware_stack.add(construct_simple_cache_middleware(
+    w3.middleware_onion.add(construct_simple_cache_middleware(
         cache_class=dict,
         rpc_whitelist={'fake_endpoint'},
     ))
@@ -86,11 +86,11 @@ def test_simple_cache_middleware_does_not_cache_none_responses(w3_base):
 
 def test_simple_cache_middleware_does_not_cache_error_responses(w3_base):
     w3 = w3_base
-    w3.middleware_stack.add(construct_error_generator_middleware({
+    w3.middleware_onion.add(construct_error_generator_middleware({
         'fake_endpoint': lambda *_: 'msg-{0}'.format(str(uuid.uuid4())),
     }))
 
-    w3.middleware_stack.add(construct_simple_cache_middleware(
+    w3.middleware_onion.add(construct_simple_cache_middleware(
         cache_class=dict,
         rpc_whitelist={'fake_endpoint'},
     ))
@@ -104,7 +104,7 @@ def test_simple_cache_middleware_does_not_cache_error_responses(w3_base):
 
 
 def test_simple_cache_middleware_does_not_cache_endpoints_not_in_whitelist(w3):
-    w3.middleware_stack.add(construct_simple_cache_middleware(
+    w3.middleware_onion.add(construct_simple_cache_middleware(
         cache_class=dict,
         rpc_whitelist={'fake_endpoint'},
     ))

--- a/tests/core/middleware/test_time_based_cache_middleware.py
+++ b/tests/core/middleware/test_time_based_cache_middleware.py
@@ -41,8 +41,8 @@ def time_cache_middleware():
 
 @pytest.fixture
 def w3(w3_base, result_generator_middleware, time_cache_middleware):
-    w3_base.middleware_stack.add(result_generator_middleware)
-    w3_base.middleware_stack.add(time_cache_middleware)
+    w3_base.middleware_onion.add(result_generator_middleware)
+    w3_base.middleware_onion.add(time_cache_middleware)
     return w3_base
 
 
@@ -57,7 +57,7 @@ def test_time_based_cache_middleware_pulls_from_cache(w3_base):
             ),
         }
 
-    w3.middleware_stack.add(construct_time_based_cache_middleware(
+    w3.middleware_onion.add(construct_time_based_cache_middleware(
         cache_class=cache_class,
         cache_expire_seconds=10,
         rpc_whitelist={'fake_endpoint'},
@@ -75,7 +75,7 @@ def test_time_based_cache_middleware_populates_cache(w3):
 
 def test_time_based_cache_middleware_expires_old_values(w3_base, result_generator_middleware):
     w3 = w3_base
-    w3.middleware_stack.add(result_generator_middleware)
+    w3.middleware_onion.add(result_generator_middleware)
 
     def cache_class():
         return {
@@ -85,7 +85,7 @@ def test_time_based_cache_middleware_expires_old_values(w3_base, result_generato
             ),
         }
 
-    w3.middleware_stack.add(construct_time_based_cache_middleware(
+    w3.middleware_onion.add(construct_time_based_cache_middleware(
         cache_class=cache_class,
         cache_expire_seconds=10,
         rpc_whitelist={'fake_endpoint'},
@@ -114,8 +114,8 @@ def test_time_based_cache_middleware_does_not_cache_bad_responses(
         next(counter)
         return None
 
-    w3.middleware_stack.add(construct_result_generator_middleware({'fake_endpoint': mk_result}))
-    w3.middleware_stack.add(time_cache_middleware)
+    w3.middleware_onion.add(construct_result_generator_middleware({'fake_endpoint': mk_result}))
+    w3.middleware_onion.add(time_cache_middleware)
 
     w3.manager.request_blocking('fake_endpoint', [])
     w3.manager.request_blocking('fake_endpoint', [])
@@ -132,10 +132,10 @@ def test_time_based_cache_middleware_does_not_cache_error_response(
     def mk_error(method, params):
         return "error-number-{0}".format(next(counter))
 
-    w3.middleware_stack.add(construct_error_generator_middleware({
+    w3.middleware_onion.add(construct_error_generator_middleware({
         'fake_endpoint': mk_error,
     }))
-    w3.middleware_stack.add(time_cache_middleware)
+    w3.middleware_onion.add(time_cache_middleware)
 
     with pytest.raises(ValueError) as err:
         w3.manager.request_blocking('fake_endpoint', [])

--- a/tests/core/middleware/test_transaction_signing.py
+++ b/tests/core/middleware/test_transaction_signing.py
@@ -94,7 +94,7 @@ def w3_base():
 
 @pytest.fixture()
 def w3_dummy(w3_base, result_generator_middleware):
-    w3_base.middleware_stack.add(result_generator_middleware)
+    w3_base.middleware_onion.add(result_generator_middleware)
     return w3_base
 
 
@@ -135,7 +135,7 @@ def test_sign_and_send_raw_middleware(
         from_,
         expected,
         key_object):
-    w3_dummy.middleware_stack.add(
+    w3_dummy.middleware_onion.add(
         construct_sign_and_send_raw_middleware(key_object))
 
     if isinstance(expected, type) and issubclass(expected, Exception):
@@ -262,7 +262,7 @@ def test_signed_transaction(
         expected,
         key_object,
         from_):
-    w3.middleware_stack.add(construct_sign_and_send_raw_middleware(key_object))
+    w3.middleware_onion.add(construct_sign_and_send_raw_middleware(key_object))
 
     # Drop any falsy addresses
     to_from = valfilter(bool, {'to': w3.eth.accounts[0], 'from': from_})
@@ -296,7 +296,7 @@ def test_sign_and_send_raw_middleware_with_byte_addresses(
     from_ = from_converter(ADDRESS_1)
     to_ = to_converter(ADDRESS_2)
 
-    w3_dummy.middleware_stack.add(
+    w3_dummy.middleware_onion.add(
         construct_sign_and_send_raw_middleware(private_key))
 
     actual = w3_dummy.manager.request_blocking(

--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -85,7 +85,7 @@ def test_web3_auto_gethdev():
     return_block_with_long_extra_data = construct_fixture_middleware({
         'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 33},
     })
-    w3.middleware_stack.inject(return_block_with_long_extra_data, layer=0)
+    w3.middleware_onion.inject(return_block_with_long_extra_data, layer=0)
     block = w3.eth.getBlock('latest')
     assert 'extraData' not in block
     assert block.proofOfAuthorityData == b'\xff' * 33

--- a/tests/ens/test_utils.py
+++ b/tests/ens/test_utils.py
@@ -6,5 +6,5 @@ from ens.utils import (
 
 def test_init_adds_middlewares():
     w3 = init_web3()
-    middlewares = map(str, w3.manager.middleware_stack)
+    middlewares = map(str, w3.manager.middleware_onion)
     assert 'stalecheck_middleware' in next(middlewares)

--- a/web3/auto/gethdev.py
+++ b/web3/auto/gethdev.py
@@ -10,4 +10,4 @@ from web3.providers.ipc import (
 )
 
 w3 = Web3(IPCProvider(get_dev_ipc_path()))
-w3.middleware_stack.inject(geth_poa_middleware, layer=0)
+w3.middleware_onion.inject(geth_poa_middleware, layer=0)

--- a/web3/main.py
+++ b/web3/main.py
@@ -135,8 +135,8 @@ class Web3:
         self.ens = ens
 
     @property
-    def middleware_stack(self):
-        return self.manager.middleware_stack
+    def middleware_onion(self):
+        return self.manager.middleware_onion
 
     @property
     def provider(self):

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -35,7 +35,7 @@ class RequestManager:
         if middlewares is None:
             middlewares = self.default_middlewares(web3)
 
-        self.middleware_stack = NamedElementOnion(middlewares)
+        self.middleware_onion = NamedElementOnion(middlewares)
 
         if provider is None:
             self.provider = AutoProvider()
@@ -75,7 +75,7 @@ class RequestManager:
     #
     def _make_request(self, method, params):
         if self.provider:
-            request_func = self.provider.request_func(self.web3, tuple(self.middleware_stack))
+            request_func = self.provider.request_func(self.web3, tuple(self.middleware_onion))
             self.logger.debug("Making request. Method: %s", method)
             return request_func(method, params)
         else:


### PR DESCRIPTION
### What was wrong?
`middleware_stack` needed to be renamed to `middleware_onion`

Related to Issue #1022 

### How was it fixed?
Renamed `middleware_stack` to `middleware_onion`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/51170297-6470c900-18ae-11e9-97ef-ca3c92d97ac0.png)

