### PR TITLE
Add Nodesmith auto-provider

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -176,6 +176,28 @@ Then set the environment variable ``WEB3_INFURA_PROJECT_ID`` with your Project I
     >>> w3.isConnected()
     True
 
+Nodesmith
+~~~~~~~~~
+
+To connect to Nodesmith's mainnet or various testnet endpoints, first register
+for a free API Key at https://nodesmith.io.
+
+Then set the environment variable ``NODESMITH_API_KEY`` with your API key::
+
+    $ export NODESMITH_API_KEY=YourApiKey
+
+In your code, import the appropriate module for the network you want to connect to
+with the format ``web3.auto.nodesmith.<network_name>``. For example, to connect to the
+`Goerli <https://goerli.net/>`_ test network:
+
+.. code-block:: python
+
+    >>> from web3.auto.nodesmith.goerli import w3
+
+    # Get the network's id, 5 for Goerli
+    >>> w3.net.version
+    '5'
+
 Geth dev Proof of Authority
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -13,8 +13,8 @@ Local Node
   When you run ``geth`` or ``parity`` on your machine, you are running a local node.
 
 Hosted Node
-  A hosted node is controlled by someone else. When you connect to Infura, you are
-  connected to a hosted node.
+  A hosted node is controlled by someone else. When you connect to Infura or Nodesmith,
+  you are connected to a hosted node.
 
 Local vs Hosted Keys
 ---------------------------------

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -3,18 +3,13 @@ import logging
 import os
 import pytest
 
-from web3.auto import (
-    nodesmith,
-)
-
 from eth_utils import (
     ValidationError,
 )
 
-from web3.exceptions import (
-    InfuraKeyNotFound,
+from web3.auto import (
+    nodesmith,
 )
-
 from web3.auto.nodesmith import (
     goerli,
     kovan,
@@ -22,7 +17,9 @@ from web3.auto.nodesmith import (
     rinkeby,
     ropsten,
 )
-
+from web3.exceptions import (
+    InfuraKeyNotFound,
+)
 from web3.providers import (
     HTTPProvider,
     IPCProvider,

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -1,9 +1,9 @@
 import importlib
+import logging
 import os
 import pytest
 
 from web3.auto import (
-    infura,
     nodesmith,
 )
 
@@ -128,6 +128,7 @@ def test_web3_auto_infura_websocket_default(monkeypatch, caplog, environ_name):
     assert isinstance(w3.provider, WebsocketProvider)
     assert getattr(w3.provider, 'endpoint_uri') == expected_url
 
+
 def test_web3_auto_infura_raises_error_with_nonexistent_scheme(monkeypatch):
     monkeypatch.setenv('WEB3_INFURA_API_KEY', 'test')
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'not-a-scheme')
@@ -136,6 +137,7 @@ def test_web3_auto_infura_raises_error_with_nonexistent_scheme(monkeypatch):
     with pytest.raises(ValidationError, match=error_msg):
         importlib.reload(infura)
 
+
 def test_web3_auto_nodesmith_missing_key(monkeypatch, caplog):
     importlib.reload(nodesmith)
     assert len(caplog.record_tuples) == 1
@@ -143,14 +145,23 @@ def test_web3_auto_nodesmith_missing_key(monkeypatch, caplog):
     assert 'NODESMITH_API_KEY' in msg
     assert level == logging.ERROR
 
-@pytest.mark.parametrize('network', [(goerli, 'goerli'), (kovan, 'kovan'), (mainnet, 'mainnet'), (rinkeby, 'rinkeby'), (ropsten, 'ropsten')])
+
+@pytest.mark.parametrize(
+    'network', [
+        (goerli, 'goerli'),
+        (kovan, 'kovan'),
+        (mainnet, 'mainnet'),
+        (rinkeby, 'rinkeby'),
+        (ropsten, 'ropsten')
+    ])
 def test_web3_auto_nodesmith_different_networks(monkeypatch, network):
 
     network_module = network[0]
     network_name = network[1]
     API_KEY = 'ns_python'
     monkeypatch.setenv('NODESMITH_API_KEY', API_KEY)
-    expected_url = nodesmith.NODESMITH_URL_FORMAT % (network_name, API_KEY)
+    expected_url = 'https://ethereum.api.nodesmith.io/v1/%s/jsonrpc?apiKey=%s' % \
+                   (network_name, API_KEY)
 
     importlib.reload(network_module)
 

--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -9,6 +9,7 @@ INFURA_MAINNET_DOMAIN = 'mainnet.infura.io'
 INFURA_ROPSTEN_DOMAIN = 'ropsten.infura.io'
 INFURA_RINKEBY_DOMAIN = 'rinkeby.infura.io'
 INFURA_KOVAN_DOMAIN = 'kovan.infura.io'
+INFURA_GOERLI_DOMAIN = 'goerli.infura.io'
 
 WEBSOCKET_SCHEME = 'wss'
 HTTP_SCHEME = 'https'

--- a/web3/auto/infura/goerli.py
+++ b/web3/auto/infura/goerli.py
@@ -1,0 +1,13 @@
+from web3 import Web3
+from web3.providers.auto import (
+    load_provider_from_uri,
+)
+
+from .endpoints import (
+    INFURA_GOERLI_DOMAIN,
+    build_infura_url,
+)
+
+_infura_url = build_infura_url(INFURA_GOERLI_DOMAIN)
+
+w3 = Web3(load_provider_from_uri(_infura_url))

--- a/web3/auto/nodesmith/__init__.py
+++ b/web3/auto/nodesmith/__init__.py
@@ -5,7 +5,6 @@ from web3.providers.auto import (
 
 from .endpoints import (
     build_nodesmith_url,
-    NODESMITH_URL_FORMAT,
 )
 
 # By default, connect to the mainnet endpoint

--- a/web3/auto/nodesmith/__init__.py
+++ b/web3/auto/nodesmith/__init__.py
@@ -1,6 +1,6 @@
 from web3 import Web3
 from web3.providers.auto import (
-    load_provider_from_uri
+    load_provider_from_uri,
 )
 
 from .endpoints import (

--- a/web3/auto/nodesmith/__init__.py
+++ b/web3/auto/nodesmith/__init__.py
@@ -1,0 +1,14 @@
+from web3 import Web3
+from web3.providers.auto import (
+    load_provider_from_uri
+)
+
+from .endpoints import (
+    build_nodesmith_url,
+    NODESMITH_URL_FORMAT,
+)
+
+# By default, connect to the mainnet endpoint
+_nodesmith_url = build_nodesmith_url("mainnet")
+
+w3 = Web3(load_provider_from_uri(_nodesmith_url))

--- a/web3/auto/nodesmith/endpoints.py
+++ b/web3/auto/nodesmith/endpoints.py
@@ -1,0 +1,19 @@
+import logging
+import os
+
+NODESMITH_URL_FORMAT = 'https://ethereum.api.nodesmith.io/v1/%s/jsonrpc?apiKey=%s'
+
+def load_api_key():
+    key = os.environ.get('NODESMITH_API_KEY', '')
+    if key == '':
+        logging.getLogger('web3.auto.infura').error(
+             "No Nodesmith API key found. Add environment variable NODESMITH_API_KEY with your key. " +
+            "Get a free API key at https://nodesmith.io"
+        )
+    return key
+
+
+def build_nodesmith_url(network):
+    key = load_api_key()
+    url = NODESMITH_URL_FORMAT % (network, key)
+    return url

--- a/web3/auto/nodesmith/endpoints.py
+++ b/web3/auto/nodesmith/endpoints.py
@@ -6,7 +6,7 @@ NODESMITH_URL_FORMAT = 'https://ethereum.api.nodesmith.io/v1/%s/jsonrpc?apiKey=%
 def load_api_key():
     key = os.environ.get('NODESMITH_API_KEY', '')
     if key == '':
-        logging.getLogger('web3.auto.infura').error(
+        logging.getLogger('web3.auto.nodesmith').error(
              "No Nodesmith API key found. Add environment variable NODESMITH_API_KEY with your key. " +
             "Get a free API key at https://nodesmith.io"
         )

--- a/web3/auto/nodesmith/endpoints.py
+++ b/web3/auto/nodesmith/endpoints.py
@@ -3,12 +3,13 @@ import os
 
 NODESMITH_URL_FORMAT = 'https://ethereum.api.nodesmith.io/v1/%s/jsonrpc?apiKey=%s'
 
+
 def load_api_key():
     key = os.environ.get('NODESMITH_API_KEY', '')
     if key == '':
         logging.getLogger('web3.auto.nodesmith').error(
-             "No Nodesmith API key found. Add environment variable NODESMITH_API_KEY with your key. " +
-            "Get a free API key at https://nodesmith.io"
+            "No Nodesmith API key found. Add environment variable NODESMITH_API_KEY with "
+            "your key. Get a free API key at https://nodesmith.io"
         )
     return key
 

--- a/web3/auto/nodesmith/goerli.py
+++ b/web3/auto/nodesmith/goerli.py
@@ -1,10 +1,10 @@
 from web3 import Web3
 from web3.providers.auto import (
-    load_provider_from_uri
+    load_provider_from_uri,
 )
 
 from .endpoints import (
-    build_nodesmith_url
+    build_nodesmith_url,
 )
 
 _nodesmith_url = build_nodesmith_url("goerli")

--- a/web3/auto/nodesmith/goerli.py
+++ b/web3/auto/nodesmith/goerli.py
@@ -1,0 +1,12 @@
+from web3 import Web3
+from web3.providers.auto import (
+    load_provider_from_uri
+)
+
+from .endpoints import (
+    build_nodesmith_url
+)
+
+_nodesmith_url = build_nodesmith_url("goerli")
+
+w3 = Web3(load_provider_from_uri(_nodesmith_url))

--- a/web3/auto/nodesmith/kovan.py
+++ b/web3/auto/nodesmith/kovan.py
@@ -1,10 +1,10 @@
 from web3 import Web3
 from web3.providers.auto import (
-    load_provider_from_uri
+    load_provider_from_uri,
 )
 
 from .endpoints import (
-    build_nodesmith_url
+    build_nodesmith_url,
 )
 
 _nodesmith_url = build_nodesmith_url("kovan")

--- a/web3/auto/nodesmith/kovan.py
+++ b/web3/auto/nodesmith/kovan.py
@@ -1,0 +1,12 @@
+from web3 import Web3
+from web3.providers.auto import (
+    load_provider_from_uri
+)
+
+from .endpoints import (
+    build_nodesmith_url
+)
+
+_nodesmith_url = build_nodesmith_url("kovan")
+
+w3 = Web3(load_provider_from_uri(_nodesmith_url))

--- a/web3/auto/nodesmith/mainnet.py
+++ b/web3/auto/nodesmith/mainnet.py
@@ -1,10 +1,10 @@
 from web3 import Web3
 from web3.providers.auto import (
-    load_provider_from_uri
+    load_provider_from_uri,
 )
 
 from .endpoints import (
-    build_nodesmith_url
+    build_nodesmith_url,
 )
 
 _nodesmith_url = build_nodesmith_url("mainnet")

--- a/web3/auto/nodesmith/mainnet.py
+++ b/web3/auto/nodesmith/mainnet.py
@@ -1,0 +1,12 @@
+from web3 import Web3
+from web3.providers.auto import (
+    load_provider_from_uri
+)
+
+from .endpoints import (
+    build_nodesmith_url
+)
+
+_nodesmith_url = build_nodesmith_url("mainnet")
+
+w3 = Web3(load_provider_from_uri(_nodesmith_url))

--- a/web3/auto/nodesmith/rinkeby.py
+++ b/web3/auto/nodesmith/rinkeby.py
@@ -1,0 +1,18 @@
+from web3 import Web3
+
+from web3.middleware import (
+    geth_poa_middleware
+)
+
+from web3.providers.auto import (
+    load_provider_from_uri
+)
+
+from .endpoints import (
+    build_nodesmith_url
+)
+
+_nodesmith_url = build_nodesmith_url("rinkeby")
+
+w3 = Web3(load_provider_from_uri(_nodesmith_url))
+w3.middleware_onion.inject(geth_poa_middleware, layer=0)

--- a/web3/auto/nodesmith/rinkeby.py
+++ b/web3/auto/nodesmith/rinkeby.py
@@ -1,15 +1,13 @@
 from web3 import Web3
-
 from web3.middleware import (
-    geth_poa_middleware
+    geth_poa_middleware,
 )
-
 from web3.providers.auto import (
-    load_provider_from_uri
+    load_provider_from_uri,
 )
 
 from .endpoints import (
-    build_nodesmith_url
+    build_nodesmith_url,
 )
 
 _nodesmith_url = build_nodesmith_url("rinkeby")

--- a/web3/auto/nodesmith/ropsten.py
+++ b/web3/auto/nodesmith/ropsten.py
@@ -1,10 +1,10 @@
 from web3 import Web3
 from web3.providers.auto import (
-    load_provider_from_uri
+    load_provider_from_uri,
 )
 
 from .endpoints import (
-    build_nodesmith_url
+    build_nodesmith_url,
 )
 
 _nodesmith_url = build_nodesmith_url("ropsten")

--- a/web3/auto/nodesmith/ropsten.py
+++ b/web3/auto/nodesmith/ropsten.py
@@ -1,0 +1,12 @@
+from web3 import Web3
+from web3.providers.auto import (
+    load_provider_from_uri
+)
+
+from .endpoints import (
+    build_nodesmith_url
+)
+
+_nodesmith_url = build_nodesmith_url("ropsten")
+
+w3 = Web3(load_provider_from_uri(_nodesmith_url))


### PR DESCRIPTION
### What was wrong?

[Nodesmith](https://nodesmith.io) is a new JSON RPC service which provides access to hosted nodes. This change adds a Nodesmith auto-provider which can be used to interact with Ethereum networks.

Related to Issue: N/A

### How was it fixed?

Added a new provider and unit tests for it.
Also added a goerli provider for Infura.



#### Cute Animal Picture

![DogChain](https://user-images.githubusercontent.com/4925051/54980199-5b613f80-4f62-11e9-9f79-56a0e4a492a2.jpeg)
