### PR TITLE
Add deprecation warning to jsonrpc endpoints dropped in EIP 1474

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -24,6 +24,7 @@ from web3.utils.blocks import (
 )
 from web3.utils.decorators import (
     deprecated_for,
+    deprecated_in_v5,
 )
 from web3.utils.empty import (
     empty,
@@ -374,6 +375,7 @@ class Eth(Module):
     def setContractFactory(self, contractFactory):
         self.defaultContractFactory = contractFactory
 
+    @deprecated_in_v5
     def getCompilers(self):
         return self.web3.manager.request_blocking("eth_getCompilers", [])
 

--- a/web3/net.py
+++ b/web3/net.py
@@ -1,6 +1,9 @@
 from web3.module import (
     Module,
 )
+from web3.utils.decorators import (
+    deprecated_in_v5,
+)
 
 
 class Net(Module):
@@ -13,6 +16,7 @@ class Net(Module):
         return self.web3.manager.request_blocking("net_peerCount", [])
 
     @property
+    @deprecated_in_v5
     def chainId(self):
         return None
 

--- a/web3/utils/decorators.py
+++ b/web3/utils/decorators.py
@@ -57,3 +57,19 @@ def deprecated_for(replace_message):
             return to_wrap(*args, **kwargs)
         return wrapper
     return decorator
+
+
+def deprecated_in_v5(f):
+    '''
+    Decorate a function to be deprecated in v5
+
+    @deprecated_for_v5
+    def toAscii(arg):
+        ...
+    '''
+    def decorator(to_wrap):
+        warnings.warn(
+            "%s to be deprecated in v5, according to EIP 1474" % (f.__name__),
+            category=DeprecationWarning,
+            stacklevel=2)
+    return decorator

--- a/web3/utils/module_testing/eth_module.py
+++ b/web3/utils/module_testing/eth_module.py
@@ -588,8 +588,8 @@ class EthModuleTest:
         pass
 
     def test_eth_getCompilers(self, web3):
-        # TODO: do we want to test this?
-        pass
+        with pytest.warns(DeprecationWarning):
+            web3.eth.getCompilers()
 
     def test_eth_compileSolidity(self, web3):
         # TODO: do we want to test this?

--- a/web3/utils/module_testing/net_module.py
+++ b/web3/utils/module_testing/net_module.py
@@ -1,3 +1,5 @@
+import pytest
+
 from eth_utils import (
     is_boolean,
     is_integer,
@@ -21,3 +23,7 @@ class NetModuleTest:
         peer_count = web3.net.peerCount
 
         assert is_integer(peer_count)
+
+    def test_net_chainId(self, web3):
+        with pytest.warns(DeprecationWarning):
+            web3.net.chainId


### PR DESCRIPTION
### What was wrong?
Add deprecation warnings for jsonrpc endpoints dropped in [EIP 1474](https://github.com/bitpshr/EIPs/blob/147609158191a701cf02c8556d5e529ffcb31cd2/EIPS/eip-1474.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/54131821-6a4cdb80-4413-11e9-8fba-6260346f2e8f.png)
