### PR TITLE
Upgrade eth-util requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,8 @@ geth_steps: &geth_steps
           export GOROOT=/usr/local/go
           export GETH_BINARY="$HOME/.py-geth/geth-$GETH_VERSION/bin/geth"
           if [ ! -e "$GETH_BINARY" ]; then
-            curl -O https://storage.googleapis.com/golang/go1.12.1.linux-amd64.tar.gz
-            tar xvf go1.12.1.linux-amd64.tar.gz
+            curl -O https://storage.googleapis.com/golang/go1.9.7.linux-amd64.tar.gz
+            tar xvf go1.9.7.linux-amd64.tar.gz
             sudo chown -R root:root ./go
             sudo mv go /usr/local
             sudo ln -s /usr/local/go/bin/go /usr/local/bin/go

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "eth-account>=0.2.1,<0.4.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",
-        "eth-utils>=1.3.0,<2.0.0",
+        "eth-utils>=1.4.0,<2.0.0",
         "ethpm>=0.1.4a13,<1.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "lru-dict>=1.1.6,<2.0.0",


### PR DESCRIPTION
### What was wrong?
web3v5 needs `collapse_if_tuple` which is a method only available in `eth-utils` v1.4.0+

Related to Issue #1285 

### How was it fixed?
Fixed the requirement in setup.py

#### Cute Animal Picture

![2026247-bigthumbnail](https://user-images.githubusercontent.com/6540608/55509831-20be6d80-561a-11e9-9c9b-e5bcc20d6e4a.jpg)

