### PR TITLE
Add manifest and input arg validation to pm.release_package()

### DIFF
--- a/tests/core/pm-module/test_ens_integration.py
+++ b/tests/core/pm-module/test_ens_integration.py
@@ -137,8 +137,8 @@ def test_web3_ens(ens):
     actual_addr = ens.address('tester.eth')
     w3.pm.set_registry('tester.eth')
     assert w3.pm.registry.address == to_canonical_address(actual_addr)
-    w3.pm.release_package('pkg', 'v1', 'website.com')
-    pkg_name, version, manifest_uri = w3.pm.get_release_data('pkg', 'v1')
-    assert pkg_name == 'pkg'
-    assert version == 'v1'
-    assert manifest_uri == 'website.com'
+    w3.pm.release_package('owned', '1.0.0', 'ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW')
+    pkg_name, version, manifest_uri = w3.pm.get_release_data('owned', '1.0.0')
+    assert pkg_name == 'owned'
+    assert version == '1.0.0'
+    assert manifest_uri == 'ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW'

--- a/tests/core/pm-module/test_registry_integration.py
+++ b/tests/core/pm-module/test_registry_integration.py
@@ -62,7 +62,7 @@ def test_pm_set_solidity_registry(empty_sol_registry, fresh_w3):
 def test_pm_must_set_registry_before_all_registry_interaction_functions(fresh_w3):
     with pytest.raises(PMError):
         fresh_w3.pm.release_package(
-            "package", "1.0.0", "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGe"
+            "package", "1.0.0", "ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW"
         )
     with pytest.raises(PMError):
         fresh_w3.pm.get_release_id_data(b"invalid_release_id")
@@ -88,21 +88,21 @@ def test_pm_must_set_registry_before_all_registry_interaction_functions(fresh_w3
 def test_pm_release_package(registry_getter, w3):
     w3.pm.registry = registry_getter
     w3.pm.release_package(
-        "package123", "1.0.0", "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGE"
+        "escrow", "1.0.0", "ipfs://QmPDwMHk8e1aMEZg3iKsUiPSkhHkywpGB3KHKM52RtGrkv"
     )
     w3.pm.release_package(
-        "package456", "1.0.0", "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGI"
+        "owned", "1.0.0", "ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW"
     )
-    release_id_1 = w3.pm.get_release_id("package123", "1.0.0")
-    release_id_2 = w3.pm.get_release_id("package456", "1.0.0")
+    release_id_1 = w3.pm.get_release_id("escrow", "1.0.0")
+    release_id_2 = w3.pm.get_release_id("owned", "1.0.0")
     package_data_1 = w3.pm.get_release_id_data(release_id_1)
     package_data_2 = w3.pm.get_release_id_data(release_id_2)
-    assert package_data_1[0] == "package123"
+    assert package_data_1[0] == "escrow"
     assert package_data_1[1] == "1.0.0"
-    assert package_data_1[2] == "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGE"
-    assert package_data_2[0] == "package456"
+    assert package_data_1[2] == "ipfs://QmPDwMHk8e1aMEZg3iKsUiPSkhHkywpGB3KHKM52RtGrkv"
+    assert package_data_2[0] == "owned"
     assert package_data_2[1] == "1.0.0"
-    assert package_data_2[2] == "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGI"
+    assert package_data_2[2] == "ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW"
 
 
 @pytest.mark.parametrize(

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -114,3 +114,10 @@ class PMError(Exception):
     Raised when an error occurs in the PM module.
     """
     pass
+
+
+class ManifestValidationError(PMError):
+    """
+    Raised when a provided manifest cannot be published, since it's invalid.
+    """
+    pass


### PR DESCRIPTION
### What was wrong?
More validation in `pm.release_package()` would be useful to prevent mix-ups between on-registry data and data actually in the manifest, and prevent pushing invalid manifest to your registry

### How was it fixed?
- Added validation to `pm.release_package()` that the manifest uri is a valid content-addressed (IPFS/github) URI.
- Add checks that given `package_name` and `version` match what's stored in the manifest


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/52443826-fbaef200-2ae3-11e9-8dec-2b65801324a6.png)
