### PR TITLE
Don't allow empty string for hex values

### DIFF
--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -252,6 +252,29 @@ def test_call_get_byte_array(arrays_contract, call):
     assert result == expected_byte_arr
 
 
+@pytest.mark.parametrize('args,expected', [([b''], [b'\x00']), (['0x'], [b'\x00'])])
+def test_set_byte_array(arrays_contract, call, transact, args, expected):
+    transact(
+        contract=arrays_contract,
+        contract_function='setByteValue',
+        func_args=[args]
+    )
+    result = call(contract=arrays_contract,
+                  contract_function='getByteValue')
+
+    assert result == expected
+
+
+@pytest.mark.parametrize('args', ([''], ['s']))
+def test_set_byte_array_with_invalid_args(arrays_contract, transact, args):
+    with pytest.raises(ValidationError):
+        transact(
+            contract=arrays_contract,
+            contract_function='setByteValue',
+            func_args=[args]
+        )
+
+
 def test_call_get_byte_const_array(arrays_contract, call):
     result = call(contract=arrays_contract,
                   contract_function='getByteConstValue')

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -147,7 +147,12 @@ class AddressEncoder(encoding.AddressEncoder):
 
 class AcceptsHexStrMixin:
     def validate_value(self, value):
-        if is_text(value):
+        if value == '':
+            self.invalidate_value(
+                value,
+                msg='invalid hex string. To pass in an empty hex string, use "0x".',
+            )
+        elif is_text(value):
             try:
                 value = decode_hex(value)
             except binascii.Error:


### PR DESCRIPTION
### What was wrong?
Because we allow a bytestring or a hexstring to be passed into functions that require bytes types, an empty string was mistakenly being decoded as hex.

Related to Issue #1412

### How was it fixed?
Added a check for an empty string in the hex string mixin class. Now an empty hexstring requires a '0x'. 

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/6540608/62753843-84becb80-ba2a-11e9-901a-b6978dd77006.png)

