### PR TITLE
Convert raw_tx from HexBytes to str

### DIFF
--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -125,7 +125,7 @@ def construct_sign_and_send_raw_middleware(private_key_or_account):
                 return make_request(method, params)
 
             account = accounts[transaction['from']]
-            raw_tx = account.signTransaction(transaction).rawTransaction
+            raw_tx = account.signTransaction(transaction).rawTransaction.hex()
 
             return make_request(
                 "eth_sendRawTransaction",


### PR DESCRIPTION
### What was wrong?
`raw_tx = account.signTransaction(transaction).rawTransaction` is a HexBytes object. This will cause issues when encoding the rpc request. 

Notably, 
```
/lib/python3.7/site-packages/web3/_utils/encoding.py in json_encode(self, obj)
    267             return self._friendly_json_encode(obj)
    268         except TypeError as exc:
--> 269             raise TypeError("Could not encode to JSON: {}".format(exc))
    270 
    271 

TypeError: Could not encode to JSON: dict had unencodable value at keys: 
{'params': because (list had unencodable value at index: [0: because (Object of type HexBytes is not JSON serializable)])}
```

Steps to reproduce: 
1. Add sign_and_send_raw_middleware to middleware stack with raw private key as a hex string.
2. Assign `Web3.eth.defaultAccount` as the account associated with the raw private key given.
3. Instantiate a contract and call `contract.functions.method_name(params).transact()`.

### How was it fixed?
Convert raw_tx from HexBytes to str


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.purch.com/w/660/aHR0cDovL3d3dy5saXZlc2NpZW5jZS5jb20vaW1hZ2VzL2kvMDAwLzAyNC8xODgvb3JpZ2luYWwvc2xlZXBpbmcta2l0dGVuLmpwZw==)
