### PR TITLE
[ethPM] Update deployments to work when only abi available

### DIFF
--- a/tests/ethpm/test_deployments.py
+++ b/tests/ethpm/test_deployments.py
@@ -69,35 +69,14 @@ def test_deployment_getitem_without_deployment_reference_raises_exception(deploy
         deployment["DoesNotExist"]
 
 
-def test_deployment_getitem_without_contract_type_reference_raises_exception(
-    invalid_deployment
-):
-    with pytest.raises(EthPMValidationError):
-        invalid_deployment["SafeMathLib"]
-
-
 def test_deployment_implements_get_items(deployment):
     expected_items = DEPLOYMENT_DATA.items()
     assert deployment.items() == expected_items
 
 
-def test_deployment_get_items_with_invalid_contract_names_raises_exception(
-    invalid_deployment
-):
-    with pytest.raises(EthPMValidationError):
-        invalid_deployment.items()
-
-
 def test_deployment_implements_get_values(deployment):
     expected_values = list(DEPLOYMENT_DATA.values())
     assert deployment.values() == expected_values
-
-
-def test_deployment_get_values_with_invalid_contract_names_raises_exception(
-    invalid_deployment
-):
-    with pytest.raises(EthPMValidationError):
-        invalid_deployment.values()
 
 
 def test_deployment_implements_key_lookup(deployment):
@@ -121,13 +100,6 @@ def test_get_instance_with_invalid_name_raises_exception(deployment, invalid_nam
 def test_get_instance_without_reference_in_deployments_raises_exception(deployment):
     with pytest.raises(KeyError):
         deployment.get_instance("InvalidContract")
-
-
-def test_get_instance_without_reference_in_contract_factories_raises(
-    invalid_deployment
-):
-    with pytest.raises(EthPMValidationError):
-        invalid_deployment.get_instance("SafeMathLib")
 
 
 def test_deployments_get_instance(safe_math_lib_package):
@@ -166,7 +138,7 @@ def test_get_linked_deployments(escrow_package):
     assert actual_linked_deployments == {"Escrow": all_deployments["Escrow"]}
     # integration via package.deployments
     deployments = escrow_package.deployments
-    assert len(deployments.contract_factories) is 2
+    assert len(deployments.contract_instances) is 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?
Currently `ethpm.deployments.get_instance()` generates a contract factory for each deployment. This will break if manifest does not contain `deployment_bytecode` for the corresponding contract type. It doesn't seem reasonable to expect a manifest to know the deployment bytecode for every deployment (for example, manifests generated from etherscan uris will have a deployments without deployment bytecode).

`ethpm.deployments.get_instance()` was updated to generate contract instances rather than factories for each deployment, requiring only the necessary abi data to successfully construct a contract instance. 

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/62808031-3524e200-bab4-11e9-98de-f7448300af75.png)

