### PR TITLE
User can use their secret key to make Infura calls

### DIFF
--- a/web3/auto/infura/__init__.py
+++ b/web3/auto/infura/__init__.py
@@ -5,9 +5,11 @@ from web3.providers.auto import (
 
 from .endpoints import (
     INFURA_MAINNET_DOMAIN,
+    build_http_headers,
     build_infura_url,
 )
 
+_headers = build_http_headers()
 _infura_url = build_infura_url(INFURA_MAINNET_DOMAIN)
 
-w3 = Web3(load_provider_from_uri(_infura_url))
+w3 = Web3(load_provider_from_uri(_infura_url, _headers))

--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -29,12 +29,24 @@ def load_api_key():
     return key
 
 
+def load_secret():
+    return os.environ.get('WEB3_INFURA_API_SECRET', '')
+
+
+def build_http_headers():
+    secret = load_secret()
+    if secret:
+        headers = {'auth': ('', secret)}
+        return headers
+
+
 def build_infura_url(domain):
     scheme = os.environ.get('WEB3_INFURA_SCHEME', WEBSOCKET_SCHEME)
     key = load_api_key()
+    secret = load_secret()
 
     if scheme == WEBSOCKET_SCHEME:
-        return "%s://%s/ws/v3/%s" % (scheme, domain, key)
+        return "%s://:%s@%s/ws/v3/%s" % (scheme, secret, domain, key)
     elif scheme == HTTP_SCHEME:
         return "%s://%s/v3/%s" % (scheme, domain, key)
     else:

--- a/web3/auto/infura/kovan.py
+++ b/web3/auto/infura/kovan.py
@@ -5,9 +5,11 @@ from web3.providers.auto import (
 
 from .endpoints import (
     INFURA_KOVAN_DOMAIN,
+    build_http_headers,
     build_infura_url,
 )
 
+_headers = build_http_headers()
 _infura_url = build_infura_url(INFURA_KOVAN_DOMAIN)
 
-w3 = Web3(load_provider_from_uri(_infura_url))
+w3 = Web3(load_provider_from_uri(_infura_url, _headers))

--- a/web3/auto/infura/mainnet.py
+++ b/web3/auto/infura/mainnet.py
@@ -5,9 +5,11 @@ from web3.providers.auto import (
 
 from .endpoints import (
     INFURA_MAINNET_DOMAIN,
+    build_http_headers,
     build_infura_url,
 )
 
+_headers = build_http_headers()
 _infura_url = build_infura_url(INFURA_MAINNET_DOMAIN)
 
-w3 = Web3(load_provider_from_uri(_infura_url))
+w3 = Web3(load_provider_from_uri(_infura_url, _headers))

--- a/web3/auto/infura/rinkeby.py
+++ b/web3/auto/infura/rinkeby.py
@@ -8,10 +8,12 @@ from web3.providers.auto import (
 
 from .endpoints import (
     INFURA_RINKEBY_DOMAIN,
+    build_http_headers,
     build_infura_url,
 )
 
+_headers = build_http_headers()
 _infura_url = build_infura_url(INFURA_RINKEBY_DOMAIN)
 
-w3 = Web3(load_provider_from_uri(_infura_url))
+w3 = Web3(load_provider_from_uri(_infura_url, _headers))
 w3.middleware_onion.inject(geth_poa_middleware, layer=0)

--- a/web3/auto/infura/ropsten.py
+++ b/web3/auto/infura/ropsten.py
@@ -5,9 +5,11 @@ from web3.providers.auto import (
 
 from .endpoints import (
     INFURA_ROPSTEN_DOMAIN,
+    build_http_headers,
     build_infura_url,
 )
 
+_headers = build_http_headers()
 _infura_url = build_infura_url(INFURA_ROPSTEN_DOMAIN)
 
-w3 = Web3(load_provider_from_uri(_infura_url))
+w3 = Web3(load_provider_from_uri(_infura_url, _headers))

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -25,12 +25,12 @@ def load_provider_from_environment():
     return load_provider_from_uri(uri_string)
 
 
-def load_provider_from_uri(uri_string):
+def load_provider_from_uri(uri_string, headers=None):
     uri = urlparse(uri_string)
     if uri.scheme == 'file':
         return IPCProvider(uri.path)
     elif uri.scheme in HTTP_SCHEMES:
-        return HTTPProvider(uri_string)
+        return HTTPProvider(uri_string, headers)
     elif uri.scheme in WS_SCHEMES:
         return WebsocketProvider(uri_string)
     else:


### PR DESCRIPTION
### What was wrong?
Originally, I thought I read somewhere that the infura-provided secret wouldn't be used for anything right now. Then, I read recently that you can check a box to make it required. v5 edition.

Related to Issue #1246 

### How was it fixed?
Added the ability for people to send in a secret key to the Websocket and HTTP providers.

#### Cute Animal Picture

![download-1](https://user-images.githubusercontent.com/6540608/54959333-58dcf680-4f1e-11e9-9658-d3383a32f472.jpg)
