### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -277,7 +277,7 @@ Each Contract Factory exposes the following methods.
 
     ``fromBlock`` is a mandatory field. Defines the starting block (exclusive) filter block range. It can be either the starting block number, or 'latest' for the last mined block, or 'pending' for unmined transactions. In the case of ``fromBlock``, 'latest' and 'pending' set the 'latest' or 'pending' block as a static value for the starting filter block.
     ``toBlock`` optional. Defaults to 'latest'. Defines the ending block (inclusive) in the filter block range.  Special values 'latest' and 'pending' set a dynamic range that always includes the 'latest' or 'pending' blocks for the filter's upper block range.
-    ``address`` optional. Defaults the the contract address. The filter matches the event logs emanating from ``address``.
+    ``address`` optional. Defaults to the contract address. The filter matches the event logs emanating from ``address``.
     ``argument_filters``, optional. Expects a dictionary of argument names and values. When provided event logs are filtered for the event argument values. Event arguments can be both indexed or unindexed. Indexed values with be translated to their corresponding topic arguments. Unindexed arguments will be filtered using a regular expression.
     ``topics`` optional, accepts the standard JSON-RPC topics argument.  See the JSON-RPC documentation for `eth_newFilter <https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter>`_ more information on the ``topics`` parameters.
 


### PR DESCRIPTION
### What was wrong?
Documentation typo.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://r.ddmcdn.com/w_624/s_f/o_1/cx_0/cy_17/cw_624/ch_416/APL/uploads/2014/06/cute-animals-pictures18.jpg)
