### PR TITLE
Change net.version to eth.chainId for default transaction params

### DIFF
--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -58,7 +58,7 @@ def test_build_transaction_not_paying_to_nonpayable_function(
         'data': '0xe4cb8f5c',
         'value': 0,
         'gasPrice': 1,
-        'chainId': 1,
+        'chainId': 61,
     }
 
 
@@ -79,7 +79,7 @@ def test_build_transaction_with_contract_no_arguments(web3, math_contract, build
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 1,
-        'chainId': 1,
+        'chainId': 61,
     }
 
 
@@ -90,7 +90,7 @@ def test_build_transaction_with_contract_fallback_function(web3, fallback_functi
         'data': '0x',
         'value': 0,
         'gasPrice': 1,
-        'chainId': 1,
+        'chainId': 61,
     }
 
 
@@ -109,7 +109,7 @@ def test_build_transaction_with_contract_class_method(
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 1,
-        'chainId': 1,
+        'chainId': 61,
     }
 
 
@@ -123,7 +123,7 @@ def test_build_transaction_with_contract_default_account_is_set(
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 1,
-        'chainId': 1,
+        'chainId': 61,
     }
 
 
@@ -137,7 +137,7 @@ def test_build_transaction_with_gas_price_strategy_set(web3, math_contract, buil
         'data': '0xd09de08a',
         'value': 0,
         'gasPrice': 5,
-        'chainId': 1,
+        'chainId': 61,
     }
 
 
@@ -165,31 +165,31 @@ def test_build_transaction_with_contract_to_address_supplied_errors(web3,
         (
             {}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'chainId': 1,
+                'value': 0, 'gasPrice': 1, 'chainId': 61,
             }, False
         ),
         (
             {'gas': 800000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'chainId': 1,
+                'value': 0, 'gasPrice': 1, 'chainId': 61,
             }, False
         ),
         (
             {'gasPrice': 21000000000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 21000000000, 'chainId': 1,
+                'value': 0, 'gasPrice': 21000000000, 'chainId': 61,
             }, False
         ),
         (
             {'nonce': 7}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'nonce': 7, 'chainId': 1,
+                'value': 0, 'gasPrice': 1, 'nonce': 7, 'chainId': 61,
             }, True
         ),
         (
             {'value': 20000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 20000, 'gasPrice': 1, 'chainId': 1,
+                'value': 20000, 'gasPrice': 1, 'chainId': 61,
             }, False
         ),
     ),

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -16,7 +16,7 @@ RECEIPT_TIMEOUT = 0.2
     'make_chain_id, expect_success',
     (
         (
-            lambda web3: web3.net.version,
+            lambda web3: int(web3.eth.chainId, 16),
             True,
         ),
         pytest.param(

--- a/tests/core/middleware/test_transaction_signing.py
+++ b/tests/core/middleware/test_transaction_signing.py
@@ -89,6 +89,7 @@ def result_generator_middleware():
     return construct_result_generator_middleware({
         'eth_sendRawTransaction': lambda *args: args,
         'net_version': lambda *_: 1,
+        'eth_chainId': lambda *_: "0x02",
     })
 
 

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -29,7 +29,7 @@ TRANSACTION_DEFAULTS = {
     'data': b'',
     'gas': lambda web3, tx: web3.eth.estimateGas(tx),
     'gasPrice': lambda web3, tx: web3.eth.generateGasPrice(tx) or web3.eth.gasPrice,
-    'chainId': lambda web3, tx: int(web3.net.version),
+    'chainId': lambda web3, tx: int(web3.eth.chainId, 16),
 }
 
 

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -29,14 +29,14 @@ is_not_null = complement(is_null)
 
 @curry
 def validate_chain_id(web3, chain_id):
-    if chain_id == web3.net.version:
+    if int(chain_id) == int(web3.eth.chainId, 16):
         return chain_id
     else:
         raise ValidationError(
             "The transaction declared chain ID %r, "
             "but the connected node is on %r" % (
                 chain_id,
-                "UNKNOWN",
+                int(web3.eth.chainId, 16),
             )
         )
 
@@ -66,7 +66,7 @@ def transaction_param_validator(web3):
     transactions_params_validators = {
         'chainId': apply_formatter_if(
             # Bypass `validate_chain_id` if chainId can't be determined
-            lambda _: is_not_null(web3.net.version),
+            lambda _: is_not_null(web3.eth.chainId),
             validate_chain_id(web3)
         ),
     }


### PR DESCRIPTION
### What was wrong?

On a chain using a different network id and chain id, the default parameters for a transaction would be incorrectly filled when using Parity / Geth. It would use the `net_version` RPC instead of `eth_chainId`

Parity's net_version RPC: https://wiki.parity.io/JSONRPC-net-module#net_version
Parity's eth_chainId RPC: https://wiki.parity.io/JSONRPC-eth-module#eth_chainid
Geth net_version RPC: https://github.com/ethereumproject/go-ethereum/wiki/JSON-RPC#net_version
Geth eth_chainId RPC: https://github.com/ethereumproject/go-ethereum/wiki/JSON-RPC#eth_chainId

Related to Issue https://github.com/ethereum/web3.py/issues/1293

### How was it fixed?

Change the `TRANSACTION_DEFAULTS` to use web3.eth.chainId
This works for Parity and Geth afaik. It does not comply with EIP1474: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#description-4
But as noted in the related issue, the EIP1474 should be updated and the EIP is in draft state.

I could not write a proper test for it since I would need a test chain with a different network and chain id, and could not find a relatively quick way to do that.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/3/39/Sitting_Samoyed.jpg)

Edit: I know I messed up and wrote `chaindId` instead of `chainId`, also looking into fixing some tests.
