### PR TITLE
Docs: fix some build warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,7 +148,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -97,8 +97,8 @@ succesful connection it can make:
 1. The connection specified by an environment variable, see :ref:`provider_uri`
 2. :class:`~web3.providers.ipc.IPCProvider`, which looks for several IPC file locations.
    `IPCProvider` will not automatically detect a testnet connection, it is suggested that the
-    user instead uses a `w3` instance from `web3.auto.infura` (eg.
-    `from web3.auto.infura.ropsten import w3`) if they want to auto-detect a testnet.
+   user instead uses a `w3` instance from `web3.auto.infura` (e.g.
+   `from web3.auto.infura.ropsten import w3`) if they want to auto-detect a testnet.
 3. :class:`~web3.providers.rpc.HTTPProvider`, which attempts to connect to "http://localhost:8545"
 4. None - if no providers are successful, you can still use Web3 APIs
    that do not require a connection, like:

--- a/docs/web3.parity.rst
+++ b/docs/web3.parity.rst
@@ -124,11 +124,11 @@ Full documentation for Parity-supported endpoints can be found `here <https://wi
     * Return the filter ID that can be used with ``ShhFilter`` to poll for new messages that match the set of criteria. 
 
     * Parameters:
-		* ``decryptWith``: 32 bytes - Identity of key used for description. Null if listening for broadcasts.
-		* ``from``: 64 bytes - If present, only accept messages signed by this key.
+        * ``decryptWith``: 32 bytes - Identity of key used for description. Null if listening for broadcasts.
+        * ``from``: 64 bytes - If present, only accept messages signed by this key.
         * ``topics``: Array of possible topics (or partial topics). Should be non-empty.
- 
-    * Returns the newly created filter id. 
+
+    * Returns the newly created filter id.
 
     .. code-block:: python
 


### PR DESCRIPTION
### What was wrong?

Building docs produces warnings.

### How was it fixed?

As warnings suggest: remove unneeded whitespace, fix indentation, comment out unused setting.

This does _not_ address issue #1330. It only fixes the other warnings.

OK to squash-merge.

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://assets.atlasobscura.com/article_images/64087/image.jpg)

Source: [Felicia of Fermilab, via AO](https://www.atlasobscura.com/articles/felicia-ferret-particle-accelerator-fermilab)