### PR TITLE
Adds support for Parity addReservedPeer for Management of PoA Parity Clusters

### DIFF
--- a/web3/_utils/module_testing/parity_module.py
+++ b/web3/_utils/module_testing/parity_module.py
@@ -91,13 +91,7 @@ class ParityModuleTest:
         trace = web3.parity.traceFilter(txn_filter_params)
         assert isinstance(trace, list)
         assert trace[0]['action']['from'] == add_0x_prefix(parity_fixture_data['coinbase'])
-        
-    
-    @pytest.mark.parametrize(
-        'params',
- ['enode://f1a6b0bdbf014355587c3018454d070ac57801f05d3b39fe85da574f002a32e929f683d72aa5a8318382e4d3c7a05c9b91687b0d997a39619fb8a6e7ad88e512@1.1.1.1:30300']
-    )
-    def test_add_reserved_peer(self, web3, params):
-        response = web3.parity.addReservedPeer([params])
-        assert response["result"]==True
-        
+
+    def test_add_reserved_peer(self, web3):
+        peer_addr = 'enode://f1a6b0bdbf014355587c3018454d070ac57801f05d3b39fe85da574f002a32e929f683d72aa5a8318382e4d3c7a05c9b91687b0d997a39619fb8a6e7ad88e512@1.1.1.1:30300'  # noqa: E501
+        assert web3.parity.addReservedPeer(peer_addr)

--- a/web3/_utils/module_testing/parity_module.py
+++ b/web3/_utils/module_testing/parity_module.py
@@ -98,6 +98,6 @@ class ParityModuleTest:
  ['enode://f1a6b0bdbf014355587c3018454d070ac57801f05d3b39fe85da574f002a32e929f683d72aa5a8318382e4d3c7a05c9b91687b0d997a39619fb8a6e7ad88e512@1.1.1.1:30300']
     )
     def test_add_reserved_peer(self, web3, params):
-        response = web3.parity.addReservedPeer(params)
+        response = web3.parity.addReservedPeer([params])
         assert response["result"]==True
         

--- a/web3/_utils/module_testing/parity_module.py
+++ b/web3/_utils/module_testing/parity_module.py
@@ -91,3 +91,13 @@ class ParityModuleTest:
         trace = web3.parity.traceFilter(txn_filter_params)
         assert isinstance(trace, list)
         assert trace[0]['action']['from'] == add_0x_prefix(parity_fixture_data['coinbase'])
+        
+    
+    @pytest.mark.parametrize(
+        'params',
+ ['enode://f1a6b0bdbf014355587c3018454d070ac57801f05d3b39fe85da574f002a32e929f683d72aa5a8318382e4d3c7a05c9b91687b0d997a39619fb8a6e7ad88e512@1.1.1.1:30300']
+    )
+    def test_add_reserved_peer(self, web3, params):
+        response = web3.parity.addReservedPeer(params)
+        assert response["result"]==True
+        

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -83,10 +83,10 @@ class Parity(Module):
             [],
         )
 
-    def addReservedPeer(self, params):
+    def addReservedPeer(self, url):
         return self.web3.manager.request_blocking(
             "parity_addReservedPeer",
-            params,
+            [url],
         )
 
     def traceReplayTransaction(self, transaction_hash, mode=['trace']):

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -82,6 +82,12 @@ class Parity(Module):
             "parity_netPeers",
             [],
         )
+    
+    def addReservedPeer(self, params=[]):
+        return self.web3.manager.request_blocking(
+            "parity_addReservedPeer",
+            params,
+        )
 
     def traceReplayTransaction(self, transaction_hash, mode=['trace']):
         return self.web3.manager.request_blocking(

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -82,7 +82,7 @@ class Parity(Module):
             "parity_netPeers",
             [],
         )
-    
+
     def addReservedPeer(self, params):
         return self.web3.manager.request_blocking(
             "parity_addReservedPeer",

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -83,7 +83,7 @@ class Parity(Module):
             [],
         )
     
-    def addReservedPeer(self, params=[]):
+    def addReservedPeer(self, params):
         return self.web3.manager.request_blocking(
             "parity_addReservedPeer",
             params,


### PR DESCRIPTION
Note: @drelu originally had PRed using his own master, but it has been so long that history got weird with all of the subsequent commits to master. Original PR is found [here](https://github.com/ethereum/web3.py/pull/1204). This is just a fresh branch. Authorship should be intact.  
Related to Issue #1203

### How was it fixed?
Added function addReservedPeer to parity module

#### Cute Animal Picture
![download](https://user-images.githubusercontent.com/6540608/55517656-5a996f00-562e-11e9-9300-c6f68439b535.jpg)
