### PR TITLE
Relax ethpm canonical address requirement

### DIFF
--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -82,7 +82,7 @@ LinkableContract
 
 .. doctest::
 
-   >>> from eth_utils import is_address, to_canonical_address
+   >>> from eth_utils import is_address
    >>> from web3 import Web3
    >>> from ethpm import Package, ASSETS_DIR
 
@@ -104,7 +104,7 @@ LinkableContract
    >>> safe_send_tx_receipt = w3.eth.waitForTransactionReceipt(safe_send_tx_hash)
 
    >>> # Link Escrow factory to deployed SafeSendLib instance
-   >>> LinkedEscrowFactory = EscrowFactory.link_bytecode({"SafeSendLib": to_canonical_address(safe_send_tx_receipt.contractAddress)})
+   >>> LinkedEscrowFactory = EscrowFactory.link_bytecode({"SafeSendLib": safe_send_tx_receipt.contractAddress})
    >>> assert LinkedEscrowFactory.needs_bytecode_linking is False
    >>> escrow_tx_hash = LinkedEscrowFactory.constructor(w3.eth.accounts[0]).transact()
    >>> escrow_tx_receipt = w3.eth.waitForTransactionReceipt(escrow_tx_hash)
@@ -725,7 +725,6 @@ This is the simplest builder function for adding a deployment to a manifest. All
 
 .. doctest::
 
-   >>> from eth_utils import to_canonical_address
    >>> expected_manifest = {
    ...   'package_name': 'owned',
    ...   'manifest_version': '2',
@@ -734,7 +733,7 @@ This is the simplest builder function for adding a deployment to a manifest. All
    ...     'blockchain://1234567890123456789012345678901234567890123456789012345678901234/block/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef': {
    ...       'Owned': {
    ...         'contract_type': 'Owned',
-   ...         'address': '0x4f5b11c860b37b68de6d14fb7e7b5f18a9a1bd00',
+   ...         'address': '0x4F5B11C860B37B68De6d14FB7e7b5f18A9a1BD00',
    ...       }
    ...     }
    ...   }
@@ -745,7 +744,7 @@ This is the simplest builder function for adding a deployment to a manifest. All
    ...         block_uri='blockchain://1234567890123456789012345678901234567890123456789012345678901234/block/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
    ...         contract_instance='Owned',
    ...         contract_type='Owned',
-   ...         address=to_canonical_address('0x4f5b11c860b37b68de6d14fb7e7b5f18a9a1bd00'),
+   ...         address='0x4F5B11C860B37B68De6d14FB7e7b5f18A9a1BD00',
    ...     ),
    ... )
    >>> assert expected_manifest == built_manifest

--- a/ethpm/deployments.py
+++ b/ethpm/deployments.py
@@ -4,10 +4,6 @@ from typing import (
     List,
 )
 
-from eth_utils import (
-    to_canonical_address,
-)
-
 from ethpm.exceptions import (
     ValidationError,
 )
@@ -64,7 +60,7 @@ class Deployments:
         # in case the deployment uses a contract alias
         contract_type = self.deployment_data[contract_name]["contract_type"]
         factory = self.contract_factories[contract_type]
-        address = to_canonical_address(self.deployment_data[contract_name]["address"])
+        address = self.deployment_data[contract_name]["address"]
         contract_kwargs = {
             "abi": factory.abi,
             "bytecode": factory.bytecode,

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -61,7 +61,6 @@ from ethpm.validation.manifest import (
     validate_raw_manifest_format,
 )
 from ethpm.validation.misc import (
-    validate_address,
     validate_w3_instance,
 )
 from ethpm.validation.package import (
@@ -73,6 +72,9 @@ from ethpm.validation.uri import (
     validate_single_matching_uri,
 )
 from web3 import Web3
+from web3._utils.validation import (
+    validate_address,
+)
 from web3.eth import (
     Contract,
 )
@@ -275,9 +277,8 @@ class Package(object):
         contract_kwargs = generate_contract_factory_kwargs(
             self.manifest["contract_types"][name]
         )
-        canonical_address = to_canonical_address(address)
         contract_instance = self.w3.eth.contract(
-            address=canonical_address, **contract_kwargs
+            address=address, **contract_kwargs
         )
         return contract_instance
 
@@ -347,7 +348,7 @@ class Package(object):
         if linked_deployments:
             for deployment_data in linked_deployments.values():
                 on_chain_bytecode = self.w3.eth.getCode(
-                    to_canonical_address(deployment_data["address"])
+                    deployment_data["address"]
                 )
                 unresolved_linked_refs = normalize_linked_references(
                     deployment_data["runtime_bytecode"]["link_dependencies"]

--- a/ethpm/tools/builder.py
+++ b/ethpm/tools/builder.py
@@ -25,8 +25,8 @@ from eth_utils import (
     is_hex,
     is_string,
     to_bytes,
+    to_checksum_address,
     to_dict,
-    to_hex,
     to_list,
 )
 from eth_utils.toolz import (
@@ -62,13 +62,13 @@ from ethpm.uri import (
 from ethpm.validation.manifest import (
     validate_manifest_against_schema,
 )
-from ethpm.validation.misc import (
-    validate_address,
-)
 from ethpm.validation.package import (
     validate_package_name,
 )
 from web3 import Web3
+from web3._utils.validation import (
+    validate_address,
+)
 
 
 def build(obj: Dict[str, Any], *fns: Callable[..., Any]) -> Dict[str, Any]:
@@ -705,7 +705,7 @@ def _build_deployments_object(
     Returns a dict with properly formatted deployment data.
     """
     yield "contract_type", contract_type
-    yield "address", to_hex(address)
+    yield "address", to_checksum_address(address)
     if deployment_bytecode:
         yield "deployment_bytecode", deployment_bytecode
     if compiler:

--- a/ethpm/validation/misc.py
+++ b/ethpm/validation/misc.py
@@ -1,29 +1,7 @@
-from typing import (
-    Any,
-)
-
-from eth_utils import (
-    is_address,
-    is_canonical_address,
-)
-
 from ethpm.exceptions import (
     ValidationError,
 )
 from web3 import Web3
-
-
-def validate_address(address: Any) -> None:
-    """
-    Raise a ValidationError if an address is not canonicalized.
-    """
-    if not is_address(address):
-        raise ValidationError(f"Expected an address, got: {address}")
-    if not is_canonical_address(address):
-        raise ValidationError(
-            "Py-EthPM library only accepts canonicalized addresses. "
-            f"{address} is not in the accepted format."
-        )
 
 
 def validate_w3_instance(w3: Web3) -> None:

--- a/tests/core/pm-module/conftest.py
+++ b/tests/core/pm-module/conftest.py
@@ -8,7 +8,6 @@ from eth_tester import (
 from eth_utils import (
     function_abi_to_4byte_selector,
     to_bytes,
-    to_canonical_address,
 )
 
 from ethpm import (
@@ -160,7 +159,7 @@ def sol_registry(w3):
     deployed_registry_package = registry_deployer.deploy("PackageRegistry")
     assert isinstance(registry_package, Package)
     registry = deployed_registry_package.deployments.get_instance("PackageRegistry")
-    return SolidityReferenceRegistry(to_canonical_address(registry.address), w3)
+    return SolidityReferenceRegistry(registry.address, w3)
 
 
 def vy_registry(w3):
@@ -171,7 +170,7 @@ def vy_registry(w3):
     deployed_registry_package = registry_deployer.deploy("registry")
     registry_instance = deployed_registry_package.deployments.get_instance("registry")
     assert registry_instance.functions.owner().call() == w3.eth.defaultAccount
-    return VyperReferenceRegistry(to_canonical_address(registry_instance.address), w3)
+    return VyperReferenceRegistry(registry_instance.address, w3)
 
 
 def release_packages(registry):

--- a/tests/core/pm-module/test_pm_init.py
+++ b/tests/core/pm-module/test_pm_init.py
@@ -1,10 +1,6 @@
 import json
 import pytest
 
-from eth_utils import (
-    to_canonical_address,
-)
-
 from ethpm import (
     Package,
 )
@@ -38,7 +34,7 @@ def test_get_contract_factory_with_valid_owned_manifest(w3):
     owned_factory = owned_package.get_contract_factory('Owned')
     tx_hash = owned_factory.constructor().transact()
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
-    owned_address = to_canonical_address(tx_receipt.contractAddress)
+    owned_address = tx_receipt.contractAddress
     owned_instance = owned_package.get_contract_instance("Owned", owned_address)
     assert owned_instance.abi == owned_factory.abi
 
@@ -49,7 +45,7 @@ def test_get_contract_factory_with_valid_safe_math_lib_manifest(w3):
     safe_math_factory = safe_math_package.get_contract_factory("SafeMathLib")
     tx_hash = safe_math_factory.constructor().transact()
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
-    safe_math_address = to_canonical_address(tx_receipt.contractAddress)
+    safe_math_address = tx_receipt.contractAddress
     safe_math_instance = safe_math_package.get_contract_instance("SafeMathLib", safe_math_address)
     assert safe_math_instance.functions.safeAdd(1, 2).call() == 3
 
@@ -62,12 +58,12 @@ def test_get_contract_factory_with_valid_escrow_manifest(w3):
     safe_send_factory = escrow_package.get_contract_factory('SafeSendLib')
     safe_send_tx_hash = safe_send_factory.constructor().transact()
     safe_send_tx_receipt = w3.eth.waitForTransactionReceipt(safe_send_tx_hash)
-    safe_send_address = to_canonical_address(safe_send_tx_receipt.contractAddress)
+    safe_send_address = safe_send_tx_receipt.contractAddress
     linked_escrow_factory = escrow_factory.link_bytecode({"SafeSendLib": safe_send_address})
     assert linked_escrow_factory.needs_bytecode_linking is False
     escrow_tx_hash = linked_escrow_factory.constructor(w3.eth.accounts[0]).transact()
     escrow_tx_receipt = w3.eth.waitForTransactionReceipt(escrow_tx_hash)
-    escrow_address = to_canonical_address(escrow_tx_receipt.contractAddress)
+    escrow_address = escrow_tx_receipt.contractAddress
     escrow_instance = linked_escrow_factory(address=escrow_address)
     assert escrow_instance.functions.sender().call() == w3.eth.accounts[0]
 
@@ -80,7 +76,7 @@ def test_deploy_a_standalone_package_integration(w3):
     # totalSupply = 100
     tx_hash = ERC20.constructor(100).transact()
     tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
-    address = to_canonical_address(tx_receipt["contractAddress"])
+    address = tx_receipt["contractAddress"]
     erc20 = w3.eth.contract(address=address, abi=ERC20.abi)
     total_supply = erc20.functions.totalSupply().call()
     assert total_supply == 100

--- a/tests/ethpm/integration/test_escrow_manifest.py
+++ b/tests/ethpm/integration/test_escrow_manifest.py
@@ -38,7 +38,7 @@ def test_deployed_escrow_and_safe_send(escrow_manifest, w3):
         "0x4F5B11c860b37b68DE6D14Fb7e7b5f18A9A1bdC0"
     ).transact()
     escrow_tx_receipt = w3.eth.waitForTransactionReceipt(escrow_tx_hash)
-    escrow_address = to_canonical_address(escrow_tx_receipt.contractAddress)
+    escrow_address = escrow_tx_receipt.contractAddress
 
     # Cannot deploy with an unlinked factory
     with pytest.raises(BytecodeLinkingError):
@@ -53,9 +53,7 @@ def test_deployed_escrow_and_safe_send(escrow_manifest, w3):
     assert EscrowFactory.needs_bytecode_linking is True
     assert LinkedEscrowFactory.needs_bytecode_linking is False
     assert isinstance(contract_instance, web3.contract.Contract)
-    assert to_canonical_address(safe_send_address) in LinkedEscrowFactory.bytecode
-    assert (
-        to_canonical_address(safe_send_address) in LinkedEscrowFactory.bytecode_runtime
-    )
-    assert to_canonical_address(safe_send_address) not in EscrowFactory.bytecode
-    assert to_canonical_address(safe_send_address) not in EscrowFactory.bytecode_runtime
+    assert safe_send_address in LinkedEscrowFactory.bytecode
+    assert safe_send_address in LinkedEscrowFactory.bytecode_runtime
+    assert safe_send_address not in EscrowFactory.bytecode
+    assert safe_send_address not in EscrowFactory.bytecode_runtime

--- a/tests/ethpm/test_contract.py
+++ b/tests/ethpm/test_contract.py
@@ -26,18 +26,14 @@ from web3.contract import (
             "escrow",
             "Escrow",
             {
-                "SafeSendLib": to_canonical_address(
-                    "0x4F5B11c860b37b68DE6D14Fb7e7b5f18A9A1bdC0"
-                )
+                "SafeSendLib": "0x4F5B11c860b37b68DE6D14Fb7e7b5f18A9A1bdC0"
             },
         ),
         (
             "wallet",
             "Wallet",
             {
-                "SafeMathLib": to_canonical_address(
-                    "0xa66A05D6AB5c1c955F4D2c3FCC166AE6300b452B"
-                )
+                "SafeMathLib": "0xa66A05D6AB5c1c955F4D2c3FCC166AE6300b452B"
             },
         ),
     ),

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -2,7 +2,6 @@ import pytest
 
 from eth_utils import (
     is_same_address,
-    to_canonical_address,
 )
 
 from ethpm.exceptions import (
@@ -26,7 +25,7 @@ def deployed_safe_math(safe_math_package, w3):
     SafeMath = safe_math_package.get_contract_factory("SafeMathLib")
     tx_hash = SafeMath.constructor().transact()
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
-    return safe_math_package, to_canonical_address(tx_receipt.contractAddress)
+    return safe_math_package, tx_receipt.contractAddress
 
 
 def test_package_object_instantiates_with_a_web3_object(all_manifests, w3):

--- a/tests/ethpm/tools/test_builder.py
+++ b/tests/ethpm/tools/test_builder.py
@@ -618,7 +618,7 @@ def test_builder_deployment_simple(w3):
                 "blockchain://1234567890123456789012345678901234567890123456789012345678901234/block/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef": {  # noqa: E501
                     "Owned": {
                         "contract_type": "Owned",
-                        "address": "0xd3cda913deb6f67967b99d67acdfa1712c293601",
+                        "address": "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
                     }
                 }
             },
@@ -663,34 +663,26 @@ def test_builder_deployment_type_complex(escrow_package):
         manifest_version("2"),
         escrow_dep_type(
             block_uri="blockchain://1111111111111111111111111111111111111111111111111111111111111111/block/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",  # noqa: E501
-            address=to_canonical_address(
-                escrow.deployments.get_instance("Escrow").address
-            ),
+            address=escrow.deployments.get_instance("Escrow").address,
         ),
         # dep_type with block uri
         safesendlib_dep_type(
             block_uri="blockchain://1111111111111111111111111111111111111111111111111111111111111111/block/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",  # noqa: E501
-            address=to_canonical_address(
-                address=escrow.deployments.get_instance("SafeSendLib").address
-            ),
+            address=escrow.deployments.get_instance("SafeSendLib").address,
         ),
         # simple deployment
         deployment(
             block_uri="blockchain://1234567890123456789012345678901234567890123456789012345678901234/block/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",  # noqa: E501
             contract_instance="Escrow",
             contract_type="Escrow",
-            address=to_canonical_address(
-                escrow.deployments.get_instance("Escrow").address
-            ),
+            address=escrow.deployments.get_instance("Escrow").address,
         ),
         # simple deployment
         deployment(
             block_uri="blockchain://1234567890123456789012345678901234567890123456789012345678901234/block/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",  # noqa: E501
             contract_instance="SafeSendLib",
             contract_type="SafeSendLib",
-            address=to_canonical_address(
-                escrow.deployments.get_instance("SafeSendLib").address
-            ),
+            address=escrow.deployments.get_instance("SafeSendLib").address,
         ),
     )
     assert len(manifest["deployments"].keys()) == 2

--- a/tests/ethpm/validation/test_misc.py
+++ b/tests/ethpm/validation/test_misc.py
@@ -4,31 +4,8 @@ from ethpm.exceptions import (
     ValidationError,
 )
 from ethpm.validation.misc import (
-    validate_address,
     validate_empty_bytes,
 )
-
-
-@pytest.mark.parametrize(
-    "address", (b"\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01",)
-)
-def test_validate_address_accepts_canonicalized_addresses(address):
-    result = validate_address(address)
-    assert result is None
-
-
-@pytest.mark.parametrize(
-    "address",
-    (
-        "d3cda913deb6f67967b99d67acdfa1712c293601",
-        "0xd3cda913deb6f67967b99d67acdfa1712c293601",
-        "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
-        "\xd3\xcd\xa9\x13\xde\xb6\xf6yg\xb9\x9dg\xac\xdf\xa1q,)6\x01xd",
-    ),
-)
-def test_validate_address_rejects_incorrectly_formatted_adresses(address):
-    with pytest.raises(ValidationError):
-        validate_address(address)
 
 
 @pytest.mark.parametrize(

--- a/web3/pm.py
+++ b/web3/pm.py
@@ -24,7 +24,6 @@ from eth_utils import (
     is_canonical_address,
     is_checksum_address,
     to_bytes,
-    to_canonical_address,
     to_checksum_address,
     to_text,
     to_tuple,
@@ -235,8 +234,7 @@ class VyperReferenceRegistry(ERCRegistry):
         registry_factory = registry_package.get_contract_factory("registry")
         tx_hash = registry_factory.constructor().transact()
         tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
-        registry_address = to_canonical_address(tx_receipt.contractAddress)
-        return cls(registry_address, w3)
+        return cls(tx_receipt.contractAddress, w3)
 
     def _release(self, package_name: str, version: str, manifest_uri: str) -> bytes:
         if len(package_name) > 32 or len(version) > 32:
@@ -460,8 +458,7 @@ class PM(Module):
             * ``address``: Address of on-chain Vyper Reference Registry.
         """
         if is_canonical_address(address) or is_checksum_address(address):
-            canonical_address = to_canonical_address(address)
-            self.registry = VyperReferenceRegistry(canonical_address, self.web3)
+            self.registry = VyperReferenceRegistry(address, self.web3)
         elif is_ens_name(address):
             self._validate_set_ens()
             addr_lookup = self.web3.ens.address(address)
@@ -469,9 +466,7 @@ class PM(Module):
                 raise NameNotFound(
                     "No address found after ENS lookup for name: {0}.".format(address)
                 )
-            self.registry = VyperReferenceRegistry(
-                to_canonical_address(addr_lookup), self.web3
-            )
+            self.registry = VyperReferenceRegistry(addr_lookup, self.web3)
         else:
             raise PMError(
                 "Expected a canonical/checksummed address or ENS name for the address, "

--- a/web3/tools/pytest_ethereum/_utils.py
+++ b/web3/tools/pytest_ethereum/_utils.py
@@ -12,7 +12,6 @@ from eth_typing import (
     Manifest,
 )
 from eth_utils import (
-    to_canonical_address,
     to_dict,
     to_hex,
     to_list,
@@ -108,7 +107,7 @@ def create_deployment_data(
     link_refs: List[Dict[str, Any]] = None,
 ) -> Iterable[Tuple[str, Any]]:
     yield "contract_type", contract_name
-    yield "address", to_hex(new_address)
+    yield "address", new_address
     yield "transaction", to_hex(tx_receipt.transactionHash)
     yield "block", to_hex(tx_receipt.blockHash)
     if link_refs:
@@ -130,9 +129,7 @@ def get_deployment_address(linked_type: str, package: Package) -> Address:
     Return the address of a linked_type found in a package's manifest deployments.
     """
     try:
-        deployment_address = to_canonical_address(
-            package.deployments.get(linked_type)["address"]
-        )
+        deployment_address = package.deployments.get(linked_type)["address"]
     except KeyError:
         raise LinkerError(
             f"Package data does not contain a valid deployment of {linked_type} on the "

--- a/web3/tools/pytest_ethereum/linker.py
+++ b/web3/tools/pytest_ethereum/linker.py
@@ -10,7 +10,6 @@ from eth_typing import (
     Address,
 )
 from eth_utils import (
-    to_canonical_address,
     to_checksum_address,
     to_hex,
 )
@@ -73,11 +72,13 @@ def _deploy(
         )
     tx_hash = factory.constructor(*args).transact(transaction)
     tx_receipt = package.w3.eth.waitForTransactionReceipt(tx_hash)
-    address = to_canonical_address(tx_receipt.contractAddress)
     # Create manifest copy with new deployment instance
     latest_block_uri = create_latest_block_uri(package.w3, 0)
     deployment_data = create_deployment_data(
-        contract_name, address, tx_receipt, factory.linked_references
+        contract_name,
+        to_checksum_address(tx_receipt.contractAddress),
+        tx_receipt,
+        factory.linked_references,
     )
     manifest = insert_deployment(
         package, contract_name, deployment_data, latest_block_uri


### PR DESCRIPTION
### What was wrong?
Updated `ethpm` to use `web3`'s `validate_address`.

from https://github.com/ethereum/web3.py/pull/1379#discussion_r302260649

> Having to convert to a canonical address feels out of place now that ethpm is embedded with web3.py. Seems like it should follow the same standard of the rest of web3.py: either a checksummed address or a canonical address is fine.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/61083162-ab202580-a3f0-11e9-85db-decc292bb053.png)

