### PR TITLE
Relocate eth_protocolVersion and web3_clientVersion

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -141,6 +141,18 @@ The following properties are available on the ``web3.eth`` namespace.
         2206939
 
 
+.. py:attribute:: Eth.protocolVersion
+
+    * Delegates to ``eth_protocolVersion`` RPC Method
+
+    Returns the id of the current Ethereum protocol version.
+
+    .. code-block:: python
+
+       >>> web3.eth.protocolVersion
+       '63'
+
+
 Methods
 -------
 

--- a/docs/web3.version.rst
+++ b/docs/web3.version.rst
@@ -27,23 +27,18 @@ The following properties are available on the ``web3.eth`` namespace.
 
 .. py:method:: Version.node(self)
 
+    Method is deprecated in favor of ``web3.clientVersion``.
+
     * Delegates to ``web3_clientVersion`` RPC Method
 
     Returns the current client version.
 
     .. code-block:: python
 
-        >>> web3.version.node
+        >>> web3.clientVersion
         'Geth/v1.4.11-stable-fed692f6/darwin/go1.7'
 
 
 .. py:method:: Version.ethereum(self)
 
-    * Delegates to ``eth_protocolVersion`` RPC Method
-
-    Returns the current ethereum protocol version.
-
-    .. code-block:: python
-
-        >>> web3.version.ethereum
-        63
+    Method is deprecated in favor of ``web3.eth.protocolVersion``.

--- a/tests/core/eth-module/test_eth_protocolVersion.py
+++ b/tests/core/eth-module/test_eth_protocolVersion.py
@@ -1,0 +1,2 @@
+def test_eth_protocolVersion(web3):
+    assert web3.eth.protocolVersion == '99'

--- a/tests/core/eth-module/test_eth_protocolVersion.py
+++ b/tests/core/eth-module/test_eth_protocolVersion.py
@@ -1,2 +1,2 @@
 def test_eth_protocolVersion(web3):
-    assert web3.eth.protocolVersion == '99'
+    assert web3.eth.protocolVersion == '63'

--- a/tests/core/version-module/test_version_module.py
+++ b/tests/core/version-module/test_version_module.py
@@ -36,8 +36,13 @@ def async_w3():
 
 def test_blocking_version(blocking_w3):
     assert blocking_w3.blocking_version.api == blocking_w3.legacy_version.api
-    assert blocking_w3.blocking_version.node == blocking_w3.legacy_version.node
-    assert blocking_w3.blocking_version.ethereum == blocking_w3.legacy_version.ethereum
+
+
+def test_legacy_version_deprecation(blocking_w3):
+    with pytest.raises(DeprecationWarning):
+        blocking_w3.legacy_version.node
+    with pytest.raises(DeprecationWarning):
+        blocking_w3.legacy_version.ethereum
 
 
 @pytest.mark.asyncio

--- a/tests/core/web3-module/test_clientVersion.py
+++ b/tests/core/web3-module/test_clientVersion.py
@@ -1,0 +1,2 @@
+def test_web3_clientVersion(web3):
+    assert web3.clientVersion.startswith("EthereumTester/")

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -31,7 +31,7 @@ UNKNOWN_HASH = '0xdeadbeef000000000000000000000000000000000000000000000000000000
 
 class EthModuleTest:
     def test_eth_protocolVersion(self, web3):
-        protocol_version = web3.version.ethereum
+        protocol_version = web3.eth.protocolVersion
 
         assert is_string(protocol_version)
         assert protocol_version.isdigit()

--- a/web3/_utils/module_testing/version_module.py
+++ b/web3/_utils/module_testing/version_module.py
@@ -5,7 +5,7 @@ from eth_utils import (
 
 class VersionModuleTest:
     def test_eth_protocolVersion(self, web3):
-        protocol_version = web3.version.ethereum
+        protocol_version = web3.eth.protocolVersion
 
         assert is_string(protocol_version)
         assert protocol_version.isdigit()

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -15,7 +15,7 @@ from web3.exceptions import (
 
 class Web3ModuleTest:
     def test_web3_clientVersion(self, web3):
-        client_version = web3.version.node
+        client_version = web3.clientVersion
         self._check_web3_clientVersion(client_version)
 
     def _check_web3_clientVersion(self, client_version):

--- a/web3/main.py
+++ b/web3/main.py
@@ -81,12 +81,16 @@ from web3.testing import (
 from web3.txpool import (
     TxPool,
 )
+from web3.version import (
+    Version,
+)
 
 
 def get_default_modules():
     return {
         "eth": (Eth,),
         "net": (Net,),
+        "version": (Version,),
         "txpool": (TxPool,),
         "miner": (Miner,),
         "admin": (Admin,),

--- a/web3/main.py
+++ b/web3/main.py
@@ -81,16 +81,12 @@ from web3.testing import (
 from web3.txpool import (
     TxPool,
 )
-from web3.version import (
-    Version,
-)
 
 
 def get_default_modules():
     return {
         "eth": (Eth,),
         "net": (Net,),
-        "version": (Version,),
         "txpool": (TxPool,),
         "miner": (Miner,),
         "admin": (Admin,),
@@ -154,6 +150,10 @@ class Web3:
     @provider.setter
     def provider(self, provider):
         self.manager.provider = provider
+
+    @property
+    def clientVersion(self):
+        return self.manager.request_blocking("web3_clientVersion", [])
 
     @staticmethod
     @apply_to_return_value(HexBytes)

--- a/web3/middleware/normalize_errors.py
+++ b/web3/middleware/normalize_errors.py
@@ -13,7 +13,7 @@ def normalize_errors_middleware(make_request, web3):
         # It used to return a result of None, so we simulate the old behavior.
 
         if method == 'eth_getTransactionReceipt' and 'error' in result:
-            is_geth = web3.version.node.startswith('Geth')
+            is_geth = web3.clientVersion.startswith('Geth')
             if is_geth and result['error']['code'] == -32000:
                 return assoc(
                     dissoc(result, 'error'),

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -162,7 +162,7 @@ API_ENDPOINTS = {
         'listening': static_return(False),
     },
     'eth': {
-        'protocolVersion': static_return('63'),
+        'protocolVersion': static_return(63),
         'syncing': static_return(False),
         'coinbase': compose(
             operator.itemgetter(0),

--- a/web3/version.py
+++ b/web3/version.py
@@ -49,8 +49,8 @@ class Version(Module):
 
     @property
     def node(self):
-        return self.web3.manager.request_blocking("web3_clientVersion", [])
+        raise DeprecationWarning("This method has been deprecated as of EIP 1474.")
 
     @property
     def ethereum(self):
-        return self.web3.manager.request_blocking("eth_protocolVersion", [])
+        raise DeprecationWarning("This method has been deprecated as of EIP 1474.")


### PR DESCRIPTION
### What was wrong?
- Moved `eth_protocolVersion` endpoint from `web3.version.ethereum` to `web3.eth.protocolVersion`
- Moved `web3_clientVersion` endpoint from `web3.version.node` to `web3.clientVersion`

Upon approval of this pr, I'll create a pr to raise deprecation warnings in v4

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/54213370-93896c80-44e4-11e9-8319-d3cb986198bb.png)
