### PR TITLE
Enforce striter CI checks for docs and fix some doc issues that would now fail the build.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -50,7 +50,7 @@ clean:
 	rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -W -T -E -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,7 @@ exclude_patterns = [
     'web3.providers.rst',
     'web3.providers.eth_tester.rst',
     'web3.testing.rst',
+    'web3.tools.*',
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -488,7 +488,7 @@ Sample standard-json-input.json
         "language": "Solidity",
         "sources": {
             "Contract.sol": {
-                "urls": [<path-to-contract>]
+                "urls": ["<path-to-contract>"]
             }
         },
         "settings": {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ Contents
     web3.miner
     web3.geth
     web3.parity
+    web3.tools
     gas_price
     ens
     ethpm

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,6 @@ Contents
     web3.miner
     web3.geth
     web3.parity
-    web3.tools
     gas_price
     ens
     ethpm

--- a/newsfragments/1437.doc.rst
+++ b/newsfragments/1437.doc.rst
@@ -1,2 +1,5 @@
 Enforce stricter doc checking, turning warnings into errors to fail CI builds
 to catch issues quickly.
+
+Add missing ``web3.tools.rst`` to the table of contents and fix incorrectly formatted
+JSON example.

--- a/newsfragments/1437.doc.rst
+++ b/newsfragments/1437.doc.rst
@@ -1,0 +1,2 @@
+Enforce stricter doc checking, turning warnings into errors to fail CI builds
+to catch issues quickly.


### PR DESCRIPTION
### What was wrong?

The current CI job to validate the docs is to weak. In fact, there are some issues that went under the radar:

1. One JSON code snippet isn't valid JSON which turns off the formatter
2. One doc isn't included in the table of contents

### How was it fixed?

1. Make errors fail the build
2. Include full tracebacks in errors
3. Do not use cache to build the docs
4. Add `web3.tools.rst` to the TOC
5. Fix JSON formatting in example

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://animalroll.com/wp-content/uploads/2017/05/shutterstock_370189526-e1494012789303.jpg)
