### PR TITLE
[ethPM] Add expression begin/close chars to package name regex

### DIFF
--- a/ethpm/constants.py
+++ b/ethpm/constants.py
@@ -1,6 +1,6 @@
 REGISTRY_URI_SCHEME = "erc1319"
 
-PACKAGE_NAME_REGEX = "[a-zA-Z][-_a-zA-Z0-9]{0,255}"
+PACKAGE_NAME_REGEX = "^[a-zA-Z][-_a-zA-Z0-9]{0,255}$"
 
 DEFAULT_IPFS_BACKEND = "ethpm.backends.ipfs.InfuraIPFSBackend"
 

--- a/ethpm/validation/uri.py
+++ b/ethpm/validation/uri.py
@@ -55,7 +55,7 @@ def validate_registry_uri(uri: str) -> None:
     )
     validate_registry_uri_scheme(scheme)
     validate_registry_uri_authority(authority)
-    pkg_name = pkg_path.lstrip("/")
+    pkg_name = pkg_path.strip("/")
     if pkg_name:
         validate_package_name(pkg_name)
     if not pkg_name and version:

--- a/tests/ethpm/validation/test_manifest.py
+++ b/tests/ethpm/validation/test_manifest.py
@@ -16,6 +16,7 @@ from ethpm.validation.manifest import (
 )
 from ethpm.validation.package import (
     validate_manifest_version,
+    validate_package_name,
 )
 
 
@@ -215,3 +216,38 @@ def test_validate_meta_object_validates(meta, extra_fields):
 def test_validate_meta_object_invalidates(meta, extra_fields):
     with pytest.raises(EthPMValidationError):
         validate_meta_object(meta, allow_extra_meta_fields=extra_fields)
+
+
+@pytest.mark.parametrize(
+    "package_name",
+    (
+        "valid",
+        "Valid",
+        "pkg1",
+        "pkg_1",
+        "pkg-1",
+        "wallet0",
+        "wallet_",
+        "wallet-",
+        "x" * 256,
+    )
+)
+def test_validate_package_name_with_valid_package_names(package_name):
+    assert validate_package_name(package_name) is None
+
+
+@pytest.mark.parametrize(
+    "package_name",
+    (
+        "",
+        "0",
+        "_invalid",
+        "-invalid",
+        ".invalid",
+        "wallet.bad",
+        "x" * 257,
+    )
+)
+def test_validate_package_name_raises_exception_for_invalid_names(package_name):
+    with pytest.raises(EthPMValidationError):
+        validate_package_name(package_name)


### PR DESCRIPTION
### What was wrong?
Package name regex expression needs expression beginning/closing chars (`^`/`$`) to correctly validate package names. 

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/62881740-0eee8480-bcf6-11e9-83f3-4da91d16c2e8.png)
