### PR TITLE
MOAR ONIONS less stacks

### DIFF
--- a/web3/auto/infura/rinkeby.py
+++ b/web3/auto/infura/rinkeby.py
@@ -14,4 +14,4 @@ from .endpoints import (
 _infura_url = build_infura_url(INFURA_RINKEBY_DOMAIN)
 
 w3 = Web3(load_provider_from_uri(_infura_url))
-w3.middleware_stack.inject(geth_poa_middleware, layer=0)
+w3.middleware_onion.inject(geth_poa_middleware, layer=0)


### PR DESCRIPTION
### What was wrong?
A reference to `middleware_stack` in the infura autoloader for the rinkeby chain was there

### How was it fixed?
Changed it to `middleware_onion` as one does

#### Cute Animal Picture

![DOG ONION](https://www.dogster.com/wp-content/uploads/2018/05/Dog-sitting-on-grass-with-fresh-onions.jpg)
