### PR TITLE
Use Twine for release script backport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ release: clean
 	git config commit.gpgSign true
 	bumpversion $(bump)
 	git push upstream && git push upstream --tags
-	python setup.py sdist bdist_wheel upload
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
 dist: clean

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
     'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],
     'linter': [
         "flake8==3.4.1",
-        "isort>=4.2.15,<5",
+        "isort>=4.2.15,<4.3.5",
     ],
     'docs': [
         "mock",
@@ -21,8 +21,8 @@ extras_require = {
         "click>=5.1",
         "configparser==3.5.0",
         "contextlib2>=0.5.4",
-        #"eth-testrpc>=0.8.0",
-        #"ethereum-tester-client>=1.1.0",
+        # "eth-testrpc>=0.8.0",
+        # "ethereum-tester-client>=1.1.0",
         "ethtoken",
         "py-geth>=1.4.0",
         "py-solc>=0.4.0",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ extras_require = {
         "pytest-xdist==1.*",
         "tox>=1.8.0",
         "tqdm",
+        "twine",
         "when-changed"
     ]
 }


### PR DESCRIPTION
### What was wrong?
Updated deploy script didn't get backported to the v4 branch. 


#### Cute Animal Picture
![apparently twine=twin](https://user-images.githubusercontent.com/6540608/53387613-e2f86600-3944-11e9-94a3-8538b6d9378b.jpg)

