### PR TITLE
Add ethpm to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y libssl-dev
 COPY web3 ./web3/
 COPY tests ./tests/
 COPY ens ./ens/
+COPY ethpm ./ethpm/
 
 COPY setup.py .
 COPY README.md .


### PR DESCRIPTION
### What was wrong?
`ethpm` module was absent from `Dockerfile`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/62230372-e6be6780-b37e-11e9-866f-a1bf11e2f251.png)
