### PR TITLE
Remove xfail from passing test

### DIFF
--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -70,7 +70,6 @@ class ParityEthModuleTest(EthModuleTest):
             web3, unlocked_account
         )
 
-    @pytest.mark.xfail(reason='Needs ability to efficiently control mining')
     def test_eth_modifyTransaction(self, web3, unlocked_account):
         super().test_eth_modifyTransaction(web3, unlocked_account)
 


### PR DESCRIPTION
### What was wrong?
A stray xfail got left behind on a test that was actually passing

### How was it fixed?
Removed it.

#### Cute Animal Picture

![download](https://user-images.githubusercontent.com/6540608/61090478-0c99c180-a3fc-11e9-8afe-a3b53962c9cc.jpg)

