### PR TITLE
Make docstring style consistent with Python PEPs

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -29,7 +29,7 @@ To run this example, you will need to install a few extra features:
     from web3.contract import ConciseContract
 
     # Solidity source code
-    contract_source_code = '''
+    contract_source_code = """
     pragma solidity ^0.4.21;
 
     contract Greeter {
@@ -47,7 +47,7 @@ To run this example, you will need to install a few extra features:
             return greeting;
         }
     }
-    '''
+    """
 
     compiled_sol = compile_source(contract_source_code) # Compiled source code
     contract_interface = compiled_sol['<stdin>:Greeter']
@@ -459,7 +459,7 @@ and the arguments are ambiguous.
 
 .. code-block:: python
 
-        >>> contract_source_code = '''
+        >>> contract_source_code = """
         pragma solidity ^0.4.21;
         contract AmbiguousDuo {
           function identity(uint256 input, bool uselessFlag) returns (uint256) {
@@ -469,7 +469,7 @@ and the arguments are ambiguous.
             return input;
           }
         }
-        '''
+        """
         # fast forward all the steps of compiling and deploying the contract.
         >>> ambiguous_contract.functions.identity(1, True) # raises ValidationError
 

--- a/ens/exceptions.py
+++ b/ens/exceptions.py
@@ -2,78 +2,78 @@ import idna
 
 
 class AddressMismatch(ValueError):
-    '''
+    """
     In order to set up reverse resolution correctly, the ENS name should first
     point to the address. This exception is raised if the name does
     not currently point to the address.
-    '''
+    """
     pass
 
 
 class InvalidName(idna.IDNAError):
-    '''
+    """
     This exception is raised if the provided name does not meet
     the syntax standards specified in `EIP 137 name syntax
     <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md#name-syntax>`_.
 
     For example: names may not start with a dot, or include a space.
-    '''
+    """
     pass
 
 
 class UnauthorizedError(Exception):
-    '''
+    """
     Raised if the sending account is not the owner of the name
     you are trying to modify. Make sure to set ``from`` in the
     ``transact`` keyword argument to the owner of the name.
-    '''
+    """
     pass
 
 
 class UnownedName(Exception):
-    '''
+    """
     Raised if you are trying to modify a name that no one owns.
 
     If working on a subdomain, make sure the subdomain gets created
     first with :meth:`~ens.main.ENS.setup_address`.
-    '''
+    """
     pass
 
 
 class BidTooLow(ValueError):
-    '''
+    """
     Raised if you bid less than the minimum amount
-    '''
+    """
     pass
 
 
 class InvalidBidHash(ValueError):
-    '''
+    """
     Raised if you supply incorrect data to generate the bid hash.
-    '''
+    """
     pass
 
 
 class InvalidLabel(ValueError):
-    '''
+    """
     Raised if you supply an invalid label
-    '''
+    """
     pass
 
 
 class OversizeTransaction(ValueError):
-    '''
+    """
     Raised if a transaction you are trying to create would cost so
     much gas that it could not fit in a block.
 
     For example: when you try to start too many auctions at once.
-    '''
+    """
     pass
 
 
 class UnderfundedBid(ValueError):
-    '''
+    """
     Raised if you send less wei with your bid than you declared
     as your intent to bid.
-    '''
+    """
     pass

--- a/ens/main.py
+++ b/ens/main.py
@@ -32,14 +32,14 @@ ENS_MAINNET_ADDR = '0x314159265dD8dbb310642f98f50C066173C1259b'
 
 
 class ENS:
-    '''
+    """
     Quick access to common Ethereum Name Service functions,
     like getting the address for a name.
 
     Unless otherwise specified, all addresses are assumed to be a `str` in
     `checksum format <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>`_,
     like: ``"0x314159265dD8dbb310642f98f50C066173C1259b"``
-    '''
+    """
 
     labelhash = staticmethod(label_to_hash)
     namehash = staticmethod(raw_name_to_hash)
@@ -48,12 +48,12 @@ class ENS:
     reverse_domain = staticmethod(address_to_reverse_domain)
 
     def __init__(self, provider=default, addr=None):
-        '''
+        """
         :param provider: a single provider used to connect to Ethereum
         :type provider: instance of `web3.providers.base.BaseProvider`
         :param hex-string addr: the address of the ENS registry on-chain. If not provided,
             ENS.py will default to the mainnet ENS registry address.
-        '''
+        """
         self.web3 = init_web3(provider)
 
         ens_addr = addr if addr else ENS_MAINNET_ADDR
@@ -62,39 +62,39 @@ class ENS:
 
     @classmethod
     def fromWeb3(cls, web3, addr=None):
-        '''
+        """
         Generate an ENS instance with web3
 
         :param `web3.Web3` web3: to infer connection information
         :param hex-string addr: the address of the ENS registry on-chain. If not provided,
             ENS.py will default to the mainnet ENS registry address.
-        '''
+        """
         return cls(web3.manager.provider, addr=addr)
 
     def address(self, name):
-        '''
+        """
         Look up the Ethereum address that `name` currently points to.
 
         :param str name: an ENS name to look up
         :raises InvalidName: if `name` has invalid syntax
-        '''
+        """
         return self.resolve(name, 'addr')
 
     def name(self, address):
-        '''
+        """
         Look up the name that the address points to, using a
         reverse lookup. Reverse lookup is opt-in for name owners.
 
         :param address:
         :type address: hex-string
-        '''
+        """
         reversed_domain = address_to_reverse_domain(address)
         return self.resolve(reversed_domain, get='name')
     reverse = name
 
     @dict_copy
     def setup_address(self, name, address=default, transact={}):
-        '''
+        """
         Set up the name to point to the supplied address.
         The sender of the transaction must own the name, or
         its parent name.
@@ -110,7 +110,7 @@ class ENS:
             :meth:`~web3.eth.Eth.sendTransaction`
         :raises InvalidName: if ``name`` has invalid syntax
         :raises UnauthorizedError: if ``'from'`` in `transact` does not own `name`
-        '''
+        """
         owner = self.setup_owner(name, transact=transact)
         self._assert_control(owner, name)
         if not address or address == EMPTY_ADDR_HEX:
@@ -131,7 +131,7 @@ class ENS:
 
     @dict_copy
     def setup_name(self, name, address=None, transact={}):
-        '''
+        """
         Set up the address for reverse lookup, aka "caller ID".
         After successful setup, the method :meth:`~ens.main.ENS.name` will return
         `name` when supplied with `address`.
@@ -144,7 +144,7 @@ class ENS:
         :raises InvalidName: if `name` has invalid syntax
         :raises UnauthorizedError: if ``'from'`` in `transact` does not own `name`
         :raises UnownedName: if no one owns `name`
-        '''
+        """
         if not name:
             self._assert_control(address, 'the reverse record')
             return self._setup_reverse(None, address, transact=transact)
@@ -193,7 +193,7 @@ class ENS:
         return self.resolver(reversed_domain)
 
     def owner(self, name):
-        '''
+        """
         Get the owner of a name. Note that this may be different from the
         deed holder in the '.eth' registrar. Learn more about the difference
         between deed and name ownership in the ENS `Managing Ownership docs
@@ -202,13 +202,13 @@ class ENS:
         :param str name: ENS name to look up
         :return: owner address
         :rtype: str
-        '''
+        """
         node = raw_name_to_hash(name)
         return self.ens.owner(node)
 
     @dict_copy
     def setup_owner(self, name, new_owner=default, transact={}):
-        '''
+        """
         Set the owner of the supplied name to `new_owner`.
 
         For typical scenarios, you'll never need to call this method directly,
@@ -230,7 +230,7 @@ class ENS:
         :raises InvalidName: if `name` has invalid syntax
         :raises UnauthorizedError: if ``'from'`` in `transact` does not own `name`
         :returns: the new owner's address
-        '''
+        """
         (super_owner, unowned, owned) = self._first_owner(name)
         if new_owner is default:
             new_owner = super_owner
@@ -257,11 +257,11 @@ class ENS:
             )
 
     def _first_owner(self, name):
-        '''
+        """
         Takes a name, and returns the owner of the deepest subdomain that has an owner
 
         :returns: (owner or None, list(unowned_subdomain_labels), first_owned_domain)
-        '''
+        """
         owner = None
         unowned = []
         pieces = normalize_name(name).split('.')

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -70,7 +70,7 @@ def customize_web3(w3):
 
 
 def normalize_name(name):
-    '''
+    """
     Clean the fully qualified name, as defined in ENS `EIP-137
     <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md#name-syntax>`_
 
@@ -78,7 +78,7 @@ def normalize_name(name):
 
     :param str name: the dot-separated ENS name
     :raises InvalidName: if ``name`` has invalid syntax
-    '''
+    """
     if not name:
         return name
     elif isinstance(name, (bytes, bytearray)):
@@ -90,13 +90,13 @@ def normalize_name(name):
 
 
 def is_valid_name(name):
-    '''
+    """
     Validate whether the fully qualified name is valid, as defined in ENS `EIP-137
     <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md#name-syntax>`_
 
     :param str name: the dot-separated ENS name
     :returns: True if ``name`` is set, and :meth:`~ens.main.ENS.nameprep` will not raise InvalidName
-    '''
+    """
     if not name:
         return False
     try:
@@ -125,11 +125,11 @@ def name_to_label(name, registrar):
 
 
 def dot_eth_label(name):
-    '''
+    """
     Convert from a name, like 'ethfinex.eth', to a label, like 'ethfinex'
     If name is already a label, this should be a noop, except for converting to a string
     and validating the name syntax.
-    '''
+    """
     label = name_to_label(name, registrar='eth')
     if len(label) < MIN_ETH_LABEL_LENGTH:
         raise InvalidLabel('name %r is too short' % label)
@@ -170,7 +170,7 @@ def normal_name_to_hash(name):
 
 
 def raw_name_to_hash(name):
-    '''
+    """
     Generate the namehash. This is also known as the ``node`` in ENS contracts.
 
     In normal operation, generating the namehash is handled
@@ -184,7 +184,7 @@ def raw_name_to_hash(name):
     :return: the namehash
     :rtype: bytes
     :raises InvalidName: if ``name`` has invalid syntax
-    '''
+    """
     normalized_name = normalize_name(name)
     return normal_name_to_hash(normalized_name)
 

--- a/tests/ens/test_setup_address.py
+++ b/tests/ens/test_setup_address.py
@@ -17,9 +17,9 @@ from ens.main import (
 from web3 import Web3
 
 
-'''
+"""
 API at: https://github.com/carver/ens.py/issues/2
-'''
+"""
 
 
 @pytest.mark.parametrize(

--- a/tests/ens/test_setup_name.py
+++ b/tests/ens/test_setup_name.py
@@ -8,9 +8,9 @@ from ens.main import (
 from web3 import Web3
 
 
-'''
+"""
 API at: https://github.com/carver/ens.py/issues/2
-'''
+"""
 
 
 @pytest.fixture()

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -516,7 +516,7 @@ def abi_to_signature(abi):
 
 @curry
 def map_abi_data(normalizers, types, data):
-    '''
+    """
     This function will apply normalizers to your data, in the
     context of the relevant types. Each normalizer is in the format:
 
@@ -537,7 +537,7 @@ def map_abi_data(normalizers, types, data):
     1. Decorating the data tree with types
     2. Recursively mapping each of the normalizers to the data
     3. Stripping the types back out of the tree
-    '''
+    """
     pipeline = itertools.chain(
         [abi_data_tree(types)],
         map(data_tree_map, normalizers),
@@ -549,7 +549,7 @@ def map_abi_data(normalizers, types, data):
 
 @curry
 def abi_data_tree(types, data):
-    '''
+    """
     Decorate the data tree with pairs of (type, data). The pair tuple is actually an
     ABITypedData, but can be accessed as a tuple.
 
@@ -557,7 +557,7 @@ def abi_data_tree(types, data):
 
     >>> abi_data_tree(types=["bool[2]", "uint"], data=[[True, False], 0])
     [("bool[2]", [("bool", True), ("bool", False)]), ("uint256", 0)]
-    '''
+    """
     return [
         abi_sub_tree(data_type, data_value)
         for data_type, data_value
@@ -567,10 +567,10 @@ def abi_data_tree(types, data):
 
 @curry
 def data_tree_map(func, data_tree):
-    '''
+    """
     Map func to every ABITypedData element in the tree. func will
     receive two args: abi_type, and data
-    '''
+    """
     def map_to_typed_data(elements):
         if isinstance(elements, ABITypedData) and elements.abi_type is not None:
             return ABITypedData(func(*elements))
@@ -580,7 +580,7 @@ def data_tree_map(func, data_tree):
 
 
 class ABITypedData(namedtuple('ABITypedData', 'abi_type, data')):
-    '''
+    """
     This class marks data as having a certain ABI-type.
 
     >>> a1 = ABITypedData(['address', addr1])
@@ -596,7 +596,7 @@ class ABITypedData(namedtuple('ABITypedData', 'abi_type, data')):
     Unlike a typical `namedtuple`, you initialize with a single
     positional argument that is iterable, to match the init
     interface of all other relevant collections.
-    '''
+    """
     def __new__(cls, iterable):
         return super().__new__(cls, *iterable)
 

--- a/web3/_utils/decorators.py
+++ b/web3/_utils/decorators.py
@@ -18,9 +18,9 @@ class combomethod:
 
 
 def reject_recursive_repeats(to_wrap):
-    '''
+    """
     Prevent simple cycles by returning None when called recursively with same instance
-    '''
+    """
     to_wrap.__already_called = {}
 
     @functools.wraps(to_wrap)
@@ -40,13 +40,13 @@ def reject_recursive_repeats(to_wrap):
 
 
 def deprecated_for(replace_message):
-    '''
+    """
     Decorate a deprecated function, with info about what to use instead, like:
 
     @deprecated_for("toBytes()")
     def toAscii(arg):
         ...
-    '''
+    """
     def decorator(to_wrap):
         @functools.wraps(to_wrap)
         def wrapper(*args, **kwargs):

--- a/web3/_utils/encoding.py
+++ b/web3/_utils/encoding.py
@@ -180,13 +180,13 @@ def to_text(primitive=None, hexstr=None, text=None):
 
 @curry
 def text_if_str(to_type, text_or_primitive):
-    '''
+    """
     Convert to a type, assuming that strings can be only unicode text (not a hexstr)
 
     @param to_type is a function that takes the arguments (primitive, hexstr=hexstr, text=text),
         eg~ to_bytes, to_text, to_hex, to_int, etc
     @param hexstr_or_primitive in bytes, str, or int.
-    '''
+    """
     if isinstance(text_or_primitive, str):
         (primitive, text) = (None, text_or_primitive)
     else:
@@ -196,13 +196,13 @@ def text_if_str(to_type, text_or_primitive):
 
 @curry
 def hexstr_if_str(to_type, hexstr_or_primitive):
-    '''
+    """
     Convert to a type, assuming that strings can be only hexstr (not unicode text)
 
     @param to_type is a function that takes the arguments (primitive, hexstr=hexstr, text=text),
         eg~ to_bytes, to_text, to_hex, to_int, etc
     @param text_or_primitive in bytes, str, or int.
-    '''
+    """
     if isinstance(hexstr_or_primitive, str):
         (primitive, hexstr) = (None, hexstr_or_primitive)
         if remove_0x_prefix(hexstr) and not is_hex(hexstr):
@@ -217,13 +217,13 @@ def hexstr_if_str(to_type, hexstr_or_primitive):
 
 
 class FriendlyJsonSerde:
-    '''
+    """
     Friendly JSON serializer & deserializer
 
     When encoding or decoding fails, this class collects
     information on which fields failed, to show more
     helpful information in the raised error messages.
-    '''
+    """
     def _json_mapping_errors(self, mapping):
         for key, val in mapping.items():
             try:

--- a/web3/_utils/ens.py
+++ b/web3/_utils/ens.py
@@ -53,12 +53,12 @@ def ens_addresses(w3, name_addr_pairs):
 
 @contextmanager
 def contract_ens_addresses(contract, name_addr_pairs):
-    '''
+    """
     Use this context manager to temporarily resolve name/address pairs
     supplied as the argument. For example:
 
     with contract_ens_addresses(mycontract, [('resolve-as-1s.eth', '0x111...111')]):
         # any contract call or transaction in here would only resolve the above ENS pair
-    '''
+    """
     with ens_addresses(contract.web3, name_addr_pairs):
         yield

--- a/web3/_utils/formatters.py
+++ b/web3/_utils/formatters.py
@@ -89,10 +89,10 @@ def apply_one_of_formatters(formatter_condition_pairs, value):
 
 
 def map_collection(func, collection):
-    '''
+    """
     Apply func to each element of a collection, or value of a dictionary.
     If the value is not a collection, return it unmodified
-    '''
+    """
     datatype = type(collection)
     if isinstance(collection, Mapping):
         return datatype((key, func(val)) for key, val in collection.items())
@@ -106,10 +106,10 @@ def map_collection(func, collection):
 
 @reject_recursive_repeats
 def recursive_map(func, data):
-    '''
+    """
     Apply func to data, and any collection items inside data (using map_collection).
     Define func so that it only applies to the type of value that you want it to apply to.
-    '''
+    """
     def recurse(item):
         return recursive_map(func, item)
     items_mapped = map_collection(recurse, data)

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -44,9 +44,9 @@ def fill_nonce(web3, transaction):
 
 @curry
 def fill_transaction_defaults(web3, transaction):
-    '''
+    """
     if web3 is None, fill as much as possible while offline
-    '''
+    """
     defaults = {}
     for key, default_getter in TRANSACTION_DEFAULTS.items():
         if key not in transaction:

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -899,7 +899,7 @@ class ConciseMethod:
 
 
 class ConciseContract:
-    '''
+    """
     An alternative Contract Factory which invokes all methods as `call()`,
     unless you add a keyword argument. The keyword argument assigns the prep method.
 
@@ -910,7 +910,7 @@ class ConciseContract:
     is equivalent to this call in the classic contract:
 
     > contract.functions.withdraw(amount).transact({'from': eth.accounts[1], 'gas': 100000, ...})
-    '''
+    """
     def __init__(self, classic_contract, method_class=ConciseMethod):
 
         classic_contract._return_data_normalizers += CONCISE_NORMALIZERS
@@ -971,7 +971,7 @@ class ImplicitMethod(ConciseMethod):
 
 
 class ImplicitContract(ConciseContract):
-    '''
+    """
     ImplicitContract class is similar to the ConciseContract class
     however it performs a transaction instead of a call if no modifier
     is given and the method is not marked 'constant' in the ABI.
@@ -985,7 +985,7 @@ class ImplicitContract(ConciseContract):
     is equivalent to this call in the classic contract:
 
     > contract.functions.withdraw(amount).transact({})
-    '''
+    """
     def __init__(self, classic_contract, method_class=ImplicitMethod):
         super().__init__(classic_contract, method_class=method_class)
 

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -97,10 +97,10 @@ class AttributeDict(ReadableAttributeDict, Hashable):
 
 
 class NamedElementOnion(Mapping):
-    '''
+    """
     Add layers to an onion-shaped structure. Optionally, inject to a specific layer.
     This structure is iterable, where the outermost layer is first, and innermost is last.
-    '''
+    """
 
     def __init__(self, init_elements, valid_element=callable):
         self._queue = OrderedDict()
@@ -123,13 +123,13 @@ class NamedElementOnion(Mapping):
         self._queue[name] = element
 
     def inject(self, element, name=None, layer=None):
-        '''
+        """
         Inject a named element to an arbitrary layer in the onion.
 
         The current implementation only supports insertion at the innermost layer,
         or at the outermost layer. Note that inserting to the outermost is equivalent
         to calling :meth:`add` .
-        '''
+        """
         if not is_integer(layer):
             raise TypeError("The layer for insertion must be an int.")
         elif layer != 0 and layer != len(self._queue):

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -12,9 +12,9 @@ class BadFunctionCallOutput(Exception):
 
 
 class BlockNumberOutofRange(Exception):
-    '''
+    """
     block_identifier passed does not match known block.
-    '''
+    """
     pass
 
 

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -55,10 +55,10 @@ class RequestManager:
 
     @staticmethod
     def default_middlewares(web3):
-        '''
+        """
         List the default middlewares for the request manager.
         Leaving ens unspecified will prevent the middleware from resolving names.
-        '''
+        """
         return [
             (request_parameter_normalizer, 'request_param_normalizer'),
             (gas_price_strategy_middleware, 'gas_price_strategy'),

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -69,10 +69,10 @@ def check_if_retry_on_failure(method):
 
 
 def exception_retry_middleware(make_request, web3, errors, retries=5):
-    '''
+    """
     Creates middleware that retries failed HTTP requests. Is a default
     middleware for HTTPProvider.
-    '''
+    """
     def middleware(method, params):
         if check_if_retry_on_failure(method):
             for i in range(retries):

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -16,7 +16,7 @@ def _isfresh(block, allowable_delay):
 def make_stalecheck_middleware(
         allowable_delay,
         skip_stalecheck_for_methods=SKIP_STALECHECK_FOR_METHODS):
-    '''
+    """
     Use to require that a function will run only of the blockchain is recently updated.
 
     This middleware takes an argument, so unlike other middleware, you must make the middleware
@@ -25,7 +25,7 @@ def make_stalecheck_middleware(
 
     If the latest block in the chain is older than 5 minutes in this example, then the
     middleware will raise a StaleBlockchain exception.
-    '''
+    """
     if allowable_delay <= 0:
         raise ValueError("You must set a positive allowable_delay in seconds for this middleware")
 

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -53,13 +53,13 @@ class AutoProvider(BaseProvider):
     _active_provider = None
 
     def __init__(self, potential_providers=None):
-        '''
+        """
         :param iterable potential_providers: ordered series of provider classes to attempt with
 
         AutoProvider will initialize each potential provider (without arguments),
         in an attempt to find an active node. The list will default to
         :attribute:`default_providers`.
-        '''
+        """
         if potential_providers:
             self._potential_providers = potential_providers
         else:

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -26,10 +26,10 @@ class BaseProvider:
         self._middlewares = tuple(values)
 
     def request_func(self, web3, outer_middlewares):
-        '''
+        """
         @param outer_middlewares is an iterable of middlewares, ordered by first to execute
         @returns a function that calls all the middleware and eventually self.make_request()
-        '''
+        """
         all_middlewares = tuple(outer_middlewares) + tuple(self.middlewares)
 
         cache_key = self._request_func_cache[0]


### PR DESCRIPTION
### What was wrong?

The style of some docstrings is not consistent with recommendations in PEP 257 and PEP 287.

### How was it fixed?

Fixed them.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.boredpanda.com/blog/wp-content/uploads/2018/03/BSRgHAPgL7E-png__880.jpg)
