### PR TITLE
mark deprecated sha3 method as static

### DIFF
--- a/tests/core/web3-module/test_keccak.py
+++ b/tests/core/web3-module/test_keccak.py
@@ -97,3 +97,10 @@ def test_keccak_raise_if_hexstr_and_text():
 def test_keccak_raise_if_no_args():
     with pytest.raises(TypeError):
         Web3.keccak()
+
+
+def test_deprecated_bound_method():
+    w3 = Web3()
+    h = HexBytes('0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8')
+    with pytest.warns(DeprecationWarning, match='sha3 is deprecated in favor of keccak'):
+        assert w3.sha3(text='cowmö') == h

--- a/web3/main.py
+++ b/web3/main.py
@@ -163,6 +163,7 @@ class Web3:
         from web3 import __version__
         return __version__
 
+    @staticmethod
     @deprecated_for("keccak")
     @apply_to_return_value(HexBytes)
     def sha3(primitive=None, text=None, hexstr=None):


### PR DESCRIPTION
### What was wrong?

Related to Issue #1349

### How was it fixed?
added @staticmethod annotation to the method


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://en.wikipedia.org/wiki/File:Cute_grey_kitten.jpg)
