### PR TITLE
Deprecate no infura api key in v5

### DIFF
--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -33,7 +33,7 @@ def test_load_provider_from_env(monkeypatch, uri, expected_type, expected_attrs)
         assert getattr(provider, attr) == val
 
 
-@pytest.mark.parametrize('environ_name', ['INFURA_API_KEY', 'WEB3_INFURA_API_KEY'])
+@pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])
 def test_web3_auto_infura_empty_key(monkeypatch, caplog, environ_name):
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'https')
     monkeypatch.setenv(environ_name, '')
@@ -41,7 +41,7 @@ def test_web3_auto_infura_empty_key(monkeypatch, caplog, environ_name):
     importlib.reload(infura)
     assert len(caplog.record_tuples) == 1
     logger, level, msg = caplog.record_tuples[0]
-    assert 'WEB3_INFURA_API_KEY' in msg
+    assert 'WEB3_INFURA_PROJECT_ID' in msg
     assert level == logging.WARNING
 
     w3 = infura.w3
@@ -49,7 +49,7 @@ def test_web3_auto_infura_empty_key(monkeypatch, caplog, environ_name):
     assert getattr(w3.provider, 'endpoint_uri') == 'https://mainnet.infura.io/'
 
 
-@pytest.mark.parametrize('environ_name', ['INFURA_API_KEY', 'WEB3_INFURA_API_KEY'])
+@pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])
 def test_web3_auto_infura_deleted_key(monkeypatch, caplog, environ_name):
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'https')
     monkeypatch.delenv(environ_name, raising=False)
@@ -57,7 +57,7 @@ def test_web3_auto_infura_deleted_key(monkeypatch, caplog, environ_name):
     importlib.reload(infura)
     assert len(caplog.record_tuples) == 1
     logger, level, msg = caplog.record_tuples[0]
-    assert 'WEB3_INFURA_API_KEY' in msg
+    assert 'WEB3_INFURA_PROJECT_ID' in msg
     assert level == logging.WARNING
 
     w3 = infura.w3
@@ -65,12 +65,42 @@ def test_web3_auto_infura_deleted_key(monkeypatch, caplog, environ_name):
     assert getattr(w3.provider, 'endpoint_uri') == 'https://mainnet.infura.io/'
 
 
-@pytest.mark.parametrize('environ_name', ['INFURA_API_KEY', 'WEB3_INFURA_API_KEY'])
+@pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])
+def test_web3_auto_infura_websocket_empty_key(monkeypatch, caplog, environ_name):
+    monkeypatch.setenv(environ_name, '')
+
+    importlib.reload(infura)
+    assert len(caplog.record_tuples) == 1
+    logger, level, msg = caplog.record_tuples[0]
+    assert 'WEB3_INFURA_PROJECT_ID' in msg
+    assert level == logging.WARNING
+
+    w3 = infura.w3
+    assert isinstance(w3.provider, WebsocketProvider)
+    assert getattr(w3.provider, 'endpoint_uri') == 'wss://mainnet.infura.io/ws/'
+
+
+@pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])
+def test_web3_auto_infura_websocket_deleted_key(monkeypatch, caplog, environ_name):
+    monkeypatch.delenv(environ_name, raising=False)
+
+    importlib.reload(infura)
+    assert len(caplog.record_tuples) == 1
+    logger, level, msg = caplog.record_tuples[0]
+    assert 'WEB3_INFURA_PROJECT_ID' in msg
+    assert level == logging.WARNING
+
+    w3 = infura.w3
+    assert isinstance(w3.provider, WebsocketProvider)
+    assert getattr(w3.provider, 'endpoint_uri') == 'wss://mainnet.infura.io/ws/'
+
+
+@pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])
 def test_web3_auto_infura(monkeypatch, caplog, environ_name):
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'https')
     API_KEY = 'aoeuhtns'
     monkeypatch.setenv(environ_name, API_KEY)
-    expected_url = 'https://%s/%s' % (infura.INFURA_MAINNET_DOMAIN, API_KEY)
+    expected_url = 'https://%s/v3/%s' % (infura.INFURA_MAINNET_DOMAIN, API_KEY)
 
     importlib.reload(infura)
     assert len(caplog.record_tuples) == 0
@@ -80,10 +110,16 @@ def test_web3_auto_infura(monkeypatch, caplog, environ_name):
     assert getattr(w3.provider, 'endpoint_uri') == expected_url
 
 
-def test_web3_auto_infura_websocket_default(caplog):
+@pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])
+def test_web3_auto_infura_websocket_default(monkeypatch, caplog, environ_name):
+    monkeypatch.setenv('WEB3_INFURA_SCHEME', 'wss')
+    API_KEY = 'aoeuhtns'
+    monkeypatch.setenv(environ_name, API_KEY)
+    expected_url = 'wss://%s/ws/v3/%s' % (infura.INFURA_MAINNET_DOMAIN, API_KEY)
+
     importlib.reload(infura)
     assert len(caplog.record_tuples) == 0
 
     w3 = infura.w3
     assert isinstance(w3.provider, WebsocketProvider)
-    assert getattr(w3.provider, 'endpoint_uri') == 'wss://mainnet.infura.io/ws'
+    assert getattr(w3.provider, 'endpoint_uri') == expected_url

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -11,7 +11,7 @@ if (3, 5) <= sys.version_info < (3, 6):
 if sys.version_info < (3, 5):
     raise EnvironmentError(
         "Python 3.5 or above is required. "
-        "Note that support for Python 3.5 will be remove in web3.py v5")
+        "Note that support for Python 3.5 will be removed in web3.py v5")
 
 from eth_account import Account  # noqa: E402
 from web3.main import Web3  # noqa: E402


### PR DESCRIPTION


### What was wrong?
Starting March 27th, Infura will officially stop supporting requests with no API key. Infura calls it a project ID, so I allow users to use either `WEB3_INFURA_API_KEY`, or `WEB3_INFURA_PROJECT_ID` env var. I took out the ability to use `INFURA_API_KEY` for this branch, but will leave it in for the v4 branch.

There is already a warning in place if there is no API key, but I updated the message. After March 27th, we should consider throwing an error if there is no key so the user can have a nice message.


Related to Issue #1246 

### How was it fixed?
See above.

#### Cute Animal Picture
![bulldog-puppy-paw-up](https://user-images.githubusercontent.com/6540608/53117408-16cc2980-3508-11e9-84d8-22af5b124f2d.jpg)