### PR TITLE
Move admin module to geth namespace

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -130,7 +130,7 @@ For example, the following retrieves the client enode endpoint for both geth and
         enode = w3.parity.enode
 
     elif connected and w3.version.node.startswith('Geth'):
-        enode = w3.admin.nodeInfo['enode']
+        enode = w3.geth.admin.nodeInfo['enode']
 
     else:
         enode = None

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -36,6 +36,8 @@ v5 Breaking Changes Summary
 
 Unreleased (latest source)
 --------------------------
+  - Move ``web3.admin`` module to ``web3.geth`` namespace.
+    - `#1288 <https://github.com/ethereum/web3.py/pull/1288>`_
   - Remove ``web3/utils`` directory in favor of ``web3/_utils``
     - `#1282 <https://github.com/ethereum/web3.py/pull/1282>`_
   - Implement ``eth_submitHashrate`` and ``eth_submitWork`` JSONRPC endpoints.

--- a/docs/web3.admin.rst
+++ b/docs/web3.admin.rst
@@ -1,21 +1,19 @@
 Admin API
 ==========
 
-.. py:module:: web3.admin
-.. py:currentmodule:: web3.admin
-
-.. py:class:: Admin
+.. py:class:: GethAdmin
 
 The ``web3.admin`` object exposes methods to interact with the RPC APIs under the
-``admin_`` namespace.
+``admin_`` namespace that are supported by the Geth client.
 
 
-Properties
-----------
+Methods
+-------
 
-The following properties are available on the ``web3.admin`` namespace.
+The following methods are available on the ``web3.geth.admin`` namespace.
 
-.. py:attribute:: datadir
+
+.. py:method:: datadir()
 
     * Delegates to ``admin_datadir`` RPC Method
 
@@ -23,11 +21,11 @@ The following properties are available on the ``web3.admin`` namespace.
 
     .. code-block:: python
 
-        >>> web3.admin.datadir
+        >>> web3.geth.admin.datadir()
         '/Users/piper/Library/Ethereum'
 
 
-.. py:attribute:: nodeInfo
+.. py:method:: nodeInfo()
 
     * Delegates to ``admin_nodeInfo`` RPC Method
 
@@ -35,7 +33,7 @@ The following properties are available on the ``web3.admin`` namespace.
 
     .. code-block:: python
 
-        >>> web3.admin.nodeInfo
+        >>> web3.geth.admin.nodeInfo()
         {
             'enode': 'enode://e54eebad24dce1f6d246bea455ffa756d97801582420b9ed681a2ea84bf376d0bd87ae8dd6dc06cdb862a2ca89ecabe1be1050be35b4e70d62bc1a092cb7e2d3@[::]:30303',
             'id': 'e54eebad24dce1f6d246bea455ffa756d97801582420b9ed681a2ea84bf376d0bd87ae8dd6dc06cdb862a2ca89ecabe1be1050be35b4e70d62bc1a092cb7e2d3',
@@ -54,7 +52,7 @@ The following properties are available on the ``web3.admin`` namespace.
         }
 
 
-.. py:attribute:: peers
+.. py:method:: peers()
 
     * Delegates to ``admin_peers`` RPC Method
 
@@ -62,7 +60,7 @@ The following properties are available on the ``web3.admin`` namespace.
 
     .. code-block:: python
 
-        >>> web3.admin.peers
+        >>> web3.geth.admin.peers()
         [
             {
                 'caps': ['eth/63'],
@@ -99,11 +97,6 @@ The following properties are available on the ``web3.admin`` namespace.
             ...
         ]
 
-Methods
--------
-
-The following methods are available on the ``web3.admin`` namespace.
-
 
 .. py:method:: addPeer(node_url)
 
@@ -113,7 +106,7 @@ The following methods are available on the ``web3.admin`` namespace.
 
     .. code-block:: python
 
-        >>> web3.admin.addPeer('enode://e54eebad24dce1f6d246bea455ffa756d97801582420b9ed681a2ea84bf376d0bd87ae8dd6dc06cdb862a2ca89ecabe1be1050be35b4e70d62bc1a092cb7e2d3@52.71.255.237:30303')
+        >>> web3.geth.admin.addPeer('enode://e54eebad24dce1f6d246bea455ffa756d97801582420b9ed681a2ea84bf376d0bd87ae8dd6dc06cdb862a2ca89ecabe1be1050be35b4e70d62bc1a092cb7e2d3@52.71.255.237:30303')
         True
 
 
@@ -127,7 +120,7 @@ The following methods are available on the ``web3.admin`` namespace.
 
     .. code-block:: python
 
-        >>> web3.admin.setSolc('/usr/local/bin/solc')
+        >>> web3.geth.admin.setSolc('/usr/local/bin/solc')
         "solc, the solidity compiler commandline interface\nVersion: 0.3.5-9da08ac3/Release-Darwin/appleclang/JIT"
 
 
@@ -142,7 +135,7 @@ The following methods are available on the ``web3.admin`` namespace.
 
     .. code-block:: python
 
-        >>> web3.admin.startRPC()
+        >>> web3.geth.admin.startRPC()
         True
 
 
@@ -157,7 +150,7 @@ The following methods are available on the ``web3.admin`` namespace.
 
     .. code-block:: python
 
-        >>> web3.admin.startWS()
+        >>> web3.geth.admin.startWS()
         True
 
 
@@ -169,7 +162,7 @@ The following methods are available on the ``web3.admin`` namespace.
 
     .. code-block:: python
 
-        >>> web3.admin.stopRPC()
+        >>> web3.geth.admin.stopRPC()
         True
 
 
@@ -181,5 +174,5 @@ The following methods are available on the ``web3.admin`` namespace.
 
     .. code-block:: python
 
-        >>> web3.admin.stopWS()
+        >>> web3.geth.admin.stopWS()
         True

--- a/tests/core/admin-module/test_admin_addPeer.py
+++ b/tests/core/admin-module/test_admin_addPeer.py
@@ -1,7 +1,7 @@
 def test_admin_addPeer(web3, skip_if_testrpc):
     skip_if_testrpc(web3)
 
-    result = web3.admin.addPeer(
+    result = web3.geth.admin.addPeer(
         'enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@127.0.0.1:30304',  # noqa: E501
     )
     assert result is True

--- a/tests/core/admin-module/test_admin_nodeInfo.py
+++ b/tests/core/admin-module/test_admin_nodeInfo.py
@@ -1,7 +1,7 @@
 def test_admin_nodeInfo(web3, skip_if_testrpc):
     skip_if_testrpc(web3)
 
-    node_info = web3.admin.nodeInfo
+    node_info = web3.geth.admin.nodeInfo
 
     assert 'enode' in node_info
     assert 'id' in node_info

--- a/tests/core/admin-module/test_admin_peers.py
+++ b/tests/core/admin-module/test_admin_peers.py
@@ -1,4 +1,4 @@
 def test_admin_peers(web3, skip_if_testrpc):
     skip_if_testrpc(web3)
 
-    assert web3.admin.peers == []
+    assert web3.geth.admin.peers == []

--- a/tests/core/admin-module/test_admin_setSolc.py
+++ b/tests/core/admin-module/test_admin_setSolc.py
@@ -15,6 +15,6 @@ def test_admin_setSolc(web3, skip_if_testrpc):
         pytest.skip('solc binary not found')
     solc_version = subprocess.check_output(['solc', '--version']).strip()
 
-    actual = web3.admin.setSolc(solc_path)
+    actual = web3.geth.admin.setSolc(solc_path)
     assert to_text(solc_version) in actual
     assert to_text(solc_path) in actual

--- a/tests/integration/generate_fixtures/parity.py
+++ b/tests/integration/generate_fixtures/parity.py
@@ -262,9 +262,9 @@ def generate_parity_fixture(destination_dir):
 def connect_nodes(w3_parity, w3_secondary):
     parity_peers = w3_parity.parity.netPeers()
     parity_enode = w3_parity.parity.enode()
-    secondary_node_info = w3_secondary.admin.nodeInfo
+    secondary_node_info = w3_secondary.geth.admin.nodeInfo
     if secondary_node_info['id'] not in (node.get('id', tuple()) for node in parity_peers['peers']):
-        w3_secondary.admin.addPeer(parity_enode)
+        w3_secondary.geth.admin.addPeer(parity_enode)
 
 
 def wait_for_chain_sync(web3, target):

--- a/web3/admin.py
+++ b/web3/admin.py
@@ -1,45 +1,71 @@
-from web3.module import (
-    Module,
+from web3.method import (
+    Method,
+    default_root_munger,
 )
 
 
-class Admin(Module):
-    def addPeer(self, node_url):
-        return self.web3.manager.request_blocking(
-            "admin_addPeer", [node_url],
-        )
+def admin_start_params_munger(module, host='localhost', port='8546', cors='', apis='eth,net,web3'):
+    return module, [host, port, cors, apis]
 
-    @property
-    def datadir(self):
-        return self.web3.manager.request_blocking("admin_datadir", [])
 
-    @property
-    def nodeInfo(self):
-        return self.web3.manager.request_blocking("admin_nodeInfo", [])
+def addPeer():
+    return Method(
+        "admin_addPeer",
+        mungers=[default_root_munger],
+    )
 
-    @property
-    def peers(self):
-        return self.web3.manager.request_blocking("admin_peers", [])
 
-    def setSolc(self, solc_path):
-        return self.web3.manager.request_blocking(
-            "admin_setSolc", [solc_path],
-        )
+def datadir():
+    return Method(
+        "admin_datadir",
+        mungers=None,
+    )
 
-    def startRPC(self, host='localhost', port='8545', cors="", apis="eth,net,web3"):
-        return self.web3.manager.request_blocking(
-            "admin_startRPC",
-            [host, port, cors, apis],
-        )
 
-    def startWS(self, host='localhost', port='8546', cors="", apis="eth,net,web3"):
-        return self.web3.manager.request_blocking(
-            "admin_startWS",
-            [host, port, cors, apis],
-        )
+def nodeInfo():
+    return Method(
+        "admin_nodeInfo",
+        mungers=None,
+    )
 
-    def stopRPC(self):
-        return self.web3.manager.request_blocking("admin_stopRPC", [])
 
-    def stopWS(self):
-        return self.web3.manager.request_blocking("admin_stopWS", [])
+def peers():
+    return Method(
+        "admin_peers",
+        mungers=None,
+    )
+
+
+def setSolc():
+    return Method(
+        "admin_setSolc",
+        mungers=[default_root_munger],
+    )
+
+
+def startRPC():
+    return Method(
+        "admin_startRPC",
+        mungers=[admin_start_params_munger],
+    )
+
+
+def startWS():
+    return Method(
+        "admin_startWS",
+        mungers=[admin_start_params_munger],
+    )
+
+
+def stopRPC():
+    return Method(
+        "admin_stopRPC",
+        mungers=None,
+    )
+
+
+def stopWS():
+    return Method(
+        "admin_stopWS",
+        mungers=None,
+    )

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -1,3 +1,14 @@
+from web3.admin import (
+    addPeer,
+    datadir,
+    nodeInfo,
+    peers,
+    setSolc,
+    startRPC,
+    startWS,
+    stopRPC,
+    stopWS,
+)
 from web3.module import (
     Module,
     ModuleV2,
@@ -44,3 +55,18 @@ class GethTxPool(ModuleV2):
     content = content()
     inspect = inspect()
     status = status()
+
+
+class GethAdmin(ModuleV2):
+    """
+    https://github.com/ethereum/go-ethereum/wiki/Management-APIs#admin
+    """
+    addPeer = addPeer()
+    datadir = datadir()
+    nodeInfo = nodeInfo()
+    peers = peers()
+    setSolc = setSolc()
+    startRPC = startRPC()
+    startWS = startWS()
+    stopRPC = stopRPC()
+    stopWS = stopWS()

--- a/web3/main.py
+++ b/web3/main.py
@@ -37,14 +37,12 @@ from web3._utils.module import (
 from web3._utils.normalizers import (
     abi_ens_resolver,
 )
-from web3.admin import (
-    Admin,
-)
 from web3.eth import (
     Eth,
 )
 from web3.geth import (
     Geth,
+    GethAdmin,
     GethPersonal,
     GethTxPool,
 )
@@ -90,11 +88,11 @@ def get_default_modules():
         "net": (Net,),
         "version": (Version,),
         "miner": (Miner,),
-        "admin": (Admin,),
         "parity": (Parity, {
             "personal": (ParityPersonal,)
         }),
         "geth": (Geth, {
+            "admin": (GethAdmin,),
             "personal": (GethPersonal,),
             "txpool": (GethTxPool,),
         }),


### PR DESCRIPTION
### What was wrong?

Related to Issue #1273 

### How was it fixed?
Moved `web3.admin` module to `web3.geth` namespace


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/54526593-8b637e00-4977-11e9-9081-ef2df1c36ca5.png)

