### PR TITLE
[ethPM] web3.pm management

### DIFF
--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -358,7 +358,7 @@ By default, the manifest builder does *not* perform any validation that the gene
    ...     validate(),
    ... )
    Traceback (most recent call last):
-   ethpm.exceptions.ValidationError: Manifest invalid for schema version 2. Reason: '_InvalidPkgName' does not match '^[a-z][-a-z0-9]{0,255}$'
+   ethpm.exceptions.EthPMValidationError: Manifest invalid for schema version 2. Reason: '_InvalidPkgName' does not match '^[a-z][-a-z0-9]{0,255}$'
 
 
 To write a manifest to disk

--- a/ethpm/_utils/deployments.py
+++ b/ethpm/_utils/deployments.py
@@ -17,7 +17,7 @@ from eth_utils.toolz import (
 
 from ethpm.exceptions import (
     BytecodeLinkingError,
-    ValidationError,
+    EthPMValidationError,
 )
 from web3 import Web3
 
@@ -60,7 +60,7 @@ def validate_linked_references(
         # Ignore b/c whitespace around ':' conflict b/w black & flake8
         actual_bytes = bytecode[offset_value:end_of_bytes]  # noqa: E203
         if actual_bytes != values[idx]:
-            raise ValidationError(
+            raise EthPMValidationError(
                 "Error validating linked reference. "
                 f"Offset: {offset} "
                 f"Value: {values[idx]} "
@@ -97,7 +97,7 @@ def validate_deployments_tx_receipt(
             tx_address = tx_receipt["contractAddress"]
 
             if tx_address is None and allow_missing_data is False:
-                raise ValidationError(
+                raise EthPMValidationError(
                     "No contract address found in tx receipt. Unable to verify "
                     "address found in tx receipt matches address in manifest's deployment data. "
                     "If this validation is not necessary, please enable `allow_missing_data` arg. "
@@ -106,7 +106,7 @@ def validate_deployments_tx_receipt(
             if tx_address is not None and not is_same_address(
                 tx_address, data["address"]
             ):
-                raise ValidationError(
+                raise EthPMValidationError(
                     f"Error validating tx_receipt for {name} deployment. "
                     f"Address found in manifest's deployment data: {data['address']} "
                     f"Does not match address found on tx_receipt: {tx_address}."
@@ -114,19 +114,19 @@ def validate_deployments_tx_receipt(
 
             if "block" in data:
                 if tx_receipt["blockHash"] != to_bytes(hexstr=data["block"]):
-                    raise ValidationError(
+                    raise EthPMValidationError(
                         f"Error validating tx_receipt for {name} deployment. "
                         f"Block found in manifest's deployment data: {data['block']} does not "
                         f"Does not match block found on tx_receipt: {tx_receipt['blockHash']}."
                     )
             elif allow_missing_data is False:
-                raise ValidationError(
+                raise EthPMValidationError(
                     "No block hash found in deployment data. "
                     "Unable to verify block hash on tx receipt. "
                     "If this validation is not necessary, please enable `allow_missing_data` arg."
                 )
         elif allow_missing_data is False:
-            raise ValidationError(
+            raise EthPMValidationError(
                 "No transaction hash found in deployment data. "
                 "Unable to validate tx_receipt. "
                 "If this validation is not necessary, please enable `allow_missing_data` arg."

--- a/ethpm/backends/ipfs.py
+++ b/ethpm/backends/ipfs.py
@@ -80,11 +80,14 @@ class IPFSOverHTTPBackend(BaseIPFSBackend):
     def fetch_uri_contents(self, uri: str) -> bytes:
         ipfs_hash = extract_ipfs_path_from_uri(uri)
         contents = self.client.cat(ipfs_hash)
-        validation_hash = generate_file_hash(contents)
-        if validation_hash != ipfs_hash:
-            raise EthPMValidationError(
-                f"Hashed IPFS contents retrieved from uri: {uri} do not match its content hash."
-            )
+        # Local validation of hashed contents only works for non-chunked files ~< 256kb
+        # Improved validation WIP @ https://github.com/ethpm/py-ethpm/pull/165
+        if len(contents) <= 262144:
+            validation_hash = generate_file_hash(contents)
+            if validation_hash != ipfs_hash:
+                raise EthPMValidationError(
+                    f"Hashed IPFS contents retrieved from uri: {uri} do not match its content hash."
+                )
         return contents
 
     @property

--- a/ethpm/backends/ipfs.py
+++ b/ethpm/backends/ipfs.py
@@ -36,7 +36,7 @@ from ethpm.constants import (
 )
 from ethpm.exceptions import (
     CannotHandleURI,
-    ValidationError,
+    EthPMValidationError,
 )
 
 
@@ -82,7 +82,7 @@ class IPFSOverHTTPBackend(BaseIPFSBackend):
         contents = self.client.cat(ipfs_hash)
         validation_hash = generate_file_hash(contents)
         if validation_hash != ipfs_hash:
-            raise ValidationError(
+            raise EthPMValidationError(
                 f"Hashed IPFS contents retrieved from uri: {uri} do not match its content hash."
             )
         return contents

--- a/ethpm/backends/registry.py
+++ b/ethpm/backends/registry.py
@@ -17,7 +17,7 @@ from ethpm.backends.base import (
 )
 from ethpm.exceptions import (
     CannotHandleURI,
-    ValidationError,
+    EthPMValidationError,
 )
 from ethpm.validation.uri import (
     validate_registry_uri,
@@ -68,7 +68,7 @@ def is_valid_registry_uri(uri: str) -> bool:
     """
     try:
         validate_registry_uri(uri)
-    except ValidationError:
+    except EthPMValidationError:
         return False
     else:
         return True

--- a/ethpm/contract.py
+++ b/ethpm/contract.py
@@ -21,7 +21,7 @@ from eth_utils.toolz import (
 
 from ethpm.exceptions import (
     BytecodeLinkingError,
-    ValidationError,
+    EthPMValidationError,
 )
 from ethpm.validation.misc import (
     validate_empty_bytes,
@@ -136,7 +136,7 @@ def is_prelinked_bytecode(bytecode: bytes, link_refs: List[Dict[str, Any]]) -> b
         for offset in link_ref["offsets"]:
             try:
                 validate_empty_bytes(offset, link_ref["length"], bytecode)
-            except ValidationError:
+            except EthPMValidationError:
                 return True
     return False
 
@@ -165,7 +165,7 @@ def apply_link_ref(offset: int, length: int, value: bytes, bytecode: bytes) -> b
     """
     try:
         validate_empty_bytes(offset, length, bytecode)
-    except ValidationError:
+    except EthPMValidationError:
         raise BytecodeLinkingError("Link references cannot be applied to bytecode")
 
     address = value if is_canonical_address(value) else to_canonical_address(value)

--- a/ethpm/deployments.py
+++ b/ethpm/deployments.py
@@ -5,7 +5,7 @@ from typing import (
 )
 
 from ethpm.exceptions import (
-    ValidationError,
+    EthPMValidationError,
 )
 from ethpm.validation.package import (
     validate_contract_name,
@@ -79,7 +79,7 @@ class Deployments:
 
         contract_type = self.deployment_data[name]["contract_type"]
         if contract_type not in self.contract_factories:
-            raise ValidationError(
+            raise EthPMValidationError(
                 f"Contract type: {contract_type} for alias: {name} not found. "
                 f"Available contract types include: {list(sorted(self.contract_factories.keys()))}."
             )

--- a/ethpm/exceptions.py
+++ b/ethpm/exceptions.py
@@ -14,7 +14,7 @@ class InsufficientAssetsError(PyEthPMError):
     pass
 
 
-class ValidationError(PyEthPMError):
+class EthPMValidationError(PyEthPMError):
     """
     Raised when something does not pass a validation check.
     """

--- a/ethpm/tools/builder.py
+++ b/ethpm/tools/builder.py
@@ -50,8 +50,8 @@ from ethpm.backends.ipfs import (
     BaseIPFSBackend,
 )
 from ethpm.exceptions import (
+    EthPMValidationError,
     ManifestBuildingError,
-    ValidationError,
 )
 from ethpm.package import (
     format_manifest,
@@ -559,7 +559,7 @@ def validate_link_ref(offset: int, length: int, bytecode: str) -> str:
     slot_length = offset + length
     slot = bytecode[offset:slot_length]
     if slot[:2] != "__" and slot[-2:] != "__":
-        raise ValidationError(
+        raise EthPMValidationError(
             f"Slot: {slot}, at offset: {offset} of length: {length} is not a valid "
             "link_ref that can be replaced."
         )
@@ -734,7 +734,7 @@ def build_dependency(package_name: str, uri: URI) -> Manifest:
 def _build_dependency(package_name: str, uri: URI, manifest: Manifest) -> Manifest:
     validate_package_name(package_name)
     if not is_supported_content_addressed_uri(uri):
-        raise ValidationError(
+        raise EthPMValidationError(
             f"{uri} is not a supported content-addressed URI. "
             "Currently only IPFS and Github blob uris are supported."
         )

--- a/ethpm/validation/manifest.py
+++ b/ethpm/validation/manifest.py
@@ -16,7 +16,7 @@ from ethpm import (
     SPEC_DIR,
 )
 from ethpm.exceptions import (
-    ValidationError,
+    EthPMValidationError,
 )
 
 MANIFEST_SCHEMA_PATH = SPEC_DIR / "package.spec.json"
@@ -37,18 +37,18 @@ def validate_meta_object(meta: Dict[str, Any], allow_extra_meta_fields: bool) ->
     for key, value in meta.items():
         if key in META_FIELDS:
             if type(value) is not META_FIELDS[key]:
-                raise ValidationError(
+                raise EthPMValidationError(
                     f"Values for {key} are expected to have the type {META_FIELDS[key]}, "
                     f"instead got {type(value)}."
                 )
         elif allow_extra_meta_fields:
             if key[:2] != "x-":
-                raise ValidationError(
+                raise EthPMValidationError(
                     "Undefined meta fields need to begin with 'x-', "
                     f"{key} is not a valid undefined meta field."
                 )
         else:
-            raise ValidationError(
+            raise EthPMValidationError(
                 f"{key} is not a permitted meta field. To allow undefined fields, "
                 "set `allow_extra_meta_fields` to True."
             )
@@ -77,7 +77,7 @@ def validate_manifest_against_schema(manifest: Dict[str, Any]) -> None:
     try:
         validate(manifest, schema_data)
     except jsonValidationError as e:
-        raise ValidationError(
+        raise EthPMValidationError(
             f"Manifest invalid for schema version {schema_data['version']}. "
             f"Reason: {e.message}"
         )
@@ -91,10 +91,10 @@ def check_for_deployments(manifest: Dict[str, Any]) -> bool:
 
 def validate_build_dependencies_are_present(manifest: Dict[str, Any]) -> None:
     if "build_dependencies" not in manifest:
-        raise ValidationError("Manifest doesn't have any build dependencies.")
+        raise EthPMValidationError("Manifest doesn't have any build dependencies.")
 
     if not manifest["build_dependencies"]:
-        raise ValidationError("Manifest's build dependencies key is empty.")
+        raise EthPMValidationError("Manifest's build dependencies key is empty.")
 
 
 def validate_manifest_deployments(manifest: Dict[str, Any]) -> None:
@@ -109,7 +109,7 @@ def validate_manifest_deployments(manifest: Dict[str, Any]) -> None:
             all_contract_types
         )
         if missing_contract_types:
-            raise ValidationError(
+            raise EthPMValidationError(
                 f"Manifest missing references to contracts: {missing_contract_types}."
             )
 
@@ -119,14 +119,14 @@ def validate_manifest_exists(manifest_id: str) -> None:
     Validate that manifest with manifest_id exists in ASSETS_DIR
     """
     if not (ASSETS_DIR / manifest_id).is_file():
-        raise ValidationError(
+        raise EthPMValidationError(
             f"Manifest not found in ASSETS_DIR with id: {manifest_id}"
         )
 
 
 def validate_raw_manifest_format(raw_manifest: str) -> None:
     """
-    Raise a ValidationError if a manifest ...
+    Raise a EthPMValidationError if a manifest ...
     - is not tightly packed (i.e. no linebreaks or extra whitespace)
     - does not have alphabetically sorted keys
     - has duplicate keys
@@ -143,7 +143,7 @@ def validate_raw_manifest_format(raw_manifest: str) -> None:
         )
     compact_manifest = json.dumps(manifest_dict, sort_keys=True, separators=(",", ":"))
     if raw_manifest != compact_manifest:
-        raise ValidationError(
+        raise EthPMValidationError(
             "The manifest appears to be malformed. Please ensure that it conforms to the "
             "EthPM-Spec for document format. "
             "http://ethpm.github.io/ethpm-spec/package-spec.html#document-format "

--- a/ethpm/validation/misc.py
+++ b/ethpm/validation/misc.py
@@ -1,5 +1,5 @@
 from ethpm.exceptions import (
-    ValidationError,
+    EthPMValidationError,
 )
 from web3 import Web3
 
@@ -17,7 +17,7 @@ def validate_empty_bytes(offset: int, length: int, bytecode: bytes) -> None:
     slot_length = offset + length
     slot = bytecode[offset:slot_length]
     if slot != bytearray(length):
-        raise ValidationError(
+        raise EthPMValidationError(
             f"Bytecode segment: [{offset}:{slot_length}] is not comprised of empty bytes, "
             f"rather: {slot}."
         )

--- a/ethpm/validation/package.py
+++ b/ethpm/validation/package.py
@@ -15,8 +15,8 @@ from ethpm.constants import (
     PACKAGE_NAME_REGEX,
 )
 from ethpm.exceptions import (
+    EthPMValidationError,
     InsufficientAssetsError,
-    ValidationError,
 )
 
 
@@ -37,7 +37,7 @@ def validate_package_version(version: Any) -> None:
     Validates that a package version is of text type.
     """
     if not is_text(version):
-        raise ValidationError(
+        raise EthPMValidationError(
             f"Expected a version of text type, instead received {type(version)}."
         )
 
@@ -48,7 +48,7 @@ def validate_package_name(pkg_name: str) -> None:
     as defined in the EthPM-Spec.
     """
     if not bool(re.match(PACKAGE_NAME_REGEX, pkg_name)):
-        raise ValidationError(f"{pkg_name} is not a valid package name.")
+        raise EthPMValidationError(f"{pkg_name} is not a valid package name.")
 
 
 def validate_manifest_version(version: str) -> None:
@@ -56,7 +56,7 @@ def validate_manifest_version(version: str) -> None:
     Raise an exception if the version is not "2".
     """
     if not version == "2":
-        raise ValidationError(
+        raise EthPMValidationError(
             f"Py-EthPM does not support the provided specification version: {version}"
         )
 
@@ -69,7 +69,7 @@ def validate_build_dependency(key: str, uri: str) -> None:
     validate_package_name(key)
     # validate is supported content-addressed uri
     if not is_ipfs_uri(uri):
-        raise ValidationError(f"URI: {uri} is not a valid IPFS URI.")
+        raise EthPMValidationError(f"URI: {uri} is not a valid IPFS URI.")
 
 
 CONTRACT_NAME_REGEX = re.compile("^[a-zA-Z][-a-zA-Z0-9_]{0,255}$")
@@ -77,4 +77,4 @@ CONTRACT_NAME_REGEX = re.compile("^[a-zA-Z][-a-zA-Z0-9_]{0,255}$")
 
 def validate_contract_name(name: str) -> None:
     if not CONTRACT_NAME_REGEX.match(name):
-        raise ValidationError(f"Contract name: {name} is not valid.")
+        raise EthPMValidationError(f"Contract name: {name} is not valid.")

--- a/ethpm/validation/uri.py
+++ b/ethpm/validation/uri.py
@@ -26,7 +26,7 @@ from ethpm.constants import (
     REGISTRY_URI_SCHEME,
 )
 from ethpm.exceptions import (
-    ValidationError,
+    EthPMValidationError,
 )
 from ethpm.validation.package import (
     validate_package_name,
@@ -39,7 +39,7 @@ def validate_ipfs_uri(uri: str) -> None:
     Raise an exception if the provided URI is not a valid IPFS URI.
     """
     if not is_ipfs_uri(uri):
-        raise ValidationError(f"URI: {uri} is not a valid IPFS URI.")
+        raise EthPMValidationError(f"URI: {uri} is not a valid IPFS URI.")
 
 
 def validate_registry_uri(uri: str) -> None:
@@ -59,7 +59,7 @@ def validate_registry_uri(uri: str) -> None:
     if pkg_name:
         validate_package_name(pkg_name)
     if not pkg_name and version:
-        raise ValidationError("Registry URIs cannot provide a version without a package name.")
+        raise EthPMValidationError("Registry URIs cannot provide a version without a package name.")
     if version:
         validate_registry_uri_version(version)
 
@@ -72,19 +72,19 @@ def validate_registry_uri_authority(auth: str) -> None:
     try:
         address, chain_id = auth.split(':')
     except ValueError:
-        raise ValidationError(
+        raise EthPMValidationError(
             f"{auth} is not a valid registry URI authority. "
             "Please try again with a valid registry URI."
         )
 
     if is_ens_domain(address) is False and not is_checksum_address(address):
-        raise ValidationError(
+        raise EthPMValidationError(
             f"{address} is not a valid registry address. "
             "Please try again with a valid registry URI."
         )
 
     if not is_supported_chain_id(to_int(text=chain_id)):
-        raise ValidationError(
+        raise EthPMValidationError(
             f"Chain ID: {chain_id} is not supported. Supported chain ids include: "
             "1 (mainnet), 3 (ropsten), 4 (rinkeby), 5 (goerli) and 42 (kovan). "
             "Please try again with a valid registry URI."
@@ -96,7 +96,7 @@ def validate_registry_uri_scheme(scheme: str) -> None:
     Raise an exception if the scheme is not the valid registry URI scheme ('ercXXX').
     """
     if scheme != REGISTRY_URI_SCHEME:
-        raise ValidationError(f"{scheme} is not a valid registry URI scheme.")
+        raise EthPMValidationError(f"{scheme} is not a valid registry URI scheme.")
 
 
 def validate_registry_uri_version(query: str) -> None:
@@ -105,7 +105,7 @@ def validate_registry_uri_version(query: str) -> None:
     """
     query_dict = parse.parse_qs(query, keep_blank_values=True)
     if "version" not in query_dict:
-        raise ValidationError(f"{query} is not a correctly formatted version param.")
+        raise EthPMValidationError(f"{query} is not a correctly formatted version param.")
 
 
 def validate_single_matching_uri(all_blockchain_uris: List[str], w3: Web3) -> str:
@@ -120,9 +120,9 @@ def validate_single_matching_uri(all_blockchain_uris: List[str], w3: Web3) -> st
     ]
 
     if not matching_uris:
-        raise ValidationError("Package has no matching URIs on chain.")
+        raise EthPMValidationError("Package has no matching URIs on chain.")
     elif len(matching_uris) != 1:
-        raise ValidationError(
+        raise EthPMValidationError(
             f"Package has too many ({len(matching_uris)}) matching URIs: {matching_uris}."
         )
     return matching_uris[0]
@@ -141,6 +141,6 @@ def validate_blob_uri_contents(contents: bytes, blob_uri: str) -> None:
     hashable_contents = "blob " + str(content_length) + "\0" + contents_str
     hash_object = hashlib.sha1(to_bytes(text=hashable_contents))
     if hash_object.hexdigest() != blob_hash:
-        raise ValidationError(
+        raise EthPMValidationError(
             f"Hash of contents fetched from {blob_uri} do not match its hash: {blob_hash}."
         )

--- a/tests/ethpm/_utils/test_contract_utils.py
+++ b/tests/ethpm/_utils/test_contract_utils.py
@@ -4,8 +4,8 @@ from ethpm._utils.contract import (
     generate_contract_factory_kwargs,
 )
 from ethpm.exceptions import (
+    EthPMValidationError,
     InsufficientAssetsError,
-    ValidationError,
 )
 from ethpm.validation.misc import (
     validate_w3_instance,
@@ -51,7 +51,7 @@ def test_validate_contract_name_validates(name):
 
 @pytest.mark.parametrize("name", ("", "-abc", "A=bc", "X" * 257))
 def test_validate_contract_name_invalidates(name):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         assert validate_contract_name(name)
 
 

--- a/tests/ethpm/_utils/test_registry_utils.py
+++ b/tests/ethpm/_utils/test_registry_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ethpm.exceptions import (
-    ValidationError,
+    EthPMValidationError,
 )
 from ethpm.validation.uri import (
     validate_registry_uri,
@@ -77,5 +77,5 @@ def test_is_registry_uri_validates(uri):
     ),
 )
 def test_is_registry_uri_raises_exception_for_invalid_uris(uri):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_registry_uri(uri)

--- a/tests/ethpm/test_dependencies.py
+++ b/tests/ethpm/test_dependencies.py
@@ -7,7 +7,7 @@ from ethpm.dependencies import (
     Dependencies,
 )
 from ethpm.exceptions import (
-    ValidationError,
+    EthPMValidationError,
 )
 from ethpm.validation.package import (
     validate_build_dependency,
@@ -65,5 +65,5 @@ def test_validate_build_dependencies(dummy_ipfs_backend):
     ),
 )
 def test_get_build_dependencies_invalidates(name, uri):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_build_dependency(name, uri)

--- a/tests/ethpm/test_deployments.py
+++ b/tests/ethpm/test_deployments.py
@@ -17,7 +17,7 @@ from ethpm.deployments import (
 )
 from ethpm.exceptions import (
     BytecodeLinkingError,
-    ValidationError,
+    EthPMValidationError,
 )
 from web3.eth import (
     Contract,
@@ -60,7 +60,7 @@ def test_deployment_implements_getitem(deployment):
 def test_deployment_getitem_with_invalid_contract_name_raises_exception(
     name, deployment
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         assert deployment[name]
 
 
@@ -72,7 +72,7 @@ def test_deployment_getitem_without_deployment_reference_raises_exception(deploy
 def test_deployment_getitem_without_contract_type_reference_raises_exception(
     invalid_deployment
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         invalid_deployment["SafeMathLib"]
 
 
@@ -84,7 +84,7 @@ def test_deployment_implements_get_items(deployment):
 def test_deployment_get_items_with_invalid_contract_names_raises_exception(
     invalid_deployment
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         invalid_deployment.items()
 
 
@@ -96,7 +96,7 @@ def test_deployment_implements_get_values(deployment):
 def test_deployment_get_values_with_invalid_contract_names_raises_exception(
     invalid_deployment
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         invalid_deployment.values()
 
 
@@ -114,7 +114,7 @@ def test_deployment_implements_key_lookup_with_nonexistent_key_raises_exception(
 
 @pytest.mark.parametrize("invalid_name", ("", "-abc", "A=bc", "X" * 257))
 def test_get_instance_with_invalid_name_raises_exception(deployment, invalid_name):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         deployment.get_instance(invalid_name)
 
 
@@ -126,7 +126,7 @@ def test_get_instance_without_reference_in_deployments_raises_exception(deployme
 def test_get_instance_without_reference_in_contract_factories_raises(
     invalid_deployment
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         invalid_deployment.get_instance("SafeMathLib")
 
 
@@ -242,5 +242,5 @@ def test_validate_linked_references(link_deps, bytecode):
     ),
 )
 def test_validate_linked_references_invalidates(link_deps, bytecode):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_linked_references(link_deps, bytecode)

--- a/tests/ethpm/test_get_build_dependencies.py
+++ b/tests/ethpm/test_get_build_dependencies.py
@@ -7,8 +7,8 @@ from ethpm.dependencies import (
     Dependencies,
 )
 from ethpm.exceptions import (
+    EthPMValidationError,
     FailureToFetchIPFSAssetsError,
-    ValidationError,
 )
 
 
@@ -35,7 +35,7 @@ def test_get_build_dependencies_without_dependencies_raises_exception(
 ):
     piper_coin_manifest.pop("build_dependencies", None)
     pkg = Package(piper_coin_manifest, w3)
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         pkg.build_dependencies
 
 
@@ -44,5 +44,5 @@ def test_get_build_dependencies_with_empty_dependencies_raises_exception(
 ):
     piper_coin_manifest["build_dependencies"] = {}
     pkg = Package(piper_coin_manifest, w3)
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         pkg.build_dependencies

--- a/tests/ethpm/test_get_deployments.py
+++ b/tests/ethpm/test_get_deployments.py
@@ -7,7 +7,7 @@ from ethpm.deployments import (
     Deployments,
 )
 from ethpm.exceptions import (
-    ValidationError,
+    EthPMValidationError,
 )
 
 
@@ -27,7 +27,7 @@ def test_get_deployments_with_no_match_raises_exception(
     manifest_with_no_matching_deployments, w3
 ):
     package = Package(manifest_with_no_matching_deployments, w3)
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         package.deployments
 
 
@@ -35,7 +35,7 @@ def test_get_deployments_with_multiple_matches_raises_exception(
     manifest_with_multiple_matches, w3
 ):
     package = Package(manifest_with_multiple_matches, w3)
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         package.deployments
 
 

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -5,8 +5,8 @@ from eth_utils import (
 )
 
 from ethpm.exceptions import (
+    EthPMValidationError,
     InsufficientAssetsError,
-    ValidationError,
 )
 from ethpm.package import (
     Package,
@@ -41,7 +41,7 @@ def test_update_web3(deployed_safe_math, w3):
     assert new_package.w3 is new_w3
     assert original_package is not new_package
     assert original_package.manifest == new_package.manifest
-    with pytest.raises(ValidationError, match="Package has no matching URIs on chain."):
+    with pytest.raises(EthPMValidationError, match="Package has no matching URIs on chain."):
         new_package.deployments
 
 

--- a/tests/ethpm/test_package_init_from_file.py
+++ b/tests/ethpm/test_package_init_from_file.py
@@ -9,7 +9,7 @@ from ethpm import (
     Package,
 )
 from ethpm.exceptions import (
-    ValidationError,
+    EthPMValidationError,
 )
 
 
@@ -61,7 +61,7 @@ def test_package_init_for_manifest_with_build_dependency(
 
 
 def test_init_from_invalid_manifest_data(w3):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         Package({}, w3)
 
 
@@ -84,7 +84,7 @@ def test_from_file_fails_with_non_json(non_json_manifest, w3):
 
 
 def test_from_file_fails_with_invalid_manifest(invalid_manifest_from_path, w3):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         Package.from_file(invalid_manifest_from_path, w3)
 
 

--- a/tests/ethpm/tools/test_builder.py
+++ b/tests/ethpm/tools/test_builder.py
@@ -20,8 +20,8 @@ from ethpm.backends.ipfs import (
     get_ipfs_backend,
 )
 from ethpm.exceptions import (
+    EthPMValidationError,
     ManifestBuildingError,
-    ValidationError,
 )
 from ethpm.tools.builder import (
     as_package,
@@ -199,7 +199,7 @@ def test_to_disk_with_invalid_args_raises_exception(manifest_dir, write_to_disk_
 
 
 def test_builder_with_manifest_validation():
-    with pytest.raises(ValidationError, match="_invalid_package_name"):
+    with pytest.raises(EthPMValidationError, match="_invalid_package_name"):
         build(
             {},
             package_name("_invalid_package_name"),
@@ -724,7 +724,7 @@ def test_builder_with_multiple_build_dependencies():
 
 def test_builder_with_invalid_uri():
     with pytest.raises(
-        ValidationError, match="is not a supported content-addressed URI"
+        EthPMValidationError, match="is not a supported content-addressed URI"
     ):
         build(
             {},

--- a/tests/ethpm/validation/test_manifest.py
+++ b/tests/ethpm/validation/test_manifest.py
@@ -4,7 +4,7 @@ from ethpm import (
     ASSETS_DIR,
 )
 from ethpm.exceptions import (
-    ValidationError,
+    EthPMValidationError,
 )
 from ethpm.validation.manifest import (
     extract_contract_types_from_deployments,
@@ -28,7 +28,7 @@ def test_validate_raw_manifest_configuration_validates_strict_manifests(
 def test_validate_raw_manifest_format_invalidates_pretty_manifests(
     all_pretty_manifests
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_raw_manifest_format(all_pretty_manifests)
 
 
@@ -50,7 +50,7 @@ def test_validate_raw_manifest_format_invalidates_invalid_manifests(tmpdir, mani
     p = tmpdir.mkdir("invalid").join("manifest.json")
     p.write(manifest)
     invalid_manifest = p.read()
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_raw_manifest_format(invalid_manifest)
 
 
@@ -62,7 +62,7 @@ def test_validate_manifest_exists_validates():
 
 
 def test_validate_manifest_exists_invalidates():
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_manifest_exists("DNE")
 
 
@@ -71,14 +71,14 @@ def test_validate_manifest_against_all_manifest_types(all_manifests):
 
 
 def test_validate_manifest_invalidates(invalid_manifest):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_manifest_against_schema(invalid_manifest)
 
 
 def test_validate_deployed_contracts_present_validates(
     manifest_with_conflicting_deployments
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_manifest_deployments(manifest_with_conflicting_deployments)
 
 
@@ -116,7 +116,7 @@ def test_validate_manifest_version_validates_version_two_string(version):
 
 @pytest.mark.parametrize("version", (1, 2, "1" "3", b"3"))
 def test_validate_manifest_version_invalidates_incorrect_versions(version):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_manifest_version(version)
 
 
@@ -213,5 +213,5 @@ def test_validate_meta_object_validates(meta, extra_fields):
     ),
 )
 def test_validate_meta_object_invalidates(meta, extra_fields):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_meta_object(meta, allow_extra_meta_fields=extra_fields)

--- a/tests/ethpm/validation/test_misc.py
+++ b/tests/ethpm/validation/test_misc.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ethpm.exceptions import (
-    ValidationError,
+    EthPMValidationError,
 )
 from ethpm.validation.misc import (
     validate_empty_bytes,
@@ -31,5 +31,5 @@ def test_validate_empty_bytes(offset, length, bytecode):
     ),
 )
 def test_validate_empty_bytes_invalidates(offset, length, bytecode):
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthPMValidationError):
         validate_empty_bytes(offset, length, bytecode)

--- a/web3/main.py
+++ b/web3/main.py
@@ -243,4 +243,5 @@ class Web3:
 
     def enable_unstable_package_management_api(self):
         from web3.pm import PM
-        PM.attach(self, '_pm')
+        if not hasattr(self, '_pm'):
+            PM.attach(self, '_pm')


### PR DESCRIPTION
### What was wrong?
If `web3.pm` is already enabled - trying to re-enable (via `w3.enable_unstable_package_management_api`) raises an error (`cannot attach an attribute that's already been attached`), this can cause problems when using `web3.auto.infura.w3` but now it silently continues about its business.

Also..
- renamed `ethpm`'s `ValidationError` to `EthPMValidationError` to avoid confusion with `web3`'s `ValidationError`
- bypass local validation for large ipfs files, since local validation only works for ipfs files < 256kb. effort to improve validation here https://github.com/ethpm/py-ethpm/pull/165. will port that over once it's working

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/61489560-3c9b1480-a968-11e9-819c-fc61c040cb35.png)

