### PR TITLE
Deprecate endpoints according to updated spec

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -332,8 +332,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
 .. py:method:: Eth.getTransactionFromBlock(block_identifier, transaction_index)
 
-  .. note:: This method is deprecated and replaced by
-    ``Eth.getTransactionByBlock``
+   .. note:: This method is deprecated in EIP 1474.
 
 
 .. py:method:: Eth.getTransactionByBlock(block_identifier, transaction_index)

--- a/docs/web3.net.rst
+++ b/docs/web3.net.rst
@@ -15,20 +15,8 @@ Properties
 
 The following properties are available on the ``web3.net`` namespace.
 
-.. py:method:: Net.chainId(self)
-
-    This method is trivially implemented.
-    It will always return `None`, which is a valid chainId to specify in the transaction.
-
-    If you want the real chainId of your node, you must manually determine it for now.
-
-    Note that your transactions (may be) replayable on forks of the network you intend, if
-    :ref:`eth-account` and using a chainId of `None`.
-
-    .. code-block:: python
-
-        >>> web3.net.chainId
-        None
+.. py:method:: Net.chainId(self)	
+    This method is deprecated as of EIP 1474.
 
 .. py:method:: Net.version(self)
 

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -57,7 +57,7 @@ def test_build_transaction_not_paying_to_nonpayable_function(
         'data': '0xe4cb8f5c',
         'value': 0,
         'gasPrice': 1,
-        'chainId': None,
+        'chainId': 1,
     }
 
 
@@ -78,7 +78,7 @@ def test_build_transaction_with_contract_no_arguments(web3, math_contract, build
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 1,
-        'chainId': None,
+        'chainId': 1,
     }
 
 
@@ -89,7 +89,7 @@ def test_build_transaction_with_contract_fallback_function(web3, fallback_functi
         'data': '0x',
         'value': 0,
         'gasPrice': 1,
-        'chainId': None,
+        'chainId': 1,
     }
 
 
@@ -108,7 +108,7 @@ def test_build_transaction_with_contract_class_method(
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 1,
-        'chainId': None,
+        'chainId': 1,
     }
 
 
@@ -122,7 +122,7 @@ def test_build_transaction_with_contract_default_account_is_set(
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 1,
-        'chainId': None,
+        'chainId': 1,
     }
 
 
@@ -136,7 +136,7 @@ def test_build_transaction_with_gas_price_strategy_set(web3, math_contract, buil
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 5,
-        'chainId': None,
+        'chainId': 1,
     }
 
 
@@ -164,31 +164,31 @@ def test_build_transaction_with_contract_to_address_supplied_errors(web3,
         (
             {}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'chainId': None,
+                'value': 0, 'gasPrice': 1, 'chainId': 1,
             }, False
         ),
         (
             {'gas': 800000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'chainId': None,
+                'value': 0, 'gasPrice': 1, 'chainId': 1,
             }, False
         ),
         (
             {'gasPrice': 21000000000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 21000000000, 'chainId': None,
+                'value': 0, 'gasPrice': 21000000000, 'chainId': 1,
             }, False
         ),
         (
             {'nonce': 7}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'nonce': 7, 'chainId': None,
+                'value': 0, 'gasPrice': 1, 'nonce': 7, 'chainId': 1,
             }, True
         ),
         (
             {'value': 20000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 20000, 'gasPrice': 1, 'chainId': None,
+                'value': 20000, 'gasPrice': 1, 'chainId': 1,
             }, False
         ),
     ),

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -16,13 +16,12 @@ RECEIPT_TIMEOUT = 0.2
     'make_chain_id, expect_success',
     (
         (
-            lambda web3: web3.net.chainId,
+            lambda web3: web3.net.version,
             True,
         ),
         pytest.param(
             lambda web3: 999999999999,
             False,
-            marks=pytest.mark.xfail,
         ),
     ),
 )

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -531,16 +531,6 @@ class EthModuleTest:
         assert is_dict(transaction)
         assert transaction['to'] is None, "to field is %r" % transaction['to']
 
-    def test_eth_getTransactionFromBlockHashAndIndex(self, web3, block_with_txn, mined_txn_hash):
-        transaction = web3.eth.getTransactionFromBlock(block_with_txn['hash'], 0)
-        assert is_dict(transaction)
-        assert transaction['hash'] == HexBytes(mined_txn_hash)
-
-    def test_eth_getTransactionFromBlockNumberAndIndex(self, web3, block_with_txn, mined_txn_hash):
-        transaction = web3.eth.getTransactionFromBlock(block_with_txn['number'], 0)
-        assert is_dict(transaction)
-        assert transaction['hash'] == HexBytes(mined_txn_hash)
-
     def test_eth_getTransactionByBlockHashAndIndex(self, web3, block_with_txn, mined_txn_hash):
         transaction = web3.eth.getTransactionByBlock(block_with_txn['hash'], 0)
         assert is_dict(transaction)
@@ -598,22 +588,6 @@ class EthModuleTest:
 
     def test_eth_getUncleByBlockNumberAndIndex(self, web3):
         # TODO: how do we make uncles....
-        pass
-
-    def test_eth_getCompilers(self, web3):
-        # TODO: do we want to test this?
-        pass
-
-    def test_eth_compileSolidity(self, web3):
-        # TODO: do we want to test this?
-        pass
-
-    def test_eth_compileLLL(self, web3):
-        # TODO: do we want to test this?
-        pass
-
-    def test_eth_compileSerpent(self, web3):
-        # TODO: do we want to test this?
         pass
 
     def test_eth_newFilter(self, web3):
@@ -828,3 +802,11 @@ class EthModuleTest:
 
         failure = web3.eth.uninstallFilter(filter.filter_id)
         assert failure is False
+
+    def test_eth_getTransactionFromBlock_deprecation(self, web3, block_with_txn):
+        with pytest.raises(DeprecationWarning):
+            web3.eth.getTransactionFromBlock(block_with_txn['hash'], 0)
+
+    def test_eth_getCompilers_deprecation(self, web3):
+        with pytest.raises(DeprecationWarning):
+            web3.eth.getCompilers()

--- a/web3/_utils/module_testing/net_module.py
+++ b/web3/_utils/module_testing/net_module.py
@@ -1,3 +1,5 @@
+import pytest
+
 from eth_utils import (
     is_boolean,
     is_integer,
@@ -21,3 +23,7 @@ class NetModuleTest:
         peer_count = web3.net.peerCount
 
         assert is_integer(peer_count)
+
+    def test_net_chainId_deprecation(self, web3):
+        with pytest.raises(DeprecationWarning):
+            web3.net.chainId

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -28,7 +28,7 @@ TRANSACTION_DEFAULTS = {
     'data': b'',
     'gas': lambda web3, tx: web3.eth.estimateGas(tx),
     'gasPrice': lambda web3, tx: web3.eth.generateGasPrice(tx) or web3.eth.gasPrice,
-    'chainId': lambda web3, tx: web3.net.chainId,
+    'chainId': lambda web3, tx: int(web3.net.version),
 }
 
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -13,9 +13,6 @@ from hexbytes import (
 from web3._utils.blocks import (
     select_method_for_block_identifier,
 )
-from web3._utils.decorators import (
-    deprecated_for,
-)
 from web3._utils.empty import (
     empty,
 )
@@ -65,10 +62,6 @@ class Eth(Module):
     defaultContractFactory = Contract
     iban = Iban
     gasPriceStrategy = None
-
-    @deprecated_for("doing nothing at all")
-    def enable_unaudited_features(self):
-        pass
 
     def namereg(self):
         raise NotImplementedError()
@@ -220,13 +213,12 @@ class Eth(Module):
             raise TransactionNotFound(f"Transaction with hash: {transaction_hash} not found.")
         return result
 
-    @deprecated_for("w3.eth.getTransactionByBlock")
     def getTransactionFromBlock(self, block_identifier, transaction_index):
         """
         Alias for the method getTransactionByBlock
         Depreceated to maintain naming consistency with the json-rpc API
         """
-        return self.getTransactionByBlock(block_identifier, transaction_index)
+        raise DeprecationWarning("This method has been deprecated as of EIP 1474.")
 
     def getTransactionByBlock(self, block_identifier, transaction_index):
         """
@@ -419,7 +411,7 @@ class Eth(Module):
         self.defaultContractFactory = contractFactory
 
     def getCompilers(self):
-        return self.web3.manager.request_blocking("eth_getCompilers", [])
+        raise DeprecationWarning("This method has been deprecated as of EIP 1474.")
 
     def getWork(self):
         return self.web3.manager.request_blocking("eth_getWork", [])

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -29,7 +29,7 @@ is_not_null = complement(is_null)
 
 @curry
 def validate_chain_id(web3, chain_id):
-    if chain_id == web3.net.chainId:
+    if chain_id == web3.net.version:
         return chain_id
     else:
         raise ValidationError(
@@ -66,7 +66,7 @@ def transaction_param_validator(web3):
     transactions_params_validators = {
         'chainId': apply_formatter_if(
             # Bypass `validate_chain_id` if chainId can't be determined
-            lambda _: is_not_null(web3.net.chainId),
+            lambda _: is_not_null(web3.net.version),
             validate_chain_id(web3)
         ),
     }

--- a/web3/net.py
+++ b/web3/net.py
@@ -14,7 +14,7 @@ class Net(Module):
 
     @property
     def chainId(self):
-        return None
+        raise DeprecationWarning("This method has been deprecated in EIP 1474.")
 
     @property
     def version(self):


### PR DESCRIPTION
### What was wrong?
RPC endpoints have changed according to new [EIP-1474](https://github.com/bitpshr/EIPs/blob/147609158191a701cf02c8556d5e529ffcb31cd2/EIPS/eip-1474.md). 

- Deprecated `web3.net.chainId()`
- Deprecated `web3.eth.getCompilers()`
- Deprecated `web3.eth.getTransactionFromBlock()`
- removed `web3.eth.enableUnauditedFeatures()`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/54129219-0ffd4c00-440e-11e9-8630-041e79fce4df.png)

