### PR TITLE
1193 bugfix: don't silently ignore constructor args when no constructor function is provided

### DIFF
--- a/tests/core/contracts/test_contract_constructor_encoding.py
+++ b/tests/core/contracts/test_contract_constructor_encoding.py
@@ -21,6 +21,19 @@ def test_contract_constructor_abi_encoding_with_constructor_with_no_args(SimpleC
 
 
 @pytest.mark.parametrize(
+    'args,kwargs',
+    (
+        (None, 'kwarg-is-ignored'),
+        ('arg-is-ignored', None),
+    ),
+)
+def test_contract_error_if_additional_args_are_supplied_with_no_constructor_fn(MathContract,
+                                                                               args, kwargs):
+    with pytest.raises(TypeError, match="Constructor args"):
+        MathContract._encode_constructor_data(args, kwargs)
+
+
+@pytest.mark.parametrize(
     'arguments',
     (
         [],

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -474,6 +474,10 @@ class Contract:
                 encode_abi(cls.web3, constructor_abi, arguments, data=cls.bytecode)
             )
         else:
+            if args is not None or kwargs is not None:
+                msg = "Constructor args were provided, but no constructor function was provided."
+                raise TypeError(msg)
+
             deploy_data = to_hex(cls.bytecode)
 
         return deploy_data


### PR DESCRIPTION
### What was wrong?

Fix bug #1193 (constructor arguments are passed and silently ignored when no constructor function is provided)

### How was it fixed?

Raise exception as suggested in the ticket

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.minipigs4sale.com/publishImages/Early-Socialization-Benefits~~element58.png)
