### PR TITLE
Clarify module installation command for >=OSX 10.15

### DIFF
--- a/docs/README-osx.md
+++ b/docs/README-osx.md
@@ -19,3 +19,14 @@ brew install openssl libffi autoconf automake libtool
 ```sh
 brew install leveldb
 ```
+
+4. When you are on `>=OSX 10.15 Catalina` and you encounter error with default `ZSH` shell:
+```sh
+pip install -e .[dev]
+zsh: no matches found: .[dev]
+```
+
+Run install commands as follows:
+```sh
+pip install -e .'[dev]'
+```

--- a/docs/README-osx.md
+++ b/docs/README-osx.md
@@ -20,7 +20,7 @@ brew install openssl libffi autoconf automake libtool
 brew install leveldb
 ```
 
-4. When you are on `>=OSX 10.15 Catalina` and you encounter error with default `ZSH` shell:
+> If you are on `>=OSX 10.15 Catalina` you may encounter the following error with the default `ZSH` shell. This can be fixed by wrapping the `[dev]` part in quotes.
 ```sh
 pip install -e .[dev]
 zsh: no matches found: .[dev]


### PR DESCRIPTION
### What was wrong?
During module installation on OSX Catalina (default shell is zsh) there was an error:
```sh
pip install -e .[dev]
zsh: no matches found: .[dev]
```

### How was it fixed?
I've added correct instruction to the `README-osx.md` that works on `zsh`

#### Cute Animal Picture

[https://i.imgur.com/2UqYyn2.jpg](https://i.imgur.com/2UqYyn2.jpg)
