### PR TITLE
Relocate personal RPC endpoints to parity and geth class

### DIFF
--- a/docs/web3.personal.rst
+++ b/docs/web3.personal.rst
@@ -142,8 +142,9 @@ The following methods are available on the ``web3.parity.personal`` namespace.
 
     .. code-block:: python
 
+        # Invalid call to personal_unlockAccount on Parity currently returns True, due to Parity bug
         >>> web3.parity.personal.unlockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601', 'wrong-passphrase')
-        False
+        True
         >>> web3.parity.personal.unlockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601', 'the-passphrase')
         True
 

--- a/docs/web3.personal.rst
+++ b/docs/web3.personal.rst
@@ -1,20 +1,22 @@
 Personal API
 ============
 
-.. py:module:: web3.personal
+There are 2 objects that expose methods to interact with the RPC APIS
+under the ``personal_`` namespace, each supporting the endpoints
+implemented in the respective clients.
 
-.. py:class:: Personal
-
-The ``web3.personal`` object exposes methods to interact with the RPC APIs
-under the ``personal_`` namespace.
+- ``web3.geth.personal``
+- ``web3.parity.personal``
 
 
-Properties
-----------
+.. py:module:: web3.geth.personal
 
-The following properties are available on the ``web3.personal`` namespace.
+Geth Methods
+------------
 
-.. py:attribute:: listAccounts
+The following methods are available on the ``web3.geth.personal`` namespace.
+
+.. py:method:: listAccounts
 
     * Delegates to ``personal_listAccounts`` RPC Method
 
@@ -22,14 +24,9 @@ The following properties are available on the ``web3.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.personal.listAccounts
+        >>> web3.geth.personal.listAccounts()
         ['0xd3cda913deb6f67967b99d67acdfa1712c293601']
 
-
-Methods
--------
-
-The following methods are available on the ``web3.personal`` namespace.
 
 .. py:method:: importRawKey(self, private_key, passphrase)
 
@@ -40,7 +37,7 @@ The following methods are available on the ``web3.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.personal.importRawKey(some_private_key, 'the-passphrase')
+        >>> web3.geth.personal.importRawKey(some_private_key, 'the-passphrase')
         '0xd3cda913deb6f67967b99d67acdfa1712c293601'
 
 
@@ -53,7 +50,7 @@ The following methods are available on the ``web3.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.personal.newAccount('the-passphrase')
+        >>> web3.geth.personal.newAccount('the-passphrase')
         '0xd3cda913deb6f67967b99d67acdfa1712c293601'
 
 
@@ -65,7 +62,7 @@ The following methods are available on the ``web3.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.personal.lockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601')
+        >>> web3.geth.personal.lockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601')
 
 
 .. py:method:: unlockAccount(self, account, passphrase, duration=None)
@@ -78,9 +75,76 @@ The following methods are available on the ``web3.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.personal.unlockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601', 'wrong-passphrase')
+        >>> web3.geth.personal.unlockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601', 'wrong-passphrase')
         False
-        >>> web3.personal.unlockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601', 'the-passphrase')
+        >>> web3.geth.personal.unlockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601', 'the-passphrase')
+        True
+
+.. py:method:: sendTransaction(self, transaction, passphrase)
+
+    * Delegates to ``personal_sendTransaction`` RPC Method
+
+    Sends the transaction.
+
+
+.. py:module:: web3.parity.personal
+
+Parity Methods
+--------------
+
+The following methods are available on the ``web3.parity.personal`` namespace.
+
+.. py:method:: listAccounts
+
+    * Delegates to ``personal_listAccounts`` RPC Method
+
+    Returns the list of known accounts.
+
+    .. code-block:: python
+
+        >>> web3.parity.personal.listAccounts()
+        ['0xd3cda913deb6f67967b99d67acdfa1712c293601']
+
+
+.. py:method:: importRawKey(self, private_key, passphrase)
+
+    * Delegates to ``personal_importRawKey`` RPC Method
+
+    Adds the given ``private_key`` to the node's keychain, encrypted with the
+    given ``passphrase``.  Returns the address of the imported account.
+
+    .. code-block:: python
+
+        >>> web3.parity.personal.importRawKey(some_private_key, 'the-passphrase')
+        '0xd3cda913deb6f67967b99d67acdfa1712c293601'
+
+
+.. py:method:: newAccount(self, password)
+
+    * Delegates to ``personal_newAccount`` RPC Method
+
+    Generates a new account in the node's keychain encrypted with the
+    given ``passphrase``.  Returns the address of the created account.
+
+    .. code-block:: python
+
+        >>> web3.parity.personal.newAccount('the-passphrase')
+        '0xd3cda913deb6f67967b99d67acdfa1712c293601'
+
+
+.. py:method:: unlockAccount(self, account, passphrase, duration=None)
+
+    * Delegates to ``personal_unlockAccount`` RPC Method
+
+    Unlocks the given ``account`` for ``duration`` seconds.  If ``duration`` is
+    ``None`` then the account will remain unlocked indefinitely.  Returns
+    boolean as to whether the account was successfully unlocked.
+
+    .. code-block:: python
+
+        >>> web3.parity.personal.unlockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601', 'wrong-passphrase')
+        False
+        >>> web3.parity.personal.unlockAccount('0xd3cda913deb6f67967b99d67acdfa1712c293601', 'the-passphrase')
         True
 
 .. py:method:: sendTransaction(self, transaction, passphrase)

--- a/tests/core/method-class/test_method.py
+++ b/tests/core/method-class/test_method.py
@@ -265,7 +265,7 @@ class FakeModule(ModuleV2):
 def dummy_w3():
     return Web3(
         EthereumTesterProvider(),
-        modules=[{'name': 'fake', 'module': FakeModule}],
+        modules={'fake': (FakeModule,)},
         middlewares=[])
 
 

--- a/tests/core/method-class/test_method.py
+++ b/tests/core/method-class/test_method.py
@@ -265,7 +265,7 @@ class FakeModule(ModuleV2):
 def dummy_w3():
     return Web3(
         EthereumTesterProvider(),
-        modules={'fake': FakeModule},
+        modules=[{'name': 'fake', 'module': FakeModule}],
         middlewares=[])
 
 

--- a/tests/core/version-module/test_version_module.py
+++ b/tests/core/version-module/test_version_module.py
@@ -18,10 +18,10 @@ from web3.version import (
 def blocking_w3():
     return Web3(
         EthereumTesterProvider(),
-        modules=[
-            {"name": "blocking_version", "module": BlockingVersion},
-            {"name": "legacy_version", "module": Version},
-        ])
+        modules={
+            "blocking_version": (BlockingVersion,),
+            "legacy_version": (Version,),
+        })
 
 
 @pytest.fixture
@@ -29,9 +29,9 @@ def async_w3():
     return Web3(
         AsyncEthereumTesterProvider(),
         middlewares=[],
-        modules=[
-            {"name": 'async_version', "module": AsyncVersion},
-        ])
+        modules={
+            'async_version': (AsyncVersion,),
+        })
 
 
 def test_blocking_version(blocking_w3):

--- a/tests/core/version-module/test_version_module.py
+++ b/tests/core/version-module/test_version_module.py
@@ -18,10 +18,10 @@ from web3.version import (
 def blocking_w3():
     return Web3(
         EthereumTesterProvider(),
-        modules={
-            'blocking_version': BlockingVersion,
-            'legacy_version': Version
-        })
+        modules=[
+            {"name": "blocking_version", "module": BlockingVersion},
+            {"name": "legacy_version", "module": Version},
+        ])
 
 
 @pytest.fixture
@@ -29,9 +29,9 @@ def async_w3():
     return Web3(
         AsyncEthereumTesterProvider(),
         middlewares=[],
-        modules={
-            'async_version': AsyncVersion,
-        })
+        modules=[
+            {"name": 'async_version', "module": AsyncVersion},
+        ])
 
 
 def test_blocking_version(blocking_w3):

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -1,9 +1,9 @@
 import pytest
 
-from web3._utils.module_testing import (
+from web3._utils.module_testing import (  # noqa: F401
     EthModuleTest,
+    GoEthereumPersonalModuleTest,
     NetModuleTest,
-    PersonalModuleTest,
     VersionModuleTest,
     Web3ModuleTest,
 )
@@ -65,8 +65,4 @@ class GoEthereumVersionModuleTest(VersionModuleTest):
 
 
 class GoEthereumNetModuleTest(NetModuleTest):
-    pass
-
-
-class GoEthereumPersonalModuleTest(PersonalModuleTest):
     pass

--- a/tests/integration/go_ethereum/conftest.py
+++ b/tests/integration/go_ethereum/conftest.py
@@ -184,9 +184,9 @@ def emitter_contract_address(emitter_contract, address_conversion_func):
 
 @pytest.fixture
 def unlocked_account(web3, unlockable_account, unlockable_account_pw):
-    web3.personal.unlockAccount(unlockable_account, unlockable_account_pw)
+    web3.geth.personal.unlockAccount(unlockable_account, unlockable_account_pw)
     yield unlockable_account
-    web3.personal.lockAccount(unlockable_account)
+    web3.geth.personal.lockAccount(unlockable_account)
 
 
 @pytest.fixture(scope='module')
@@ -206,9 +206,9 @@ def unlockable_account_dual_type(unlockable_account, address_conversion_func):
 
 @pytest.yield_fixture
 def unlocked_account_dual_type(web3, unlockable_account_dual_type, unlockable_account_pw):
-    web3.personal.unlockAccount(unlockable_account_dual_type, unlockable_account_pw)
+    web3.geth.personal.unlockAccount(unlockable_account_dual_type, unlockable_account_pw)
     yield unlockable_account_dual_type
-    web3.personal.lockAccount(unlockable_account_dual_type)
+    web3.geth.personal.lockAccount(unlockable_account_dual_type)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -4,10 +4,10 @@ from flaky import (
     flaky,
 )
 
-from web3._utils.module_testing import (
+from web3._utils.module_testing import (  # noqa: F401
     EthModuleTest,
     ParityModuleTest as TraceModuleTest,
-    PersonalModuleTest,
+    ParityPersonalModuleTest,
     Web3ModuleTest,
 )
 
@@ -118,54 +118,6 @@ class ParityEthModuleTest(EthModuleTest):
         # should be '1' on first flaky run, '2' on second, or '3' on third
         if pending_call_result not in range(1, MAX_FLAKY_RUNS + 1):
             raise AssertionError("pending call result was %d!" % pending_call_result)
-
-
-class ParityPersonalModuleTest(PersonalModuleTest):
-    def test_personal_importRawKey(self, web3):
-        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
-        super().test_personal_importRawKey(web3)
-
-    def test_personal_listAccounts(self, web3):
-        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
-        super().test_personal_listAccounts(web3)
-
-    def test_personal_lockAccount(self, web3, unlocked_account):
-        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
-        super().test_personal_lockAccount(web3, unlocked_account)
-
-    def test_personal_unlockAccount_success(self, web3):
-        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
-        super().test_personal_unlockAccount_success(web3)
-
-    def test_personal_unlockAccount_failure(self, web3, unlockable_account):
-        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
-        super().test_personal_unlockAccount_failure(web3, unlockable_account)
-
-    def test_personal_newAccount(self, web3):
-        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
-        super().test_personal_newAccount(web3)
-
-    def test_personal_sendTransaction(
-            self,
-            web3,
-            unlockable_account,
-            unlockable_account_pw):
-        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
-        super().test_personal_sendTransaction(
-            web3,
-            unlockable_account,
-            unlockable_account_pw)
-
-    def test_personal_sign_and_ecrecover(
-            self,
-            web3,
-            unlockable_account,
-            unlockable_account_pw):
-        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
-        super().test_personal_sign_and_ecrecover(
-            web3,
-            unlockable_account,
-            unlockable_account_pw)
 
 
 class ParityTraceModuleTest(TraceModuleTest):

--- a/tests/integration/parity/test_parity_http.py
+++ b/tests/integration/parity/test_parity_http.py
@@ -47,6 +47,7 @@ def parity_command_arguments(
         '--unlock', author,
         '--password', passwordfile,
         '--jsonrpc-port', rpc_port,
+        '--jsonrpc-apis', 'all',
         '--no-ipc',
         '--no-ws',
     )
@@ -61,6 +62,7 @@ def parity_import_blocks_command(parity_binary, rpc_port, datadir, passwordfile)
         '--base-path', datadir,
         '--password', passwordfile,
         '--jsonrpc-port', str(rpc_port),
+        '--jsonrpc-apis', 'all',
         '--no-ipc',
         '--no-ws',
         '--tracing', 'on',

--- a/tests/integration/parity/test_parity_ipc.py
+++ b/tests/integration/parity/test_parity_ipc.py
@@ -45,6 +45,7 @@ def parity_command_arguments(
         '--base-path', datadir,
         '--unlock', author,
         '--password', passwordfile,
+        '--ipc-apis', 'all',
         '--no-jsonrpc',
         '--no-ws',
     )
@@ -59,6 +60,7 @@ def parity_import_blocks_command(parity_binary, ipc_path, datadir, passwordfile)
         '--ipc-path', ipc_path,
         '--base-path', datadir,
         '--password', passwordfile,
+        '--ipc-apis', 'all',
         '--no-jsonrpc',
         '--no-ws',
         '--tracing', 'on',

--- a/tests/integration/parity/test_parity_ws.py
+++ b/tests/integration/parity/test_parity_ws.py
@@ -49,6 +49,7 @@ def parity_command_arguments(
         '--password', passwordfile,
         '--ws-port', ws_port,
         '--ws-origins', '*',
+        '--ws-apis', 'all',
         '--no-ipc',
         '--no-jsonrpc',
     )
@@ -64,6 +65,7 @@ def parity_import_blocks_command(parity_binary, ws_port, datadir, passwordfile):
         '--password', passwordfile,
         '--ws-port', str(ws_port),
         '--ws-origins', '*',
+        '--ws-apis', 'all',
         '--no-ipc',
         '--no-jsonrpc',
         '--tracing', 'on',

--- a/web3/_utils/module.py
+++ b/web3/_utils/module.py
@@ -1,0 +1,16 @@
+from web3.exceptions import (
+    ValidationError,
+)
+
+
+def attach_modules(parent_module, module_definitions):
+    for module_name, module_info in module_definitions.items():
+        module_class = module_info[0]
+        module_class.attach(parent_module, module_name)
+
+        if len(module_info) == 2:
+            submodule_definitions = module_info[1]
+            module = getattr(parent_module, module_name)
+            attach_modules(module, submodule_definitions)
+        elif len(module_info) != 1:
+            raise ValidationError("Module definitions can only have 1 or 2 elements.")

--- a/web3/_utils/module_testing/__init__.py
+++ b/web3/_utils/module_testing/__init__.py
@@ -8,7 +8,8 @@ from .net_module import (  # noqa: F401
     NetModuleTest,
 )
 from .personal_module import (  # noqa: F401
-    PersonalModuleTest,
+    GoEthereumPersonalModuleTest,
+    ParityPersonalModuleTest,
 )
 from .version_module import (  # noqa: F401
     VersionModuleTest,

--- a/web3/_utils/module_testing/personal_module.py
+++ b/web3/_utils/module_testing/personal_module.py
@@ -1,3 +1,5 @@
+import pytest
+
 from eth_utils import (
     is_checksum_address,
     is_list_like,
@@ -13,13 +15,13 @@ PRIVATE_KEY_FOR_UNLOCK = '0x392f63a79b1ff8774845f3fa69de4a13800a59e7083f5187f155
 ACCOUNT_FOR_UNLOCK = '0x12efDc31B1a8FA1A1e756DFD8A1601055C971E13'
 
 
-class PersonalModuleTest:
+class GoEthereumPersonalModuleTest:
     def test_personal_importRawKey(self, web3):
         actual = web3.geth.personal.importRawKey(PRIVATE_KEY_HEX, PASSWORD)
         assert actual == ADDRESS
 
     def test_personal_listAccounts(self, web3):
-        accounts = web3.geth.personal.listAccounts
+        accounts = web3.geth.personal.listAccounts()
         assert is_list_like(accounts)
         assert len(accounts) > 0
         assert all((
@@ -36,14 +38,17 @@ class PersonalModuleTest:
                                             web3,
                                             unlockable_account_dual_type,
                                             unlockable_account_pw):
-        result = web3.geth.personal.unlockAccount(unlockable_account_dual_type, unlockable_account_pw)
+        result = web3.geth.personal.unlockAccount(
+            unlockable_account_dual_type,
+            unlockable_account_pw
+        )
         assert result is True
 
     def test_personal_unlockAccount_failure(self,
                                             web3,
                                             unlockable_account_dual_type):
-        result = web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
-        assert result is False
+        with pytest.raises(ValueError):
+            web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
 
     def test_personal_newAccount(self, web3):
         new_account = web3.geth.personal.newAccount(PASSWORD)
@@ -76,6 +81,90 @@ class PersonalModuleTest:
                                          unlockable_account_dual_type,
                                          unlockable_account_pw):
         message = 'test-web3-geth-personal-sign'
-        signature = web3.geth.personal.sign(message, unlockable_account_dual_type, unlockable_account_pw)
+        signature = web3.geth.personal.sign(
+            message,
+            unlockable_account_dual_type,
+            unlockable_account_pw
+        )
         signer = web3.geth.personal.ecRecover(message, signature)
+        assert is_same_address(signer, unlockable_account_dual_type)
+
+
+class ParityPersonalModuleTest():
+    def test_personal_listAccounts(self, web3):
+        accounts = web3.parity.personal.listAccounts()
+        assert is_list_like(accounts)
+        assert len(accounts) > 0
+        assert all((
+            is_checksum_address(item)
+            for item
+            in accounts
+        ))
+
+    def test_personal_unlockAccount_success(self,
+                                            web3,
+                                            unlockable_account_dual_type,
+                                            unlockable_account_pw):
+        result = web3.parity.personal.unlockAccount(
+            unlockable_account_dual_type,
+            unlockable_account_pw,
+            None
+        )
+        assert result is True
+
+    def test_personal_unlockAccount_failure(self,
+                                            web3,
+                                            unlockable_account_dual_type):
+        result = web3.parity.personal.unlockAccount(
+            unlockable_account_dual_type,
+            'bad-password',
+            None
+        )
+        assert result is True
+
+    def test_personal_newAccount(self, web3):
+        new_account = web3.parity.personal.newAccount(PASSWORD)
+        assert is_checksum_address(new_account)
+
+    def test_personal_lockAccount(self, web3, unlocked_account):
+        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
+        super().test_personal_lockAccount(web3, unlocked_account)
+
+    def test_personal_importRawKey(self, web3):
+        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
+        super().test_personal_importRawKey(web3)
+
+    def test_personal_sendTransaction(self,
+                                      web3,
+                                      unlockable_account_dual_type,
+                                      unlockable_account_pw):
+        assert web3.eth.getBalance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
+        txn_params = {
+            'from': unlockable_account_dual_type,
+            'to': unlockable_account_dual_type,
+            'gas': 21000,
+            'value': 1,
+            'gasPrice': web3.toWei(1, 'gwei'),
+        }
+        txn_hash = web3.parity.personal.sendTransaction(txn_params, unlockable_account_pw)
+        assert txn_hash
+        transaction = web3.eth.getTransaction(txn_hash)
+
+        assert is_same_address(transaction['from'], txn_params['from'])
+        assert is_same_address(transaction['to'], txn_params['to'])
+        assert transaction['gas'] == txn_params['gas']
+        assert transaction['value'] == txn_params['value']
+        assert transaction['gasPrice'] == txn_params['gasPrice']
+
+    def test_personal_sign_and_ecrecover(self,
+                                         web3,
+                                         unlockable_account_dual_type,
+                                         unlockable_account_pw):
+        message = 'test-web3-parity-personal-sign'
+        signature = web3.parity.personal.sign(
+            message,
+            unlockable_account_dual_type,
+            unlockable_account_pw
+        )
+        signer = web3.parity.personal.ecRecover(message, signature)
         assert is_same_address(signer, unlockable_account_dual_type)

--- a/web3/_utils/module_testing/personal_module.py
+++ b/web3/_utils/module_testing/personal_module.py
@@ -112,6 +112,7 @@ class ParityPersonalModuleTest():
         )
         assert result is True
 
+    # Seems to be an issue with Parity since this should return False
     def test_personal_unlockAccount_failure(self,
                                             web3,
                                             unlockable_account_dual_type):

--- a/web3/_utils/module_testing/personal_module.py
+++ b/web3/_utils/module_testing/personal_module.py
@@ -15,11 +15,11 @@ ACCOUNT_FOR_UNLOCK = '0x12efDc31B1a8FA1A1e756DFD8A1601055C971E13'
 
 class PersonalModuleTest:
     def test_personal_importRawKey(self, web3):
-        actual = web3.personal.importRawKey(PRIVATE_KEY_HEX, PASSWORD)
+        actual = web3.geth.personal.importRawKey(PRIVATE_KEY_HEX, PASSWORD)
         assert actual == ADDRESS
 
     def test_personal_listAccounts(self, web3):
-        accounts = web3.personal.listAccounts
+        accounts = web3.geth.personal.listAccounts
         assert is_list_like(accounts)
         assert len(accounts) > 0
         assert all((
@@ -30,23 +30,23 @@ class PersonalModuleTest:
 
     def test_personal_lockAccount(self, web3, unlockable_account_dual_type):
         # TODO: how do we test this better?
-        web3.personal.lockAccount(unlockable_account_dual_type)
+        web3.geth.personal.lockAccount(unlockable_account_dual_type)
 
     def test_personal_unlockAccount_success(self,
                                             web3,
                                             unlockable_account_dual_type,
                                             unlockable_account_pw):
-        result = web3.personal.unlockAccount(unlockable_account_dual_type, unlockable_account_pw)
+        result = web3.geth.personal.unlockAccount(unlockable_account_dual_type, unlockable_account_pw)
         assert result is True
 
     def test_personal_unlockAccount_failure(self,
                                             web3,
                                             unlockable_account_dual_type):
-        result = web3.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
+        result = web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
         assert result is False
 
     def test_personal_newAccount(self, web3):
-        new_account = web3.personal.newAccount(PASSWORD)
+        new_account = web3.geth.personal.newAccount(PASSWORD)
         assert is_checksum_address(new_account)
 
     def test_personal_sendTransaction(self,
@@ -61,7 +61,7 @@ class PersonalModuleTest:
             'value': 1,
             'gasPrice': web3.toWei(1, 'gwei'),
         }
-        txn_hash = web3.personal.sendTransaction(txn_params, unlockable_account_pw)
+        txn_hash = web3.geth.personal.sendTransaction(txn_params, unlockable_account_pw)
         assert txn_hash
         transaction = web3.eth.getTransaction(txn_hash)
 
@@ -75,7 +75,7 @@ class PersonalModuleTest:
                                          web3,
                                          unlockable_account_dual_type,
                                          unlockable_account_pw):
-        message = 'test-web3-personal-sign'
-        signature = web3.personal.sign(message, unlockable_account_dual_type, unlockable_account_pw)
-        signer = web3.personal.ecRecover(message, signature)
+        message = 'test-web3-geth-personal-sign'
+        signature = web3.geth.personal.sign(message, unlockable_account_dual_type, unlockable_account_pw)
+        signer = web3.geth.personal.ecRecover(message, signature)
         assert is_same_address(signer, unlockable_account_dual_type)

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -1,0 +1,20 @@
+from web3.module import (
+    Module,
+)
+from web3.personal import (
+    Personal,
+)
+
+
+class GethPersonal(Personal):
+    """
+    https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal
+    """
+    def __init__(self, w3):
+        self.w3 = w3
+
+
+class Geth(Module):
+    @property
+    def personal(self):
+        return GethPersonal(self.web3)

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -1,20 +1,32 @@
 from web3.module import (
     Module,
+    ModuleV2,
 )
 from web3.personal import (
-    Personal,
+    ecRecover,
+    importRawKey,
+    listAccounts,
+    lockAccount,
+    newAccount,
+    sendTransaction,
+    sign,
+    unlockAccount,
 )
-
-
-class GethPersonal(Personal):
-    """
-    https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal
-    """
-    def __init__(self, w3):
-        self.w3 = w3
 
 
 class Geth(Module):
-    @property
-    def personal(self):
-        return GethPersonal(self.web3)
+    pass
+
+
+class GethPersonal(ModuleV2):
+    """
+    https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal
+    """
+    ecRecover = ecRecover()
+    importRawKey = importRawKey()
+    listAccounts = listAccounts()
+    lockAccount = lockAccount()
+    newAccount = newAccount()
+    sendTransaction = sendTransaction()
+    sign = sign()
+    unlockAccount = unlockAccount()

--- a/web3/main.py
+++ b/web3/main.py
@@ -42,6 +42,7 @@ from web3.eth import (
 )
 from web3.geth import (
     Geth,
+    GethPersonal,
 )
 from web3.iban import (
     Iban,
@@ -57,6 +58,7 @@ from web3.net import (
 )
 from web3.parity import (
     Parity,
+    ParityPersonal,
 )
 from web3.providers.eth_tester import (
     EthereumTesterProvider,
@@ -82,17 +84,17 @@ from web3.version import (
 
 
 def get_default_modules():
-    return {
-        "eth": Eth,
-        "net": Net,
-        "version": Version,
-        "txpool": TxPool,
-        "miner": Miner,
-        "admin": Admin,
-        "parity": Parity,
-        "geth": Geth,
-        "testing": Testing,
-    }
+    return [
+        {"name": "eth", "module": Eth},
+        {"name": "net", "module": Net},
+        {"name": "version", "module": Version},
+        {"name": "txpool", "module": TxPool},
+        {"name": "miner", "module": Miner},
+        {"name": "admin", "module": Admin},
+        {"name": "parity", "module": Parity, 'submodules': {'personal': ParityPersonal}},
+        {"name": "geth", "module": Geth, 'submodules': {'personal': GethPersonal}},
+        {"name": "testing", "module": Testing},
+    ]
 
 
 class Web3:
@@ -130,8 +132,11 @@ class Web3:
         if modules is None:
             modules = get_default_modules()
 
-        for module_name, module_class in modules.items():
-            module_class.attach(self, module_name)
+        for module in modules:
+            module['module'].attach(self, module['name'])
+            if 'submodules' in module:
+                for subname, submodule in module['submodules'].items():
+                    submodule.attach(getattr(self, module['name']), subname)
 
         self.ens = ens
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -40,6 +40,9 @@ from web3.admin import (
 from web3.eth import (
     Eth,
 )
+from web3.geth import (
+    Geth,
+)
 from web3.iban import (
     Iban,
 )
@@ -54,9 +57,6 @@ from web3.net import (
 )
 from web3.parity import (
     Parity,
-)
-from web3.personal import (
-    Personal,
 )
 from web3.providers.eth_tester import (
     EthereumTesterProvider,
@@ -85,12 +85,12 @@ def get_default_modules():
     return {
         "eth": Eth,
         "net": Net,
-        "personal": Personal,
         "version": Version,
         "txpool": TxPool,
         "miner": Miner,
         "admin": Admin,
         "parity": Parity,
+        "geth": Geth,
         "testing": Testing,
     }
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -31,6 +31,9 @@ from web3._utils.encoding import (
     to_text,
     to_json,
 )
+from web3._utils.module import (
+    attach_modules,
+)
 from web3._utils.normalizers import (
     abi_ens_resolver,
 )
@@ -84,17 +87,21 @@ from web3.version import (
 
 
 def get_default_modules():
-    return [
-        {"name": "eth", "module": Eth},
-        {"name": "net", "module": Net},
-        {"name": "version", "module": Version},
-        {"name": "txpool", "module": TxPool},
-        {"name": "miner", "module": Miner},
-        {"name": "admin", "module": Admin},
-        {"name": "parity", "module": Parity, 'submodules': {'personal': ParityPersonal}},
-        {"name": "geth", "module": Geth, 'submodules': {'personal': GethPersonal}},
-        {"name": "testing", "module": Testing},
-    ]
+    return {
+        "eth": (Eth,),
+        "net": (Net,),
+        "version": (Version,),
+        "txpool": (TxPool,),
+        "miner": (Miner,),
+        "admin": (Admin,),
+        "parity": (Parity, {
+            "personal": (ParityPersonal,)
+        }),
+        "geth": (Geth, {
+            "personal": (GethPersonal,)
+        }),
+        "testing": (Testing,),
+    }
 
 
 class Web3:
@@ -132,11 +139,7 @@ class Web3:
         if modules is None:
             modules = get_default_modules()
 
-        for module in modules:
-            module['module'].attach(self, module['name'])
-            if 'submodules' in module:
-                for subname, submodule in module['submodules'].items():
-                    submodule.attach(getattr(self, module['name']), subname)
+        attach_modules(self, modules)
 
         self.ens = ens
 

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -5,30 +5,32 @@ from eth_utils import (
 from web3._utils.toolz import (
     assoc,
 )
-from web3.personal import (
-    Personal,
-)
 from web3.module import (
     Module,
+    ModuleV2,
+)
+from web3.personal import (
+    ecRecover,
+    importRawKey,
+    listAccounts,
+    newAccount,
+    sendTransaction,
+    sign,
+    unlockAccount,
 )
 
 
-class ParityPersonal(Personal):
+class ParityPersonal(ModuleV2):
     """
     https://wiki.parity.io/JSONRPC-personal-module
     """
-    def __init__(self, w3):
-        self.w3 = w3
-
-    def importRawKey(self, private_key, passphrase):
-        raise NotImplementedError(
-            "personal_importRawKey RPC-endpoint is not supported by the Parity client."
-        )
-
-    def lockAccount(self, account):
-        raise NotImplementedError(
-            "personal_lockAccount RPC-endpoint is not supported by the Parity client."
-        )
+    ecRecover = ecRecover()
+    importRawKey = importRawKey()
+    listAccounts = listAccounts()
+    newAccount = newAccount()
+    sendTransaction = sendTransaction()
+    sign = sign()
+    unlockAccount = unlockAccount()
 
 
 class Parity(Module):
@@ -36,10 +38,6 @@ class Parity(Module):
     https://paritytech.github.io/wiki/JSONRPC-parity-module
     """
     defaultBlock = "latest"
-
-    @property
-    def personal(self):
-        return ParityPersonal(self.web3)
 
     def enode(self):
         return self.web3.manager.request_blocking(

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -5,9 +5,30 @@ from eth_utils import (
 from web3._utils.toolz import (
     assoc,
 )
+from web3.personal import (
+    Personal,
+)
 from web3.module import (
     Module,
 )
+
+
+class ParityPersonal(Personal):
+    """
+    https://wiki.parity.io/JSONRPC-personal-module
+    """
+    def __init__(self, w3):
+        self.w3 = w3
+
+    def importRawKey(self, private_key, passphrase):
+        raise NotImplementedError(
+            "personal_importRawKey RPC-endpoint is not supported by the Parity client."
+        )
+
+    def lockAccount(self, account):
+        raise NotImplementedError(
+            "personal_lockAccount RPC-endpoint is not supported by the Parity client."
+        )
 
 
 class Parity(Module):
@@ -15,6 +36,10 @@ class Parity(Module):
     https://paritytech.github.io/wiki/JSONRPC-parity-module
     """
     defaultBlock = "latest"
+
+    @property
+    def personal(self):
+        return ParityPersonal(self.web3)
 
     def enode(self):
         return self.web3.manager.request_blocking(

--- a/web3/personal.py
+++ b/web3/personal.py
@@ -11,7 +11,6 @@ def importRawKey():
     return Method(
         "personal_importRawKey",
         mungers=[default_root_munger],
-        formatter_lookup_fn=None,
     )
 
 
@@ -19,7 +18,6 @@ def newAccount():
     return Method(
         "personal_newAccount",
         mungers=[default_root_munger],
-        formatter_lookup_fn=None,
     )
 
 
@@ -27,7 +25,6 @@ def listAccounts():
     return Method(
         "personal_listAccounts",
         mungers=None,
-        formatter_lookup_fn=None,
     )
 
 
@@ -35,7 +32,6 @@ def sendTransaction():
     return Method(
         "personal_sendTransaction",
         mungers=[default_root_munger],
-        formatter_lookup_fn=None,
     )
 
 
@@ -43,7 +39,6 @@ def lockAccount():
     return Method(
         "personal_lockAccount",
         mungers=[default_root_munger],
-        formatter_lookup_fn=None,
     )
 
 
@@ -51,7 +46,6 @@ def unlockAccount():
     return Method(
         "personal_unlockAccount",
         mungers=[default_root_munger],
-        formatter_lookup_fn=None,
     )
 
 
@@ -59,7 +53,6 @@ def sign():
     return Method(
         "personal_sign",
         mungers=[default_root_munger],
-        formatter_lookup_fn=None,
     )
 
 
@@ -67,5 +60,4 @@ def ecRecover():
     return Method(
         "personal_ecRecover",
         mungers=[default_root_munger],
-        formatter_lookup_fn=None,
     )

--- a/web3/personal.py
+++ b/web3/personal.py
@@ -1,11 +1,10 @@
-from web3.module import (
-    Module,
-)
-
-
-class Personal(Module):
+class Personal():
     """
-    https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal
+    This API is not automatically available on a `web3` instance, rather it should be accessed
+    through `web3.geth.personal` or `web3.parity.personal`.
+
+    All RPC endpoints under the personal namespace should be added here, and NotImplementedErrors
+    should be raised in subclasses if the endpoints are not supported by the respective client.
     """
     def importRawKey(self, private_key, passphrase):
         return self.web3.manager.request_blocking(

--- a/web3/personal.py
+++ b/web3/personal.py
@@ -1,61 +1,71 @@
-class Personal():
-    """
-    This API is not automatically available on a `web3` instance, rather it should be accessed
-    through `web3.geth.personal` or `web3.parity.personal`.
+from web3.method import (
+    Method,
+)
 
-    All RPC endpoints under the personal namespace should be added here, and NotImplementedErrors
-    should be raised in subclasses if the endpoints are not supported by the respective client.
-    """
-    def importRawKey(self, private_key, passphrase):
-        return self.web3.manager.request_blocking(
-            "personal_importRawKey",
-            [private_key, passphrase],
-        )
 
-    def newAccount(self, password):
-        return self.web3.manager.request_blocking(
-            "personal_newAccount", [password],
-        )
+def default_root_munger(module, *args):
+    return [*args]
 
-    @property
-    def listAccounts(self):
-        return self.web3.manager.request_blocking(
-            "personal_listAccounts", [],
-        )
 
-    def sendTransaction(self, transaction, passphrase):
-        return self.web3.manager.request_blocking(
-            "personal_sendTransaction",
-            [transaction, passphrase],
-        )
+def importRawKey():
+    return Method(
+        "personal_importRawKey",
+        mungers=[default_root_munger],
+        formatter_lookup_fn=None,
+    )
 
-    def lockAccount(self, account):
-        return self.web3.manager.request_blocking(
-            "personal_lockAccount",
-            [account],
-        )
 
-    def unlockAccount(self, account, passphrase, duration=None):
-        try:
-            return self.web3.manager.request_blocking(
-                "personal_unlockAccount",
-                [account, passphrase, duration],
-            )
-        except ValueError as err:
-            if "could not decrypt" in str(err):
-                # Hack to handle go-ethereum error response.
-                return False
-            else:
-                raise
+def newAccount():
+    return Method(
+        "personal_newAccount",
+        mungers=[default_root_munger],
+        formatter_lookup_fn=None,
+    )
 
-    def sign(self, message, signer, passphrase):
-        return self.web3.manager.request_blocking(
-            'personal_sign',
-            [message, signer, passphrase],
-        )
 
-    def ecRecover(self, message, signature):
-        return self.web3.manager.request_blocking(
-            'personal_ecRecover',
-            [message, signature],
-        )
+def listAccounts():
+    return Method(
+        "personal_listAccounts",
+        mungers=None,
+        formatter_lookup_fn=None,
+    )
+
+
+def sendTransaction():
+    return Method(
+        "personal_sendTransaction",
+        mungers=[default_root_munger],
+        formatter_lookup_fn=None,
+    )
+
+
+def lockAccount():
+    return Method(
+        "personal_lockAccount",
+        mungers=[default_root_munger],
+        formatter_lookup_fn=None,
+    )
+
+
+def unlockAccount():
+    return Method(
+        "personal_unlockAccount",
+        mungers=[default_root_munger],
+        formatter_lookup_fn=None,
+    )
+
+
+def sign():
+    return Method(
+        "personal_sign",
+        mungers=[default_root_munger],
+        formatter_lookup_fn=None,
+    )
+
+
+def ecRecover():
+    return Method(
+        "personal_ecRecover",
+        mungers=[default_root_munger],
+        formatter_lookup_fn=None,
+    )


### PR DESCRIPTION
### What was wrong?

Updated `web3.personal` namespace to `web3.geth.personal` and `web3.parity.personal` which each reflect the personal jsonrpc endpoints supported by the respective client. Made the same update to `PersonalModuleTest` -> `GoEthereumPersonalModuleTest` and `ParityPersonalModuleTest` for integration testing.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/53604694-75ca1800-3b72-11e9-97ef-6d45548b6ff3.png)
