### PR TITLE
Change CircleCI badge link to the CircleCI project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/ethereum/web3.py](https://badges.gitter.im/ethereum/web3.py.svg)](https://gitter.im/ethereum/web3.py?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![Build Status](https://circleci.com/gh/ethereum/web3.py.svg?style=shield)](https://circleci.com/gh/ethereum/web3.py.svg?style=shield)
+[![Build Status](https://circleci.com/gh/ethereum/web3.py.svg?style=shield)](https://circleci.com/gh/ethereum/web3.py)
 
 
 A Python implementation of [web3.js](https://github.com/ethereum/web3.js)


### PR DESCRIPTION
### What was wrong?
Clicking on Circle badge only brought up the badge svg. Now it links to the project on circleci.

#### Cute Animal Picture


![bcfa7ff2dd04a6ce93dc97e6c92ce548](https://user-images.githubusercontent.com/6540608/51277485-0965d180-1995-11e9-98b6-9c4e3a768a57.jpg)

