### PR TITLE
methods for setting/getting parity operating mode

### DIFF
--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -6,8 +6,10 @@ from flaky import (
 
 from web3._utils.module_testing import (  # noqa: F401
     EthModuleTest,
-    ParityModuleTest as TraceModuleTest,
+    ParityModuleTest,
     ParityPersonalModuleTest,
+    ParitySetModuleTest,
+    ParityTraceModuleTest,
     Web3ModuleTest,
 )
 from web3._utils.module_testing.eth_module import (
@@ -178,7 +180,15 @@ class ParityEthModuleTest(EthModuleTest):
         )
 
 
-class ParityTraceModuleTest(TraceModuleTest):
+class ParityTraceModuleTest(ParityTraceModuleTest):
+    pass
+
+
+class ParitySetModuleTest(ParitySetModuleTest):
+    pass
+
+
+class ParityModuleTest(ParityModuleTest):
     pass
 
 

--- a/tests/integration/parity/test_parity_ipc.py
+++ b/tests/integration/parity/test_parity_ipc.py
@@ -14,7 +14,9 @@ from web3._utils.module_testing import (
 from .common import (
     CommonParityShhModuleTest,
     ParityEthModuleTest,
+    ParityModuleTest,
     ParityPersonalModuleTest,
+    ParitySetModuleTest,
     ParityTraceModuleTest,
     ParityWeb3ModuleTest,
 )
@@ -99,6 +101,14 @@ class TestParityPersonalModuleTest(ParityPersonalModuleTest):
 
 
 class TestParityTraceModuleTest(ParityTraceModuleTest):
+    pass
+
+
+class TestParityModuleTest(ParityModuleTest):
+    pass
+
+
+class TestParitySetModuleTest(ParitySetModuleTest):
     pass
 
 

--- a/tests/integration/parity/test_parity_ws.py
+++ b/tests/integration/parity/test_parity_ws.py
@@ -17,7 +17,9 @@ from web3._utils.module_testing import (
 from .common import (
     CommonParityShhModuleTest,
     ParityEthModuleTest,
+    ParityModuleTest,
     ParityPersonalModuleTest,
+    ParitySetModuleTest,
     ParityTraceModuleTest,
     ParityWeb3ModuleTest,
 )
@@ -104,6 +106,14 @@ class TestParityPersonalModuleTest(ParityPersonalModuleTest):
 
 
 class TestParityTraceModuleTest(ParityTraceModuleTest):
+    pass
+
+
+class TestParityModuleTest(ParityModuleTest):
+    pass
+
+
+class TestParitySetModuleTest(ParitySetModuleTest):
     pass
 
 

--- a/web3/_utils/module_testing/__init__.py
+++ b/web3/_utils/module_testing/__init__.py
@@ -19,5 +19,7 @@ from .version_module import (  # noqa: F401
     VersionModuleTest,
 )
 from .parity_module import (  # noqa: F401
+    ParitySetModuleTest,
+    ParityTraceModuleTest,
     ParityModuleTest,
 )

--- a/web3/_utils/module_testing/parity_module.py
+++ b/web3/_utils/module_testing/parity_module.py
@@ -9,11 +9,7 @@ from web3._utils.formatters import (
 )
 
 
-class ParityModuleTest:
-
-    def test_list_storage_keys_no_support(self, web3, emitter_contract_address):
-        keys = web3.parity.listStorageKeys(emitter_contract_address, 10, None)
-        assert keys is None
+class ParityTraceModuleTest:
 
     def test_trace_replay_transaction(self, web3, parity_fixture_data):
         trace = web3.parity.traceReplayTransaction(parity_fixture_data['mined_txn_hash'])
@@ -92,6 +88,39 @@ class ParityModuleTest:
         assert isinstance(trace, list)
         assert trace[0]['action']['from'] == add_0x_prefix(parity_fixture_data['coinbase'])
 
+
+class ParityModuleTest:
+
     def test_add_reserved_peer(self, web3):
         peer_addr = 'enode://f1a6b0bdbf014355587c3018454d070ac57801f05d3b39fe85da574f002a32e929f683d72aa5a8318382e4d3c7a05c9b91687b0d997a39619fb8a6e7ad88e512@1.1.1.1:30300'  # noqa: E501
         assert web3.parity.addReservedPeer(peer_addr)
+
+    def test_list_storage_keys_no_support(self, web3, emitter_contract_address):
+        keys = web3.parity.listStorageKeys(emitter_contract_address, 10, None)
+        assert keys is None
+
+    def test_mode(self, web3):
+        assert web3.parity.mode() is not None
+
+
+class ParitySetModuleTest:
+
+    @pytest.mark.parametrize(
+        'mode',
+        [
+            ('dark'),
+            ('offline'),
+            ('active'),
+            ('passive'),
+        ]
+    )
+    def test_set_mode(self, web3, mode):
+        assert web3.parity.setMode(mode) is True
+
+    def test_set_mode_with_bad_string(self, web3):
+        with pytest.raises(ValueError, match="Couldn't parse parameters: mode"):
+            web3.parity.setMode('not a mode')
+
+    def test_set_mode_with_no_argument(self, web3):
+        with pytest.raises(TypeError, match='missing 1 required positional argument'):
+            web3.parity.setMode()

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -146,7 +146,7 @@ class Parity(Module):
             [mode]
         )
 
-    def getMode(self):
+    def mode(self):
         return self.web3.manager.request_blocking(
             "parity_mode",
             []

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -139,3 +139,15 @@ class Parity(Module):
             "trace_rawTransaction",
             [raw_transaction, mode],
         )
+
+    def setMode(self, mode):
+        return self.web3.manager.request_blocking(
+            "parity_setMode",
+            [mode]
+        )
+
+    def getMode(self):
+        return self.web3.manager.request_blocking(
+            "parity_mode",
+            []
+        )


### PR DESCRIPTION
### What was wrong?

Nothing. But there's always space for improvements. Since I needed functionality for getting and setting parity operating modes, I propose to add methods for that (see https://wiki.parity.io/JSONRPC-parity_set-module#parity_setmode and https://wiki.parity.io/JSONRPC-parity-module#parity_mode).

### How was it fixed?

Before I searched for a cute animal picture I added two methods for easy mode control. Please check diff, it adds only 12 lines.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://abovethelaw.com/uploads/01-stick-em-up-kitty-kitten-cat-gun-e1286641024121-300x224.jpg)
