### PR TITLE
Remove process type utility function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "eth-abi>=2.0.0b6,<3.0.0",
         "eth-account>=0.2.1,<0.4.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
+        "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.3.0,<2.0.0",
         "ethpm>=0.1.4a12,<1.0.0",
         "hexbytes>=0.1.0,<1.0.0",

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     url='https://github.com/ethereum/web3.py',
     include_package_data=True,
     install_requires=[
-        "eth-abi>=2.0.0b5,<3.0.0",
+        "eth-abi>=2.0.0b6,<3.0.0",
         "eth-account>=0.2.1,<0.4.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-utils>=1.3.0,<2.0.0",

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -582,9 +582,9 @@ def abi_sub_tree(abi_type: Optional[Union[TypeStr, ABIType]], data_value: Any) -
 
     if abi_type.is_array:
         it = abi_type.item_type
-        return ABITypedData([str(abi_type), [abi_sub_tree(it, i) for i in data_value]])
+        return ABITypedData([abi_type.to_type_str(), [abi_sub_tree(it, i) for i in data_value]])
     else:
-        return ABITypedData([str(abi_type), data_value])
+        return ABITypedData([abi_type.to_type_str(), data_value])
 
 
 def strip_abi_type(elements):

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -4,6 +4,11 @@ from collections import (
 )
 import itertools
 import re
+from typing import (
+    Any,
+    Optional,
+    Union,
+)
 
 from eth_abi import (
     decoding,
@@ -13,11 +18,15 @@ from eth_abi.codec import (
     ABICodec,
 )
 from eth_abi.grammar import (
+    ABIType,
     parse,
 )
 from eth_abi.registry import (
     BaseEquals,
     registry as default_registry,
+)
+from eth_typing import (
+    TypeStr,
 )
 from eth_utils import (
     decode_hex,
@@ -564,11 +573,11 @@ class ABITypedData(namedtuple('ABITypedData', 'abi_type, data')):
         return super().__new__(cls, *iterable)
 
 
-def abi_sub_tree(abi_type, data_value):
+def abi_sub_tree(abi_type: Optional[Union[TypeStr, ABIType]], data_value: Any) -> ABITypedData:
     if abi_type is None:
         return ABITypedData([None, data_value])
 
-    if isinstance(abi_type, str):
+    if isinstance(abi_type, TypeStr):
         abi_type = parse(abi_type)
 
     if abi_type.is_array:

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -597,7 +597,7 @@ class ABITypedData(namedtuple('ABITypedData', 'abi_type, data')):
 
     >>> a1 = ABITypedData(['address', addr1])
     >>> a2 = ABITypedData(['address', addr2])
-    >>> addrs = ABITypedData(['address[]', [a1, a2])
+    >>> addrs = ABITypedData(['address[]', [a1, a2]])
 
     You can access the fields using tuple() interface, or with
     attributes:

--- a/web3/_utils/encoding.py
+++ b/web3/_utils/encoding.py
@@ -305,7 +305,7 @@ def encode_single_packed(_type, value):
     from eth_abi.registry import has_arrlist, registry
     abi_type = abi_type_parser.parse(_type)
     if has_arrlist(_type):
-        item_encoder = registry.get_encoder(str(abi_type.item_type))
+        item_encoder = registry.get_encoder(abi_type.item_type.to_type_str())
         if abi_type.arrlist[-1] != 1:
             return DynamicArrayPackedEncoder(item_encoder=item_encoder).encode(value)
         else:

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -10,6 +10,9 @@ from eth_abi import (
     encode_single,
     grammar,
 )
+from eth_typing import (
+    TypeStr,
+)
 from eth_utils import (
     encode_hex,
     event_abi_to_log_topic,
@@ -133,8 +136,8 @@ def construct_event_data_set(event_abi, arguments=None):
     return data
 
 
-def is_dynamic_sized_type(abi_type):
-    abi_type = grammar.parse(abi_type)
+def is_dynamic_sized_type(type_str: TypeStr) -> bool:
+    abi_type = grammar.parse(type_str)
     return abi_type.is_dynamic
 
 

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -8,6 +8,7 @@ from eth_abi import (
     decode_abi,
     decode_single,
     encode_single,
+    grammar,
 )
 from eth_utils import (
     encode_hex,
@@ -51,7 +52,6 @@ from .abi import (
     get_indexed_event_inputs,
     map_abi_data,
     normalize_event_input_types,
-    process_type,
 )
 
 
@@ -133,15 +133,9 @@ def construct_event_data_set(event_abi, arguments=None):
     return data
 
 
-def is_dynamic_sized_type(_type):
-    base_type, type_size, arrlist = process_type(_type)
-    if arrlist:
-        return True
-    elif base_type == 'string':
-        return True
-    elif base_type == 'bytes' and type_size == '':
-        return True
-    return False
+def is_dynamic_sized_type(abi_type):
+    abi_type = grammar.parse(abi_type)
+    return abi_type.is_dynamic
 
 
 @to_tuple

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -46,10 +46,10 @@ from web3.exceptions import (
 
 def implicitly_identity(to_wrap):
     @functools.wraps(to_wrap)
-    def wrapper(abi_type, data):
-        modified = to_wrap(abi_type, data)
+    def wrapper(type_str, data):
+        modified = to_wrap(type_str, data)
         if modified is None:
-            return abi_type, data
+            return type_str, data
         else:
             return modified
     return wrapper
@@ -61,15 +61,15 @@ def implicitly_identity(to_wrap):
 
 
 @implicitly_identity
-def addresses_checksummed(abi_type, data):
-    if abi_type == 'address':
-        return abi_type, to_checksum_address(data)
+def addresses_checksummed(type_str, data):
+    if type_str == 'address':
+        return type_str, to_checksum_address(data)
 
 
 @implicitly_identity
-def decode_abi_strings(abi_type, data):
-    if abi_type == 'string':
-        return abi_type, codecs.decode(data, 'utf8', 'backslashreplace')
+def decode_abi_strings(type_str, data):
+    if type_str == 'string':
+        return type_str, codecs.decode(data, 'utf8', 'backslashreplace')
 
 
 #
@@ -78,17 +78,17 @@ def decode_abi_strings(abi_type, data):
 
 
 @implicitly_identity
-def abi_bytes_to_hex(abi_type, data):
-    base, sub, arrlist = process_type(abi_type)
+def abi_bytes_to_hex(type_str, data):
+    base, sub, arrlist = process_type(type_str)
     if base == 'bytes' and not arrlist:
         bytes_data = hexstr_if_str(to_bytes, data)
         if not sub:
-            return abi_type, to_hex(bytes_data)
+            return type_str, to_hex(bytes_data)
         else:
             num_bytes = int(sub)
             if len(bytes_data) <= num_bytes:
                 padded = bytes_data.ljust(num_bytes, b'\0')
-                return abi_type, to_hex(padded)
+                return type_str, to_hex(padded)
             else:
                 raise ValueError(
                     "This value was expected to be at most %d bytes, but instead was %d: %r" % (
@@ -98,42 +98,42 @@ def abi_bytes_to_hex(abi_type, data):
 
 
 @implicitly_identity
-def abi_int_to_hex(abi_type, data):
-    base, _sub, arrlist = process_type(abi_type)
+def abi_int_to_hex(type_str, data):
+    base, _sub, arrlist = process_type(type_str)
     if base == 'uint' and not arrlist:
-        return abi_type, hexstr_if_str(to_hex, data)
+        return type_str, hexstr_if_str(to_hex, data)
 
 
 @implicitly_identity
-def abi_string_to_hex(abi_type, data):
-    if abi_type == 'string':
-        return abi_type, text_if_str(to_hex, data)
+def abi_string_to_hex(type_str, data):
+    if type_str == 'string':
+        return type_str, text_if_str(to_hex, data)
 
 
 @implicitly_identity
-def abi_string_to_text(abi_type, data):
-    if abi_type == 'string':
-        return abi_type, text_if_str(to_text, data)
+def abi_string_to_text(type_str, data):
+    if type_str == 'string':
+        return type_str, text_if_str(to_text, data)
 
 
 @implicitly_identity
-def abi_bytes_to_bytes(abi_type, data):
-    base, sub, arrlist = process_type(abi_type)
+def abi_bytes_to_bytes(type_str, data):
+    base, sub, arrlist = process_type(type_str)
     if base == 'bytes' and not arrlist:
-        return abi_type, hexstr_if_str(to_bytes, data)
+        return type_str, hexstr_if_str(to_bytes, data)
 
 
 @implicitly_identity
-def abi_address_to_hex(abi_type, data):
-    if abi_type == 'address':
+def abi_address_to_hex(type_str, data):
+    if type_str == 'address':
         validate_address(data)
         if is_binary_address(data):
-            return abi_type, to_checksum_address(data)
+            return type_str, to_checksum_address(data)
 
 
 @curry
-def abi_ens_resolver(w3, abi_type, val):
-    if abi_type == 'address' and is_ens_name(val):
+def abi_ens_resolver(w3, type_str, val):
+    if type_str == 'address' and is_ens_name(val):
         if w3 is None:
             raise InvalidAddress(
                 "Could not look up name %r because no web3"
@@ -150,9 +150,9 @@ def abi_ens_resolver(w3, abi_type, val):
                 " not connected to mainnet" % (val)
             )
         else:
-            return (abi_type, validate_name_has_address(w3.ens, val))
+            return type_str, validate_name_has_address(w3.ens, val)
     else:
-        return (abi_type, val)
+        return type_str, val
 
 
 BASE_RETURN_NORMALIZERS = [


### PR DESCRIPTION
### What was wrong?

Web3.py still included a legacy `process_type` function that was used to do parsing of simple, non-tuple type strings.

### How was it fixed?

To facilitate support for tuple types, uses of `process_type` were removed in favor of functionality provided by eth-abi.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.cbc.ca/natureofthings/content/images/episodes/foxtales_1920.jpg)
