### PR TITLE
Move txpool to geth namespace

### DIFF
--- a/docs/web3.txpool.rst
+++ b/docs/web3.txpool.rst
@@ -1,22 +1,22 @@
 TX Pool API
 ===========
 
-.. py:module:: web3.txpool
-.. py:currentmodule:: web3.txpool
-
-.. py:class:: TxPool
-
-The ``web3.txpool`` object exposes methods to interact with the RPC APIs under
-the ``txpool_`` namespace.
+.. py:module:: web3.geth.txpool
+.. py:currentmodule:: web3.geth.txpool
 
 
-Properties
-----------
+The ``web3.geth.txpool`` object exposes methods to interact with the RPC APIs under
+the ``txpool_`` namespace. These methods are only exposed under the ``geth`` namespace
+since they are not standard nor supported in Parity.
 
-The following properties are available on the ``web3.txpool`` namespace.
+
+Methods
+-------
+
+The following methods are available on the ``web3.geth.txpool`` namespace.
 
 
-.. py:attribute:: TxPool.inspect
+.. py:method:: TxPool.inspect()
 
     * Delegates to ``txpool_inspect`` RPC Method
 
@@ -26,7 +26,7 @@ The following properties are available on the ``web3.txpool`` namespace.
 
     .. code-block:: python
 
-        >>> web3.txpool.inspect
+        >>> web3.geth.txpool.inspect()
         {
             'pending': {
                 '0x26588a9301b0428d95e6fc3a5024fce8bec12d51': {
@@ -78,7 +78,7 @@ The following properties are available on the ``web3.txpool`` namespace.
         }
 
 
-.. py:attribute:: TxPool.status
+.. py:method:: TxPool.status()
 
     * Delegates to ``txpool_status`` RPC Method
 
@@ -94,7 +94,7 @@ The following properties are available on the ``web3.txpool`` namespace.
         }
 
 
-.. py:attribute:: TxPool.content
+.. py:method:: TxPool.content()
 
     * Delegates to ``txpool_content`` RPC Method
 
@@ -102,7 +102,7 @@ The following properties are available on the ``web3.txpool`` namespace.
 
     .. code-block:: python
 
-        >>> web3.txpool.content
+        >>> web3.geth.txpool.content()
         {
           'pending': {
             '0x0216d5032f356960cd3749c31ab34eeff21b3395': {

--- a/tests/core/txpool-module/test_txpool_content.py
+++ b/tests/core/txpool-module/test_txpool_content.py
@@ -27,7 +27,7 @@ def test_txpool_content(web3_empty):
     })
     txn_2 = web3.eth.getTransaction(txn_2_hash)
 
-    content = web3.txpool.content
+    content = web3.geth.txpool.content
 
     assert web3.eth.coinbase in content['pending']
 

--- a/tests/core/txpool-module/test_txpool_inspect.py
+++ b/tests/core/txpool-module/test_txpool_inspect.py
@@ -27,7 +27,7 @@ def test_txpool_inspect(web3_empty):
     })
     txn_2 = web3.eth.getTransaction(txn_2_hash)
 
-    inspect_content = web3.txpool.inspect
+    inspect_content = web3.geth.txpool.inspect
 
     assert web3.eth.coinbase in inspect_content['pending']
 

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -12,6 +12,11 @@ from web3.personal import (
     sign,
     unlockAccount,
 )
+from web3.txpool import (
+    content,
+    inspect,
+    status,
+)
 
 
 class Geth(Module):
@@ -30,3 +35,12 @@ class GethPersonal(ModuleV2):
     sendTransaction = sendTransaction()
     sign = sign()
     unlockAccount = unlockAccount()
+
+
+class GethTxPool(ModuleV2):
+    """
+    https://github.com/ethereum/go-ethereum/wiki/Management-APIs#txpool
+    """
+    content = content()
+    inspect = inspect()
+    status = status()

--- a/web3/main.py
+++ b/web3/main.py
@@ -46,6 +46,7 @@ from web3.eth import (
 from web3.geth import (
     Geth,
     GethPersonal,
+    GethTxPool,
 )
 from web3.iban import (
     Iban,
@@ -78,9 +79,6 @@ from web3.providers.websocket import (
 from web3.testing import (
     Testing,
 )
-from web3.txpool import (
-    TxPool,
-)
 from web3.version import (
     Version,
 )
@@ -91,14 +89,14 @@ def get_default_modules():
         "eth": (Eth,),
         "net": (Net,),
         "version": (Version,),
-        "txpool": (TxPool,),
         "miner": (Miner,),
         "admin": (Admin,),
         "parity": (Parity, {
             "personal": (ParityPersonal,)
         }),
         "geth": (Geth, {
-            "personal": (GethPersonal,)
+            "personal": (GethPersonal,),
+            "txpool": (GethTxPool,),
         }),
         "testing": (Testing,),
     }

--- a/web3/method.py
+++ b/web3/method.py
@@ -27,6 +27,10 @@ def default_munger(module, *args, **kwargs):
         raise TypeError("Parameters passed to method without parameter mungers defined.")
 
 
+def default_root_munger(module, *args):
+    return [*args]
+
+
 class Method:
     """Method object for web3 module methods
 

--- a/web3/personal.py
+++ b/web3/personal.py
@@ -1,10 +1,7 @@
 from web3.method import (
     Method,
+    default_root_munger,
 )
-
-
-def default_root_munger(module, *args):
-    return [*args]
 
 
 def importRawKey():

--- a/web3/txpool.py
+++ b/web3/txpool.py
@@ -1,17 +1,24 @@
-from web3.module import (
-    Module,
+from web3.method import (
+    Method,
 )
 
 
-class TxPool(Module):
-    @property
-    def content(self):
-        return self.web3.manager.request_blocking("txpool_content", [])
+def content():
+    return Method(
+        "txpool_content",
+        mungers=None,
+    )
 
-    @property
-    def inspect(self):
-        return self.web3.manager.request_blocking("txpool_inspect", [])
 
-    @property
-    def status(self):
-        return self.web3.manager.request_blocking("txpool_status", [])
+def inspect():
+    return Method(
+        "txpool_inspect",
+        mungers=None,
+    )
+
+
+def status():
+    return Method(
+        "txpool_status",
+        mungers=None,
+    )


### PR DESCRIPTION
### What was wrong?
Since only geth supports `txpool_*` jsonrpc endpoints, and they are also not defined in EIP 1474, `web3.txpool` was moved to `web3.geth.txpool`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/54215815-d8170700-44e8-11e9-8858-98e7ffdf4072.png)
