### PR TITLE
Implement eth_chainId endpoint

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -153,6 +153,18 @@ The following properties are available on the ``web3.eth`` namespace.
        '63'
 
 
+.. py:attribute:: Eth.chainId
+
+    * Delegates to ``eth_chainId`` RPC Method
+
+    Returns a hex-encoded integer value for the currently configured "Chain Id" value introduced in `EIP-155 <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>`_. Returns ``None`` if no Chain Id is available.
+
+    .. code-block:: python
+
+       >>> web3.eth.chainId
+       '0x3d'
+
+
 Methods
 -------
 

--- a/tests/core/eth-module/test_eth_properties.py
+++ b/tests/core/eth-module/test_eth_properties.py
@@ -1,2 +1,6 @@
 def test_eth_protocolVersion(web3):
     assert web3.eth.protocolVersion == '63'
+
+
+def test_eth_chainId(web3):
+    assert web3.eth.chainId == '0x3d'

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -65,6 +65,11 @@ class GoEthereumEthModuleTest(EthModuleTest):
             pytest.xfail('eth_submitHashrate depracated in 1.8.22 for ethash_submitHashRate')
         super().test_eth_submitHashrate(web3)
 
+    def test_eth_chainId(self, web3):
+        if 'v1.7.2' in web3.clientVersion:
+            pytest.xfail('eth_chainId not implemented in geth 1.7.2')
+        super().test_eth_chainId(web3)
+
 
 class GoEthereumVersionModuleTest(VersionModuleTest):
     pass

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -24,6 +24,11 @@ class ParityWeb3ModuleTest(Web3ModuleTest):
 
 
 class ParityEthModuleTest(EthModuleTest):
+    def test_eth_chainId(self, web3):
+        # Parity will return null if chainId is not available
+        chain_id = web3.eth.chainId
+        assert chain_id is None
+
     def test_eth_getBlockByNumber_pending(self, web3):
         pytest.xfail('Parity dropped "pending" option in 1.11.1')
         super().test_eth_getBlockByNumber_pending(web3)

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -7,9 +7,13 @@ from eth_tester import (
 from eth_utils import (
     is_checksum_address,
     is_dict,
+    is_hex,
 )
 
 from web3 import Web3
+from web3._utils.formatters import (
+    hex_to_integer,
+)
 from web3._utils.module_testing import (
     EthModuleTest,
     GoEthereumPersonalModuleTest,
@@ -290,6 +294,11 @@ class TestEthereumTesterEthModule(EthModuleTest):
         super().test_eth_estimateGas_with_block(
             web3, unlocked_account_dual_type
         )
+
+    def test_eth_chainId(self, web3):
+        chain_id = web3.eth.chainId
+        assert is_hex(chain_id)
+        assert hex_to_integer(chain_id) is 61
 
 
 class TestEthereumTesterVersionModule(VersionModuleTest):

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -14,6 +14,7 @@ from eth_utils import (
     is_list_like,
     is_same_address,
     is_string,
+    to_int,
 )
 from hexbytes import (
     HexBytes,
@@ -64,6 +65,11 @@ class EthModuleTest:
         hashrate = web3.eth.hashrate
         assert is_integer(hashrate)
         assert hashrate >= 0
+
+    def test_eth_chainId(self, web3):
+        chain_id = web3.eth.chainId
+        # chain id value from geth fixture genesis file
+        assert to_int(hexstr=chain_id) == 131277322940537
 
     def test_eth_gasPrice(self, web3):
         gas_price = web3.eth.gasPrice

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -101,6 +101,10 @@ class Eth(Module):
     def blockNumber(self):
         return self.web3.manager.request_blocking("eth_blockNumber", [])
 
+    @property
+    def chainId(self):
+        return self.web3.manager.request_blocking("eth_chainId", [])
+
     def getBalance(self, account, block_identifier=None):
         if block_identifier is None:
             block_identifier = self.defaultBlock

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -170,6 +170,7 @@ API_ENDPOINTS = {
         ),
         'mining': static_return(False),
         'hashrate': static_return(0),
+        'chainId': static_return('0x3d'),
         'gasPrice': static_return(1),
         'accounts': call_eth_tester('get_accounts'),
         'blockNumber': compose(


### PR DESCRIPTION
### What was wrong?
Implement `eth_chainId` re: @carver 's comment [here](https://twitter.com/pedrouid/status/1107976163312455680?s=09) & on Gitter.

Though, it appears it's not implemented in Geth yet? Or just not in the versions we're testing against. Also, Parity simply returns a `null`, which according to [this](https://wiki.parity.io/JSONRPC-eth-module#eth_chainid) means that it's unavailable.


#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/54757169-f61bf000-4be9-11e9-958c-e4089a5b0c74.png)

