### PR TITLE
[WIP] Updated GethPersonal to snake_case 

### DIFF
--- a/docs/web3.geth.rst
+++ b/docs/web3.geth.rst
@@ -211,7 +211,7 @@ GethPersonal API
 
 The following methods are available on the ``web3.geth.personal`` namespace.
 
-.. py:method:: listAccounts
+.. py:method:: list_accounts
 
     * Delegates to ``personal_listAccounts`` RPC Method
 
@@ -219,11 +219,15 @@ The following methods are available on the ``web3.geth.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.geth.personal.listAccounts()
+        >>> web3.geth.personal.list_accounts()
         ['0xd3CdA913deB6f67967B99D67aCDFa1712C293601']
 
+.. py:method:: listAccounts()
 
-.. py:method:: importRawKey(self, private_key, passphrase)
+    .. warning:: Deprecated: This method is deprecated in favor of
+       :meth:`~web3.geth.personal.list_accounts()`
+
+.. py:method:: import_raw_key(self, private_key, passphrase)
 
     * Delegates to ``personal_importRawKey`` RPC Method
 
@@ -232,11 +236,15 @@ The following methods are available on the ``web3.geth.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.geth.personal.importRawKey(some_private_key, 'the-passphrase')
+        >>> web3.geth.personal.import_raw_key(some_private_key, 'the-passphrase')
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 
+.. py:method:: importRawKey()
 
-.. py:method:: newAccount(self, password)
+    .. warning:: Deprecated: This method is deprecated in favor of
+       :meth:`~web3.geth.personal.import_raw_key()`
+
+.. py:method:: new_account(self, password)
 
     * Delegates to ``personal_newAccount`` RPC Method
 
@@ -245,11 +253,15 @@ The following methods are available on the ``web3.geth.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.geth.personal.newAccount('the-passphrase')
+        >>> web3.geth.personal.new_account('the-passphrase')
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 
+.. py:method:: newAccount()
 
-.. py:method:: lockAccount(self, account)
+    .. warning:: Deprecated: This method is deprecated in favor of
+       :meth:`~web3.geth.personal.new_account()`
+
+.. py:method:: lock_account(self, account)
 
     * Delegates to ``personal_lockAccount`` RPC Method
 
@@ -257,10 +269,14 @@ The following methods are available on the ``web3.geth.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.geth.personal.lockAccount('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
+        >>> web3.geth.personal.lock_account('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
 
+.. py:method:: lockAccount()
 
-.. py:method:: unlockAccount(self, account, passphrase, duration=None)
+    .. warning:: Deprecated: This method is deprecated in favor of
+       :meth:`~web3.geth.personal.lock_account()`
+
+.. py:method:: unlock_account(self, account, passphrase, duration=None)
 
     * Delegates to ``personal_unlockAccount`` RPC Method
 
@@ -271,18 +287,26 @@ The following methods are available on the ``web3.geth.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.geth.personal.unlockAccount('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'wrong-passphrase')
+        >>> web3.geth.personal.unlock_account('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'wrong-passphrase')
         False
-        >>> web3.geth.personal.unlockAccount('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'the-passphrase')
+        >>> web3.geth.personal.unlock_account('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'the-passphrase')
         True
 
+.. py:method:: unlockAccount()
 
-.. py:method:: sendTransaction(self, transaction, passphrase)
+    .. warning:: Deprecated: This method is deprecated in favor of
+       :meth:`~web3.geth.personal.unlock_account()`
+
+.. py:method:: send_transaction(self, transaction, passphrase)
 
     * Delegates to ``personal_sendTransaction`` RPC Method
 
     Sends the transaction.
 
+.. py:method:: sendTransaction()
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+       :meth:`~web3.geth.personal.send_transaction()`
 
 .. py:module:: web3.geth.txpool
 

--- a/tests/core/eth-module/conftest.py
+++ b/tests/core/eth-module/conftest.py
@@ -12,7 +12,7 @@ def extra_accounts(web3, account_password):
     num_accounts_to_create = 10 - len(web3.eth.accounts)
 
     for i in range(num_accounts_to_create):
-        web3.personal.newAccount(account_password)
+        web3.personal.new_account(account_password)
 
     return web3.eth.accounts
 

--- a/tests/core/mining-module/test_setEtherBase.py
+++ b/tests/core/mining-module/test_setEtherBase.py
@@ -2,6 +2,6 @@
 def test_miner_setEtherbase(web3_empty):
     web3 = web3_empty
     assert web3.eth.coinbase == web3.eth.accounts[0]
-    new_account = web3.personal.newAccount('this-is-a-password')
+    new_account = web3.personal.new_account('this-is-a-password')
     web3.geth.miner.setEtherBase(new_account)
     assert web3.eth.coinbase == new_account

--- a/tests/generate_go_ethereum_fixture.py
+++ b/tests/generate_go_ethereum_fixture.py
@@ -316,7 +316,7 @@ def mine_block(web3):
 
 
 def deploy_contract(web3, name, factory):
-    web3.geth.personal.unlockAccount(web3.eth.coinbase, KEYFILE_PW)
+    web3.geth.personal.unlock_account(web3.eth.coinbase, KEYFILE_PW)
     deploy_txn_hash = factory.constructor().transact({'from': web3.eth.coinbase})
     print('{0}_CONTRACT_DEPLOY_HASH: '.format(name.upper()), deploy_txn_hash)
     deploy_receipt = mine_transaction_hash(web3, deploy_txn_hash)
@@ -375,7 +375,7 @@ def setup_chain_state(web3):
     #
     # Block with Transaction
     #
-    web3.geth.personal.unlockAccount(coinbase, KEYFILE_PW)
+    web3.geth.personal.unlock_account(coinbase, KEYFILE_PW)
     web3.geth.miner.start(1)
     mined_txn_hash = web3.eth.sendTransaction({
         'from': coinbase,

--- a/tests/integration/generate_fixtures/common.py
+++ b/tests/integration/generate_fixtures/common.py
@@ -228,7 +228,7 @@ def mine_transaction_hash(web3, txn_hash):
 
 
 def deploy_contract(web3, name, factory):
-    web3.geth.personal.unlockAccount(web3.eth.coinbase, KEYFILE_PW)
+    web3.geth.personal.unlock_account(web3.eth.coinbase, KEYFILE_PW)
     deploy_txn_hash = factory.constructor().transact({'from': web3.eth.coinbase})
     print('{0}_CONTRACT_DEPLOY_HASH: '.format(name.upper()), deploy_txn_hash)
     deploy_receipt = mine_transaction_hash(web3, deploy_txn_hash)

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -120,7 +120,7 @@ def setup_chain_state(web3):
     #
     # Block with Transaction
     #
-    web3.geth.personal.unlockAccount(coinbase, common.KEYFILE_PW)
+    web3.geth.personal.unlock_account(coinbase, common.KEYFILE_PW)
     web3.geth.miner.start(1)
     mined_txn_hash = web3.eth.sendTransaction({
         'from': coinbase,

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -124,3 +124,7 @@ class CommonGoEthereumShhModuleTest(GoEthereumShhModuleTest):
 
 class GoEthereumAdminModuleTest(GoEthereumAdminModuleTest):
     pass
+
+
+class GoEthereumPersonalModuleTest(GoEthereumPersonalModuleTest):
+    pass

--- a/tests/integration/go_ethereum/conftest.py
+++ b/tests/integration/go_ethereum/conftest.py
@@ -152,9 +152,9 @@ def emitter_contract_address(emitter_contract, address_conversion_func):
 
 @pytest.fixture
 def unlocked_account(web3, unlockable_account, unlockable_account_pw):
-    web3.geth.personal.unlockAccount(unlockable_account, unlockable_account_pw)
+    web3.geth.personal.unlock_account(unlockable_account, unlockable_account_pw)
     yield unlockable_account
-    web3.geth.personal.lockAccount(unlockable_account)
+    web3.geth.personal.lock_account(unlockable_account)
 
 
 @pytest.fixture(scope='module')
@@ -174,9 +174,9 @@ def unlockable_account_dual_type(unlockable_account, address_conversion_func):
 
 @pytest.yield_fixture
 def unlocked_account_dual_type(web3, unlockable_account_dual_type, unlockable_account_pw):
-    web3.geth.personal.unlockAccount(unlockable_account_dual_type, unlockable_account_pw)
+    web3.geth.personal.unlock_account(unlockable_account_dual_type, unlockable_account_pw)
     yield unlockable_account_dual_type
-    web3.geth.personal.lockAccount(unlockable_account_dual_type)
+    web3.geth.personal.lock_account(unlockable_account_dual_type)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -147,7 +147,7 @@ def unlockable_account_pw(web3):
 
 @pytest.fixture(scope='module')
 def unlockable_account(web3, unlockable_account_pw):
-    account = web3.geth.personal.importRawKey(UNLOCKABLE_PRIVATE_KEY, unlockable_account_pw)
+    account = web3.geth.personal.import_raw_key(UNLOCKABLE_PRIVATE_KEY, unlockable_account_pw)
     web3.eth.sendTransaction({
         'from': web3.eth.coinbase,
         'to': account,
@@ -158,9 +158,9 @@ def unlockable_account(web3, unlockable_account_pw):
 
 @pytest.fixture
 def unlocked_account(web3, unlockable_account, unlockable_account_pw):
-    web3.geth.personal.unlockAccount(unlockable_account, unlockable_account_pw)
+    web3.geth.personal.unlock_account(unlockable_account, unlockable_account_pw)
     yield unlockable_account
-    web3.geth.personal.lockAccount(unlockable_account)
+    web3.geth.personal.lock_account(unlockable_account)
 
 
 @pytest.fixture()
@@ -170,9 +170,9 @@ def unlockable_account_dual_type(unlockable_account, address_conversion_func):
 
 @pytest.fixture
 def unlocked_account_dual_type(web3, unlockable_account_dual_type, unlockable_account_pw):
-    web3.geth.personal.unlockAccount(unlockable_account_dual_type, unlockable_account_pw)
+    web3.geth.personal.unlock_account(unlockable_account_dual_type, unlockable_account_pw)
     yield unlockable_account_dual_type
-    web3.geth.personal.lockAccount(unlockable_account_dual_type)
+    web3.geth.personal.lock_account(unlockable_account_dual_type)
 
 
 @pytest.fixture(scope="module")
@@ -310,7 +310,7 @@ class TestEthereumTesterNetModule(NetModuleTest):
 # Use web3.geth.personal namespace for testing eth-tester
 class TestEthereumTesterPersonalModule(GoEthereumPersonalModuleTest):
     test_personal_sign_and_ecrecover = not_implemented(
-        GoEthereumPersonalModuleTest.test_personal_sign_and_ecrecover,
+        GoEthereumPersonalModuleTest.test_personal_sign_and_ec_recover,
         ValueError,
     )
 
@@ -318,5 +318,5 @@ class TestEthereumTesterPersonalModule(GoEthereumPersonalModuleTest):
     def test_personal_unlockAccount_failure(self,
                                             web3,
                                             unlockable_account_dual_type):
-        result = web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
+        result = web3.geth.personal.unlock_account(unlockable_account_dual_type, 'bad-password')
         assert result is False

--- a/web3/_utils/module_testing/personal_module.py
+++ b/web3/_utils/module_testing/personal_module.py
@@ -20,12 +20,12 @@ ACCOUNT_FOR_UNLOCK = '0x12efDc31B1a8FA1A1e756DFD8A1601055C971E13'
 
 
 class GoEthereumPersonalModuleTest:
-    def test_personal_importRawKey(self, web3):
-        actual = web3.geth.personal.importRawKey(PRIVATE_KEY_HEX, PASSWORD)
+    def test_personal_import_raw_key(self, web3):
+        actual = web3.geth.personal.import_raw_key(PRIVATE_KEY_HEX, PASSWORD)
         assert actual == ADDRESS
 
-    def test_personal_listAccounts(self, web3):
-        accounts = web3.geth.personal.listAccounts()
+    def test_personal_list_accounts(self, web3):
+        accounts = web3.geth.personal.list_accounts()
         assert is_list_like(accounts)
         assert len(accounts) > 0
         assert all((
@@ -34,31 +34,31 @@ class GoEthereumPersonalModuleTest:
             in accounts
         ))
 
-    def test_personal_lockAccount(self, web3, unlockable_account_dual_type):
+    def test_personal_lock_account(self, web3, unlockable_account_dual_type):
         # TODO: how do we test this better?
-        web3.geth.personal.lockAccount(unlockable_account_dual_type)
+        web3.geth.personal.lock_account(unlockable_account_dual_type)
 
-    def test_personal_unlockAccount_success(self,
+    def test_personal_unlock_account_success(self,
                                             web3,
                                             unlockable_account_dual_type,
                                             unlockable_account_pw):
-        result = web3.geth.personal.unlockAccount(
+        result = web3.geth.personal.unlock_account(
             unlockable_account_dual_type,
             unlockable_account_pw
         )
         assert result is True
 
-    def test_personal_unlockAccount_failure(self,
+    def test_personal_unlock_account_failure(self,
                                             web3,
                                             unlockable_account_dual_type):
         with pytest.raises(ValueError):
-            web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
+            web3.geth.personal.unlock_account(unlockable_account_dual_type, 'bad-password')
 
-    def test_personal_newAccount(self, web3):
-        new_account = web3.geth.personal.newAccount(PASSWORD)
+    def test_personal_new_account(self, web3):
+        new_account = web3.geth.personal.new_account(PASSWORD)
         assert is_checksum_address(new_account)
 
-    def test_personal_sendTransaction(self,
+    def test_personal_send_transaction(self,
                                       web3,
                                       unlockable_account_dual_type,
                                       unlockable_account_pw):
@@ -70,7 +70,7 @@ class GoEthereumPersonalModuleTest:
             'value': 1,
             'gasPrice': web3.toWei(1, 'gwei'),
         }
-        txn_hash = web3.geth.personal.sendTransaction(txn_params, unlockable_account_pw)
+        txn_hash = web3.geth.personal.send_transaction(txn_params, unlockable_account_pw)
         assert txn_hash
         transaction = web3.eth.getTransaction(txn_hash)
 
@@ -80,7 +80,7 @@ class GoEthereumPersonalModuleTest:
         assert transaction['value'] == txn_params['value']
         assert transaction['gasPrice'] == txn_params['gasPrice']
 
-    def test_personal_sign_and_ecrecover(self,
+    def test_personal_sign_and_ec_recover(self,
                                          web3,
                                          unlockable_account_dual_type,
                                          unlockable_account_pw):
@@ -90,7 +90,7 @@ class GoEthereumPersonalModuleTest:
             unlockable_account_dual_type,
             unlockable_account_pw
         )
-        signer = web3.geth.personal.ecRecover(message, signature)
+        signer = web3.geth.personal.ec_recover(message, signature)
         assert is_same_address(signer, unlockable_account_dual_type)
 
     @pytest.mark.xfail(reason="personal_signTypedData JSON RPC call has not been released in geth")
@@ -137,7 +137,7 @@ class GoEthereumPersonalModuleTest:
                 }
             }
         '''
-        signature = HexBytes(web3.geth.personal.signTypedData(
+        signature = HexBytes(web3.geth.personal.sign_typed_data(
             json.loads(typed_message),
             unlockable_account_dual_type,
             unlockable_account_pw
@@ -151,191 +151,344 @@ class GoEthereumPersonalModuleTest:
         assert signature == expected_signature
         assert len(signature) == 32 + 32 + 1
 
+    #
+    # Deprecated
+    #    
+    def test_personal_importRawKey(self, web3):
+        with pytest.warns(DeprecationWarning):
+            actual = web3.geth.personal.importRawKey(PRIVATE_KEY_HEX, PASSWORD)
+            assert actual == ADDRESS
 
-class ParityPersonalModuleTest():
     def test_personal_listAccounts(self, web3):
-        accounts = web3.parity.personal.listAccounts()
-        assert is_list_like(accounts)
-        assert len(accounts) > 0
-        assert all((
-            is_checksum_address(item)
-            for item
-            in accounts
-        ))
+        with pytest.warns(DeprecationWarning):
+            accounts = web3.geth.personal.listAccounts()
+            assert is_list_like(accounts)
+            assert len(accounts) > 0
+            assert all((
+                is_checksum_address(item)
+                for item
+                in accounts
+            ))
+
+    def test_personal_lockAccount(self, web3, unlockable_account_dual_type):
+        # TODO: how do we test this better?
+        with pytest.warns(DeprecationWarning):
+            web3.geth.personal.lockAccount(unlockable_account_dual_type)
 
     def test_personal_unlockAccount_success(self,
                                             web3,
                                             unlockable_account_dual_type,
                                             unlockable_account_pw):
-        result = web3.parity.personal.unlockAccount(
-            unlockable_account_dual_type,
-            unlockable_account_pw,
-            None
-        )
-        assert result is True
+        with pytest.warns(DeprecationWarning):
+            result = web3.geth.personal.unlockAccount(
+                unlockable_account_dual_type,
+                unlockable_account_pw
+            )
+            assert result is True
 
-    # Seems to be an issue with Parity since this should return False
     def test_personal_unlockAccount_failure(self,
                                             web3,
                                             unlockable_account_dual_type):
-        result = web3.parity.personal.unlockAccount(
-            unlockable_account_dual_type,
-            'bad-password',
-            None
-        )
-        assert result is True
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(ValueError):
+                web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
 
     def test_personal_newAccount(self, web3):
-        new_account = web3.parity.personal.newAccount(PASSWORD)
-        assert is_checksum_address(new_account)
-
-    @pytest.mark.xfail(reason='this non-standard json-rpc method is not implemented on parity')
-    def test_personal_lockAccount(self, web3, unlocked_account):
-        super().test_personal_lockAccount(web3, unlocked_account)
-
-    @pytest.mark.xfail(reason='this non-standard json-rpc method is not implemented on parity')
-    def test_personal_importRawKey(self, web3):
-        super().test_personal_importRawKey(web3)
+        with pytest.warns(DeprecationWarning):
+            new_account = web3.geth.personal.newAccount(PASSWORD)
+            assert is_checksum_address(new_account)
 
     def test_personal_sendTransaction(self,
                                       web3,
                                       unlockable_account_dual_type,
                                       unlockable_account_pw):
-        assert web3.eth.getBalance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
-        txn_params = {
-            'from': unlockable_account_dual_type,
-            'to': unlockable_account_dual_type,
-            'gas': 21000,
-            'value': 1,
-            'gasPrice': web3.toWei(1, 'gwei'),
-        }
-        txn_hash = web3.parity.personal.sendTransaction(txn_params, unlockable_account_pw)
-        assert txn_hash
-        transaction = web3.eth.getTransaction(txn_hash)
+        with pytest.warns(DeprecationWarning):
+            assert web3.eth.getBalance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
+            txn_params = {
+                'from': unlockable_account_dual_type,
+                'to': unlockable_account_dual_type,
+                'gas': 21000,
+                'value': 1,
+                'gasPrice': web3.toWei(1, 'gwei'),
+            }
+            txn_hash = web3.geth.personal.sendTransaction(txn_params, unlockable_account_pw)
+            assert txn_hash
+            transaction = web3.eth.getTransaction(txn_hash)
 
-        assert is_same_address(transaction['from'], txn_params['from'])
-        assert is_same_address(transaction['to'], txn_params['to'])
-        assert transaction['gas'] == txn_params['gas']
-        assert transaction['value'] == txn_params['value']
-        assert transaction['gasPrice'] == txn_params['gasPrice']
+            assert is_same_address(transaction['from'], txn_params['from'])
+            assert is_same_address(transaction['to'], txn_params['to'])
+            assert transaction['gas'] == txn_params['gas']
+            assert transaction['value'] == txn_params['value']
+            assert transaction['gasPrice'] == txn_params['gasPrice']
 
     def test_personal_sign_and_ecrecover(self,
                                          web3,
                                          unlockable_account_dual_type,
                                          unlockable_account_pw):
-        message = 'test-web3-parity-personal-sign'
-        signature = web3.parity.personal.sign(
-            message,
-            unlockable_account_dual_type,
-            unlockable_account_pw
-        )
-        signer = web3.parity.personal.ecRecover(message, signature)
-        assert is_same_address(signer, unlockable_account_dual_type)
+        with pytest.warns(DeprecationWarning):
+            message = 'test-web3-geth-personal-sign'
+            signature = web3.geth.personal.sign(
+                message,
+                unlockable_account_dual_type,
+                unlockable_account_pw
+            )
+            signer = web3.geth.personal.ecRecover(message, signature)
+            assert is_same_address(signer, unlockable_account_dual_type)
+
+    @pytest.mark.xfail(reason="personal_signTypedData JSON RPC call has not been released in geth")
+    def test_personal_sign_typed_data(self,
+                                      web3,
+                                      unlockable_account_dual_type,
+                                      unlockable_account_pw):
+        with pytest.warns(DeprecationWarning):
+            typed_message = '''
+                {
+                    "types": {
+                        "EIP712Domain": [
+                            {"name": "name", "type": "string"},
+                            {"name": "version", "type": "string"},
+                            {"name": "chainId", "type": "uint256"},
+                            {"name": "verifyingContract", "type": "address"}
+                        ],
+                        "Person": [
+                            {"name": "name", "type": "string"},
+                            {"name": "wallet", "type": "address"}
+                        ],
+                        "Mail": [
+                            {"name": "from", "type": "Person"},
+                            {"name": "to", "type": "Person"},
+                            {"name": "contents", "type": "string"}
+                        ]
+                    },
+                    "primaryType": "Mail",
+                    "domain": {
+                        "name": "Ether Mail",
+                        "version": "1",
+                        "chainId": "0x01",
+                        "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+                    },
+                    "message": {
+                        "from": {
+                            "name": "Cow",
+                            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+                        },
+                        "to": {
+                            "name": "Bob",
+                            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+                        },
+                        "contents": "Hello, Bob!"
+                    }
+                }
+            '''
+            signature = HexBytes(web3.geth.personal.signTypedData(
+                json.loads(typed_message),
+                unlockable_account_dual_type,
+                unlockable_account_pw
+            ))
+
+            expected_signature = HexBytes(
+                "0xc8b56aaeefd10ab4005c2455daf28d9082af661ac347cd"
+                "b612d5b5e11f339f2055be831bf57a6e6cb5f6d93448fa35"
+                "c1bd56fe1d745ffa101e74697108668c401c"
+            )
+            assert signature == expected_signature
+            assert len(signature) == 32 + 32 + 1
+
+
+class ParityPersonalModuleTest():
+    def test_personal_listAccounts(self, web3):
+        with pytest.warns(DeprecationWarning):
+            accounts = web3.parity.personal.listAccounts()
+            assert is_list_like(accounts)
+            assert len(accounts) > 0
+            assert all((
+                is_checksum_address(item)
+                for item
+                in accounts
+            ))
+
+    def test_personal_unlockAccount_success(self,
+                                            web3,
+                                            unlockable_account_dual_type,
+                                            unlockable_account_pw):
+        with pytest.warns(DeprecationWarning):
+            result = web3.parity.personal.unlockAccount(
+                unlockable_account_dual_type,
+                unlockable_account_pw,
+                None
+            )
+            assert result is True
+
+    # Seems to be an issue with Parity since this should return False
+    def test_personal_unlockAccount_failure(self,
+                                            web3,
+                                            unlockable_account_dual_type):
+        with pytest.warns(DeprecationWarning):
+            result = web3.parity.personal.unlockAccount(
+                unlockable_account_dual_type,
+                'bad-password',
+                None
+            )
+            assert result is True
+
+    def test_personal_newAccount(self, web3):
+        with pytest.warns(DeprecationWarning):
+            new_account = web3.parity.personal.newAccount(PASSWORD)
+            assert is_checksum_address(new_account)
+
+    @pytest.mark.xfail(reason='this non-standard json-rpc method is not implemented on parity')
+    def test_personal_lockAccount(self, web3, unlocked_account):
+        with pytest.warns(DeprecationWarning):
+            super().test_personal_lockAccount(web3, unlocked_account)
+
+    @pytest.mark.xfail(reason='this non-standard json-rpc method is not implemented on parity')
+    def test_personal_importRawKey(self, web3):
+        with pytest.warns(DeprecationWarning):
+            super().test_personal_importRawKey(web3)
+
+    def test_personal_sendTransaction(self,
+                                      web3,
+                                      unlockable_account_dual_type,
+                                      unlockable_account_pw):
+        with pytest.warns(DeprecationWarning):
+            assert web3.eth.getBalance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
+            txn_params = {
+                'from': unlockable_account_dual_type,
+                'to': unlockable_account_dual_type,
+                'gas': 21000,
+                'value': 1,
+                'gasPrice': web3.toWei(1, 'gwei'),
+            }
+            txn_hash = web3.parity.personal.sendTransaction(txn_params, unlockable_account_pw)
+            assert txn_hash
+            transaction = web3.eth.getTransaction(txn_hash)
+
+            assert is_same_address(transaction['from'], txn_params['from'])
+            assert is_same_address(transaction['to'], txn_params['to'])
+            assert transaction['gas'] == txn_params['gas']
+            assert transaction['value'] == txn_params['value']
+            assert transaction['gasPrice'] == txn_params['gasPrice']
+
+    def test_personal_sign_and_ecrecover(self,
+                                         web3,
+                                         unlockable_account_dual_type,
+                                         unlockable_account_pw):
+        with pytest.warns(DeprecationWarning):
+            message = 'test-web3-parity-personal-sign'
+            signature = web3.parity.personal.sign(
+                message,
+                unlockable_account_dual_type,
+                unlockable_account_pw
+            )
+            signer = web3.parity.personal.ecRecover(message, signature)
+            assert is_same_address(signer, unlockable_account_dual_type)
 
     def test_personal_sign_typed_data(self,
                                       web3,
                                       unlockable_account_dual_type,
                                       unlockable_account_pw):
-        typed_message = '''
-            {
-                "types": {
-                    "EIP712Domain": [
-                        {"name": "name", "type": "string"},
-                        {"name": "version", "type": "string"},
-                        {"name": "chainId", "type": "uint256"},
-                        {"name": "verifyingContract", "type": "address"}
-                    ],
-                    "Person": [
-                        {"name": "name", "type": "string"},
-                        {"name": "wallet", "type": "address"}
-                    ],
-                    "Mail": [
-                        {"name": "from", "type": "Person"},
-                        {"name": "to", "type": "Person"},
-                        {"name": "contents", "type": "string"}
-                    ]
-                },
-                "primaryType": "Mail",
-                "domain": {
-                    "name": "Ether Mail",
-                    "version": "1",
-                    "chainId": "0x01",
-                    "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
-                },
-                "message": {
-                    "from": {
-                        "name": "Cow",
-                        "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+        with pytest.warns(DeprecationWarning):
+            typed_message = '''
+                {
+                    "types": {
+                        "EIP712Domain": [
+                            {"name": "name", "type": "string"},
+                            {"name": "version", "type": "string"},
+                            {"name": "chainId", "type": "uint256"},
+                            {"name": "verifyingContract", "type": "address"}
+                        ],
+                        "Person": [
+                            {"name": "name", "type": "string"},
+                            {"name": "wallet", "type": "address"}
+                        ],
+                        "Mail": [
+                            {"name": "from", "type": "Person"},
+                            {"name": "to", "type": "Person"},
+                            {"name": "contents", "type": "string"}
+                        ]
                     },
-                    "to": {
-                        "name": "Bob",
-                        "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+                    "primaryType": "Mail",
+                    "domain": {
+                        "name": "Ether Mail",
+                        "version": "1",
+                        "chainId": "0x01",
+                        "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
                     },
-                    "contents": "Hello, Bob!"
+                    "message": {
+                        "from": {
+                            "name": "Cow",
+                            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+                        },
+                        "to": {
+                            "name": "Bob",
+                            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+                        },
+                        "contents": "Hello, Bob!"
+                    }
                 }
-            }
-        '''
-        signature = HexBytes(web3.parity.personal.signTypedData(
-            json.loads(typed_message),
-            unlockable_account_dual_type,
-            unlockable_account_pw
-        ))
+            '''
+            signature = HexBytes(web3.parity.personal.signTypedData(
+                json.loads(typed_message),
+                unlockable_account_dual_type,
+                unlockable_account_pw
+            ))
 
-        expected_signature = HexBytes(
-            "0xc8b56aaeefd10ab4005c2455daf28d9082af661ac347cd"
-            "b612d5b5e11f339f2055be831bf57a6e6cb5f6d93448fa35"
-            "c1bd56fe1d745ffa101e74697108668c401c"
-        )
-        assert signature == expected_signature
-        assert len(signature) == 32 + 32 + 1
+            expected_signature = HexBytes(
+                "0xc8b56aaeefd10ab4005c2455daf28d9082af661ac347cd"
+                "b612d5b5e11f339f2055be831bf57a6e6cb5f6d93448fa35"
+                "c1bd56fe1d745ffa101e74697108668c401c"
+            )
+            assert signature == expected_signature
+            assert len(signature) == 32 + 32 + 1
 
     def test_invalid_personal_sign_typed_data(self,
                                               web3,
                                               unlockable_account_dual_type,
                                               unlockable_account_pw):
-        invalid_typed_message = '''
-            {
-                "types": {
-                    "EIP712Domain": [
-                        {"name": "name", "type": "string"},
-                        {"name": "version", "type": "string"},
-                        {"name": "chainId", "type": "uint256"},
-                        {"name": "verifyingContract", "type": "address"}
-                    ],
-                    "Person": [
-                        {"name": "name", "type": "string"},
-                        {"name": "wallet", "type": "address"}
-                    ],
-                    "Mail": [
-                        {"name": "from", "type": "Person"},
-                        {"name": "to", "type": "Person[2]"},
-                        {"name": "contents", "type": "string"}
-                    ]
-                },
-                "primaryType": "Mail",
-                "domain": {
-                    "name": "Ether Mail",
-                    "version": "1",
-                    "chainId": "0x01",
-                    "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
-                },
-                "message": {
-                    "from": {
-                        "name": "Cow",
-                        "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+        with pytest.warns(DeprecationWarning):
+            invalid_typed_message = '''
+                {
+                    "types": {
+                        "EIP712Domain": [
+                            {"name": "name", "type": "string"},
+                            {"name": "version", "type": "string"},
+                            {"name": "chainId", "type": "uint256"},
+                            {"name": "verifyingContract", "type": "address"}
+                        ],
+                        "Person": [
+                            {"name": "name", "type": "string"},
+                            {"name": "wallet", "type": "address"}
+                        ],
+                        "Mail": [
+                            {"name": "from", "type": "Person"},
+                            {"name": "to", "type": "Person[2]"},
+                            {"name": "contents", "type": "string"}
+                        ]
                     },
-                    "to": [{
-                        "name": "Bob",
-                        "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
-                    }],
-                    "contents": "Hello, Bob!"
+                    "primaryType": "Mail",
+                    "domain": {
+                        "name": "Ether Mail",
+                        "version": "1",
+                        "chainId": "0x01",
+                        "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+                    },
+                    "message": {
+                        "from": {
+                            "name": "Cow",
+                            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+                        },
+                        "to": [{
+                            "name": "Bob",
+                            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+                        }],
+                        "contents": "Hello, Bob!"
+                    }
                 }
-            }
-        '''
-        with pytest.raises(ValueError,
-                           match=r".*Expected 2 items for array type Person\[2\], got 1 items.*"):
-            web3.parity.personal.signTypedData(
-                json.loads(invalid_typed_message),
-                unlockable_account_dual_type,
-                unlockable_account_pw
-            )
+            '''
+            with pytest.raises(ValueError,
+                               match=r".*Expected 2 items for array type Person\[2\], got 1 items.*"):
+                web3.parity.personal.signTypedData(
+                    json.loads(invalid_typed_message),
+                    unlockable_account_dual_type,
+                    unlockable_account_pw
+                )

--- a/web3/_utils/personal.py
+++ b/web3/_utils/personal.py
@@ -1,39 +1,40 @@
 from web3.method import (
+    DeprecatedMethod,
     Method,
     default_root_munger,
 )
 
-importRawKey = Method(
+import_raw_key = Method(
     "personal_importRawKey",
     mungers=[default_root_munger],
 )
 
 
-newAccount = Method(
+new_account = Method(
     "personal_newAccount",
     mungers=[default_root_munger],
 )
 
 
-listAccounts = Method(
+list_accounts = Method(
     "personal_listAccounts",
     mungers=None,
 )
 
 
-sendTransaction = Method(
+send_transaction = Method(
     "personal_sendTransaction",
     mungers=[default_root_munger],
 )
 
 
-lockAccount = Method(
+lock_account = Method(
     "personal_lockAccount",
     mungers=[default_root_munger],
 )
 
 
-unlockAccount = Method(
+unlock_account = Method(
     "personal_unlockAccount",
     mungers=[default_root_munger],
 )
@@ -45,13 +46,26 @@ sign = Method(
 )
 
 
-signTypedData = Method(
+sign_typed_data = Method(
     "personal_signTypedData",
     mungers=[default_root_munger],
 )
 
 
-ecRecover = Method(
+ec_recover = Method(
     "personal_ecRecover",
     mungers=[default_root_munger],
 )
+
+
+#
+# Deprecated Methods
+#
+importRawKey = DeprecatedMethod(import_raw_key, 'importRawKey', 'import_raw_key')
+newAccount = DeprecatedMethod(new_account, 'newAccount', 'new_account')
+listAccounts = DeprecatedMethod(list_accounts, 'listAccounts', 'list_accounts')
+sendTransaction = DeprecatedMethod(send_transaction, 'sendTransaction', 'send_transaction')
+lockAccount = DeprecatedMethod(lock_account, 'lockAccount', 'lock_account')
+unlockAccount = DeprecatedMethod(unlock_account, 'unlockAccount', 'unlock_account')
+signTypedData = DeprecatedMethod(sign_typed_data, 'signTypedData', 'sign_typed_data')
+ecRecover = DeprecatedMethod(ec_recover, 'ecRecover', 'ec_recover')

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -29,14 +29,22 @@ from web3._utils.miner import (
 )
 from web3._utils.personal import (
     ecRecover,
+    ec_recover,
     importRawKey,
+    import_raw_key,
     listAccounts,
+    list_accounts,
     lockAccount,
+    lock_account,
     newAccount,
+    new_account,
     sendTransaction,
+    send_transaction,
     sign,
     signTypedData,
+    sign_typed_data,
     unlockAccount,
+    unlock_account,
 )
 from web3._utils.txpool import (
     content,
@@ -57,13 +65,22 @@ class GethPersonal(ModuleV2):
     """
     https://github.com/ethereum/go-ethereum/wiki/management-apis#personal
     """
+    ec_recover = ec_recover
+    import_raw_key = import_raw_key
+    list_accounts = list_accounts
+    lock_account = lock_account
+    new_account = new_account
+    send_transaction = send_transaction
+    sign = sign
+    sign_typed_data = sign_typed_data
+    unlock_account = unlock_account
+    # deprecated
     ecRecover = ecRecover
     importRawKey = importRawKey
     listAccounts = listAccounts
     lockAccount = lockAccount
     newAccount = newAccount
     sendTransaction = sendTransaction
-    sign = sign
     signTypedData = signTypedData
     unlockAccount = unlockAccount
 

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -9,14 +9,14 @@ from web3._utils import (
     shh,
 )
 from web3._utils.personal import (
-    ecRecover,
-    importRawKey,
-    listAccounts,
-    newAccount,
-    sendTransaction,
+    ec_recover,
+    import_raw_key,
+    list_accounts,
+    new_account,
+    send_transaction,
     sign,
-    signTypedData,
-    unlockAccount,
+    sign_typed_data,
+    unlock_account,
 )
 from web3.module import (
     Module,
@@ -61,14 +61,22 @@ class ParityPersonal(ModuleV2):
     """
     https://wiki.parity.io/JSONRPC-personal-module
     """
-    ecRecover = ecRecover
-    importRawKey = importRawKey
-    listAccounts = listAccounts
-    newAccount = newAccount
-    sendTransaction = sendTransaction
     sign = sign
-    signTypedData = signTypedData
-    unlockAccount = unlockAccount
+    ec_recover = ec_recover
+    import_raw_key = import_raw_key
+    list_accounts = list_accounts
+    new_account = new_account
+    send_transaction = send_transaction
+    sign_typed_data = sign_typed_data
+    unlock_account = unlock_account
+    # Deprecated
+    ecRecover = ec_recover
+    importRawKey = import_raw_key
+    listAccounts = list_accounts
+    newAccount = new_account
+    sendTransaction = send_transaction
+    signTypedData = sign_typed_data
+    unlockAccount = unlock_account
 
 
 class Parity(Module):

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -352,22 +352,30 @@ API_ENDPOINTS = {
         'stopAutoDAG': not_implemented,
     },
     'personal': {
-        'ecRecover': not_implemented,
-        'importRawKey': call_eth_tester('add_account'),
-        'listAccounts': call_eth_tester('get_accounts'),
-        'lockAccount': excepts(
+        'ec_recover': not_implemented,
+        'import_raw_key': call_eth_tester('add_account'),
+        'list_accounts': call_eth_tester('get_accounts'),
+        'lock_account': excepts(
             ValidationError,
             compose(static_return(True), call_eth_tester('lock_account')),
             static_return(False),
         ),
-        'newAccount': create_new_account,
-        'unlockAccount': excepts(
+        'new_account': create_new_account,
+        'unlock_account': excepts(
             ValidationError,
             compose(static_return(True), call_eth_tester('unlock_account')),
             static_return(False),
         ),
-        'sendTransaction': personal_send_transaction,
+        'send_transaction': personal_send_transaction,
         'sign': not_implemented,
+        # deprecated
+        'ecRecover': not_implemented,
+        'importRawKey': not_implemented,
+        'listAccounts': not_implemented,
+        'lockAccount': not_implemented,
+        'newAccount': not_implemented,
+        'unlockAccount': not_implemented,
+        'sendTransaction': not_implemented,
     },
     'testing': {
         'timeTravel': call_eth_tester('time_travel'),


### PR DESCRIPTION
### What was wrong?
GethPersonal module needed to use snake_case names for JSON-RPC methods.
Related to Issue https://github.com/ethereum/web3.py/issues/1429

### How was it fixed?
Added deprecation warnings to the old method tests in GethPersonal class , added new snake_case methods to said class, added methods to the eth-tester, updated GethPersonal rst file in the docs.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/66/36/74/663674bc8ac58e2016f08cf58113f5e4.jpg)
