### PR TITLE
Fix bug when checking _pm attr on w3

### DIFF
--- a/web3/main.py
+++ b/web3/main.py
@@ -203,7 +203,7 @@ class Web3:
 
     @property
     def pm(self):
-        if self._pm is not None:
+        if hasattr(self, '_pm'):
             return self._pm
         else:
             raise AttributeError(


### PR DESCRIPTION
### What was wrong?
`w3.pm` would raise a generic `AttributeError` rather than the intended `AttributeError` when checking for `web3._pm` if the attribute hadn't been set yet.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/51544085-5ea35680-1e5f-11e9-96cb-27c38211da76.png)
