### PR TITLE
[ethPM] Update registry uri to support basic uris w/o package id

### DIFF
--- a/ethpm/backends/registry.py
+++ b/ethpm/backends/registry.py
@@ -81,6 +81,8 @@ def parse_registry_uri(uri: str) -> RegistryURI:
     validate_registry_uri(uri)
     parsed_uri = parse.urlparse(uri)
     address, chain_id = parsed_uri.netloc.split(":")
-    pkg_name = parsed_uri.path.strip("/")
-    pkg_version = parsed_uri.query.lstrip("version=").strip("/")
+    parsed_name = parsed_uri.path.strip("/")
+    parsed_version = parsed_uri.query.lstrip("version=").strip("/")
+    pkg_name = parsed_name if parsed_name else None
+    pkg_version = parsed_version if parsed_version else None
     return RegistryURI(address, chain_id, pkg_name, pkg_version)

--- a/ethpm/validation/uri.py
+++ b/ethpm/validation/uri.py
@@ -47,7 +47,7 @@ def validate_registry_uri(uri: str) -> None:
     Raise an exception if the URI does not conform to the registry URI scheme.
     """
     parsed = parse.urlparse(uri)
-    scheme, authority, pkg_name, query = (
+    scheme, authority, pkg_path, version = (
         parsed.scheme,
         parsed.netloc,
         parsed.path,
@@ -55,9 +55,13 @@ def validate_registry_uri(uri: str) -> None:
     )
     validate_registry_uri_scheme(scheme)
     validate_registry_uri_authority(authority)
-    if query:
-        validate_registry_uri_version(query)
-    validate_package_name(pkg_name[1:])
+    pkg_name = pkg_path.lstrip("/")
+    if pkg_name:
+        validate_package_name(pkg_name)
+    if not pkg_name and version:
+        raise ValidationError("Registry URIs cannot provide a version without a package name.")
+    if version:
+        validate_registry_uri_version(version)
 
 
 def validate_registry_uri_authority(auth: str) -> None:
@@ -75,7 +79,7 @@ def validate_registry_uri_authority(auth: str) -> None:
 
     if is_ens_domain(address) is False and not is_checksum_address(address):
         raise ValidationError(
-            f"{auth} is not a valid registry address. "
+            f"{address} is not a valid registry address. "
             "Please try again with a valid registry URI."
         )
 

--- a/tests/ethpm/_utils/test_registry_utils.py
+++ b/tests/ethpm/_utils/test_registry_utils.py
@@ -11,7 +11,14 @@ from ethpm.validation.uri import (
 @pytest.mark.parametrize(
     "uri",
     (
-        ("erc1319://zeppelinos.eth:1/erc20/"),
+        # no package id in uri
+        ("erc1319://zeppelinos.eth:1"),
+        ("erc1319://zeppelinos.eth:1/"),
+        ("erc1319://packages.zeppelinos.eth:1"),
+        ("erc1319://packages.zeppelinos.eth:1/"),
+        ("erc1319://0xd3CdA913deB6f67967B99D67aCDFa1712C293601:1"),
+        ("erc1319://0xd3CdA913deB6f67967B99D67aCDFa1712C293601:1/"),
+        # with package id in uri
         ("erc1319://zeppelinos.eth:1/erc20/"),
         ("erc1319://zeppelinos.eth:1/erc20//"),
         ("erc1319://zeppelinos.eth:1/erc20?version=1.0.0"),
@@ -33,6 +40,8 @@ def test_is_registry_uri_validates(uri):
     "uri",
     (
         # invalid authority
+        ("erc1319://zeppelinos.eth"),
+        ("erc1319://zeppelinos.eth/"),
         ("erc1319://zeppelinos.eth/erc20?version=1.0.0"),
         ("erc1319://zeppelinos.eth:333/erc20?version=1.0.0"),
         ("erc1319://packages.zeppelinos.com:1/erc20?version=1.0.0"),
@@ -40,10 +49,10 @@ def test_is_registry_uri_validates(uri):
         ("erc1319://packageszeppelinoseth:1/erc20?version=1.0.0"),
         ("erc1319://0xd3cda913deb6f67967b99d67acdfa1712c293601:1/erc20?version=1.0.0"),
         # invalid package name
-        ("erc1319://packages.zeppelinos.eth:1/"),
-        ("erc1319://packages.zeppelinos.eth:1///"),
         ("erc1319://packages.zeppelinos.eth:1/?version=1.0.0"),
+        ("erc1319://packages.zeppelinos.eth:1/?version=1.0.0/"),
         ("erc1319://packages.zeppelinos.eth:1/!rc20?version=1.0.0"),
+        ("erc1319://packages.zeppelinos.eth:1/!rc20?version=1.0.0/"),
         # invalid version param
         ("erc1319://zeppelinos.eth:1/erc20?versions=1.0.0"),
         ("erc1319://zeppelinos.eth:1/erc20?version1.0.0"),

--- a/tests/ethpm/test_uri.py
+++ b/tests/ethpm/test_uri.py
@@ -71,6 +71,14 @@ def test_create_github_uri():
     "uri,expected",
     (
         (
+            "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1",
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", None, None],
+        ),
+        (
+            "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/owned",
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "owned", None],
+        ),
+        (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/owned?version=1.0.0",
             ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "owned", "1.0.0"],
         ),


### PR DESCRIPTION
### What was wrong?
Supporting registry uri's without a package id (name/version) would be very useful in `ethpm-cli` to be able to identify ethPM registries. 

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/61249522-103e8880-a71b-11e9-9e1c-56602d5f25b1.png)
