### PR TITLE
testrpc isn't needed anymore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ extras_require = {
         "py-geth>=2.0.1,<3.0.0",
         "pytest-ethereum>=0.1.3a6,<1.0.0",
     ],
-    'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],
     'linter': [
         "flake8==3.4.1",
         "isort>=4.2.15,<4.3.5",


### PR DESCRIPTION
### What was wrong?

Just a bit of cleanup

### How was it fixed?

Removed an unused extra.

Should be added to #722 so that it gets documented that the extra is gone (and any other references to the testrpc extra removed)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wallpapercave.com/wp/j6UADEt.jpg)
