### PR TITLE
Update examples.rst with Infura/rinkeby steps

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -471,3 +471,50 @@ like so:
 .. include::  ../tests/core/contracts/test_contract_example.py
     :code: python
     :start-line: 1
+    
+Using Infura Rinkeby Node
+-------------------------
+Import your required libraries
+
+.. code-block:: python
+
+    from web3 import Web3, HTTPProvider
+    
+Initialize a web3 instance with an Infura node
+
+.. code-block:: python
+    
+    w3 = Web3(Web3.HTTPProvider("https://rinkeby.infura.io/v3/YOUR_INFURA_KEY"))
+
+ 
+Inject the middleware into the middleware onion
+
+.. code-block:: python
+
+    from web3.middleware import geth_poa_middleware
+    w3.middleware_onion.inject(geth_poa_middleware, layer=0)
+    
+Just remember that you have to sign all transactions locally, as infura does not handle any keys from your wallet ( refer to `this`_  )
+
+
+..  _this: https://web3py.readthedocs.io/en/stable/web3.eth.account.html#local-vs-hosted-nodes
+
+.. code-block:: python
+    
+    transaction = contract.functions.function_Name(params).buildTransaction()
+    transaction.update({ 'gas' : appropriate_gas_amount })  
+    transaction.update({ 'nonce' : web3.eth.getTransactionCount('Your_Wallet_Address') })
+    signed_tx = w3.eth.account.signTransaction(transaction, private_key)
+    
+P.S : the two updates are done to the transaction dictionary, since a raw transaction might not contain gas & nonce amounts, so you have to add them manually.
+    
+And finally, send the transaction
+
+.. code-block:: python
+
+    txn_hash = w3.eth.sendRawTransaction(signed_tx.rawTransaction)
+    txn_receipt = w3.eth.waitForTransactionReceipt(txn_hash)
+    
+Tip : afterwards you can use the value stored in ``txn_hash``, in an explorer like `etherscan`_ to view the transaction's details
+
+.. _etherscan: https://rinkeby.etherscan.io

--- a/newsfragments/1444.doc.rst
+++ b/newsfragments/1444.doc.rst
@@ -1,0 +1,1 @@
+Add example using Geth POA Middleware with Infura Rinkeby Node


### PR DESCRIPTION
Using Infura Rinkeby Node
=========================

Import your required libraries

    from web3 import Web3, HTTPProvider
    
Initialize a web3 instance with an Infura node
    
    w3 = Web3(Web3.HTTPProvider("https://rinkeby.infura.io/v3/YOUR_INFURA_KEY"))
 
Inject the middleware into the middleware onion
    
    w3.middleware_onion.inject(geth_poa_middleware, layer=0)
    
Just remember that you have to sign all transactions locally, as infura does not handle any keys from your wallet
    
    transaction = contract.functions.function_Name(params).buildTransaction()
    transaction.update({ 'gas' : appropriate_gas_amount })  
    transaction.update({ 'nonce' : web3.eth.getTransactionCount('Your_Wallet_Address') })
    signed_tx = w3.eth.account.signTransaction(transaction, private_key)

P,S : the two updates are done to the transaction dictionary, since it might not contain gas & nonce amounts, so you have to add them manually.

And then send the transaction

    txn_hash = w3.eth.sendRawTransaction(signed_tx.rawTransaction) 
    txn_receipt = w3.eth.waitForTransactionReceipt(txn_hash)

### What was wrong?

Related to Issue # ; not sure about which issue this might correspond to, but there was terrible documentation regarding how to inject the POA middleware and calling a state-changing transaction also yielded alot of errors in my experimentation. so i thought to contribute a combined solution, outlining the simple yet subtle step of injecting middle-ware and also how to constuct a raw transaction to interact with a state-changing function in your smart contract.

### How was it fixed?

It can be seen in the code. However, to put it briefly, i just simplified the steps on injecting the geth-style middleware in web3.py, when using an Infura Rinkeby node and i also outlined the steps on how to properly construct a transaction for calling a state-changing function in a smart-contract deployed on Rinkeby testnet.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/QLJ99iuValY/maxresdefault.jpg)
