### PR TITLE
Validate ethereum_tester class in web3.EthereumTesterProvider

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -301,11 +301,11 @@ EthereumTesterProvider
 
 .. py:class:: EthereumTesterProvider(eth_tester=None)
 
-    This provider integrates with the ``eth-tester`` library.  The
-    ``eth_tester`` constructor argument should be an instance of the
-    :class:`~eth_tester.EthereumTester` class provided by the ``eth-tester``
-    library.  If you would like a custom eth-tester instance to test with,
-    see the ``eth-tester`` library documentation for details.
+    This provider integrates with the ``eth-tester`` library.  The ``eth_tester`` constructor
+    argument should be an instance of the :class:`~eth_tester.EthereumTester` or
+    :class:`~eth_tester.PyEVMBackend` class provided by the ``eth-tester`` library.
+    If you would like a custom eth-tester instance to test with, see the
+    ``eth-tester`` library `documentation <https://github.com/ethereum/eth-tester>`_ for details.
 
     .. code-block:: python
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -302,8 +302,8 @@ EthereumTesterProvider
 .. py:class:: EthereumTesterProvider(eth_tester=None)
 
     This provider integrates with the ``eth-tester`` library.  The ``eth_tester`` constructor
-    argument should be an instance of the :class:`~eth_tester.EthereumTester` or
-    :class:`~eth_tester.PyEVMBackend` class provided by the ``eth-tester`` library.
+    argument should be an instance of the :class:`~eth_tester.EthereumTester` or a subclass of
+    :class:`~eth_tester.backends.base.BaseChainBackend` class provided by the ``eth-tester`` library.
     If you would like a custom eth-tester instance to test with, see the
     ``eth-tester`` library `documentation <https://github.com/ethereum/eth-tester>`_ for details.
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'tester': [
-        "eth-tester[py-evm]==0.1.0-beta.36",
+        "eth-tester[py-evm]==0.1.0-beta.37",
         "py-geth>=2.0.1,<3.0.0",
     ],
     'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],

--- a/web3/main.py
+++ b/web3/main.py
@@ -19,7 +19,6 @@ from web3._utils.abi import (
 )
 from web3._utils.decorators import (
     combomethod,
-    deprecated_for,
 )
 from web3._utils.empty import (
     empty,
@@ -161,11 +160,6 @@ class Web3:
                 {'text': text, 'hexstr': hexstr}
             )
         )
-
-    @combomethod
-    @deprecated_for("solidityKeccak")
-    def soliditySha3(cls, abi_types, values):
-        return cls.solidityKeccak(abi_types, values)
 
     @combomethod
     def solidityKeccak(cls, abi_types, values):

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -31,21 +31,22 @@ class EthereumTesterProvider(BaseProvider):
 
     def __init__(self, ethereum_tester=None, api_endpoints=None):
         # do not import eth_tester until runtime, it is not a default dependency
-        from eth_tester import EthereumTester, PyEVMBackend
+        from eth_tester import EthereumTester
+        from eth_tester.backends.base import BaseChainBackend
         if ethereum_tester is None:
             self.ethereum_tester = EthereumTester()
+        elif isinstance(ethereum_tester, EthereumTester):
+            self.ethereum_tester = ethereum_tester
+        elif isinstance(ethereum_tester, BaseChainBackend):
+            self.ethereum_tester = EthereumTester(ethereum_tester)
         else:
-            if isinstance(ethereum_tester, EthereumTester):
-                self.ethereum_tester = ethereum_tester
-            elif isinstance(ethereum_tester, PyEVMBackend):
-                self.ethereum_tester = EthereumTester(ethereum_tester)
-            else:
-                raise TypeError(
-                    "Expected ethereum_tester to be of type `eth_tester.EthereumTester` or "
-                    f"`eth_tester.PyEVMBackend`, instead received {type(ethereum_tester)}. "
-                    "If you would like a custom eth-tester instance to test with, see the "
-                    "eth-tester documentation. https://github.com/ethereum/eth-tester."
-                )
+            raise TypeError(
+                "Expected ethereum_tester to be of type `eth_tester.EthereumTester` or "
+                "a subclass of `eth_tester.backends.base.BaseChainBackend`, "
+                f"instead received {type(ethereum_tester)}. "
+                "If you would like a custom eth-tester instance to test with, see the "
+                "eth-tester documentation. https://github.com/ethereum/eth-tester."
+            )
 
         if api_endpoints is None:
             # do not import eth_tester derivatives until runtime, it is not a default dependency

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -30,12 +30,22 @@ class EthereumTesterProvider(BaseProvider):
     api_endpoints = None
 
     def __init__(self, ethereum_tester=None, api_endpoints=None):
+        # do not import eth_tester until runtime, it is not a default dependency
+        from eth_tester import EthereumTester, PyEVMBackend
         if ethereum_tester is None:
-            # do not import eth_tester until runtime, it is not a default dependency
-            from eth_tester import EthereumTester
             self.ethereum_tester = EthereumTester()
         else:
-            self.ethereum_tester = ethereum_tester
+            if isinstance(ethereum_tester, EthereumTester):
+                self.ethereum_tester = ethereum_tester
+            elif isinstance(ethereum_tester, PyEVMBackend):
+                self.ethereum_tester = EthereumTester(ethereum_tester)
+            else:
+                raise TypeError(
+                    "Expected ethereum_tester to be of type `eth_tester.EthereumTester` or "
+                    f"`eth_tester.PyEVMBackend`, instead received {type(ethereum_tester)}. "
+                    "If you would like a custom eth-tester instance to test with, see the "
+                    "eth-tester documentation. https://github.com/ethereum/eth-tester."
+                )
 
         if api_endpoints is None:
             # do not import eth_tester derivatives until runtime, it is not a default dependency


### PR DESCRIPTION
### What was wrong?
Instantiating a provider with `PyEVMBackend` should be done like `web3 = Web3(Web3.EthereumTesterProvider(EthereumTester(PyEVMBackend())))`, but can be mistakenly instantiated without the `EthereumTester` which will cause tx normalization errors. 

fixes #1213 
fixes #1212 

Also dropped the already deprecated `web3.soliditySha3` method in this pr.

### How was it fixed?
Added a check in `EthereumTesterProvider.init()` that the `ethereum_tester` arg is one of
1. instance of `EthereumTester`
2. instance of `PyEVMBackend` and then auto-wraps it in `EthereumTester`
3. raise error

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/51380548-44414400-1b12-11e9-936d-0626c98b3afa.png)

