### PR TITLE
added next_nonce to parity module

### DIFF
--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -387,5 +387,7 @@ pythonic_middleware = construct_formatting_middleware(
         'evm_snapshot': hex_to_integer,
         # Net
         'net_peerCount': to_integer_if_hex,
+        # Parity
+        'parity_nextNonce': to_integer_if_hex,
     },
 )

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -19,13 +19,9 @@ from eth_utils.toolz import (
     curry,
     partial,
 )
-from hexbytes import (
-    HexBytes,
-)
+from hexbytes import HexBytes
 
-from web3._utils.abi import (
-    is_length,
-)
+from web3._utils.abi import is_length
 from web3._utils.encoding import (
     hexstr_if_str,
     to_hex,
@@ -43,13 +39,11 @@ from web3._utils.formatters import (
     remove_key_if,
 )
 
-from .formatting import (
-    construct_formatting_middleware,
-)
+from .formatting import construct_formatting_middleware
 
 
 def bytes_to_ascii(value):
-    return codecs.decode(value, 'ascii')
+    return codecs.decode(value, "ascii")
 
 
 to_ascii_if_bytes = apply_formatter_if(is_bytes, bytes_to_ascii)
@@ -77,29 +71,28 @@ def to_hexbytes(num_bytes, val, variable_length=False):
         return HexBytes(result[extra_bytes:])
     else:
         raise ValueError(
-            "The value %r is %d bytes, but should be %d" % (
-                result, len(result), num_bytes
-            )
+            "The value %r is %d bytes, but should be %d"
+            % (result, len(result), num_bytes)
         )
 
 
 TRANSACTION_FORMATTERS = {
-    'blockHash': apply_formatter_if(is_not_null, to_hexbytes(32)),
-    'blockNumber': apply_formatter_if(is_not_null, to_integer_if_hex),
-    'transactionIndex': apply_formatter_if(is_not_null, to_integer_if_hex),
-    'nonce': to_integer_if_hex,
-    'gas': to_integer_if_hex,
-    'gasPrice': to_integer_if_hex,
-    'value': to_integer_if_hex,
-    'from': to_checksum_address,
-    'publicKey': apply_formatter_if(is_not_null, to_hexbytes(64)),
-    'r': to_hexbytes(32, variable_length=True),
-    'raw': HexBytes,
-    's': to_hexbytes(32, variable_length=True),
-    'to': apply_formatter_if(is_address, to_checksum_address),
-    'hash': to_hexbytes(32),
-    'v': apply_formatter_if(is_not_null, to_integer_if_hex),
-    'standardV': apply_formatter_if(is_not_null, to_integer_if_hex),
+    "blockHash": apply_formatter_if(is_not_null, to_hexbytes(32)),
+    "blockNumber": apply_formatter_if(is_not_null, to_integer_if_hex),
+    "transactionIndex": apply_formatter_if(is_not_null, to_integer_if_hex),
+    "nonce": to_integer_if_hex,
+    "gas": to_integer_if_hex,
+    "gasPrice": to_integer_if_hex,
+    "value": to_integer_if_hex,
+    "from": to_checksum_address,
+    "publicKey": apply_formatter_if(is_not_null, to_hexbytes(64)),
+    "r": to_hexbytes(32, variable_length=True),
+    "raw": HexBytes,
+    "s": to_hexbytes(32, variable_length=True),
+    "to": apply_formatter_if(is_address, to_checksum_address),
+    "hash": to_hexbytes(32),
+    "v": apply_formatter_if(is_not_null, to_integer_if_hex),
+    "standardV": apply_formatter_if(is_not_null, to_integer_if_hex),
 }
 
 
@@ -107,8 +100,8 @@ transaction_formatter = apply_formatters_to_dict(TRANSACTION_FORMATTERS)
 
 
 SIGNED_TX_FORMATTER = {
-    'raw': HexBytes,
-    'tx': transaction_formatter,
+    "raw": HexBytes,
+    "tx": transaction_formatter,
 }
 
 
@@ -116,12 +109,12 @@ signed_tx_formatter = apply_formatters_to_dict(SIGNED_TX_FORMATTER)
 
 
 WHISPER_LOG_FORMATTERS = {
-    'sig': to_hexbytes(130),
-    'topic': to_hexbytes(8),
-    'payload': HexBytes,
-    'padding': apply_formatter_if(is_not_null, HexBytes),
-    'hash': to_hexbytes(64),
-    'recipientPublicKey': apply_formatter_if(is_not_null, to_hexbytes(130)),
+    "sig": to_hexbytes(130),
+    "topic": to_hexbytes(8),
+    "payload": HexBytes,
+    "padding": apply_formatter_if(is_not_null, HexBytes),
+    "hash": to_hexbytes(64),
+    "recipientPublicKey": apply_formatter_if(is_not_null, to_hexbytes(130)),
 }
 
 
@@ -129,14 +122,14 @@ whisper_log_formatter = apply_formatters_to_dict(WHISPER_LOG_FORMATTERS)
 
 
 LOG_ENTRY_FORMATTERS = {
-    'blockHash': apply_formatter_if(is_not_null, to_hexbytes(32)),
-    'blockNumber': apply_formatter_if(is_not_null, to_integer_if_hex),
-    'transactionIndex': apply_formatter_if(is_not_null, to_integer_if_hex),
-    'transactionHash': apply_formatter_if(is_not_null, to_hexbytes(32)),
-    'logIndex': to_integer_if_hex,
-    'address': to_checksum_address,
-    'topics': apply_formatter_to_array(to_hexbytes(32)),
-    'data': to_ascii_if_bytes,
+    "blockHash": apply_formatter_if(is_not_null, to_hexbytes(32)),
+    "blockNumber": apply_formatter_if(is_not_null, to_integer_if_hex),
+    "transactionIndex": apply_formatter_if(is_not_null, to_integer_if_hex),
+    "transactionHash": apply_formatter_if(is_not_null, to_hexbytes(32)),
+    "logIndex": to_integer_if_hex,
+    "address": to_checksum_address,
+    "topics": apply_formatter_to_array(to_hexbytes(32)),
+    "data": to_ascii_if_bytes,
 }
 
 
@@ -144,45 +137,47 @@ log_entry_formatter = apply_formatters_to_dict(LOG_ENTRY_FORMATTERS)
 
 
 RECEIPT_FORMATTERS = {
-    'blockHash': apply_formatter_if(is_not_null, to_hexbytes(32)),
-    'blockNumber': apply_formatter_if(is_not_null, to_integer_if_hex),
-    'transactionIndex': apply_formatter_if(is_not_null, to_integer_if_hex),
-    'transactionHash': to_hexbytes(32),
-    'cumulativeGasUsed': to_integer_if_hex,
-    'status': to_integer_if_hex,
-    'gasUsed': to_integer_if_hex,
-    'contractAddress': apply_formatter_if(is_not_null, to_checksum_address),
-    'logs': apply_formatter_to_array(log_entry_formatter),
-    'logsBloom': to_hexbytes(256),
+    "blockHash": apply_formatter_if(is_not_null, to_hexbytes(32)),
+    "blockNumber": apply_formatter_if(is_not_null, to_integer_if_hex),
+    "transactionIndex": apply_formatter_if(is_not_null, to_integer_if_hex),
+    "transactionHash": to_hexbytes(32),
+    "cumulativeGasUsed": to_integer_if_hex,
+    "status": to_integer_if_hex,
+    "gasUsed": to_integer_if_hex,
+    "contractAddress": apply_formatter_if(is_not_null, to_checksum_address),
+    "logs": apply_formatter_to_array(log_entry_formatter),
+    "logsBloom": to_hexbytes(256),
 }
 
 
 receipt_formatter = apply_formatters_to_dict(RECEIPT_FORMATTERS)
 
 BLOCK_FORMATTERS = {
-    'extraData': to_hexbytes(32, variable_length=True),
-    'gasLimit': to_integer_if_hex,
-    'gasUsed': to_integer_if_hex,
-    'size': to_integer_if_hex,
-    'timestamp': to_integer_if_hex,
-    'hash': apply_formatter_if(is_not_null, to_hexbytes(32)),
-    'logsBloom': to_hexbytes(256),
-    'miner': apply_formatter_if(is_not_null, to_checksum_address),
-    'mixHash': to_hexbytes(32),
-    'nonce': apply_formatter_if(is_not_null, to_hexbytes(8, variable_length=True)),
-    'number': apply_formatter_if(is_not_null, to_integer_if_hex),
-    'parentHash': apply_formatter_if(is_not_null, to_hexbytes(32)),
-    'sha3Uncles': apply_formatter_if(is_not_null, to_hexbytes(32)),
-    'uncles': apply_formatter_to_array(to_hexbytes(32)),
-    'difficulty': to_integer_if_hex,
-    'receiptsRoot': to_hexbytes(32),
-    'stateRoot': to_hexbytes(32),
-    'totalDifficulty': to_integer_if_hex,
-    'transactions': apply_one_of_formatters((
-        (apply_formatter_to_array(transaction_formatter), is_array_of_dicts),
-        (apply_formatter_to_array(to_hexbytes(32)), is_array_of_strings),
-    )),
-    'transactionsRoot': to_hexbytes(32),
+    "extraData": to_hexbytes(32, variable_length=True),
+    "gasLimit": to_integer_if_hex,
+    "gasUsed": to_integer_if_hex,
+    "size": to_integer_if_hex,
+    "timestamp": to_integer_if_hex,
+    "hash": apply_formatter_if(is_not_null, to_hexbytes(32)),
+    "logsBloom": to_hexbytes(256),
+    "miner": apply_formatter_if(is_not_null, to_checksum_address),
+    "mixHash": to_hexbytes(32),
+    "nonce": apply_formatter_if(is_not_null, to_hexbytes(8, variable_length=True)),
+    "number": apply_formatter_if(is_not_null, to_integer_if_hex),
+    "parentHash": apply_formatter_if(is_not_null, to_hexbytes(32)),
+    "sha3Uncles": apply_formatter_if(is_not_null, to_hexbytes(32)),
+    "uncles": apply_formatter_to_array(to_hexbytes(32)),
+    "difficulty": to_integer_if_hex,
+    "receiptsRoot": to_hexbytes(32),
+    "stateRoot": to_hexbytes(32),
+    "totalDifficulty": to_integer_if_hex,
+    "transactions": apply_one_of_formatters(
+        (
+            (apply_formatter_to_array(transaction_formatter), is_array_of_dicts),
+            (apply_formatter_to_array(to_hexbytes(32)), is_array_of_strings),
+        )
+    ),
+    "transactionsRoot": to_hexbytes(32),
 }
 
 
@@ -190,30 +185,32 @@ block_formatter = apply_formatters_to_dict(BLOCK_FORMATTERS)
 
 
 STORAGE_PROOF_FORMATTERS = {
-    'key': HexBytes,
-    'value': HexBytes,
-    'proof': apply_formatter_to_array(HexBytes),
+    "key": HexBytes,
+    "value": HexBytes,
+    "proof": apply_formatter_to_array(HexBytes),
 }
 
 ACCOUNT_PROOF_FORMATTERS = {
-    'address': to_checksum_address,
-    'accountProof': apply_formatter_to_array(HexBytes),
-    'balance': to_integer_if_hex,
-    'codeHash': to_hexbytes(32),
-    'nonce': to_integer_if_hex,
-    'storageHash': to_hexbytes(32),
-    'storageProof': apply_formatter_to_array(apply_formatters_to_dict(STORAGE_PROOF_FORMATTERS))
+    "address": to_checksum_address,
+    "accountProof": apply_formatter_to_array(HexBytes),
+    "balance": to_integer_if_hex,
+    "codeHash": to_hexbytes(32),
+    "nonce": to_integer_if_hex,
+    "storageHash": to_hexbytes(32),
+    "storageProof": apply_formatter_to_array(
+        apply_formatters_to_dict(STORAGE_PROOF_FORMATTERS)
+    ),
 }
 
 proof_formatter = apply_formatters_to_dict(ACCOUNT_PROOF_FORMATTERS)
 
 
 SYNCING_FORMATTERS = {
-    'startingBlock': to_integer_if_hex,
-    'currentBlock': to_integer_if_hex,
-    'highestBlock': to_integer_if_hex,
-    'knownStates': to_integer_if_hex,
-    'pulledStates': to_integer_if_hex,
+    "startingBlock": to_integer_if_hex,
+    "currentBlock": to_integer_if_hex,
+    "highestBlock": to_integer_if_hex,
+    "knownStates": to_integer_if_hex,
+    "pulledStates": to_integer_if_hex,
 }
 
 
@@ -221,13 +218,11 @@ syncing_formatter = apply_formatters_to_dict(SYNCING_FORMATTERS)
 
 
 TRANSACTION_POOL_CONTENT_FORMATTERS = {
-    'pending': compose(
-        curried.keymap(to_ascii_if_bytes),
-        curried.valmap(transaction_formatter),
+    "pending": compose(
+        curried.keymap(to_ascii_if_bytes), curried.valmap(transaction_formatter),
     ),
-    'queued': compose(
-        curried.keymap(to_ascii_if_bytes),
-        curried.valmap(transaction_formatter),
+    "queued": compose(
+        curried.keymap(to_ascii_if_bytes), curried.valmap(transaction_formatter),
     ),
 }
 
@@ -238,8 +233,8 @@ transaction_pool_content_formatter = apply_formatters_to_dict(
 
 
 TRANSACTION_POOL_INSPECT_FORMATTERS = {
-    'pending': curried.keymap(to_ascii_if_bytes),
-    'queued': curried.keymap(to_ascii_if_bytes),
+    "pending": curried.keymap(to_ascii_if_bytes),
+    "queued": curried.keymap(to_ascii_if_bytes),
 }
 
 
@@ -249,145 +244,150 @@ transaction_pool_inspect_formatter = apply_formatters_to_dict(
 
 
 FILTER_PARAMS_FORMATTERS = {
-    'fromBlock': apply_formatter_if(is_integer, integer_to_hex),
-    'toBlock': apply_formatter_if(is_integer, integer_to_hex),
+    "fromBlock": apply_formatter_if(is_integer, integer_to_hex),
+    "toBlock": apply_formatter_if(is_integer, integer_to_hex),
 }
 
 
 filter_params_formatter = apply_formatters_to_dict(FILTER_PARAMS_FORMATTERS)
 
 
-filter_result_formatter = apply_one_of_formatters((
-    (apply_formatter_to_array(log_entry_formatter), is_array_of_dicts),
-    (apply_formatter_to_array(to_hexbytes(32)), is_array_of_strings),
-))
+filter_result_formatter = apply_one_of_formatters(
+    (
+        (apply_formatter_to_array(log_entry_formatter), is_array_of_dicts),
+        (apply_formatter_to_array(to_hexbytes(32)), is_array_of_strings),
+    )
+)
 
 
 transaction_param_formatter = compose(
-    remove_key_if('to', lambda txn: txn['to'] in {'', b'', None}),
+    remove_key_if("to", lambda txn: txn["to"] in {"", b"", None}),
 )
 
 
 estimate_gas_without_block_id = apply_formatter_at_index(transaction_param_formatter, 0)
-estimate_gas_with_block_id = apply_formatters_to_sequence([
-    transaction_param_formatter,
-    block_number_formatter,
-])
+estimate_gas_with_block_id = apply_formatters_to_sequence(
+    [transaction_param_formatter, block_number_formatter,]
+)
 
 
 pythonic_middleware = construct_formatting_middleware(
     request_formatters={
         # Eth
-        'eth_getBalance': apply_formatter_at_index(block_number_formatter, 1),
-        'eth_getBlockByNumber': apply_formatter_at_index(block_number_formatter, 0),
-        'eth_getBlockTransactionCountByNumber': apply_formatter_at_index(
-            block_number_formatter,
-            0,
+        "eth_getBalance": apply_formatter_at_index(block_number_formatter, 1),
+        "eth_getBlockByNumber": apply_formatter_at_index(block_number_formatter, 0),
+        "eth_getBlockTransactionCountByNumber": apply_formatter_at_index(
+            block_number_formatter, 0,
         ),
-        'eth_getCode': apply_formatter_at_index(block_number_formatter, 1),
-        'eth_getStorageAt': apply_formatter_at_index(block_number_formatter, 2),
-        'eth_getProof': apply_formatter_at_index(block_number_formatter, 2),
-        'eth_getTransactionByBlockNumberAndIndex': compose(
+        "eth_getCode": apply_formatter_at_index(block_number_formatter, 1),
+        "eth_getStorageAt": apply_formatter_at_index(block_number_formatter, 2),
+        "eth_getProof": apply_formatter_at_index(block_number_formatter, 2),
+        "eth_getTransactionByBlockNumberAndIndex": compose(
             apply_formatter_at_index(block_number_formatter, 0),
             apply_formatter_at_index(integer_to_hex, 1),
         ),
-        'eth_getTransactionCount': apply_formatter_at_index(block_number_formatter, 1),
-        'eth_getUncleCountByBlockNumber': apply_formatter_at_index(block_number_formatter, 0),
-        'eth_getUncleByBlockNumberAndIndex': compose(
+        "eth_getTransactionCount": apply_formatter_at_index(block_number_formatter, 1),
+        "eth_getUncleCountByBlockNumber": apply_formatter_at_index(
+            block_number_formatter, 0
+        ),
+        "eth_getUncleByBlockNumberAndIndex": compose(
             apply_formatter_at_index(block_number_formatter, 0),
             apply_formatter_at_index(integer_to_hex, 1),
         ),
-        'eth_getUncleByBlockHashAndIndex': apply_formatter_at_index(integer_to_hex, 1),
-        'eth_newFilter': apply_formatter_at_index(filter_params_formatter, 0),
-        'eth_getLogs': apply_formatter_at_index(filter_params_formatter, 0),
-        'eth_call': apply_formatters_to_sequence([
-            transaction_param_formatter,
-            block_number_formatter,
-        ]),
-        'eth_estimateGas': apply_one_of_formatters((
-            (estimate_gas_without_block_id, is_length(1)),
-            (estimate_gas_with_block_id, is_length(2)),
-        )),
-        'eth_sendTransaction': apply_formatter_at_index(transaction_param_formatter, 0),
+        "eth_getUncleByBlockHashAndIndex": apply_formatter_at_index(integer_to_hex, 1),
+        "eth_newFilter": apply_formatter_at_index(filter_params_formatter, 0),
+        "eth_getLogs": apply_formatter_at_index(filter_params_formatter, 0),
+        "eth_call": apply_formatters_to_sequence(
+            [transaction_param_formatter, block_number_formatter,]
+        ),
+        "eth_estimateGas": apply_one_of_formatters(
+            (
+                (estimate_gas_without_block_id, is_length(1)),
+                (estimate_gas_with_block_id, is_length(2)),
+            )
+        ),
+        "eth_sendTransaction": apply_formatter_at_index(transaction_param_formatter, 0),
         # personal
-        'personal_importRawKey': apply_formatter_at_index(
-            compose(remove_0x_prefix, hexstr_if_str(to_hex)),
-            0,
+        "personal_importRawKey": apply_formatter_at_index(
+            compose(remove_0x_prefix, hexstr_if_str(to_hex)), 0,
         ),
-        'personal_sign': apply_formatter_at_index(text_if_str(to_hex), 0),
-        'personal_ecRecover': apply_formatter_at_index(text_if_str(to_hex), 0),
-        'personal_sendTransaction': apply_formatter_at_index(transaction_param_formatter, 0),
+        "personal_sign": apply_formatter_at_index(text_if_str(to_hex), 0),
+        "personal_ecRecover": apply_formatter_at_index(text_if_str(to_hex), 0),
+        "personal_sendTransaction": apply_formatter_at_index(
+            transaction_param_formatter, 0
+        ),
         # Snapshot and Revert
-        'evm_revert': apply_formatter_at_index(integer_to_hex, 0),
-        'trace_replayBlockTransactions': apply_formatter_at_index(block_number_formatter, 0),
-        'trace_block': apply_formatter_at_index(block_number_formatter, 0),
-        'trace_call': compose(
+        "evm_revert": apply_formatter_at_index(integer_to_hex, 0),
+        "trace_replayBlockTransactions": apply_formatter_at_index(
+            block_number_formatter, 0
+        ),
+        "trace_block": apply_formatter_at_index(block_number_formatter, 0),
+        "trace_call": compose(
             apply_formatter_at_index(transaction_param_formatter, 0),
-            apply_formatter_at_index(block_number_formatter, 2)
+            apply_formatter_at_index(block_number_formatter, 2),
         ),
     },
     result_formatters={
         # Eth
-        'eth_accounts': apply_formatter_to_array(to_checksum_address),
-        'eth_blockNumber': to_integer_if_hex,
-        'eth_chainId': to_integer_if_hex,
-        'eth_coinbase': to_checksum_address,
-        'eth_estimateGas': to_integer_if_hex,
-        'eth_gasPrice': to_integer_if_hex,
-        'eth_getBalance': to_integer_if_hex,
-        'eth_getBlockByHash': apply_formatter_if(is_not_null, block_formatter),
-        'eth_getBlockByNumber': apply_formatter_if(is_not_null, block_formatter),
-        'eth_getBlockTransactionCountByHash': to_integer_if_hex,
-        'eth_getBlockTransactionCountByNumber': to_integer_if_hex,
-        'eth_getCode': HexBytes,
-        'eth_getFilterChanges': filter_result_formatter,
-        'eth_getFilterLogs': filter_result_formatter,
-        'eth_getLogs': filter_result_formatter,
-        'eth_getStorageAt': HexBytes,
-        'eth_getProof': apply_formatter_if(is_not_null, proof_formatter),
-        'eth_getTransactionByBlockHashAndIndex': apply_formatter_if(
-            is_not_null,
-            transaction_formatter,
+        "eth_accounts": apply_formatter_to_array(to_checksum_address),
+        "eth_blockNumber": to_integer_if_hex,
+        "eth_chainId": to_integer_if_hex,
+        "eth_coinbase": to_checksum_address,
+        "eth_estimateGas": to_integer_if_hex,
+        "eth_gasPrice": to_integer_if_hex,
+        "eth_getBalance": to_integer_if_hex,
+        "eth_getBlockByHash": apply_formatter_if(is_not_null, block_formatter),
+        "eth_getBlockByNumber": apply_formatter_if(is_not_null, block_formatter),
+        "eth_getBlockTransactionCountByHash": to_integer_if_hex,
+        "eth_getBlockTransactionCountByNumber": to_integer_if_hex,
+        "eth_getCode": HexBytes,
+        "eth_getFilterChanges": filter_result_formatter,
+        "eth_getFilterLogs": filter_result_formatter,
+        "eth_getLogs": filter_result_formatter,
+        "eth_getStorageAt": HexBytes,
+        "eth_getProof": apply_formatter_if(is_not_null, proof_formatter),
+        "eth_getTransactionByBlockHashAndIndex": apply_formatter_if(
+            is_not_null, transaction_formatter,
         ),
-        'eth_getTransactionByBlockNumberAndIndex': apply_formatter_if(
-            is_not_null,
-            transaction_formatter,
+        "eth_getTransactionByBlockNumberAndIndex": apply_formatter_if(
+            is_not_null, transaction_formatter,
         ),
-        'eth_getTransactionByHash': apply_formatter_if(is_not_null, transaction_formatter),
-        'eth_getTransactionCount': to_integer_if_hex,
-        'eth_getTransactionReceipt': apply_formatter_if(
-            is_not_null,
-            receipt_formatter,
+        "eth_getTransactionByHash": apply_formatter_if(
+            is_not_null, transaction_formatter
         ),
-        'eth_getUncleCountByBlockHash': to_integer_if_hex,
-        'eth_getUncleCountByBlockNumber': to_integer_if_hex,
-        'eth_hashrate': to_integer_if_hex,
-        'eth_protocolVersion': compose(
-            apply_formatter_if(is_integer, str),
-            to_integer_if_hex,
+        "eth_getTransactionCount": to_integer_if_hex,
+        "eth_getTransactionReceipt": apply_formatter_if(
+            is_not_null, receipt_formatter,
         ),
-        'eth_sendRawTransaction': to_hexbytes(32),
-        'eth_sendTransaction': to_hexbytes(32),
-        'eth_signTransaction': apply_formatter_if(is_not_null, signed_tx_formatter),
-        'eth_sign': HexBytes,
-        'eth_signTypedData': HexBytes,
-        'eth_syncing': apply_formatter_if(is_not_false, syncing_formatter),
+        "eth_getUncleCountByBlockHash": to_integer_if_hex,
+        "eth_getUncleCountByBlockNumber": to_integer_if_hex,
+        "eth_hashrate": to_integer_if_hex,
+        "eth_protocolVersion": compose(
+            apply_formatter_if(is_integer, str), to_integer_if_hex,
+        ),
+        "eth_sendRawTransaction": to_hexbytes(32),
+        "eth_sendTransaction": to_hexbytes(32),
+        "eth_signTransaction": apply_formatter_if(is_not_null, signed_tx_formatter),
+        "eth_sign": HexBytes,
+        "eth_signTypedData": HexBytes,
+        "eth_syncing": apply_formatter_if(is_not_false, syncing_formatter),
         # personal
-        'personal_importRawKey': to_checksum_address,
-        'personal_listAccounts': apply_formatter_to_array(to_checksum_address),
-        'personal_newAccount': to_checksum_address,
-        'personal_signTypedData': HexBytes,
-        'personal_sendTransaction': to_hexbytes(32),
+        "personal_importRawKey": to_checksum_address,
+        "personal_listAccounts": apply_formatter_to_array(to_checksum_address),
+        "personal_newAccount": to_checksum_address,
+        "personal_signTypedData": HexBytes,
+        "personal_sendTransaction": to_hexbytes(32),
         # SHH
-        'shh_getFilterMessages': apply_formatter_to_array(whisper_log_formatter),
+        "shh_getFilterMessages": apply_formatter_to_array(whisper_log_formatter),
         # Transaction Pool
-        'txpool_content': transaction_pool_content_formatter,
-        'txpool_inspect': transaction_pool_inspect_formatter,
+        "txpool_content": transaction_pool_content_formatter,
+        "txpool_inspect": transaction_pool_inspect_formatter,
         # Snapshot and Revert
-        'evm_snapshot': hex_to_integer,
+        "evm_snapshot": hex_to_integer,
         # Net
-        'net_peerCount': to_integer_if_hex,
+        "net_peerCount": to_integer_if_hex,
         # Parity
-        'parity_nextNonce': to_integer_if_hex,
+        "parity_nextNonce": to_integer_if_hex,
+        "parity_allTransactions": apply_formatter_to_array(transaction_formatter),
     },
 )

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -151,3 +151,9 @@ class Parity(Module):
             "parity_mode",
             []
         )
+    
+    def nextNonce(self, account):
+        return self.web3.manager.request_blocking(
+            "parity_nextNonce",
+            [account]
+        )

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -1,13 +1,7 @@
-from eth_utils import (
-    is_checksum_address,
-)
-from eth_utils.toolz import (
-    assoc,
-)
+from eth_utils import is_checksum_address
+from eth_utils.toolz import assoc
 
-from web3._utils import (
-    shh,
-)
+from web3._utils import shh
 from web3._utils.personal import (
     ecRecover,
     importRawKey,
@@ -28,6 +22,7 @@ class ParityShh(ModuleV2):
     """
     https://wiki.parity.io/JSONRPC-shh-module
     """
+
     info = shh.info
     newKeyPair = shh.newKeyPair
     addPrivateKey = shh.addPrivateKey
@@ -49,6 +44,7 @@ class ParityPersonal(ModuleV2):
     """
     https://wiki.parity.io/JSONRPC-personal-module
     """
+
     ecRecover = ecRecover
     importRawKey = importRawKey
     listAccounts = listAccounts
@@ -63,97 +59,71 @@ class Parity(Module):
     """
     https://paritytech.github.io/wiki/JSONRPC-parity-module
     """
+
     defaultBlock = "latest"
 
     def enode(self):
-        return self.web3.manager.request_blocking(
-            "parity_enode",
-            [],
-        )
+        return self.web3.manager.request_blocking("parity_enode", [],)
 
     def listStorageKeys(self, address, quantity, hash_, block_identifier=None):
         if block_identifier is None:
             block_identifier = self.defaultBlock
         return self.web3.manager.request_blocking(
-            "parity_listStorageKeys",
-            [address, quantity, hash_, block_identifier],
+            "parity_listStorageKeys", [address, quantity, hash_, block_identifier],
         )
 
     def netPeers(self):
-        return self.web3.manager.request_blocking(
-            "parity_netPeers",
-            [],
-        )
+        return self.web3.manager.request_blocking("parity_netPeers", [],)
 
     def addReservedPeer(self, url):
+        return self.web3.manager.request_blocking("parity_addReservedPeer", [url],)
+
+    def traceReplayTransaction(self, transaction_hash, mode=["trace"]):
         return self.web3.manager.request_blocking(
-            "parity_addReservedPeer",
-            [url],
+            "trace_replayTransaction", [transaction_hash, mode],
         )
 
-    def traceReplayTransaction(self, transaction_hash, mode=['trace']):
+    def traceReplayBlockTransactions(self, block_identifier, mode=["trace"]):
         return self.web3.manager.request_blocking(
-            "trace_replayTransaction",
-            [transaction_hash, mode],
-        )
-
-    def traceReplayBlockTransactions(self, block_identifier, mode=['trace']):
-        return self.web3.manager.request_blocking(
-            "trace_replayBlockTransactions",
-            [block_identifier, mode]
+            "trace_replayBlockTransactions", [block_identifier, mode]
         )
 
     def traceBlock(self, block_identifier):
-        return self.web3.manager.request_blocking(
-            "trace_block",
-            [block_identifier]
-        )
+        return self.web3.manager.request_blocking("trace_block", [block_identifier])
 
     def traceFilter(self, params):
-        return self.web3.manager.request_blocking(
-            "trace_filter",
-            [params]
-        )
+        return self.web3.manager.request_blocking("trace_filter", [params])
 
     def traceTransaction(self, transaction_hash):
         return self.web3.manager.request_blocking(
-            "trace_transaction",
-            [transaction_hash]
+            "trace_transaction", [transaction_hash]
         )
 
-    def traceCall(self, transaction, mode=['trace'], block_identifier=None):
+    def traceCall(self, transaction, mode=["trace"], block_identifier=None):
         # TODO: move to middleware
-        if 'from' not in transaction and is_checksum_address(self.defaultAccount):
-            transaction = assoc(transaction, 'from', self.defaultAccount)
+        if "from" not in transaction and is_checksum_address(self.defaultAccount):
+            transaction = assoc(transaction, "from", self.defaultAccount)
 
         # TODO: move to middleware
         if block_identifier is None:
             block_identifier = self.defaultBlock
         return self.web3.manager.request_blocking(
-            "trace_call",
-            [transaction, mode, block_identifier],
+            "trace_call", [transaction, mode, block_identifier],
         )
 
-    def traceRawTransaction(self, raw_transaction, mode=['trace']):
+    def traceRawTransaction(self, raw_transaction, mode=["trace"]):
         return self.web3.manager.request_blocking(
-            "trace_rawTransaction",
-            [raw_transaction, mode],
+            "trace_rawTransaction", [raw_transaction, mode],
         )
 
     def setMode(self, mode):
-        return self.web3.manager.request_blocking(
-            "parity_setMode",
-            [mode]
-        )
+        return self.web3.manager.request_blocking("parity_setMode", [mode])
 
     def mode(self):
-        return self.web3.manager.request_blocking(
-            "parity_mode",
-            []
-        )
+        return self.web3.manager.request_blocking("parity_mode", [])
 
     def nextNonce(self, account):
-        return self.web3.manager.request_blocking(
-            "parity_nextNonce",
-            [account]
-        )
+        return self.web3.manager.request_blocking("parity_nextNonce", [account])
+
+    def allTransactions(self):
+        return self.web3.manager.request_blocking("parity_allTransactions", [])

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -151,7 +151,7 @@ class Parity(Module):
             "parity_mode",
             []
         )
-    
+
     def nextNonce(self, account):
         return self.web3.manager.request_blocking(
             "parity_nextNonce",


### PR DESCRIPTION
### What was wrong?

The parity JSON-RPC method `parity_nextNonce` was not implemented.
https://wiki.parity.io/JSONRPC-parity-module#parity_nextnonce

### How was it fixed?
Added the method and its respective result formatter


### Further direction:
Any ideas on how I can test this?

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://ichef.bbci.co.uk/news/660/cpsprodpb/21CF/production/_104455680_capture.jpg)
