### PR TITLE
chainId returns an int instead of hex

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -157,12 +157,12 @@ The following properties are available on the ``web3.eth`` namespace.
 
     * Delegates to ``eth_chainId`` RPC Method
 
-    Returns a hex-encoded integer value for the currently configured "Chain Id" value introduced in `EIP-155 <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>`_. Returns ``None`` if no Chain Id is available.
+    Returns an integer value for the currently configured "Chain Id" value introduced in `EIP-155 <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>`_. Returns ``None`` if no Chain Id is available.
 
     .. code-block:: python
 
        >>> web3.eth.chainId
-       '0x3d'
+       61
 
 
 Methods

--- a/tests/core/eth-module/test_eth_properties.py
+++ b/tests/core/eth-module/test_eth_properties.py
@@ -3,4 +3,4 @@ def test_eth_protocolVersion(web3):
 
 
 def test_eth_chainId(web3):
-    assert web3.eth.chainId == '0x3d'
+    assert web3.eth.chainId == 61

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -16,7 +16,7 @@ RECEIPT_TIMEOUT = 0.2
     'make_chain_id, expect_success',
     (
         (
-            lambda web3: int(web3.eth.chainId, 16),
+            lambda web3: web3.eth.chainId,
             True,
         ),
         pytest.param(

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -7,13 +7,10 @@ from eth_tester import (
 from eth_utils import (
     is_checksum_address,
     is_dict,
-    is_hex,
+    is_integer,
 )
 
 from web3 import Web3
-from web3._utils.formatters import (
-    hex_to_integer,
-)
 from web3._utils.module_testing import (
     EthModuleTest,
     GoEthereumPersonalModuleTest,
@@ -298,8 +295,8 @@ class TestEthereumTesterEthModule(EthModuleTest):
 
     def test_eth_chainId(self, web3):
         chain_id = web3.eth.chainId
-        assert is_hex(chain_id)
-        assert hex_to_integer(chain_id) is 61
+        assert is_integer(chain_id)
+        assert chain_id is 61
 
 
 class TestEthereumTesterVersionModule(VersionModuleTest):

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -15,7 +15,6 @@ from eth_utils import (
     is_list_like,
     is_same_address,
     is_string,
-    to_int,
 )
 from hexbytes import (
     HexBytes,
@@ -70,7 +69,7 @@ class EthModuleTest:
     def test_eth_chainId(self, web3):
         chain_id = web3.eth.chainId
         # chain id value from geth fixture genesis file
-        assert to_int(hexstr=chain_id) == 131277322940537
+        assert chain_id == 131277322940537
 
     def test_eth_gasPrice(self, web3):
         gas_price = web3.eth.gasPrice

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -29,7 +29,7 @@ TRANSACTION_DEFAULTS = {
     'data': b'',
     'gas': lambda web3, tx: web3.eth.estimateGas(tx),
     'gasPrice': lambda web3, tx: web3.eth.generateGasPrice(tx) or web3.eth.gasPrice,
-    'chainId': lambda web3, tx: int(web3.eth.chainId, 16),
+    'chainId': lambda web3, tx: web3.eth.chainId,
 }
 
 

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -262,15 +262,11 @@ filter_result_formatter = apply_one_of_formatters((
     (apply_formatter_to_array(to_hexbytes(32)), is_array_of_strings),
 ))
 
-TRANSACTION_PARAM_FORMATTERS = {
-    'chainId': apply_formatter_if(is_integer, str),
-}
-
 
 transaction_param_formatter = compose(
     remove_key_if('to', lambda txn: txn['to'] in {'', b'', None}),
-    apply_formatters_to_dict(TRANSACTION_PARAM_FORMATTERS),
 )
+
 
 estimate_gas_without_block_id = apply_formatter_at_index(transaction_param_formatter, 0)
 estimate_gas_with_block_id = apply_formatters_to_sequence([
@@ -334,6 +330,7 @@ pythonic_middleware = construct_formatting_middleware(
         # Eth
         'eth_accounts': apply_formatter_to_array(to_checksum_address),
         'eth_blockNumber': to_integer_if_hex,
+        'eth_chainId': to_integer_if_hex,
         'eth_coinbase': to_checksum_address,
         'eth_estimateGas': to_integer_if_hex,
         'eth_gasPrice': to_integer_if_hex,

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -29,14 +29,14 @@ is_not_null = complement(is_null)
 
 @curry
 def validate_chain_id(web3, chain_id):
-    if int(chain_id) == int(web3.eth.chainId, 16):
+    if int(chain_id) == web3.eth.chainId:
         return chain_id
     else:
         raise ValidationError(
             "The transaction declared chain ID %r, "
             "but the connected node is on %r" % (
                 chain_id,
-                int(web3.eth.chainId, 16),
+                web3.eth.chainId,
             )
         )
 


### PR DESCRIPTION
### What was wrong?
`web3.eth.chainId` returned a hex instead of an int. 

Related to Issue #1387 

### How was it fixed?
Added a function to the pythonic middleware to convert the result returned from the JSON RPC call to an int

#### Cute Animal Picture

![](https://user-images.githubusercontent.com/6540608/61553262-429bfe80-aa17-11e9-9fda-c26b248258b3.png)
