### PR TITLE
Display hexstr not bytes tx hash on tx timeout

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -260,7 +260,7 @@ class Eth(Module):
         except Timeout:
             raise TimeExhausted(
                 "Transaction {} is not in the chain, after {} seconds".format(
-                    transaction_hash,
+                    to_hex(transaction_hash),
                     timeout,
                 )
             )


### PR DESCRIPTION
### What was wrong?
Is there a reason we display the bytes representation of a tx hash in a tx timeout error message? I always find myself converting it to a hexstr so I can look it up on etherscan, and figured it would be easier to build in the conversion.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/63465998-8e2f3700-c41f-11e9-8f2b-5623652ea46c.png)
