### PR TITLE
Cast gas price values to integers in gas strategies

### DIFF
--- a/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
+++ b/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
@@ -150,7 +150,7 @@ def test_time_based_gas_price_strategy(strategy_params, expected):
     )
     w3.eth.setGasPriceStrategy(time_based_gas_price_strategy)
     actual = w3.eth.generateGasPrice()
-    assert int(actual) == expected
+    assert actual == expected
 
 
 @pytest.mark.parametrize(

--- a/web3/gas_strategies/time_based.py
+++ b/web3/gas_strategies/time_based.py
@@ -105,9 +105,9 @@ def _compute_gas_price(probabilities, desired_probability):
     last = probabilities[-1]
 
     if desired_probability >= first.prob:
-        return first.gas_price
+        return int(first.gas_price)
     elif desired_probability <= last.prob:
-        return last.gas_price
+        return int(last.gas_price)
 
     for left, right in sliding_window(2, probabilities):
         if desired_probability < right.prob:


### PR DESCRIPTION
### What was wrong?

Related to Issue #1220. 

### How was it fixed?

As suggested in #1220, the returned gas prices from `_compute_gas_price` are cast to integers.

#### Cute Animal Picture

![Cats exhibiting righting reflexes](https://cdn.shopify.com/s/files/1/1459/7106/articles/koop-cats-Landing-on-their-feet_grande.gif?v=1473881648)
