### PR TITLE
ethpm version constraint to <v0.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.4.0,<2.0.0",
-        "ethpm>=0.1.4a19,<2.0.0",
+        "ethpm>=0.1.4a19,<0.2.0",
         "hexbytes>=0.1.0,<1.0.0",
         "lru-dict>=1.1.6,<2.0.0",
         "requests>=2.16.0,<3.0.0",


### PR DESCRIPTION
Packages can break compatibility at v0 minor bumps

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/HbnIr0k.jpg)
