### PR TITLE
Add custom registry for encodability checks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     url='https://github.com/ethereum/web3.py',
     include_package_data=True,
     install_requires=[
-        "eth-abi>=2.0.0b4,<3.0.0",
+        "eth-abi>=2.0.0b5,<3.0.0",
         "eth-account>=0.2.1,<0.4.0",
         "eth-utils>=1.3.0,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",

--- a/tests/core/utilities/test_abi_is_encodable.py
+++ b/tests/core/utilities/test_abi_is_encodable.py
@@ -8,59 +8,68 @@ from web3._utils.abi import (
 @pytest.mark.parametrize(
     'value,_type,expected',
     (
-        # bytes
-        ('12', 'bytes2', True),  # undersize OK
-        ('0x12', 'bytes2', True),  # with or without 0x OK
-        ('0123', 'bytes2', True),  # exact size OK
-        (b'\x12', 'bytes2', True),  # as bytes value undersize OK
-        (b'\x01\x23', 'bytes2', True),  # as bytes value exact size OK
+        # Some sanity checks to make sure our custom registrations didn't bork
+        # anything
+        ('0x' + '00' * 20, 'address', True),
+        ('0x' + '00' * 32, 'address', False),  # no oversized addresses
+        ('0xff', 'address', False),  # no undersized addresses
+        (None, 'address', False),  # no wrong types
+
+        (b'\x01\x23', 'bytes2', True),  # valid cases should be same
         (b'\x01\x23', 'bytes1', False),  # no oversize bytes
-        ('0123', 'bytes1', False),  # no oversize hex strings
-        ('1', 'bytes2', False),  # no odd length
-        ('0x1', 'bytes2', False),  # no odd length
         (True, 'bytes32', False),  # no wrong types
         (0, 'bytes32', False),  # no wrong types
-        # int
-        (-1 * 2**255 - 1, 'int256', False),
-        (-1 * 2**255, 'int256', True),
-        (-1, 'int256', True),
-        (0, 'int256', True),
-        (1, 'int256', True),
-        (2**255 - 1, 'int256', True),
-        (2**255, 'int256', False),
-        ('abc', 'int256', False),
-        (True, 'int256', False),
-        # uint
-        (-1, 'uint256', False),
-        (0, 'uint256', True),
-        (1, 'uint256', True),
-        (2**256 - 1, 'uint256', True),
-        (2**256, 'uint256', False),
-        ('abc', 'uint256', False),
-        (True, 'uint256', False),
-        # function
-        (0, 'function', False),
-        (b'\0' * 24, 'function', True),
-        (b'\0' * 25, 'function', False),
-        (True, 'function', False),
-        (False, 'function', False),
-        # address
-        ('0x' + '00' * 20, 'address', True),
-        ('0x' + '00' * 32, 'address', False),
-        (None, 'address', False),
+
+        (b'\x12', 'bytes', True),
+
+        ('', 'string', True),
+        ('anything', 'string', True),
+
+        (['0x' + '00' * 20, 0], '(address,uint256)', True),
+        (('0x' + '00' * 20, 0), '(address,uint256)', True),
+        ([0], '(address,uint256)', False),
+        (['0x' + '00' * 20], '(uint256)', False),
+
+        # Special address behavior
         ('dennisthepeasant.eth', 'address', True),  # passes because eth_utils converts to bytes :/
         ('autonomouscollective.eth', 'address', True),
         ('all-TLDs-valid-now.test', 'address', True),
         ('-rejects-invalid-names.test', 'address', False),
         ('ff', 'address', True),  # this could theoretically be a top-level domain (TLD)
         ('0xname.eth', 'address', True),  # 0x in name is fine, if it is not a TLD
-        ('0xff', 'address', False),  # but any valid hex starting with 0x should be rejected
-        # string
-        ('', 'string', True),
-        ('anything', 'string', True),
+
+        # Special bytes<M> behavior
+        ('12', 'bytes2', True),  # undersize OK
+        ('0x12', 'bytes2', True),  # with or without 0x OK
+        ('0123', 'bytes2', True),  # exact size OK
+        (b'\x12', 'bytes2', True),  # as bytes value undersize OK
+        ('0123', 'bytes1', False),  # no oversize hex strings
+        ('1', 'bytes2', False),  # no odd length
+        ('0x1', 'bytes2', False),  # no odd length
+
+        # Special bytes behavior
+        ('12', 'bytes', True),
+        ('0x12', 'bytes', True),
+        ('1', 'bytes', False),
+        ('0x1', 'bytes', False),
+
+        # Special string behavior
         (b'', 'string', True),
         (b'anything', 'string', True),
         (b'\x80', 'string', False),  # bytes that cannot be decoded with utf-8 are invalid
+
+        # Special tuple behavior
+        (('0x1234', 0), '(bytes2,int128)', True),
+        (('0x123456', 0), '(bytes2,int128)', False),
+
+        (('0x1234', 0), '(bytes,int128)', True),
+        (('1', 0), '(bytes,int128)', False),
+
+        (('dennisthepeasant.eth', 0), '(address,int128)', True),
+        (('-rejects-invalid-names.test', 0), '(address,int128)', False),
+
+        ((b'anything', 0), '(string,int128)', True),
+        ((b'\x80', 0), '(string,int128)', False),
     ),
 )
 def test_is_encodable(value, _type, expected):


### PR DESCRIPTION
### What was wrong?

Related to PR #1147.  Web3.py's encodability checking does not support tuple values.

### How was it fixed?

Added a custom eth-abi registry and encoder subclasses to take advantage of eth-abi's encodability checking for tuple values.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wallpaper.hinaji.com/wp-content/uploads/2016/09/Tons-of-Awesome-Red-Fox-Wallpapers.jpg)
