### PR TITLE
Find matching

### DIFF
--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -93,8 +93,10 @@ def find_matching_fn_abi(abi, fn_identifier=None, args=None, kwargs=None):
     else:
         matching_identifiers = name_filter(abi)
         matching_function_signatures = [abi_to_signature(func) for func in matching_identifiers]
+
         arg_count_matches = len(arg_count_filter(matching_identifiers))
         encoding_matches = len(encoding_filter(matching_identifiers))
+
         if arg_count_matches == 0:
             diagnosis = "\nFunction invocation failed due to improper number of arguments."
         elif encoding_matches == 0:
@@ -104,6 +106,7 @@ def find_matching_fn_abi(abi, fn_identifier=None, args=None, kwargs=None):
                 "\nAmbiguous argument encoding. "
                 "Provided arguments can be encoded to multiple functions matching this call."
             )
+
         message = (
             "\nCould not identify the intended function with name `{name}`, "
             "positional argument(s) of type `{arg_types}` and "
@@ -118,6 +121,7 @@ def find_matching_fn_abi(abi, fn_identifier=None, args=None, kwargs=None):
             candidates=matching_function_signatures,
             diagnosis=diagnosis,
         )
+
         raise ValidationError(message)
 
 

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -74,7 +74,6 @@ def find_matching_event_abi(abi, event_name=None, argument_names=None):
 def find_matching_fn_abi(abi, fn_identifier=None, args=None, kwargs=None):
     args = args or tuple()
     kwargs = kwargs or dict()
-    filters = []
     num_arguments = len(args) + len(kwargs)
 
     if fn_identifier is FallbackFn:
@@ -86,12 +85,9 @@ def find_matching_fn_abi(abi, fn_identifier=None, args=None, kwargs=None):
     name_filter = functools.partial(filter_by_name, fn_identifier)
     arg_count_filter = functools.partial(filter_by_argument_count, num_arguments)
     encoding_filter = functools.partial(filter_by_encodability, args, kwargs)
-    filters.extend([
-        name_filter,
-        arg_count_filter,
-        encoding_filter,
-    ])
-    function_candidates = pipe(abi, *filters)
+
+    function_candidates = pipe(abi, name_filter, arg_count_filter, encoding_filter)
+
     if len(function_candidates) == 1:
         return function_candidates[0]
     else:


### PR DESCRIPTION
### What was wrong?

Noticed a small opportunity for cleanup in `find_matching_fn_abi`.

### How was it fixed?

Removed unnecessary use of python `*args`.  Added a bit of whitespace.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://wallpapermine.com/wp-content/uploads/2013/11/Frog_peeking_out_from_behind_the_leaves.jpg)
