### PR TITLE
Add Geth POA middleware to use Rinkeby with Infura Auto

### DIFF
--- a/web3/auto/infura/rinkeby.py
+++ b/web3/auto/infura/rinkeby.py
@@ -1,9 +1,10 @@
 from web3 import Web3
-from web3.middleware import geth_poa_middleware
+from web3.middleware import (
+    geth_poa_middleware,
+)
 from web3.providers.auto import (
     load_provider_from_uri,
 )
-
 
 from .endpoints import (
     INFURA_RINKEBY_DOMAIN,

--- a/web3/auto/infura/rinkeby.py
+++ b/web3/auto/infura/rinkeby.py
@@ -1,9 +1,9 @@
 from web3 import Web3
+from web3.middleware import geth_poa_middleware
 from web3.providers.auto import (
     load_provider_from_uri,
 )
 
-from web3.middleware import geth_poa_middleware
 
 from .endpoints import (
     INFURA_RINKEBY_DOMAIN,

--- a/web3/auto/infura/rinkeby.py
+++ b/web3/auto/infura/rinkeby.py
@@ -3,6 +3,8 @@ from web3.providers.auto import (
     load_provider_from_uri,
 )
 
+from web3.middleware import geth_poa_middleware
+
 from .endpoints import (
     INFURA_RINKEBY_DOMAIN,
     build_infura_url,
@@ -11,3 +13,4 @@ from .endpoints import (
 _infura_url = build_infura_url(INFURA_RINKEBY_DOMAIN)
 
 w3 = Web3(load_provider_from_uri(_infura_url))
+w3.middleware_stack.inject(geth_poa_middleware, layer=0)


### PR DESCRIPTION
### What was wrong?
Rinkeby wouldn't work with Infura. I forgot to add the middleware.

### How was it fixed?
Added the middleware. Now it works!

Used this: https://web3py.readthedocs.io/en/stable/middleware.html?highlight=rinkeby#geth-style-proof-of-authority

#### Cute Animal Picture

![lazy rhino](https://i.pinimg.com/originals/8b/97/70/8b97708cd9c0ca476b3a1db70a53d7ad.jpg)
