### PR TITLE
Add note about web3[tester] in documentation.

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -317,6 +317,11 @@ EthereumTesterProvider
         >>> from web3 import Web3, EthereumTesterProvider
         >>> w3 = Web3(EthereumTesterProvider())
 
+.. NOTE:: To install the needed dependencies to use EthereumTesterProvider, you can install the
+    pip extras package that has the correct interoperable versions of the ``eth-tester``
+    and ``py-evm`` dependencies needed to do testing: e.g. ``pip install web3[tester]``
+
+
 
 AutoProvider
 ~~~~~~~~~~~~


### PR DESCRIPTION
### What was wrong?

Related to Issue #1321- Carver pointed out where to add a note about the extras package for tester, so I added it to the RST

### How was it fixed?

with vim, and about 20 seconds of my time.

#### Cute Animal Picture
```

  _--_                                     _--_
/#()# #\         0             0         /# #()#\
|()##  \#\_       \           /       _/#/  ##()|
|#()##-=###\_      \         /      _/###=-##()#|
 \#()#-=##  #\_     \       /     _/#  ##=-#()#/
  |#()#--==### \_    \     /    _/ ###==--#()#|
  |#()##--=#    #\_   \!!!/   _/#    #=--##()#|
   \#()##---===####\   O|O   /####===---##()#/
    |#()#____==#####\ / Y \ /#####==____#()#|
     \###______######|\/#\/|######______###/
        ()#O#/      ##\_#_/##      \#O#()
       ()#O#(__-===###/ _ \###===-__)#O#()
      ()#O#(   #  ###_(_|_)_###  #   )#O#()
      ()#O(---#__###/ (_|_) \###__#---)O#()
      ()#O#( / / ##/  (_|_)  \## \ \ )#O#()
      ()##O#\_/  #/   (_|_)   \#  \_/#O##()
       \)##OO#\ -)    (_|_)    (- /#OO##(/
        )//##OOO*|    / | \    |*OOO##\\(
        |/_####_/    ( /X\ )    \_####_\|
       /X/ \__/       \___/       \__/ \X\
      (#/                               \#)


```

