### PR TITLE
Moved pytest.xfail to pytest.mark.xfail

### DIFF
--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -21,11 +21,9 @@ class GoEthereumEthModuleTest(EthModuleTest):
         super().test_eth_replaceTransaction(web3, unlocked_account)
 
     def test_eth_replaceTransaction_incorrect_nonce(self, web3, unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_incorrect_nonce(web3, unlocked_account)
 
     def test_eth_replaceTransaction_gas_price_too_low(self, web3, unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_gas_price_too_low(web3, unlocked_account)
 
     @pytest.mark.xfail(reason='Needs ability to efficiently control mining')

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -16,8 +16,8 @@ class GoEthereumTest(Web3ModuleTest):
 
 
 class GoEthereumEthModuleTest(EthModuleTest):
+    @pytest.mark.xfail(reason='Needs ability to efficiently control mining')
     def test_eth_replaceTransaction(self, web3, unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction(web3, unlocked_account)
 
     def test_eth_replaceTransaction_incorrect_nonce(self, web3, unlocked_account):
@@ -28,34 +28,34 @@ class GoEthereumEthModuleTest(EthModuleTest):
         pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_gas_price_too_low(web3, unlocked_account)
 
+    @pytest.mark.xfail(reason='Needs ability to efficiently control mining')
     def test_eth_replaceTransaction_gas_price_defaulting_minimum(self, web3, unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_gas_price_defaulting_minimum(web3, unlocked_account)
 
+    @pytest.mark.xfail(reason='Needs ability to efficiently control mining')
     def test_eth_replaceTransaction_gas_price_defaulting_strategy_higher(self,
                                                                          web3,
                                                                          unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_gas_price_defaulting_strategy_higher(
             web3, unlocked_account
         )
 
+    @pytest.mark.xfail(reason='Needs ability to efficiently control mining')
     def test_eth_replaceTransaction_gas_price_defaulting_strategy_lower(self,
                                                                         web3,
                                                                         unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_gas_price_defaulting_strategy_lower(
             web3, unlocked_account
         )
 
+    @pytest.mark.xfail(reason='Needs ability to efficiently control mining')
     def test_eth_modifyTransaction(self, web3, unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_modifyTransaction(web3, unlocked_account)
 
+    @pytest.mark.xfail(reason='Block identifier has not been implemented in geth')
     def test_eth_estimateGas_with_block(self,
                                         web3,
                                         unlocked_account_dual_type):
-        pytest.xfail('Block identifier has not been implemented in geth')
         super().test_eth_estimateGas_with_block(
             web3, unlocked_account_dual_type
         )

--- a/tests/integration/go_ethereum/test_goethereum_ws.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws.py
@@ -77,6 +77,6 @@ class TestMiscWebsocketTest(MiscWebsocketTest):
 
 
 class TestGoEthereumShhModuleTest(CommonGoEthereumShhModuleTest):
-    @pytest.mark.xfail(reason="async filter bug in geth ws version")
     def test_shh_async_filter(self, web3):
+        pytest.xfail("async filter bug in geth ws version")
         super().test_shh_async_filter(web3)

--- a/tests/integration/go_ethereum/test_goethereum_ws.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws.py
@@ -77,6 +77,6 @@ class TestMiscWebsocketTest(MiscWebsocketTest):
 
 
 class TestGoEthereumShhModuleTest(CommonGoEthereumShhModuleTest):
+    @pytest.mark.xfail(reason="async filter bug in geth ws version")
     def test_shh_async_filter(self, web3):
-        pytest.xfail("async filter bug in geth ws version")
         super().test_shh_async_filter(web3)

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -32,8 +32,8 @@ class ParityEthModuleTest(EthModuleTest):
         chain_id = web3.eth.chainId
         assert chain_id is None
 
+    @pytest.mark.xfail(reason='Parity dropped "pending" option in 1.11.1')
     def test_eth_getBlockByNumber_pending(self, web3):
-        pytest.xfail('Parity dropped "pending" option in 1.11.1')
         super().test_eth_getBlockByNumber_pending(web3)
 
     def test_eth_uninstallFilter(self, web3):
@@ -44,8 +44,8 @@ class ParityEthModuleTest(EthModuleTest):
         pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction(web3, unlocked_account)
 
+    @pytest.mark.xfail(reason='Parity is not setup to auto mine')
     def test_eth_replaceTransaction_already_mined(self, web3, unlocked_account):
-        pytest.xfail('Parity is not setup to auto mine')
         super().test_eth_replaceTransaction_already_mined(web3, unlocked_account)
 
     def test_eth_replaceTransaction_incorrect_nonce(self, web3, unlocked_account):
@@ -76,8 +76,8 @@ class ParityEthModuleTest(EthModuleTest):
             web3, unlocked_account
         )
 
+    @pytest.mark.xfail(reason='Needs ability to efficiently control mining')
     def test_eth_modifyTransaction(self, web3, unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_modifyTransaction(web3, unlocked_account)
 
     @flaky(max_runs=MAX_FLAKY_RUNS)
@@ -95,8 +95,8 @@ class ParityEthModuleTest(EthModuleTest):
         assert receipt is not None
         assert receipt['blockHash'] is None
 
+    @pytest.mark.xfail(reason="Parity matches None to asbent values")
     def test_eth_getLogs_with_logs_none_topic_args(self, web3):
-        pytest.xfail("Parity matches None to asbent values")
         super().test_eth_getLogs_with_logs_none_topic_args(web3)
 
     @flaky(max_runs=MAX_FLAKY_RUNS)
@@ -190,12 +190,12 @@ class ParityTraceModuleTest(TraceModuleTest):
 
 
 class CommonParityShhModuleTest(ParityShhModuleTest):
+    @pytest.mark.xfail(reason="Skip until parity filter bug is resolved")
     def test_shh_sync_filter(self, web3):
         # https://github.com/paritytech/parity-ethereum/issues/10565
-        pytest.xfail("Skip until parity filter bug is resolved")
         super().test_shh_sync_filter(web3)
 
+    @pytest.mark.xfail(reason="Skip until parity filter bug is resolved")
     def test_shh_async_filter(self, web3):
         # https://github.com/paritytech/parity-ethereum/issues/10565
-        pytest.xfail("Skip until parity filter bug is resolved")
         super().test_shh_async_filter(web3)

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -41,7 +41,6 @@ class ParityEthModuleTest(EthModuleTest):
         super().test_eth_uninstallFilter(web3)
 
     def test_eth_replaceTransaction(self, web3, unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction(web3, unlocked_account)
 
     @pytest.mark.xfail(reason='Parity is not setup to auto mine')
@@ -49,21 +48,17 @@ class ParityEthModuleTest(EthModuleTest):
         super().test_eth_replaceTransaction_already_mined(web3, unlocked_account)
 
     def test_eth_replaceTransaction_incorrect_nonce(self, web3, unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_incorrect_nonce(web3, unlocked_account)
 
     def test_eth_replaceTransaction_gas_price_too_low(self, web3, unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_gas_price_too_low(web3, unlocked_account)
 
     def test_eth_replaceTransaction_gas_price_defaulting_minimum(self, web3, unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_gas_price_defaulting_minimum(web3, unlocked_account)
 
     def test_eth_replaceTransaction_gas_price_defaulting_strategy_higher(self,
                                                                          web3,
                                                                          unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_gas_price_defaulting_strategy_higher(
             web3, unlocked_account
         )
@@ -71,7 +66,6 @@ class ParityEthModuleTest(EthModuleTest):
     def test_eth_replaceTransaction_gas_price_defaulting_strategy_lower(self,
                                                                         web3,
                                                                         unlocked_account):
-        pytest.xfail('Needs ability to efficiently control mining')
         super().test_eth_replaceTransaction_gas_price_defaulting_strategy_lower(
             web3, unlocked_account
         )
@@ -190,12 +184,12 @@ class ParityTraceModuleTest(TraceModuleTest):
 
 
 class CommonParityShhModuleTest(ParityShhModuleTest):
-    @pytest.mark.xfail(reason="Skip until parity filter bug is resolved")
     def test_shh_sync_filter(self, web3):
         # https://github.com/paritytech/parity-ethereum/issues/10565
+        pytest.xfail("Skip until parity filter bug is resolved")
         super().test_shh_sync_filter(web3)
 
-    @pytest.mark.xfail(reason="Skip until parity filter bug is resolved")
     def test_shh_async_filter(self, web3):
         # https://github.com/paritytech/parity-ethereum/issues/10565
+        pytest.xfail("Skip until parity filter bug is resolved")
         super().test_shh_async_filter(web3)

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -284,14 +284,14 @@ class TestEthereumTesterEthModule(EthModuleTest):
         else:
             raise AssertionError("eth-tester was unexpectedly able to give the pending call result")
 
+    @pytest.mark.xfail(reason='json-rpc method is not implemented on eth-tester')
     def test_eth_getStorageAt(self, web3, emitter_contract_address):
-        pytest.xfail('json-rpc method is not implemented on eth-tester')
         super().test_eth_getStorageAt(web3, emitter_contract_address)
 
+    @pytest.mark.xfail(reason='Block identifier has not been implemented in eth-tester')
     def test_eth_estimateGas_with_block(self,
                                         web3,
                                         unlocked_account_dual_type):
-        pytest.xfail('Block identifier has not been implemented in eth-tester')
         super().test_eth_estimateGas_with_block(
             web3, unlocked_account_dual_type
         )

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -361,7 +361,7 @@ class EthModuleTest:
             'value': 1,
             'gas': 21000,
             # Increased gas price to ensure transaction hash different from other tests
-            'gasPrice': web3.eth.gasPrice * 2,
+            'gasPrice': web3.eth.gasPrice * 3,
             'nonce': web3.eth.getTransactionCount(unlocked_account),
         }
         txn_hash = web3.eth.sendTransaction(txn_params)

--- a/web3/_utils/module_testing/personal_module.py
+++ b/web3/_utils/module_testing/personal_module.py
@@ -189,12 +189,12 @@ class ParityPersonalModuleTest():
         new_account = web3.parity.personal.newAccount(PASSWORD)
         assert is_checksum_address(new_account)
 
+    @pytest.mark.xfail(reason='this non-standard json-rpc method is not implemented on parity')
     def test_personal_lockAccount(self, web3, unlocked_account):
-        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
         super().test_personal_lockAccount(web3, unlocked_account)
 
+    @pytest.mark.xfail(reason='this non-standard json-rpc method is not implemented on parity')
     def test_personal_importRawKey(self, web3):
-        pytest.xfail('this non-standard json-rpc method is not implemented on parity')
         super().test_personal_importRawKey(web3)
 
     def test_personal_sendTransaction(self,


### PR DESCRIPTION
### What was wrong?
`pytest.xfail` makes the test unconditionally xfail, and no code after the `xfail` is run. The `@pytest.mark.xfail` decorator lets the test run.

Related to Issue #1341

### How was it fixed?
Added @pytest.mark.xfail where appropriate, and removed xfails on tests that are passing


#### Cute Animal Picture
![download-1](https://user-images.githubusercontent.com/6540608/60627021-e182f280-9da9-11e9-8b9b-ec9b17e0404d.jpg)