### PR TITLE
Raise exceptions rather than return None in all jsonrpc calls

### DIFF
--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -53,7 +53,8 @@ def test_unmined_transaction_wait_for_receipt(web3):
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 123457
     })
-    assert web3.eth.getTransactionReceipt(txn_hash) is None
+    with pytest.raises(ValueError):
+        web3.eth.getTransactionReceipt(txn_hash)
 
     txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
     assert txn_receipt['transactionHash'] == txn_hash

--- a/tests/core/middleware/test_latest_block_based_cache_middleware.py
+++ b/tests/core/middleware/test_latest_block_based_cache_middleware.py
@@ -182,7 +182,8 @@ def test_latest_block_based_cache_middleware_busts_cache(w3, mocker):
     result = w3.manager.request_blocking('fake_endpoint', [])
 
     assert w3.manager.request_blocking('fake_endpoint', []) == result
-    w3.testing.mine()
+    with pytest.raises(ValueError):
+        w3.testing.mine()
 
     # should still be cached for at least 1 second.  This also verifies that
     # the middleware caches the latest block based on the block time.
@@ -211,8 +212,10 @@ def test_latest_block_cache_middleware_does_not_cache_bad_responses(
     }))
     w3.middleware_onion.add(latest_block_based_cache_middleware)
 
-    w3.manager.request_blocking('fake_endpoint', [])
-    w3.manager.request_blocking('fake_endpoint', [])
+    with pytest.raises(ValueError):
+        w3.manager.request_blocking('fake_endpoint', [])
+    with pytest.raises(ValueError):
+        w3.manager.request_blocking('fake_endpoint', [])
 
     assert next(counter) == 2
 

--- a/tests/core/middleware/test_simple_cache_middleware.py
+++ b/tests/core/middleware/test_simple_cache_middleware.py
@@ -78,8 +78,10 @@ def test_simple_cache_middleware_does_not_cache_none_responses(w3_base):
         rpc_whitelist={'fake_endpoint'},
     ))
 
-    w3.manager.request_blocking('fake_endpoint', [])
-    w3.manager.request_blocking('fake_endpoint', [])
+    with pytest.raises(ValueError):
+        w3.manager.request_blocking('fake_endpoint', [])
+    with pytest.raises(ValueError):
+        w3.manager.request_blocking('fake_endpoint', [])
 
     assert next(counter) == 2
 

--- a/tests/core/middleware/test_time_based_cache_middleware.py
+++ b/tests/core/middleware/test_time_based_cache_middleware.py
@@ -117,8 +117,10 @@ def test_time_based_cache_middleware_does_not_cache_bad_responses(
     w3.middleware_onion.add(construct_result_generator_middleware({'fake_endpoint': mk_result}))
     w3.middleware_onion.add(time_cache_middleware)
 
-    w3.manager.request_blocking('fake_endpoint', [])
-    w3.manager.request_blocking('fake_endpoint', [])
+    with pytest.raises(ValueError):
+        w3.manager.request_blocking('fake_endpoint', [])
+    with pytest.raises(ValueError):
+        w3.manager.request_blocking('fake_endpoint', [])
 
     assert next(counter) == 2
 

--- a/tests/core/testing-module/test_testing_snapshot_and_revert.py
+++ b/tests/core/testing-module/test_testing_snapshot_and_revert.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_snapshot_revert_to_latest_snapshot(web3):
     web3.testing.mine(5)
 
@@ -11,7 +14,8 @@ def test_snapshot_revert_to_latest_snapshot(web3):
 
     block_after_mining = web3.eth.getBlock("latest")
 
-    web3.testing.revert()
+    with pytest.raises(ValueError):
+        web3.testing.revert()
 
     block_after_revert = web3.eth.getBlock("latest")
 
@@ -38,7 +42,8 @@ def test_snapshot_revert_to_specific(web3):
 
     block_after_mining = web3.eth.getBlock("latest")
 
-    web3.testing.revert(snapshot_idx)
+    with pytest.raises(ValueError):
+        web3.testing.revert(snapshot_idx)
 
     block_after_revert = web3.eth.getBlock("latest")
 

--- a/tests/core/testing-module/test_testing_timeTravel.py
+++ b/tests/core/testing-module/test_testing_timeTravel.py
@@ -1,9 +1,13 @@
+import pytest
+
+
 def test_time_traveling(web3):
     current_block_time = web3.eth.getBlock("pending")['timestamp']
 
     time_travel_to = current_block_time + 12345
 
-    web3.testing.timeTravel(time_travel_to)
+    with pytest.raises(ValueError):
+        web3.testing.timeTravel(time_travel_to)
 
     latest_block_time = web3.eth.getBlock("pending")['timestamp']
     assert latest_block_time >= time_travel_to

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -485,8 +485,8 @@ class EthModuleTest:
         assert block['hash'] == empty_block['hash']
 
     def test_eth_getBlockByHash_not_found(self, web3, empty_block):
-        block = web3.eth.getBlock(UNKNOWN_HASH)
-        assert block is None
+        with pytest.raises(ValueError):
+            web3.eth.getBlock(UNKNOWN_HASH)
 
     def test_eth_getBlockByNumber_with_integer(self, web3, empty_block):
         block = web3.eth.getBlock(empty_block['number'])
@@ -498,8 +498,8 @@ class EthModuleTest:
         assert block['number'] == current_block_number
 
     def test_eth_getBlockByNumber_not_found(self, web3, empty_block):
-        block = web3.eth.getBlock(12345)
-        assert block is None
+        with pytest.raises(ValueError):
+            web3.eth.getBlock(12345)
 
     def test_eth_getBlockByNumber_pending(self, web3, empty_block):
         current_block_number = web3.eth.blockNumber

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -565,8 +565,8 @@ class EthModuleTest:
             'gas': 21000,
             'gasPrice': web3.eth.gasPrice,
         })
-        receipt = web3.eth.getTransactionReceipt(txn_hash)
-        assert receipt is None
+        with pytest.raises(ValueError):
+            web3.eth.getTransactionReceipt(txn_hash)
 
     def test_eth_getTransactionReceipt_with_log_entry(self,
                                                       web3,

--- a/web3/_utils/module_testing/parity_module.py
+++ b/web3/_utils/module_testing/parity_module.py
@@ -12,8 +12,8 @@ from web3._utils.formatters import (
 class ParityModuleTest:
 
     def test_list_storage_keys_no_support(self, web3, emitter_contract_address):
-        keys = web3.parity.listStorageKeys(emitter_contract_address, 10, None)
-        assert keys is None
+        with pytest.raises(ValueError):
+            web3.parity.listStorageKeys(emitter_contract_address, 10, None)
 
     def test_trace_replay_transaction(self, web3, parity_fixture_data):
         trace = web3.parity.traceReplayTransaction(parity_fixture_data['mined_txn_hash'])

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -64,7 +64,10 @@ def fill_transaction_defaults(web3, transaction):
 def wait_for_transaction_receipt(web3, txn_hash, timeout=120, poll_latency=0.1):
     with Timeout(timeout) as _timeout:
         while True:
-            txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
+            try:
+                txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
+            except ValueError:
+                txn_receipt = None
             # FIXME: The check for a null `blockHash` is due to parity's
             # non-standard implementation of the JSON-RPC API and should
             # be removed once the formal spec for the JSON-RPC endpoints

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -96,6 +96,10 @@ class RequestManager:
         if "error" in response:
             raise ValueError(response["error"])
 
+        # Raise exception for all jsonrpc calls that return None except getTransactionReceipt
+        if method != 'eth_getTransactionReceipt' and response['result'] is None:
+            raise ValueError(f"The call to {method} did not return a value.")
+
         return response['result']
 
     async def coro_request(self, method, params):

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -96,8 +96,7 @@ class RequestManager:
         if "error" in response:
             raise ValueError(response["error"])
 
-        # Raise exception for all jsonrpc calls that return None except getTransactionReceipt
-        if method != 'eth_getTransactionReceipt' and response['result'] is None:
+        if response['result'] is None:
             raise ValueError(f"The call to {method} did not return a value.")
 
         return response['result']

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -110,6 +110,9 @@ class RequestManager:
         if "error" in response:
             raise ValueError(response["error"])
 
+        if response['result'] is None:
+            raise ValueError(f"The call to {method} did not return a value.")
+
         return response['result']
 
     @deprecated_for("coro_request")


### PR DESCRIPTION
### What was wrong?
https://github.com/ethereum/web3.py/issues/722#issuecomment-438041562

> I propose that we change web3.eth.getBlock, web3.eth.getTransaction and other similar methods to no longer return None, but instead to raise an exception. The current API encourages/requires return value checking which is not a pattern I think we should be promoting.

### How was it fixed?
Raised a `ValueError` if return value from `Manager._make_request()` is `None`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/51381981-df87e880-1b15-11e9-8e0d-6a12c57c067b.png)

