### PR TITLE
Upgrade eth-tester

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'tester': [
-        "eth-tester[py-evm]==0.1.0-beta.37",
+        "eth-tester[py-evm]==0.1.0-beta.39",
         "py-geth>=2.0.1,<3.0.0",
         "pytest-ethereum>=0.1.3a6,<1.0.0",
     ],


### PR DESCRIPTION
### What was wrong?
There was an Invalid opcode Exception with Solidity 0.5.7 but not with 0.5.3

Related to py-evm issue [#1748](https://github.com/ethereum/py-evm/issues/1748)

### How was it fixed?
Pinned eth-tester py-evm requirement to 0.1.0-beta.39

#### Cute Animal Picture
![cute-baby-animals-2](https://user-images.githubusercontent.com/6540608/56169769-70972000-5f9c-11e9-98dc-091e19a87684.jpg)

