### PR TITLE
Add error if no Infura key is found

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import time
 import warnings

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.3.0,<2.0.0",
-        "ethpm>=0.1.4a12,<1.0.0",
+        "ethpm>=0.1.4a13,<1.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "lru-dict>=1.1.6,<2.0.0",
         "requests>=2.16.0,<3.0.0",

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -1,9 +1,13 @@
 import importlib
-import logging
+import os
 import pytest
 
-from web3.auto import (
-    infura,
+from eth_utils import (
+    ValidationError,
+)
+
+from web3.exceptions import (
+    InfuraKeyNotFound,
 )
 from web3.providers import (
     HTTPProvider,
@@ -13,6 +17,18 @@ from web3.providers import (
 from web3.providers.auto import (
     load_provider_from_environment,
 )
+
+# Ugly hack to import infura now that API KEY is required
+os.environ['WEB3_INFURA_API_KEY'] = 'test'
+from web3.auto import (  # noqa E402 isort:skip
+    infura,
+)
+
+
+@pytest.fixture(autouse=True)
+def delete_infura_key(monkeypatch):
+    monkeypatch.delenv('INFURA_API_KEY', raising=False)
+    monkeypatch.delenv('WEB3_INFURA_API_KEY', raising=False)
 
 
 @pytest.mark.parametrize(
@@ -38,75 +54,49 @@ def test_web3_auto_infura_empty_key(monkeypatch, caplog, environ_name):
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'https')
     monkeypatch.setenv(environ_name, '')
 
-    importlib.reload(infura)
-    assert len(caplog.record_tuples) == 1
-    logger, level, msg = caplog.record_tuples[0]
-    assert 'WEB3_INFURA_PROJECT_ID' in msg
-    assert level == logging.WARNING
-
-    w3 = infura.w3
-    assert isinstance(w3.provider, HTTPProvider)
-    assert getattr(w3.provider, 'endpoint_uri') == 'https://mainnet.infura.io/'
+    with pytest.raises(InfuraKeyNotFound):
+        importlib.reload(infura)
 
 
 @pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])
 def test_web3_auto_infura_deleted_key(monkeypatch, caplog, environ_name):
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'https')
+
     monkeypatch.delenv(environ_name, raising=False)
 
-    importlib.reload(infura)
-    assert len(caplog.record_tuples) == 1
-    logger, level, msg = caplog.record_tuples[0]
-    assert 'WEB3_INFURA_PROJECT_ID' in msg
-    assert level == logging.WARNING
-
-    w3 = infura.w3
-    assert isinstance(w3.provider, HTTPProvider)
-    assert getattr(w3.provider, 'endpoint_uri') == 'https://mainnet.infura.io/'
+    with pytest.raises(InfuraKeyNotFound):
+        importlib.reload(infura)
 
 
 @pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])
 def test_web3_auto_infura_websocket_empty_key(monkeypatch, caplog, environ_name):
     monkeypatch.setenv(environ_name, '')
 
-    importlib.reload(infura)
-    assert len(caplog.record_tuples) == 1
-    logger, level, msg = caplog.record_tuples[0]
-    assert 'WEB3_INFURA_PROJECT_ID' in msg
-    assert level == logging.WARNING
-
-    w3 = infura.w3
-    assert isinstance(w3.provider, WebsocketProvider)
-    assert getattr(w3.provider, 'endpoint_uri') == 'wss://mainnet.infura.io/ws/'
+    with pytest.raises(InfuraKeyNotFound):
+        importlib.reload(infura)
 
 
 @pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])
 def test_web3_auto_infura_websocket_deleted_key(monkeypatch, caplog, environ_name):
     monkeypatch.delenv(environ_name, raising=False)
 
-    importlib.reload(infura)
-    assert len(caplog.record_tuples) == 1
-    logger, level, msg = caplog.record_tuples[0]
-    assert 'WEB3_INFURA_PROJECT_ID' in msg
-    assert level == logging.WARNING
-
-    w3 = infura.w3
-    assert isinstance(w3.provider, WebsocketProvider)
-    assert getattr(w3.provider, 'endpoint_uri') == 'wss://mainnet.infura.io/ws/'
+    with pytest.raises(InfuraKeyNotFound):
+        importlib.reload(infura)
 
 
 @pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])
 def test_web3_auto_infura(monkeypatch, caplog, environ_name):
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'https')
     API_KEY = 'aoeuhtns'
+
     monkeypatch.setenv(environ_name, API_KEY)
-    expected_url = 'https://%s/v3/%s' % (infura.INFURA_MAINNET_DOMAIN, API_KEY)
 
     importlib.reload(infura)
     assert len(caplog.record_tuples) == 0
 
     w3 = infura.w3
     assert isinstance(w3.provider, HTTPProvider)
+    expected_url = 'https://%s/v3/%s' % (infura.INFURA_MAINNET_DOMAIN, API_KEY)
     assert getattr(w3.provider, 'endpoint_uri') == expected_url
 
 
@@ -123,3 +113,12 @@ def test_web3_auto_infura_websocket_default(monkeypatch, caplog, environ_name):
     w3 = infura.w3
     assert isinstance(w3.provider, WebsocketProvider)
     assert getattr(w3.provider, 'endpoint_uri') == expected_url
+
+
+def test_web3_auto_infura_raises_error_with_nonexistent_scheme(monkeypatch):
+    monkeypatch.setenv('WEB3_INFURA_API_KEY', 'test')
+    monkeypatch.setenv('WEB3_INFURA_SCHEME', 'not-a-scheme')
+
+    error_msg = "Cannot connect to Infura with scheme 'not-a-scheme'"
+    with pytest.raises(ValidationError, match=error_msg):
+        importlib.reload(infura)

--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -1,8 +1,11 @@
-import logging
 import os
 
 from eth_utils import (
     ValidationError,
+)
+
+from web3.exceptions import (
+    InfuraKeyNotFound,
 )
 
 INFURA_MAINNET_DOMAIN = 'mainnet.infura.io'
@@ -19,10 +22,9 @@ def load_api_key():
     key = os.environ.get('WEB3_INFURA_PROJECT_ID',
                          os.environ.get('WEB3_INFURA_API_KEY', ''))
     if key == '':
-        logging.getLogger('web3.auto.infura').warning(
-            "No Infura Project ID found. Add environment variable WEB3_INFURA_PROJECT_ID to "
-            "ensure continued API access after March 27th. "
-            "New keys are available at https://infura.io/register"
+        raise InfuraKeyNotFound(
+            "No Infura Project ID found. Please ensure "
+            "that the environment variable WEB3_INFURA_PROJECT_ID is set."
         )
     return key
 
@@ -31,13 +33,9 @@ def build_infura_url(domain):
     scheme = os.environ.get('WEB3_INFURA_SCHEME', WEBSOCKET_SCHEME)
     key = load_api_key()
 
-    if key and scheme == WEBSOCKET_SCHEME:
+    if scheme == WEBSOCKET_SCHEME:
         return "%s://%s/ws/v3/%s" % (scheme, domain, key)
-    elif key and scheme == HTTP_SCHEME:
-        return "%s://%s/v3/%s" % (scheme, domain, key)
-    elif scheme == WEBSOCKET_SCHEME:
-        return "%s://%s/ws/" % (scheme, domain)
     elif scheme == HTTP_SCHEME:
-        return "%s://%s/%s" % (scheme, domain, key)
+        return "%s://%s/v3/%s" % (scheme, domain, key)
     else:
         raise ValidationError("Cannot connect to Infura with scheme %r" % scheme)

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -142,3 +142,10 @@ class BlockNotFound(Exception):
     Raised when the block id used to lookup a block in a jsonrpc call cannot be found.
     """
     pass
+
+
+class InfuraKeyNotFound(Exception):
+    """
+    Raised when there is no Infura Project Id set.
+    """
+    pass


### PR DESCRIPTION
### What was wrong?
Infura will stop supporting API calls without a key on 3/27. 

Related to Issue #1246 

### How was it fixed?
Now an error is thrown when connecting to Infura if there is no API key found. 


#### Cute Animal Picture

![maxresdefault](https://user-images.githubusercontent.com/6540608/54721639-213e0b00-4b28-11e9-9611-5cbb718fb459.jpg)

