### PR TITLE
[ethPM] Update Infura strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-ethpm
+      WEB3_INFURA_PROJECT_ID: 4f1a358967c7474aae6f8f4a7698aefc
 
   py36-integration-goethereum-ipc-1.7.2:
     <<: *geth_steps
@@ -285,6 +286,7 @@ jobs:
       - image: circleci/python:3.7
     environment:
       TOXENV: py37-ethpm
+      WEB3_INFURA_PROJECT_ID: 4f1a358967c7474aae6f8f4a7698aefc
 
   py37-integration-goethereum-ipc-1.7.2:
     <<: *geth_steps

--- a/ethpm/backends/registry.py
+++ b/ethpm/backends/registry.py
@@ -1,7 +1,6 @@
 from collections import (
     namedtuple,
 )
-import os
 from urllib import (
     parse,
 )
@@ -16,19 +15,12 @@ from ethpm._utils.registry import (
 from ethpm.backends.base import (
     BaseURIBackend,
 )
-from ethpm.constants import (
-    ETHPM_INFURA_API_KEY,
-)
 from ethpm.exceptions import (
     CannotHandleURI,
     ValidationError,
 )
 from ethpm.validation.uri import (
     validate_registry_uri,
-)
-from web3 import Web3
-from web3.exceptions import (
-    InfuraKeyNotFound,
 )
 
 # TODO: Update registry ABI once ERC is finalized.
@@ -44,10 +36,6 @@ class RegistryURIBackend(BaseURIBackend):
     """
 
     def __init__(self) -> None:
-        try:
-            from web3.auto.infura.endpoints import load_api_key
-        except InfuraKeyNotFound:
-            os.environ['WEB3_INFURA_PROJECT_ID'] = ETHPM_INFURA_API_KEY
         from web3.auto.infura import w3
         self.w3 = w3
 

--- a/ethpm/backends/registry.py
+++ b/ethpm/backends/registry.py
@@ -17,7 +17,7 @@ from ethpm.backends.base import (
     BaseURIBackend,
 )
 from ethpm.constants import (
-    INFURA_API_KEY,
+    ETHPM_INFURA_API_KEY,
 )
 from ethpm.exceptions import (
     CannotHandleURI,
@@ -27,8 +27,8 @@ from ethpm.validation.uri import (
     validate_registry_uri,
 )
 from web3 import Web3
-from web3.providers.auto import (
-    load_provider_from_uri,
+from web3.exceptions import (
+    InfuraKeyNotFound,
 )
 
 # TODO: Update registry ABI once ERC is finalized.
@@ -44,9 +44,12 @@ class RegistryURIBackend(BaseURIBackend):
     """
 
     def __init__(self) -> None:
-        os.environ.setdefault("INFUFA_API_KEY", INFURA_API_KEY)
-        infura_url = f"wss://mainnet.infura.io/ws/v3/{INFURA_API_KEY}"
-        self.w3 = Web3(load_provider_from_uri(infura_url))
+        try:
+            from web3.auto.infura.endpoints import load_api_key
+        except InfuraKeyNotFound:
+            os.environ['WEB3_INFURA_PROJECT_ID'] = ETHPM_INFURA_API_KEY
+        from web3.auto.infura import w3
+        self.w3 = w3
 
     def can_translate_uri(self, uri: str) -> bool:
         return is_valid_registry_uri(uri)

--- a/ethpm/constants.py
+++ b/ethpm/constants.py
@@ -8,7 +8,7 @@ IPFS_GATEWAY_PREFIX = "https://ipfs.io/ipfs/"
 
 # TODO Deprecate in favor of a better scheme for fetching registry URIs.
 # Please play nice and don't use this key for any shenanigans, thanks!
-INFURA_API_KEY = "4f1a358967c7474aae6f8f4a7698aefc"
+ETHPM_INFURA_API_KEY = "4f1a358967c7474aae6f8f4a7698aefc"
 
 INFURA_GATEWAY_MULTIADDR = "/dns4/ipfs.infura.io/tcp/5001/https/"
 

--- a/ethpm/constants.py
+++ b/ethpm/constants.py
@@ -6,10 +6,6 @@ DEFAULT_IPFS_BACKEND = "ethpm.backends.ipfs.InfuraIPFSBackend"
 
 IPFS_GATEWAY_PREFIX = "https://ipfs.io/ipfs/"
 
-# TODO Deprecate in favor of a better scheme for fetching registry URIs.
-# Please play nice and don't use this key for any shenanigans, thanks!
-ETHPM_INFURA_API_KEY = "4f1a358967c7474aae6f8f4a7698aefc"
-
 INFURA_GATEWAY_MULTIADDR = "/dns4/ipfs.infura.io/tcp/5001/https/"
 
 GITHUB_API_AUTHORITY = "api.github.com"

--- a/tests/ethpm/_utils/test_backend_utils.py
+++ b/tests/ethpm/_utils/test_backend_utils.py
@@ -42,7 +42,7 @@ def test_get_resolvable_backends_for_supported_uris(dummy_ipfs_backend, uri, bac
     ),
 )
 def test_get_translatable_backends_for_supported_uris(
-    dummy_ipfs_backend, uri, backends
+    dummy_ipfs_backend, uri, backends, infura_env
 ):
     good_backends = get_translatable_backends_for_uri(uri)
     assert good_backends == backends
@@ -65,6 +65,6 @@ def test_get_translatable_backends_for_supported_uris(
         "https://github.com/ethpm/ethpm-spec/examples/owned/1.0.0.json#content_hash",
     ),
 )
-def test_resolve_uri_contents_raises_exception_for_unsupported_schemes(uri):
+def test_resolve_uri_contents_raises_exception_for_unsupported_schemes(uri, infura_env):
     with pytest.raises(CannotHandleURI):
         resolve_uri_contents(uri)

--- a/tests/ethpm/_utils/test_backend_utils.py
+++ b/tests/ethpm/_utils/test_backend_utils.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from ethpm._utils.backend import (
@@ -29,6 +30,7 @@ from ethpm.uri import (
         ("erc1319://packages.zeppelinos.eth:1/erc20?version=1.0.0", ()),
     ),
 )
+@pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
 def test_get_resolvable_backends_for_supported_uris(dummy_ipfs_backend, uri, backends):
     good_backends = get_resolvable_backends_for_uri(uri)
     assert good_backends == backends
@@ -41,8 +43,9 @@ def test_get_resolvable_backends_for_supported_uris(dummy_ipfs_backend, uri, bac
         ("ipfs://QmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/", ()),
     ),
 )
+@pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
 def test_get_translatable_backends_for_supported_uris(
-    dummy_ipfs_backend, uri, backends, infura_env
+    dummy_ipfs_backend, uri, backends
 ):
     good_backends = get_translatable_backends_for_uri(uri)
     assert good_backends == backends
@@ -65,6 +68,7 @@ def test_get_translatable_backends_for_supported_uris(
         "https://github.com/ethpm/ethpm-spec/examples/owned/1.0.0.json#content_hash",
     ),
 )
-def test_resolve_uri_contents_raises_exception_for_unsupported_schemes(uri, infura_env):
+@pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
+def test_resolve_uri_contents_raises_exception_for_unsupported_schemes(uri):
     with pytest.raises(CannotHandleURI):
         resolve_uri_contents(uri)

--- a/tests/ethpm/backends/test_http_backends.py
+++ b/tests/ethpm/backends/test_http_backends.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from requests.exceptions import (
@@ -21,7 +22,8 @@ from ethpm.constants import (
         "https://api.github.com/repos/ethpm/py-ethpm/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03480",  # noqa: E501
     ),
 )
-def test_github_over_https_backend_fetch_uri_contents(uri, owned_contract, w3, infura_env):
+@pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
+def test_github_over_https_backend_fetch_uri_contents(uri, owned_contract, w3):
     # these tests may occassionally fail CI as a result of their network requests
     backend = GithubOverHTTPSBackend()
     assert backend.base_uri == GITHUB_API_AUTHORITY
@@ -30,7 +32,8 @@ def test_github_over_https_backend_fetch_uri_contents(uri, owned_contract, w3, i
     assert owned_package.name == "owned"
 
 
-def test_github_over_https_backend_raises_error_with_invalid_content_hash(w3, infura_env):
+@pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
+def test_github_over_https_backend_raises_error_with_invalid_content_hash(w3):
     invalid_uri = "https://api.github.com/repos/ethpm/py-ethpm/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03123"  # noqa: E501
     with pytest.raises(HTTPError):
         Package.from_uri(invalid_uri, w3)

--- a/tests/ethpm/backends/test_http_backends.py
+++ b/tests/ethpm/backends/test_http_backends.py
@@ -21,7 +21,7 @@ from ethpm.constants import (
         "https://api.github.com/repos/ethpm/py-ethpm/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03480",  # noqa: E501
     ),
 )
-def test_github_over_https_backend_fetch_uri_contents(uri, owned_contract, w3):
+def test_github_over_https_backend_fetch_uri_contents(uri, owned_contract, w3, infura_env):
     # these tests may occassionally fail CI as a result of their network requests
     backend = GithubOverHTTPSBackend()
     assert backend.base_uri == GITHUB_API_AUTHORITY
@@ -30,7 +30,7 @@ def test_github_over_https_backend_fetch_uri_contents(uri, owned_contract, w3):
     assert owned_package.name == "owned"
 
 
-def test_github_over_https_backend_raises_error_with_invalid_content_hash(w3):
+def test_github_over_https_backend_raises_error_with_invalid_content_hash(w3, infura_env):
     invalid_uri = "https://api.github.com/repos/ethpm/py-ethpm/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03123"  # noqa: E501
     with pytest.raises(HTTPError):
         Package.from_uri(invalid_uri, w3)

--- a/tests/ethpm/backends/test_registry_backend.py
+++ b/tests/ethpm/backends/test_registry_backend.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from ethpm.backends.registry import (
@@ -13,6 +14,7 @@ def backend():
     return RegistryURIBackend()
 
 
+@pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
 def test_registry_uri_backend(backend):
     valid_uri = "erc1319://snakecharmers.eth:1/owned?version=1.0.0"
     expected_uri = 'ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW'
@@ -21,6 +23,7 @@ def test_registry_uri_backend(backend):
     assert backend.fetch_uri_contents(valid_uri) == expected_uri
 
 
+@pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
 def test_registry_uri_backend_raises_exception_for_non_mainnet_chains(backend):
     ropsten_uri = "erc1319://snakecharmers.eth:3/owned?version=1.0.0"
     with pytest.raises(CannotHandleURI, match="Currently only mainnet"):

--- a/tests/ethpm/conftest.py
+++ b/tests/ethpm/conftest.py
@@ -41,12 +41,6 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
-def infura_env(monkeypatch):
-    # Please play nice and don't use this key for any shenanigans, thanks!
-    monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", '4f1a358967c7474aae6f8f4a7698aefc')
-
-
-@pytest.fixture
 def package_names():
     return PACKAGE_NAMES
 

--- a/tests/ethpm/conftest.py
+++ b/tests/ethpm/conftest.py
@@ -41,6 +41,12 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
+def infura_env(monkeypatch):
+    # Please play nice and don't use this key for any shenanigans, thanks!
+    monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", '4f1a358967c7474aae6f8f4a7698aefc')
+
+
+@pytest.fixture
 def package_names():
     return PACKAGE_NAMES
 

--- a/tests/ethpm/test_package_init_from_registry_uri.py
+++ b/tests/ethpm/test_package_init_from_registry_uri.py
@@ -15,6 +15,6 @@ from ethpm.exceptions import (
         "bzz://da6adeeb4589d8652bbe5679aae6b6409ec85a20e92a8823c7c99e25dba9493d",
     ),
 )
-def test_package_init_with_unsupported_uris_raises_exception(uri, w3):
+def test_package_init_with_unsupported_uris_raises_exception(uri, w3, infura_env):
     with pytest.raises(CannotHandleURI):
         Package.from_uri(uri, w3)

--- a/tests/ethpm/test_package_init_from_registry_uri.py
+++ b/tests/ethpm/test_package_init_from_registry_uri.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from ethpm import (
@@ -15,6 +16,7 @@ from ethpm.exceptions import (
         "bzz://da6adeeb4589d8652bbe5679aae6b6409ec85a20e92a8823c7c99e25dba9493d",
     ),
 )
-def test_package_init_with_unsupported_uris_raises_exception(uri, w3, infura_env):
+@pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
+def test_package_init_with_unsupported_uris_raises_exception(uri, w3):
     with pytest.raises(CannotHandleURI):
         Package.from_uri(uri, w3)

--- a/tests/ethpm/test_package_init_from_uri.py
+++ b/tests/ethpm/test_package_init_from_uri.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from ethpm import (
@@ -26,6 +27,7 @@ def test_package_from_uri_with_valid_uri(dummy_ipfs_backend, w3):
         "ipfsQmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
     ),
 )
-def test_package_from_uri_rejects_invalid_ipfs_uri(invalid, w3, infura_env):
+@pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
+def test_package_from_uri_rejects_invalid_ipfs_uri(invalid, w3):
     with pytest.raises(CannotHandleURI):
         Package.from_uri(invalid, w3)

--- a/tests/ethpm/test_package_init_from_uri.py
+++ b/tests/ethpm/test_package_init_from_uri.py
@@ -26,6 +26,6 @@ def test_package_from_uri_with_valid_uri(dummy_ipfs_backend, w3):
         "ipfsQmTKB75Y73zhNbD3Y73xeXGjYrZHmaXXNxoZqGCagu7r8u/readme/",
     ),
 )
-def test_package_from_uri_rejects_invalid_ipfs_uri(invalid, w3):
+def test_package_from_uri_rejects_invalid_ipfs_uri(invalid, w3, infura_env):
     with pytest.raises(CannotHandleURI):
         Package.from_uri(invalid, w3)

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ passenv =
     PARITY_OS
     GOROOT
     GOPATH
+    WEB3_INFURA_PROJECT_ID
 basepython =
     doctest: python3.6
     py36: python3.6


### PR DESCRIPTION
### What was wrong?
`ethpm` had its own strategy for connecting to infura via an api key set as an environment variable, which has been updated to use `web3`'s strategy. I'd like to get rid of hardcoding the api key, but since we rely on it for testing I'm not sure the best way to achieve that is / if it's even possible.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/61146810-83889600-a4a0-11e9-97fa-1ee5702b3351.png)

