### PR TITLE
Raise Infura error v4 backport

### DIFF
--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -1,5 +1,5 @@
 import importlib
-import logging
+import os
 import pytest
 import sys
 from tempfile import (
@@ -10,8 +10,8 @@ from eth_utils import (
     ValidationError,
 )
 
-from web3.auto import (
-    infura,
+from web3.exceptions import (
+    InfuraKeyNotFound,
 )
 from web3.providers import (
     HTTPProvider,
@@ -23,6 +23,19 @@ from web3.providers.auto import (
 )
 
 TEMP_DIR = gettempdir()
+
+
+# Ugly hack to import Infura now that API KEY is required
+os.environ['WEB3_INFURA_API_KEY'] = 'test'
+from web3.auto import (  # noqa E402 isort:skip
+    infura,
+)
+
+
+@pytest.fixture(autouse=True)
+def delete_infura_key(monkeypatch):
+    monkeypatch.delenv('INFURA_API_KEY', raising=False)
+    monkeypatch.delenv('WEB3_INFURA_API_KEY', raising=False)
 
 
 @pytest.mark.parametrize(
@@ -51,16 +64,8 @@ def test_web3_auto_infura_empty_key(monkeypatch, caplog, environ_name):
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'https')
     monkeypatch.setenv(environ_name, '')
 
-    importlib.reload(infura)
-    assert len(caplog.record_tuples) == 1
-    logger, level, msg = caplog.record_tuples[0]
-    assert 'WEB3_INFURA_API_KEY' in msg
-    assert level == logging.WARNING
-
-    w3 = infura.w3
-    assert isinstance(w3.providers[0], HTTPProvider)
-    expected_url = 'https://%s/' % (infura.INFURA_MAINNET_DOMAIN)
-    assert getattr(w3.providers[0], 'endpoint_uri') == expected_url
+    with pytest.raises(InfuraKeyNotFound):
+        importlib.reload(infura)
 
 
 @pytest.mark.parametrize('environ_name', ['INFURA_API_KEY', 'WEB3_INFURA_API_KEY'])
@@ -68,54 +73,31 @@ def test_web3_auto_infura_deleted_key(monkeypatch, caplog, environ_name):
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'https')
     monkeypatch.delenv(environ_name, raising=False)
 
-    importlib.reload(infura)
-    assert len(caplog.record_tuples) == 1
-    logger, level, msg = caplog.record_tuples[0]
-    assert 'WEB3_INFURA_API_KEY' in msg
-    assert level == logging.WARNING
-
-    w3 = infura.w3
-    assert isinstance(w3.providers[0], HTTPProvider)
-    expected_url = 'https://%s/' % (infura.INFURA_MAINNET_DOMAIN)
-    assert getattr(w3.providers[0], 'endpoint_uri') == expected_url
+    with pytest.raises(InfuraKeyNotFound):
+        importlib.reload(infura)
 
 
 @pytest.mark.parametrize('environ_name', ['INFURA_API_KEY', 'WEB3_INFURA_API_KEY'])
 def test_web3_auto_infura_websocket_empty_key(monkeypatch, caplog, environ_name):
     monkeypatch.setenv(environ_name, '')
 
-    importlib.reload(infura)
-    assert len(caplog.record_tuples) == 1
-    logger, level, msg = caplog.record_tuples[0]
-    assert 'WEB3_INFURA_API_KEY' in msg
-    assert level == logging.WARNING
-
-    w3 = infura.w3
-    assert isinstance(w3.providers[0], WebsocketProvider)
-    expected_url = 'wss://%s/ws/' % (infura.INFURA_MAINNET_DOMAIN)
-    assert getattr(w3.providers[0], 'endpoint_uri') == expected_url
+    with pytest.raises(InfuraKeyNotFound):
+        importlib.reload(infura)
 
 
 @pytest.mark.parametrize('environ_name', ['INFURA_API_KEY', 'WEB3_INFURA_API_KEY'])
 def test_web3_auto_infura_websocket_deleted_key(monkeypatch, caplog, environ_name):
-    monkeypatch.delenv(environ_name, raising=False)
+    monkeypatch.setenv(environ_name, '')
 
-    importlib.reload(infura)
-    assert len(caplog.record_tuples) == 1
-    logger, level, msg = caplog.record_tuples[0]
-    assert 'WEB3_INFURA_API_KEY' in msg
-    assert level == logging.WARNING
-
-    w3 = infura.w3
-    assert isinstance(w3.providers[0], WebsocketProvider)
-    expected_url = 'wss://%s/ws/' % (infura.INFURA_MAINNET_DOMAIN)
-    assert getattr(w3.providers[0], 'endpoint_uri') == expected_url
+    with pytest.raises(InfuraKeyNotFound):
+        importlib.reload(infura)
 
 
 @pytest.mark.parametrize('environ_name', ['INFURA_API_KEY', 'WEB3_INFURA_API_KEY'])
 def test_web3_auto_infura(monkeypatch, caplog, environ_name):
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'https')
     API_KEY = 'aoeuhtns'
+
     monkeypatch.setenv(environ_name, API_KEY)
 
     importlib.reload(infura)
@@ -142,6 +124,8 @@ def test_web3_auto_infura_websocket_default(monkeypatch, caplog, environ_name):
 
 
 def test_web3_auto_infura_raises_error_with_nonexistent_scheme(monkeypatch):
+    monkeypatch.setenv('WEB3_INFURA_API_KEY', 'test')
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'not-a-scheme')
+
     with pytest.raises(ValidationError):
         importlib.reload(infura)

--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -1,8 +1,11 @@
-import logging
 import os
 
 from eth_utils import (
     ValidationError,
+)
+
+from web3.exceptions import (
+    InfuraKeyNotFound,
 )
 
 INFURA_MAINNET_DOMAIN = 'mainnet.infura.io'
@@ -19,10 +22,9 @@ def load_api_key():
         os.environ.get('INFURA_API_KEY', '')
     )
     if key == '':
-        logging.getLogger('web3.auto.infura').warning(
-            "No Infura API Key found. Add environment variable WEB3_INFURA_API_KEY to "
-            "ensure continued API access after March 27th. "
-            "New keys are available at https://infura.io/register"
+        raise InfuraKeyNotFound(
+            "No Infura Project ID found. Please ensure "
+            "that the environment variable WEB3_INFURA_API_KEY is set."
         )
     return key
 
@@ -31,13 +33,9 @@ def build_infura_url(domain):
     scheme = os.environ.get('WEB3_INFURA_SCHEME', WEBSOCKET_SCHEME)
     key = load_api_key()
 
-    if key and scheme == WEBSOCKET_SCHEME:
+    if scheme == WEBSOCKET_SCHEME:
         return "%s://%s/ws/v3/%s" % (scheme, domain, key)
-    elif key and scheme == HTTP_SCHEME:
-        return "%s://%s/v3/%s" % (scheme, domain, key)
-    elif scheme == WEBSOCKET_SCHEME:
-        return "%s://%s/ws/" % (scheme, domain)
     elif scheme == HTTP_SCHEME:
-        return "%s://%s/%s" % (scheme, domain, key)
+        return "%s://%s/v3/%s" % (scheme, domain, key)
     else:
         raise ValidationError("Cannot connect to Infura with scheme %r" % scheme)

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -107,3 +107,10 @@ class InsufficientData(Exception):
     complete a calculation
     """
     pass
+
+
+class InfuraKeyNotFound(Exception):
+    """
+    Raised when there is no Infura Project Id set.
+    """
+    pass


### PR DESCRIPTION
### What was wrong?
Infura will no longer allow API access without a key after 3/27.

Related to Issue #1246 

### How was it fixed?
Now, an error will be raised when infura is loaded if there is no API key.

#### Cute Animal Picture

![download-1](https://user-images.githubusercontent.com/6540608/54783254-85bf9f80-4be6-11e9-8420-fba4911376ac.jpg)
