### PR TITLE
Move miner module to geth namespace

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -38,6 +38,8 @@ Unreleased (latest source)
 --------------------------
   - Move ``web3.admin`` module to ``web3.geth`` namespace.
     - `#1288 <https://github.com/ethereum/web3.py/pull/1288>`_
+  - Move ``web3.miner`` module to ``web3.geth`` namespace.
+    - `#1287 <https://github.com/ethereum/web3.py/pull/1287>`_
   - Remove ``web3/utils`` directory in favor of ``web3/_utils``
     - `#1282 <https://github.com/ethereum/web3.py/pull/1282>`_
   - Implement ``eth_submitHashrate`` and ``eth_submitWork`` JSONRPC endpoints.

--- a/docs/web3.miner.rst
+++ b/docs/web3.miner.rst
@@ -1,21 +1,19 @@
 Miner API
 =========
 
-.. py:module:: web3.miner
+.. py:module:: web3.geth.miner
 
-.. py:class:: Miner
-
-The ``web3.miner`` object exposes methods to interact with the RPC APIs under
-the ``miner_`` namespace.
+The ``web3.geth.miner`` object exposes methods to interact with the RPC APIs under
+the ``miner_`` namespace that are supported by the Geth client.
 
 
 Methods
 -------
 
-The following methods are available on the ``web3.miner`` namespace.
+The following methods are available on the ``web3.geth.miner`` namespace.
 
 
-.. py:method:: Miner.makeDAG(number)
+.. py:method:: GethMiner.makeDAG(number)
 
     * Delegates to ``miner_makeDag`` RPC Method
 
@@ -23,10 +21,10 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.miner.makeDag(10000)
+        >>> web3.geth.miner.makeDag(10000)
 
 
-.. py:method:: Miner.setExtra(extra)
+.. py:method:: GethMiner.setExtra(extra)
 
     * Delegates to ``miner_setExtra`` RPC Method
 
@@ -35,10 +33,10 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.miner.setExtra('abcdefghijklmnopqrstuvwxyzABCDEF')
+        >>> web3.geth.miner.setExtra('abcdefghijklmnopqrstuvwxyzABCDEF')
 
 
-.. py:method:: Miner.setGasPrice(gas_price)
+.. py:method:: GethMiner.setGasPrice(gas_price)
 
     * Delegates to ``miner_setGasPrice`` RPC Method
 
@@ -48,10 +46,10 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.miner.setGasPrice(19999999999)
+        >>> web3.geth.miner.setGasPrice(19999999999)
 
 
-.. py:method:: Miner.start(num_threads)
+.. py:method:: GethMiner.start(num_threads)
 
     * Delegates to ``miner_start`` RPC Method
 
@@ -59,10 +57,10 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.miner.start(2)
+        >>> web3.geth.miner.start(2)
 
 
-.. py:method:: Miner.stop()
+.. py:method:: GethMiner.stop()
 
     * Delegates to ``miner_stop`` RPC Method
 
@@ -70,10 +68,10 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.miner.stop()
+        >>> web3.geth.miner.stop()
 
 
-.. py:method:: Miner.startAutoDAG()
+.. py:method:: GethMiner.startAutoDAG()
 
     * Delegates to ``miner_startAutoDag`` RPC Method
 
@@ -81,10 +79,10 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.miner.startAutoDAG()
+        >>> web3.geth.miner.startAutoDAG()
 
 
-.. py:method:: Miner.stopAutoDAG()
+.. py:method:: GethMiner.stopAutoDAG()
 
     * Delegates to ``miner_stopAutoDag`` RPC Method
 
@@ -92,4 +90,4 @@ The following methods are available on the ``web3.miner`` namespace.
 
     .. code-block:: python
 
-        >>> web3.miner.stopAutoDAG()
+        >>> web3.geth.miner.stopAutoDAG()

--- a/tests/core/mining-module/test_miner_setExtra.py
+++ b/tests/core/mining-module/test_miner_setExtra.py
@@ -23,7 +23,7 @@ def test_miner_setExtra(web3_empty, wait_for_block):
     # sanity
     assert initial_extra != new_extra_data
 
-    web3.miner.setExtra(new_extra_data)
+    web3.geth.miner.setExtra(new_extra_data)
 
     with Timeout(60) as timeout:
         while True:

--- a/tests/core/mining-module/test_miner_setGasPrice.py
+++ b/tests/core/mining-module/test_miner_setGasPrice.py
@@ -18,7 +18,7 @@ def test_miner_setGasPrice(web3_empty, wait_for_block):
     # sanity check
     assert web3.eth.gasPrice > 1000
 
-    web3.miner.setGasPrice(initial_gas_price // 2)
+    web3.geth.miner.setGasPrice(initial_gas_price // 2)
 
     with Timeout(60) as timeout:
         while web3.eth.gasPrice == initial_gas_price:

--- a/tests/core/mining-module/test_miner_start.py
+++ b/tests/core/mining-module/test_miner_start.py
@@ -17,7 +17,7 @@ def test_miner_start(web3_empty, wait_for_miner_start):
     assert web3.eth.mining
     assert web3.eth.hashrate
 
-    web3.miner.stop()
+    web3.geth.miner.stop()
 
     with Timeout(60) as timeout:
         while web3.eth.mining or web3.eth.hashrate:

--- a/tests/core/mining-module/test_miner_stop.py
+++ b/tests/core/mining-module/test_miner_stop.py
@@ -16,7 +16,7 @@ def test_miner_stop(web3_empty):
     assert web3.eth.mining
     assert web3.eth.hashrate
 
-    web3.miner.stop()
+    web3.geth.miner.stop()
 
     with Timeout(60) as timeout:
         while web3.eth.mining or web3.eth.hashrate:

--- a/tests/core/mining-module/test_setEtherBase.py
+++ b/tests/core/mining-module/test_setEtherBase.py
@@ -3,5 +3,5 @@ def test_miner_setEtherbase(web3_empty):
     web3 = web3_empty
     assert web3.eth.coinbase == web3.eth.accounts[0]
     new_account = web3.personal.newAccount('this-is-a-password')
-    web3.miner.setEtherBase(new_account)
+    web3.geth.miner.setEtherBase(new_account)
     assert web3.eth.coinbase == new_account

--- a/tests/core/txpool-module/test_txpool_content.py
+++ b/tests/core/txpool-module/test_txpool_content.py
@@ -8,7 +8,7 @@ from web3._utils.threads import (
 def test_txpool_content(web3_empty):
     web3 = web3_empty
 
-    web3.miner.stop()
+    web3.geth.miner.stop()
 
     with Timeout(60) as timeout:
         while web3.eth.hashrate or web3.eth.mining:

--- a/tests/core/txpool-module/test_txpool_inspect.py
+++ b/tests/core/txpool-module/test_txpool_inspect.py
@@ -8,7 +8,7 @@ from web3._utils.threads import (
 def test_txpool_inspect(web3_empty):
     web3 = web3_empty
 
-    web3.miner.stop()
+    web3.geth.miner.stop()
 
     with Timeout(60) as timeout:
         while web3.eth.hashrate or web3.eth.mining:

--- a/tests/generate_go_ethereum_fixture.py
+++ b/tests/generate_go_ethereum_fixture.py
@@ -292,22 +292,22 @@ def verify_chain_state(web3, chain_data):
 
 
 def mine_transaction_hash(web3, txn_hash):
-    web3.miner.start(1)
+    web3.geth.miner.start(1)
     try:
         return web3.eth.waitForTransactionReceipt(txn_hash, timeout=60)
     finally:
-        web3.miner.stop()
+        web3.geth.miner.stop()
 
 
 def mine_block(web3):
     origin_block_number = web3.eth.blockNumber
 
     start_time = time.time()
-    web3.miner.start(1)
+    web3.geth.miner.start(1)
     while time.time() < start_time + 60:
         block_number = web3.eth.blockNumber
         if block_number > origin_block_number:
-            web3.miner.stop()
+            web3.geth.miner.stop()
             return block_number
         else:
             time.sleep(0.1)
@@ -376,7 +376,7 @@ def setup_chain_state(web3):
     # Block with Transaction
     #
     web3.personal.unlockAccount(coinbase, KEYFILE_PW)
-    web3.miner.start(1)
+    web3.geth.miner.start(1)
     mined_txn_hash = web3.eth.sendTransaction({
         'from': coinbase,
         'to': coinbase,

--- a/tests/integration/generate_fixtures/common.py
+++ b/tests/integration/generate_fixtures/common.py
@@ -194,11 +194,11 @@ def mine_block(web3):
     origin_block_number = web3.eth.blockNumber
 
     start_time = time.time()
-    web3.miner.start(1)
+    web3.geth.miner.start(1)
     while time.time() < start_time + 120:
         block_number = web3.eth.blockNumber
         if block_number > origin_block_number:
-            web3.miner.stop()
+            web3.geth.miner.stop()
             return block_number
         else:
             time.sleep(0.1)
@@ -208,11 +208,11 @@ def mine_block(web3):
 
 def mine_transaction_hash(web3, txn_hash):
     start_time = time.time()
-    web3.miner.start(1)
+    web3.geth.miner.start(1)
     while time.time() < start_time + 120:
         receipt = web3.eth.getTransactionReceipt(txn_hash)
         if receipt is not None:
-            web3.miner.stop()
+            web3.geth.miner.stop()
             return receipt
         else:
             time.sleep(0.1)

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -118,7 +118,7 @@ def setup_chain_state(web3):
     # Block with Transaction
     #
     web3.personal.unlockAccount(coinbase, common.KEYFILE_PW)
-    web3.miner.start(1)
+    web3.geth.miner.start(1)
     mined_txn_hash = web3.eth.sendTransaction({
         'from': coinbase,
         'to': coinbase,

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -9,6 +9,16 @@ from web3.admin import (
     stopRPC,
     stopWS,
 )
+from web3.miner import (
+    makeDag,
+    setEtherbase,
+    setExtra,
+    setGasPrice,
+    start,
+    startAutoDag,
+    stop,
+    stopAutoDag,
+)
 from web3.module import (
     Module,
     ModuleV2,
@@ -36,7 +46,7 @@ class Geth(Module):
 
 class GethPersonal(ModuleV2):
     """
-    https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal
+    https://github.com/ethereum/go-ethereum/wiki/management-apis#personal
     """
     ecRecover = ecRecover()
     importRawKey = importRawKey()
@@ -70,3 +80,17 @@ class GethAdmin(ModuleV2):
     startWS = startWS()
     stopRPC = stopRPC()
     stopWS = stopWS()
+
+
+class GethMiner(ModuleV2):
+    """
+    https://github.com/ethereum/go-ethereum/wiki/Management-APIs#miner
+    """
+    makeDag = makeDag()
+    setExtra = setExtra()
+    setEtherbase = setEtherbase()
+    setGasPrice = setGasPrice()
+    start = start()
+    stop = stop()
+    startAutoDag = startAutoDag()
+    stopAutoDag = stopAutoDag()

--- a/web3/main.py
+++ b/web3/main.py
@@ -46,15 +46,13 @@ from web3.geth import (
     GethAdmin,
     GethPersonal,
     GethTxPool,
+    GethMiner,
 )
 from web3.iban import (
     Iban,
 )
 from web3.manager import (
     RequestManager as DefaultRequestManager,
-)
-from web3.miner import (
-    Miner,
 )
 from web3.net import (
     Net,
@@ -88,12 +86,12 @@ def get_default_modules():
         "eth": (Eth,),
         "net": (Net,),
         "version": (Version,),
-        "miner": (Miner,),
         "parity": (Parity, {
             "personal": (ParityPersonal,)
         }),
         "geth": (Geth, {
             "admin": (GethAdmin,),
+            "miner": (GethMiner,),
             "personal": (GethPersonal,),
             "txpool": (GethTxPool,),
         }),

--- a/web3/miner.py
+++ b/web3/miner.py
@@ -1,33 +1,60 @@
-from web3.module import (
-    Module,
+from web3.method import (
+    Method,
+    default_root_munger,
 )
 
 
-class Miner(Module):
-    def makeDAG(self, number):
-        return self.web3.manager.request_blocking("miner_makeDag", [number])
+def makeDag():
+    return Method(
+        "miner_makeDag",
+        mungers=[default_root_munger],
+    )
 
-    def setExtra(self, extra):
-        return self.web3.manager.request_blocking("miner_setExtra", [extra])
 
-    def setEtherBase(self, etherbase):
-        return self.web3.manager.request_blocking("miner_setEtherbase", [etherbase])
+def setExtra():
+    return Method(
+        "miner_setExtra",
+        mungers=[default_root_munger],
+    )
 
-    def setGasPrice(self, gas_price):
-        return self.web3.manager.request_blocking(
-            "miner_setGasPrice", [gas_price],
-        )
 
-    def start(self, num_threads):
-        return self.web3.manager.request_blocking(
-            "miner_start", [num_threads],
-        )
+def setEtherbase():
+    return Method(
+        "miner_setEtherbase",
+        mungers=[default_root_munger],
+    )
 
-    def stop(self):
-        return self.web3.manager.request_blocking("miner_stop", [])
 
-    def startAutoDAG(self):
-        return self.web3.manager.request_blocking("miner_startAutoDag", [])
+def setGasPrice():
+    return Method(
+        "miner_setGasPrice",
+        mungers=[default_root_munger],
+    )
 
-    def stopAutoDAG(self):
-        return self.web3.manager.request_blocking("miner_stopAutoDag", [])
+
+def start():
+    return Method(
+        "miner_start",
+        mungers=[default_root_munger],
+    )
+
+
+def stop():
+    return Method(
+        "miner_stop",
+        mungers=None,
+    )
+
+
+def startAutoDag():
+    return Method(
+        "miner_startAutoDag",
+        mungers=None,
+    )
+
+
+def stopAutoDag():
+    return Method(
+        "miner_stopAutoDag",
+        mungers=None,
+    )


### PR DESCRIPTION
### What was wrong?

Related to Issue #1273 

### How was it fixed?
Moved the `Miner` module to the `geth` namespace.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/54520496-2143dc80-4969-11e9-84de-8a7eb4611eb4.png)

