### PR TITLE
Update release notes to include breaking changes

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -89,3 +89,7 @@ so that is a good place to start.
 If you want to dive straight into contracts, check out the section on :ref:`contracts`,
 including a :ref:`contract_example`, and how to create a contract instance using
 :meth:`w3.eth.contract() <web3.eth.Eth.contract>`.
+
+.. NOTE:: It is recommended that your development environment have the ``PYTHONWARNINGS=default``
+    environment variable set. Some deprecation warnings will not show up
+    without this variable being set.

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -6,6 +6,30 @@ Breaking Change to Infura coming March 27th.
  Sign up for one at https://infura.io/register.
 
 
+v5 Breaking Changes Summary
+  - Remove deprecated ``buildTransaction``, ``call``, ``deploy``,
+    ``estimateGas``, and ``transact`` methods
+    - `#1232 <https://github.com/ethereum/web3.py/pull/1232>`_
+  - Rename ``middleware_stack`` to ``middleware_onion``
+    - `#1210 <https://github.com/ethereum/web3.py/pull/1210>`_
+  - Drop already deprecated ``web3.soliditySha3``
+    - `#1217 <https://github.com/ethereum/web3.py/pull/1217>`_
+  - ENS: Stop inferring ``.eth`` TLD on domain names
+    - `#1205 <https://github.com/ethereum/web3.py/pull/1205>`_
+  - Remove ``web3.miner.hashrate`` and ``web3.version.network``
+    - `#1198 <https://github.com/ethereum/web3.py/pull/1198>`_
+  - Remove ``web3.providers.tester.EthereumTesterProvider``
+    and ``web3.providers.tester.TestRPCProvider``
+    - `#1199 <https://github.com/ethereum/web3.py/pull/1199>`_
+  - Change ``manager.providers`` from list to single ``manager.provider``
+    - `#1200 <https://github.com/ethereum/web3.py/pull/1200>`_
+  - Replace deprecated ``web3.sha3`` method with ``web3.keccak`` method
+    - `#1207 <https://github.com/ethereum/web3.py/pull/1207>`_
+  - Drop auto detect testnets for IPCProvider
+    - `#1206 <https://github.com/ethereum/web3.py/pull/1206>`_
+  - Remove support for python3.5, drop support for eth-abi v1
+    - `#1163 <https://github.com/ethereum/web3.py/pull/1163>`_
+
 v5.0.0-alpha.6
 --------------
 Released February 25th, 2019


### PR DESCRIPTION
### What was wrong?
Added a list of v5 breaking changes at the top of the release notes. 

Also added a note in the Quickstart section about setting `PYTHONWARNINGS=default`. I am not sure this is the right place for it, but there wasn't another place that really felt right either. Let me know if you can think of a better one.

Related to Issue #1140 and comment on #1232 

#### Cute Animal Picture
![download](https://user-images.githubusercontent.com/6540608/53510695-d591c780-3a7b-11e9-812d-c69b42e9f3e5.jpg)

