### PR TITLE
Add getLogs by blockHash

### DIFF
--- a/tests/core/filtering/test_contract_getLogs.py
+++ b/tests/core/filtering/test_contract_getLogs.py
@@ -79,17 +79,17 @@ def test_contract_getLogs_argument_filter(
     for txn_hash in txn_hashes:
         wait_for_transaction(web3, txn_hash)
 
-    all_logs = contract.events.LogTripleWithIndex.getLogs()
+    all_logs = contract.events.LogTripleWithIndex.getLogs(fromBlock=1)
     assert len(all_logs) == 4
 
     # Filter all entries where arg1 in (1, 2)
-    partial_logs = contract.events.LogTripleWithIndex.getLogs(
+    partial_logs = contract.events.LogTripleWithIndex.getLogs(fromBlock=1,
         argument_filters={'arg1': [1, 2]},
     )
     assert len(partial_logs) == 2
 
     # Filter all entries where arg0 == 1
-    partial_logs = contract.events.LogTripleWithIndex.getLogs(
+    partial_logs = contract.events.LogTripleWithIndex.getLogs(fromBlock=1,
         argument_filters={'arg0': 1},
     )
     assert len(partial_logs) == 4

--- a/tests/core/filtering/test_contract_getLogs.py
+++ b/tests/core/filtering/test_contract_getLogs.py
@@ -83,13 +83,15 @@ def test_contract_getLogs_argument_filter(
     assert len(all_logs) == 4
 
     # Filter all entries where arg1 in (1, 2)
-    partial_logs = contract.events.LogTripleWithIndex.getLogs(fromBlock=1,
+    partial_logs = contract.events.LogTripleWithIndex.getLogs(
+        fromBlock=1,
         argument_filters={'arg1': [1, 2]},
     )
     assert len(partial_logs) == 2
 
     # Filter all entries where arg0 == 1
-    partial_logs = contract.events.LogTripleWithIndex.getLogs(fromBlock=1,
+    partial_logs = contract.events.LogTripleWithIndex.getLogs(
+        fromBlock=1,
         argument_filters={'arg0': 1},
     )
     assert len(partial_logs) == 4

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1067,7 +1067,8 @@ class ContractEvent:
     def getLogs(self,
                 argument_filters=None,
                 fromBlock=1,
-                toBlock="latest"):
+                toBlock="latest",
+                blockHash=None):
         """Get events for this contract instance using eth_getLogs API.
 
         This is a stateless method, as opposed to createFilter.
@@ -1142,6 +1143,13 @@ class ContractEvent:
             toBlock=toBlock,
             address=self.address,
         )
+
+        if blockHash is not None:
+            if 'fromBlock' in event_filter_params:
+                del event_filter_params['fromBlock']
+            if 'toBlock' in event_filter_params:
+                del event_filter_params['toBlock']
+            event_filter_params['blockHash'] = blockHash
 
         # Call JSON-RPC API
         logs = self.web3.eth.getLogs(event_filter_params)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -9,7 +9,6 @@ from eth_abi import (
 )
 from eth_abi.exceptions import (
     DecodingError,
-    ValidationError,
 )
 from eth_utils import (
     add_0x_prefix,
@@ -90,6 +89,7 @@ from web3.exceptions import (
     NoABIEventsFound,
     NoABIFound,
     NoABIFunctionsFound,
+    ValidationError,
 )
 
 DEPRECATED_SIGNATURE_MESSAGE = (

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1066,8 +1066,8 @@ class ContractEvent:
     @combomethod
     def getLogs(self,
                 argument_filters=None,
-                fromBlock=1,
-                toBlock="latest",
+                fromBlock=None,
+                toBlock=None,
                 blockHash=None):
         """Get events for this contract instance using eth_getLogs API.
 
@@ -1075,7 +1075,7 @@ class ContractEvent:
         It can be safely called against nodes which do not provide
         eth_newFilter API, like Infura nodes.
 
-        If no block range is provided and there are many events,
+        If there are many events,
         like ``Transfer`` events for a popular token,
         the Ethereum node might be overloaded and timeout
         on the underlying JSON-RPC call.
@@ -1117,8 +1117,10 @@ class ContractEvent:
         See also: :func:`web3.middleware.filter.local_filter_middleware`.
 
         :param argument_filters:
-        :param fromBlock: block number, defaults to 1
+        :param fromBlock: block number or "latest", defaults to "latest"
         :param toBlock: block number or "latest". Defaults to "latest"
+        :param blockHash: block hash. blockHash cannot be set at the
+          same time as fromBlock or toBlock
         :yield: Tuple of :class:`AttributeDict` instances
         """
 
@@ -1133,6 +1135,12 @@ class ContractEvent:
 
         _filters = dict(**argument_filters)
 
+        blkhash_set = blockHash is not None
+        blknum_set = fromBlock is not None or toBlock is not None
+        if blkhash_set and blknum_set:
+            raise ValidationError('blockHash cannot be set at the same'
+                    ' time as fromBlock or toBlock')
+
         # Construct JSON-RPC raw filter presentation based on human readable Python descriptions
         # Namely, convert event names to their keccak signatures
         data_filter_set, event_filter_params = construct_event_filter_params(
@@ -1145,10 +1153,6 @@ class ContractEvent:
         )
 
         if blockHash is not None:
-            if 'fromBlock' in event_filter_params:
-                del event_filter_params['fromBlock']
-            if 'toBlock' in event_filter_params:
-                del event_filter_params['toBlock']
             event_filter_params['blockHash'] = blockHash
 
         # Call JSON-RPC API

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -9,6 +9,7 @@ from eth_abi import (
 )
 from eth_abi.exceptions import (
     DecodingError,
+    ValidationError,
 )
 from eth_utils import (
     add_0x_prefix,
@@ -1138,7 +1139,8 @@ class ContractEvent:
         blkhash_set = blockHash is not None
         blknum_set = fromBlock is not None or toBlock is not None
         if blkhash_set and blknum_set:
-            raise ValidationError('blockHash cannot be set at the same'
+            raise ValidationError(
+                    'blockHash cannot be set at the same'
                     ' time as fromBlock or toBlock')
 
         # Construct JSON-RPC raw filter presentation based on human readable Python descriptions

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1140,8 +1140,8 @@ class ContractEvent:
         blknum_set = fromBlock is not None or toBlock is not None
         if blkhash_set and blknum_set:
             raise ValidationError(
-                    'blockHash cannot be set at the same'
-                    ' time as fromBlock or toBlock')
+                'blockHash cannot be set at the same'
+                ' time as fromBlock or toBlock')
 
         # Construct JSON-RPC raw filter presentation based on human readable Python descriptions
         # Namely, convert event names to their keccak signatures


### PR DESCRIPTION
### What was wrong?
getLogs did not accept the blockHash parameter.

Related to Issue #1236 

### How was it fixed?
Added blockHash as a parameter in `contract.getLogs`. Marked WIP because I was not sure if my approach was in line with the style of the rest of the code base, but I did not want to touch `construct_event_filter_params` because that can also be used to create a filter (for which `blockHash` is not a valid parameter). Feedback/guidance on my approach would be appreciated!

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.ageekyworld.com/wp-content/uploads/2014/09/Photogenic-and-Cute-Animals-14.png)
