### PR TITLE
Fix LogsBloom formatter error

### DIFF
--- a/newsfragments/1445.bugfix.rst
+++ b/newsfragments/1445.bugfix.rst
@@ -1,0 +1,1 @@
+Add null check to logsbloom formatter

--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -166,7 +166,7 @@ BLOCK_FORMATTERS = {
     'size': to_integer_if_hex,
     'timestamp': to_integer_if_hex,
     'hash': apply_formatter_if(is_not_null, to_hexbytes(32)),
-    'logsBloom': to_hexbytes(256),
+    'logsBloom': apply_formatter_if(is_not_null, to_hexbytes(256)),
     'miner': apply_formatter_if(is_not_null, to_checksum_address),
     'mixHash': to_hexbytes(32),
     'nonce': apply_formatter_if(is_not_null, to_hexbytes(8, variable_length=True)),


### PR DESCRIPTION
### What was wrong?

When `getBlock(block_identifier='pending')` is called, the pending block will return `logsBloom = null`. The current block formatter attempts to convert the null value to HexBytes and fail.

### How was it fixed?
The LogsBloom HexBytes formatter is only applied when logsBloom is not null.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![lilly](https://user-images.githubusercontent.com/11431787/64308702-8655c200-cfdd-11e9-9bc0-e65ad7be1fa7.jpg)
