### PR TITLE
Remove eth-account deprecation warnings

### DIFF
--- a/newsfragments/1468.misc.rst
+++ b/newsfragments/1468.misc.rst
@@ -1,0 +1,1 @@
+Remove deprecation warnings from eth-account dependency upgrade

--- a/tests/core/middleware/test_transaction_signing.py
+++ b/tests/core/middleware/test_transaction_signing.py
@@ -53,7 +53,7 @@ ADDRESS_2 = '0x91eD14b5956DBcc1310E65DC4d7E82f02B95BA46'
 
 KEY_FUNCS = (
     eth_keys.keys.PrivateKey,
-    Account.privateKeyToAccount,
+    Account.from_key,
     HexBytes,
     to_hex,
     identity,


### PR DESCRIPTION
### What was wrong?
There were lots of deprecation warnings from eth-account when the tests were run.

### How was it fixed?
Began using the new eth-account methods that were introduced.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="255" alt="image" src="https://user-images.githubusercontent.com/6540608/66227111-bbffd080-e699-11e9-89dc-e4a96ac2942d.png">
