### PR TITLE
Add custom exceptions for jsonrpc lookups that return none

### DIFF
--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -2,6 +2,7 @@ import pytest
 
 from web3.exceptions import (
     TimeExhausted,
+    TransactionNotFound,
     ValidationError,
 )
 from web3.middleware.simulate_unmined_transaction import (
@@ -53,7 +54,7 @@ def test_unmined_transaction_wait_for_receipt(web3):
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 123457
     })
-    with pytest.raises(ValueError):
+    with pytest.raises(TransactionNotFound):
         web3.eth.getTransactionReceipt(txn_hash)
 
     txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)

--- a/tests/core/middleware/test_latest_block_based_cache_middleware.py
+++ b/tests/core/middleware/test_latest_block_based_cache_middleware.py
@@ -182,8 +182,7 @@ def test_latest_block_based_cache_middleware_busts_cache(w3, mocker):
     result = w3.manager.request_blocking('fake_endpoint', [])
 
     assert w3.manager.request_blocking('fake_endpoint', []) == result
-    with pytest.raises(ValueError):
-        w3.testing.mine()
+    w3.testing.mine()
 
     # should still be cached for at least 1 second.  This also verifies that
     # the middleware caches the latest block based on the block time.
@@ -212,10 +211,8 @@ def test_latest_block_cache_middleware_does_not_cache_bad_responses(
     }))
     w3.middleware_onion.add(latest_block_based_cache_middleware)
 
-    with pytest.raises(ValueError):
-        w3.manager.request_blocking('fake_endpoint', [])
-    with pytest.raises(ValueError):
-        w3.manager.request_blocking('fake_endpoint', [])
+    w3.manager.request_blocking('fake_endpoint', [])
+    w3.manager.request_blocking('fake_endpoint', [])
 
     assert next(counter) == 2
 

--- a/tests/core/middleware/test_simple_cache_middleware.py
+++ b/tests/core/middleware/test_simple_cache_middleware.py
@@ -78,10 +78,8 @@ def test_simple_cache_middleware_does_not_cache_none_responses(w3_base):
         rpc_whitelist={'fake_endpoint'},
     ))
 
-    with pytest.raises(ValueError):
-        w3.manager.request_blocking('fake_endpoint', [])
-    with pytest.raises(ValueError):
-        w3.manager.request_blocking('fake_endpoint', [])
+    w3.manager.request_blocking('fake_endpoint', [])
+    w3.manager.request_blocking('fake_endpoint', [])
 
     assert next(counter) == 2
 

--- a/tests/core/middleware/test_time_based_cache_middleware.py
+++ b/tests/core/middleware/test_time_based_cache_middleware.py
@@ -117,10 +117,8 @@ def test_time_based_cache_middleware_does_not_cache_bad_responses(
     w3.middleware_onion.add(construct_result_generator_middleware({'fake_endpoint': mk_result}))
     w3.middleware_onion.add(time_cache_middleware)
 
-    with pytest.raises(ValueError):
-        w3.manager.request_blocking('fake_endpoint', [])
-    with pytest.raises(ValueError):
-        w3.manager.request_blocking('fake_endpoint', [])
+    w3.manager.request_blocking('fake_endpoint', [])
+    w3.manager.request_blocking('fake_endpoint', [])
 
     assert next(counter) == 2
 

--- a/tests/core/testing-module/test_testing_snapshot_and_revert.py
+++ b/tests/core/testing-module/test_testing_snapshot_and_revert.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_snapshot_revert_to_latest_snapshot(web3):
     web3.testing.mine(5)
 
@@ -14,8 +11,7 @@ def test_snapshot_revert_to_latest_snapshot(web3):
 
     block_after_mining = web3.eth.getBlock("latest")
 
-    with pytest.raises(ValueError):
-        web3.testing.revert()
+    web3.testing.revert()
 
     block_after_revert = web3.eth.getBlock("latest")
 
@@ -42,8 +38,7 @@ def test_snapshot_revert_to_specific(web3):
 
     block_after_mining = web3.eth.getBlock("latest")
 
-    with pytest.raises(ValueError):
-        web3.testing.revert(snapshot_idx)
+    web3.testing.revert(snapshot_idx)
 
     block_after_revert = web3.eth.getBlock("latest")
 

--- a/tests/core/testing-module/test_testing_timeTravel.py
+++ b/tests/core/testing-module/test_testing_timeTravel.py
@@ -1,13 +1,9 @@
-import pytest
-
-
 def test_time_traveling(web3):
     current_block_time = web3.eth.getBlock("pending")['timestamp']
 
     time_travel_to = current_block_time + 12345
 
-    with pytest.raises(ValueError):
-        web3.testing.timeTravel(time_travel_to)
+    web3.testing.timeTravel(time_travel_to)
 
     latest_block_time = web3.eth.getBlock("pending")['timestamp']
     assert latest_block_time >= time_travel_to

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -20,7 +20,9 @@ from hexbytes import (
 )
 
 from web3.exceptions import (
+    BlockNotFound,
     InvalidAddress,
+    TransactionNotFound,
 )
 
 UNKNOWN_ADDRESS = '0xdEADBEeF00000000000000000000000000000000'
@@ -278,7 +280,7 @@ class EthModuleTest:
             'gas': 21000,
             'gasPrice': web3.eth.gasPrice,
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(TransactionNotFound):
             web3.eth.replaceTransaction(
                 '0x98e8cc09b311583c5079fa600f6c2a3bea8611af168c52e4b60b5b243a441997',
                 txn_params
@@ -485,7 +487,7 @@ class EthModuleTest:
         assert block['hash'] == empty_block['hash']
 
     def test_eth_getBlockByHash_not_found(self, web3, empty_block):
-        with pytest.raises(ValueError):
+        with pytest.raises(BlockNotFound):
             web3.eth.getBlock(UNKNOWN_HASH)
 
     def test_eth_getBlockByNumber_with_integer(self, web3, empty_block):
@@ -498,7 +500,7 @@ class EthModuleTest:
         assert block['number'] == current_block_number
 
     def test_eth_getBlockByNumber_not_found(self, web3, empty_block):
-        with pytest.raises(ValueError):
+        with pytest.raises(BlockNotFound):
             web3.eth.getBlock(12345)
 
     def test_eth_getBlockByNumber_pending(self, web3, empty_block):
@@ -565,7 +567,7 @@ class EthModuleTest:
             'gas': 21000,
             'gasPrice': web3.eth.gasPrice,
         })
-        with pytest.raises(ValueError):
+        with pytest.raises(TransactionNotFound):
             web3.eth.getTransactionReceipt(txn_hash)
 
     def test_eth_getTransactionReceipt_with_log_entry(self,

--- a/web3/_utils/module_testing/parity_module.py
+++ b/web3/_utils/module_testing/parity_module.py
@@ -12,8 +12,8 @@ from web3._utils.formatters import (
 class ParityModuleTest:
 
     def test_list_storage_keys_no_support(self, web3, emitter_contract_address):
-        with pytest.raises(ValueError):
-            web3.parity.listStorageKeys(emitter_contract_address, 10, None)
+        keys = web3.parity.listStorageKeys(emitter_contract_address, 10, None)
+        assert keys is None
 
     def test_trace_replay_transaction(self, web3, parity_fixture_data):
         trace = web3.parity.traceReplayTransaction(parity_fixture_data['mined_txn_hash'])

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -8,6 +8,9 @@ from web3._utils.toolz import (
     curry,
     merge,
 )
+from web3.exceptions import (
+    TransactionNotFound,
+)
 
 VALID_TRANSACTION_PARAMS = [
     'from',
@@ -66,7 +69,7 @@ def wait_for_transaction_receipt(web3, txn_hash, timeout=120, poll_latency=0.1):
         while True:
             try:
                 txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
-            except ValueError:
+            except TransactionNotFound:
                 txn_receipt = None
             # FIXME: The check for a null `blockHash` is due to parity's
             # non-standard implementation of the JSON-RPC API and should

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -46,7 +46,9 @@ from web3.contract import (
     Contract,
 )
 from web3.exceptions import (
+    BlockNotFound,
     TimeExhausted,
+    TransactionNotFound,
 )
 from web3.iban import (
     Iban,
@@ -142,10 +144,13 @@ class Eth(Module):
             if_number='eth_getBlockByNumber',
         )
 
-        return self.web3.manager.request_blocking(
-            method,
-            [block_identifier, full_transactions],
-        )
+        try:
+            return self.web3.manager.request_blocking(
+                method,
+                [block_identifier, full_transactions],
+            )
+        except ValueError:
+            raise BlockNotFound(f"Block with id: {block_identifier} not found.")
 
     def getBlockTransactionCount(self, block_identifier):
         """
@@ -158,10 +163,13 @@ class Eth(Module):
             if_hash='eth_getBlockTransactionCountByHash',
             if_number='eth_getBlockTransactionCountByNumber',
         )
-        return self.web3.manager.request_blocking(
-            method,
-            [block_identifier],
-        )
+        try:
+            return self.web3.manager.request_blocking(
+                method,
+                [block_identifier],
+            )
+        except ValueError:
+            raise BlockNotFound(f"Block with id: {block_identifier} not found.")
 
     def getUncleCount(self, block_identifier):
         """
@@ -174,10 +182,13 @@ class Eth(Module):
             if_hash='eth_getUncleCountByBlockHash',
             if_number='eth_getUncleCountByBlockNumber',
         )
-        return self.web3.manager.request_blocking(
-            method,
-            [block_identifier],
-        )
+        try:
+            return self.web3.manager.request_blocking(
+                method,
+                [block_identifier],
+            )
+        except ValueError:
+            raise BlockNotFound(f"Block with id: {block_identifier} not found.")
 
     def getUncleByBlock(self, block_identifier, uncle_index):
         """
@@ -190,16 +201,24 @@ class Eth(Module):
             if_hash='eth_getUncleByBlockHashAndIndex',
             if_number='eth_getUncleByBlockNumberAndIndex',
         )
-        return self.web3.manager.request_blocking(
-            method,
-            [block_identifier, uncle_index],
-        )
+        try:
+            return self.web3.manager.request_blocking(
+                method,
+                [block_identifier, uncle_index],
+            )
+        except ValueError:
+            raise BlockNotFound(
+                f"Uncle at index: {uncle_index} of block with id: {block_identifier} not found."
+            )
 
     def getTransaction(self, transaction_hash):
-        return self.web3.manager.request_blocking(
-            "eth_getTransactionByHash",
-            [transaction_hash],
-        )
+        try:
+            return self.web3.manager.request_blocking(
+                "eth_getTransactionByHash",
+                [transaction_hash],
+            )
+        except ValueError:
+            raise TransactionNotFound(f"Transaction with hash: {transaction_hash} not found.")
 
     @deprecated_for("w3.eth.getTransactionByBlock")
     def getTransactionFromBlock(self, block_identifier, transaction_index):
@@ -220,10 +239,16 @@ class Eth(Module):
             if_hash='eth_getTransactionByBlockHashAndIndex',
             if_number='eth_getTransactionByBlockNumberAndIndex',
         )
-        return self.web3.manager.request_blocking(
-            method,
-            [block_identifier, transaction_index],
-        )
+        try:
+            return self.web3.manager.request_blocking(
+                method,
+                [block_identifier, transaction_index],
+            )
+        except ValueError:
+            raise TransactionNotFound(
+                f"Transaction index: {transaction_index} "
+                f"on block id: {block_identifier} not found."
+            )
 
     def waitForTransactionReceipt(self, transaction_hash, timeout=120):
         try:
@@ -237,20 +262,20 @@ class Eth(Module):
             )
 
     def getTransactionReceipt(self, transaction_hash):
-        return self.web3.manager.request_blocking(
-            "eth_getTransactionReceipt",
-            [transaction_hash],
-        )
+        try:
+            return self.web3.manager.request_blocking(
+                "eth_getTransactionReceipt",
+                [transaction_hash],
+            )
+        except ValueError:
+            raise TransactionNotFound(f"Transaction with hash: {transaction_hash} not found.")
 
     def getTransactionCount(self, account, block_identifier=None):
         if block_identifier is None:
             block_identifier = self.defaultBlock
         return self.web3.manager.request_blocking(
             "eth_getTransactionCount",
-            [
-                account,
-                block_identifier,
-            ],
+            [account, block_identifier],
         )
 
     def replaceTransaction(self, transaction_hash, new_transaction):

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -144,13 +144,13 @@ class Eth(Module):
             if_number='eth_getBlockByNumber',
         )
 
-        try:
-            return self.web3.manager.request_blocking(
-                method,
-                [block_identifier, full_transactions],
-            )
-        except ValueError:
+        result = self.web3.manager.request_blocking(
+            method,
+            [block_identifier, full_transactions],
+        )
+        if result is None:
             raise BlockNotFound(f"Block with id: {block_identifier} not found.")
+        return result
 
     def getBlockTransactionCount(self, block_identifier):
         """
@@ -163,13 +163,13 @@ class Eth(Module):
             if_hash='eth_getBlockTransactionCountByHash',
             if_number='eth_getBlockTransactionCountByNumber',
         )
-        try:
-            return self.web3.manager.request_blocking(
-                method,
-                [block_identifier],
-            )
-        except ValueError:
+        result = self.web3.manager.request_blocking(
+            method,
+            [block_identifier],
+        )
+        if result is None:
             raise BlockNotFound(f"Block with id: {block_identifier} not found.")
+        return result
 
     def getUncleCount(self, block_identifier):
         """
@@ -182,13 +182,13 @@ class Eth(Module):
             if_hash='eth_getUncleCountByBlockHash',
             if_number='eth_getUncleCountByBlockNumber',
         )
-        try:
-            return self.web3.manager.request_blocking(
-                method,
-                [block_identifier],
-            )
-        except ValueError:
+        result = self.web3.manager.request_blocking(
+            method,
+            [block_identifier],
+        )
+        if result is None:
             raise BlockNotFound(f"Block with id: {block_identifier} not found.")
+        return result
 
     def getUncleByBlock(self, block_identifier, uncle_index):
         """
@@ -201,24 +201,24 @@ class Eth(Module):
             if_hash='eth_getUncleByBlockHashAndIndex',
             if_number='eth_getUncleByBlockNumberAndIndex',
         )
-        try:
-            return self.web3.manager.request_blocking(
-                method,
-                [block_identifier, uncle_index],
-            )
-        except ValueError:
+        result = self.web3.manager.request_blocking(
+            method,
+            [block_identifier, uncle_index],
+        )
+        if result is None:
             raise BlockNotFound(
                 f"Uncle at index: {uncle_index} of block with id: {block_identifier} not found."
             )
+        return result
 
     def getTransaction(self, transaction_hash):
-        try:
-            return self.web3.manager.request_blocking(
-                "eth_getTransactionByHash",
-                [transaction_hash],
-            )
-        except ValueError:
+        result = self.web3.manager.request_blocking(
+            "eth_getTransactionByHash",
+            [transaction_hash],
+        )
+        if result is None:
             raise TransactionNotFound(f"Transaction with hash: {transaction_hash} not found.")
+        return result
 
     @deprecated_for("w3.eth.getTransactionByBlock")
     def getTransactionFromBlock(self, block_identifier, transaction_index):
@@ -239,16 +239,16 @@ class Eth(Module):
             if_hash='eth_getTransactionByBlockHashAndIndex',
             if_number='eth_getTransactionByBlockNumberAndIndex',
         )
-        try:
-            return self.web3.manager.request_blocking(
-                method,
-                [block_identifier, transaction_index],
-            )
-        except ValueError:
+        result = self.web3.manager.request_blocking(
+            method,
+            [block_identifier, transaction_index],
+        )
+        if result is None:
             raise TransactionNotFound(
                 f"Transaction index: {transaction_index} "
                 f"on block id: {block_identifier} not found."
             )
+        return result
 
     def waitForTransactionReceipt(self, transaction_hash, timeout=120):
         try:
@@ -262,13 +262,13 @@ class Eth(Module):
             )
 
     def getTransactionReceipt(self, transaction_hash):
-        try:
-            return self.web3.manager.request_blocking(
-                "eth_getTransactionReceipt",
-                [transaction_hash],
-            )
-        except ValueError:
+        result = self.web3.manager.request_blocking(
+            "eth_getTransactionReceipt",
+            [transaction_hash],
+        )
+        if result is None:
             raise TransactionNotFound(f"Transaction with hash: {transaction_hash} not found.")
+        return result
 
     def getTransactionCount(self, account, block_identifier=None):
         if block_identifier is None:

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -128,3 +128,17 @@ class ManifestValidationError(PMError):
     Raised when a provided manifest cannot be published, since it's invalid.
     """
     pass
+
+
+class TransactionNotFound(Exception):
+    """
+    Raised when a tx hash used to lookup a tx in a jsonrpc call cannot be found.
+    """
+    pass
+
+
+class BlockNotFound(Exception):
+    """
+    Raised when the block id used to lookup a block in a jsonrpc call cannot be found.
+    """
+    pass

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -96,9 +96,6 @@ class RequestManager:
         if "error" in response:
             raise ValueError(response["error"])
 
-        if response['result'] is None:
-            raise ValueError(f"The call to {method} did not return a value.")
-
         return response['result']
 
     async def coro_request(self, method, params):


### PR DESCRIPTION
### What was wrong?
Rather than simply raising a `ValueError` when jsonrpc lookup calls returned `None`, raise a custom exception with better info.

re. [comment here](https://github.com/ethereum/web3.py/pull/1218/files/cf6c556013214a8ab05c08b537107e7fe229c907#r262141215)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/53872743-26b33580-3fff-11e9-98d2-c71b33d460af.png)
