### PR TITLE
Ensure build-docs job triggers doctest check

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -44,7 +44,7 @@ help:
 	@echo "  xml        to make Docutils-native XML files"
 	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
 	@echo "  linkcheck  to check all external links for integrity"
-	@echo "  docs       to run all doctests embedded in the documentation (if enabled)"
+	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
 	rm -rf $(BUILDDIR)/*
@@ -161,7 +161,7 @@ linkcheck:
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
-docs:
+doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."


### PR DESCRIPTION
### What was wrong?

The `doctest` job in the `docs/Makefile` accidentially got deleted which caused the `doctest` job (the one running the code examples) to not run anymore.

### How was it fixed?

Change back the rename. I've intentionally left out a release notes entry because this just broke with a recent PR so not worth adding a release notes entry for something that was just temporary broken.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.cnn.com/cnnnext/dam/assets/130819170426-cutest-animal-19-pygmy-hippopotamus-horizontal-large-gallery.jpg)
