### PR TITLE
Allow infura secret

### DIFF
--- a/web3/auto/infura/__init__.py
+++ b/web3/auto/infura/__init__.py
@@ -5,9 +5,11 @@ from web3.providers.auto import (
 
 from .endpoints import (
     INFURA_MAINNET_DOMAIN,
+    build_http_headers,
     build_infura_url,
 )
 
 _infura_url = build_infura_url(INFURA_MAINNET_DOMAIN)
+_headers = build_http_headers()
 
-w3 = Web3(load_provider_from_uri(_infura_url))
+w3 = Web3(load_provider_from_uri(_infura_url, _headers))

--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -21,6 +21,7 @@ def load_api_key():
         'WEB3_INFURA_API_KEY',
         os.environ.get('INFURA_API_KEY', '')
     )
+
     if key == '':
         raise InfuraKeyNotFound(
             "No Infura Project ID found. Please ensure "
@@ -29,18 +30,25 @@ def load_api_key():
     return key
 
 
+def load_secret():
+    secret = os.environ.get('WEB3_INFURA_API_SECRET', '')
+    return secret
+
+
+def build_http_headers():
+    secret = load_secret()
+    if secret:
+        headers = {'auth': ('', secret)}
+        return headers
+
+
 def build_infura_url(domain):
     scheme = os.environ.get('WEB3_INFURA_SCHEME', WEBSOCKET_SCHEME)
     key = load_api_key()
+    secret = load_secret()
 
-    secret = os.environ.get('WEB3_INFURA_API_SECRET', '')
-
-    if secret and scheme == WEBSOCKET_SCHEME:
+    if scheme == WEBSOCKET_SCHEME:
         return "%s://:%s@%s/ws/v3/%s" % (scheme, secret, domain, key)
-    elif secret and scheme == HTTP_SCHEME:
-        return "%s://:%s@%s/v3/%s" % (scheme, secret, domain, key)
-    elif scheme == WEBSOCKET_SCHEME:
-        return "%s://%s/ws/" % (scheme, domain)
     elif scheme == HTTP_SCHEME:
         return "%s://%s/v3/%s" % (scheme, domain, key)
     else:

--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -33,8 +33,14 @@ def build_infura_url(domain):
     scheme = os.environ.get('WEB3_INFURA_SCHEME', WEBSOCKET_SCHEME)
     key = load_api_key()
 
-    if scheme == WEBSOCKET_SCHEME:
-        return "%s://%s/ws/v3/%s" % (scheme, domain, key)
+    secret = os.environ.get('WEB3_INFURA_API_SECRET', '')
+
+    if secret and scheme == WEBSOCKET_SCHEME:
+        return "%s://:%s@%s/ws/v3/%s" % (scheme, secret, domain, key)
+    elif secret and scheme == HTTP_SCHEME:
+        return "%s://:%s@%s/v3/%s" % (scheme, secret, domain, key)
+    elif scheme == WEBSOCKET_SCHEME:
+        return "%s://%s/ws/" % (scheme, domain)
     elif scheme == HTTP_SCHEME:
         return "%s://%s/v3/%s" % (scheme, domain, key)
     else:

--- a/web3/auto/infura/ropsten.py
+++ b/web3/auto/infura/ropsten.py
@@ -5,9 +5,11 @@ from web3.providers.auto import (
 
 from .endpoints import (
     INFURA_ROPSTEN_DOMAIN,
+    build_http_headers,
     build_infura_url,
 )
 
 _infura_url = build_infura_url(INFURA_ROPSTEN_DOMAIN)
+_headers = build_http_headers()
 
-w3 = Web3(load_provider_from_uri(_infura_url))
+w3 = Web3(load_provider_from_uri(_infura_url, _headers))

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -25,12 +25,12 @@ def load_provider_from_environment():
     return load_provider_from_uri(uri_string)
 
 
-def load_provider_from_uri(uri_string):
+def load_provider_from_uri(uri_string, headers=None):
     uri = urlparse(uri_string)
     if uri.scheme == 'file':
         return IPCProvider(uri.path)
     elif uri.scheme in HTTP_SCHEMES:
-        return HTTPProvider(uri_string)
+        return HTTPProvider(uri_string, headers)
     elif uri.scheme in WS_SCHEMES:
         return WebsocketProvider(uri_string)
     else:


### PR DESCRIPTION
### What was wrong?
Originally, I thought I read somewhere that the infura-provided secret wouldn't be used for anything right now. Then, I read recently that you can check a box to make it required.

Related to Issue #1246 

### How was it fixed?
Added the ability for people to send in a secret key to the Websocket and HTTP providers.


#### Cute Animal Picture
![download](https://user-images.githubusercontent.com/6540608/54943033-07b90c80-4ef6-11e9-9d80-8c4f155139a4.jpg)

