### PR TITLE
Add python3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,6 +370,113 @@ jobs:
     environment:
       TOXENV: py37-integration-ethtester
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
+  #
+  # Python 3.8
+  #
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXENV: py38-core
+
+  py38-ens:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXENV: py38-ens
+
+  py38-ethpm:
+    <<: *ethpm_steps
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXENV: py38-ethpm
+      WEB3_INFURA_PROJECT_ID: 4f1a358967c7474aae6f8f4a7698aefc
+
+  py38-integration-goethereum-ipc-1.7.2:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXENV: py38-integration-goethereum-ipc
+      GETH_VERSION: v1.7.2
+
+  py38-integration-goethereum-http-1.7.2:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXENV: py38-integration-goethereum-http
+      GETH_VERSION: v1.7.2
+
+  py38-integration-goethereum-ws-1.7.2:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXENV: py38-integration-goethereum-ws
+      GETH_VERSION: v1.7.2
+
+  py38-integration-goethereum-ipc-1.8.22:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXENV: py38-integration-goethereum-ipc
+      GETH_VERSION: v1.8.22
+
+  py38-integration-goethereum-http-1.8.22:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXENV: py38-integration-goethereum-http
+      GETH_VERSION: v1.8.22
+
+  py38-integration-goethereum-ws-1.8.22:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXENV: py38-integration-goethereum-ws
+      GETH_VERSION: v1.8.22
+
+  py38-integration-parity-ipc:
+    <<: *parity_steps
+    docker:
+      - image: circleci/python:3.8-stretch
+    environment:
+      TOXENV: py38-integration-parity-ipc
+      PARITY_VERSION: v2.3.5
+      PARITY_OS: linux
+
+  py37-integration-parity-http:
+    <<: *parity_steps
+    docker:
+      - image: circleci/python:3.8-stretch
+    environment:
+      TOXENV: py38-integration-parity-http
+      PARITY_VERSION: v2.3.5
+      PARITY_OS: linux
+
+  py38-integration-parity-ws:
+    <<: *parity_steps
+    docker:
+      - image: circleci/python:3.8-stretch
+    environment:
+      TOXENV: py38-integration-parity-ws
+      PARITY_VERSION: v2.3.5
+      PARITY_OS: linux
+
+  py38-integration-ethtester-pyevm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+    environment:
+      TOXENV: py38-integration-ethtester
+      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
 
 workflows:
   version: 2
@@ -403,3 +510,16 @@ workflows:
       - py37-integration-parity-http
       - py37-integration-parity-ws
       - py37-integration-ethtester-pyevm
+      - py38-core
+      - py38-ens
+      - py38-ethpm
+      - py38-integration-goethereum-ipc-1.7.2
+      - py38-integration-goethereum-http-1.7.2
+      - py38-integration-goethereum-ws-1.7.2
+      - py38-integration-goethereum-ipc-1.8.22
+      - py38-integration-goethereum-http-1.8.22
+      - py38-integration-goethereum-ws-1.8.22
+      - py38-integration-parity-ipc
+      - py38-integration-parity-http
+      - py38-integration-parity-ws
+      - py38-integration-ethtester-pyevm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,9 @@ jobs:
       - image: circleci/python:3.6
     environment:
       TOXENV: py36-ethpm
-      WEB3_INFURA_PROJECT_ID: 4f1a358967c7474aae6f8f4a7698aefc
+      # Please don't use this key for any shenanigans
+      WEB3_INFURA_PROJECT_ID: 7707850c2fb7465ebe6f150d67182e22
+      WEB3_INFURA_API_SECRET: 1955838f22ac4d858434f41498557130
 
   py36-integration-goethereum-ipc-1.7.2:
     <<: *geth_steps
@@ -286,7 +288,8 @@ jobs:
       - image: circleci/python:3.7
     environment:
       TOXENV: py37-ethpm
-      WEB3_INFURA_PROJECT_ID: 4f1a358967c7474aae6f8f4a7698aefc
+      WEB3_INFURA_PROJECT_ID: ae13436d29b34850b640af9c80f80871
+      WEB3_INFURA_API_SECRET: 067ddad6021048f0840a38a4e52eb568
 
   py37-integration-goethereum-ipc-1.7.2:
     <<: *geth_steps
@@ -393,7 +396,8 @@ jobs:
       - image: circleci/python:3.8
     environment:
       TOXENV: py38-ethpm
-      WEB3_INFURA_PROJECT_ID: 4f1a358967c7474aae6f8f4a7698aefc
+      WEB3_INFURA_PROJECT_ID: ae13436d29b34850b640af9c80f80871
+      WEB3_INFURA_API_SECRET: 067ddad6021048f0840a38a4e52eb568
 
   py38-integration-goethereum-ipc-1.7.2:
     <<: *geth_steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,16 +446,16 @@ jobs:
   py38-integration-parity-ipc:
     <<: *parity_steps
     docker:
-      - image: circleci/python:3.8-stretch
+      - image: circleci/python:3.8
     environment:
       TOXENV: py38-integration-parity-ipc
       PARITY_VERSION: v2.3.5
       PARITY_OS: linux
 
-  py37-integration-parity-http:
+  py38-integration-parity-http:
     <<: *parity_steps
     docker:
-      - image: circleci/python:3.8-stretch
+      - image: circleci/python:3.8
     environment:
       TOXENV: py38-integration-parity-http
       PARITY_VERSION: v2.3.5
@@ -464,7 +464,7 @@ jobs:
   py38-integration-parity-ws:
     <<: *parity_steps
     docker:
-      - image: circleci/python:3.8-stretch
+      - image: circleci/python:3.8
     environment:
       TOXENV: py38-integration-parity-ws
       PARITY_VERSION: v2.3.5

--- a/newsfragments/1471.misc.rst
+++ b/newsfragments/1471.misc.rst
@@ -1,0 +1,1 @@
+Add python3.8 support

--- a/setup.py
+++ b/setup.py
@@ -98,5 +98,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@ extras_require = {
         "eth-tester[py-evm]==v0.2.0-beta.2",
         "py-geth>=2.0.1,<3.0.0",
     ],
-    'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],
-    'eth-tester-rpc': ['eth-tester-rpc==0.1.0b2'],
     'linter': [
         "flake8==3.4.1",
         "isort>=4.2.15,<4.3.5",

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "eth-account>=0.4.0,<0.5.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",
-        "eth-utils>=1.4.0,<2.0.0",
+        "eth-utils>=1.8.0,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "ipfshttpclient>=0.4.12,<1",
         "jsonschema>=3.0.0,<4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ extras_require = {
         "eth-tester[py-evm]==v0.2.0-beta.2",
         "py-geth>=2.0.1,<3.0.0",
     ],
+    'testrpc': ["eth-testrpc>=1.3.3,<2.0.0"],
+    'eth-tester-rpc': ['eth-tester-rpc==0.1.0b2'],
     'linter': [
         "flake8==3.4.1",
         "isort>=4.2.15,<4.3.5",
@@ -79,7 +81,7 @@ setup(
         "protobuf>=3.0.0,<4",
         "pypiwin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
-        "websockets>=7.0.0,<8.0.0",
+        "websockets>=8.1.0,<9.0.0",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.6,<4',

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -1,8 +1,6 @@
 import asyncio
-from concurrent.futures import (
-    TimeoutError,
-)
 import pytest
+import sys
 from threading import (
     Thread,
 )
@@ -19,6 +17,15 @@ from web3.exceptions import (
 from web3.providers.websocket import (
     WebsocketProvider,
 )
+
+if sys.version_info >= (3, 8):
+    from asyncio.exceptions import (
+        TimeoutError,
+    )
+else:
+    from concurrent.futures import (
+        TimeoutError,
+    )
 
 
 @pytest.yield_fixture

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist=
-    py{36,37}-ens
-    py{36,37}-ethpm
-    py{36,37}-core
-    py{36,37}-integration-{goethereum,ethtester,parity}
+    py{36,37,38}-ens
+    py{36,37,38}-ethpm
+    py{36,37,38}-core
+    py{36,37,38}-integration-{goethereum,ethtester,parity}
     lint
     docs
 
@@ -55,6 +55,7 @@ basepython =
     docs: python3.6
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 
 [testenv:lint]
 basepython=python

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ passenv =
     GOROOT
     GOPATH
     WEB3_INFURA_PROJECT_ID
+    WEB3_INFURA_API_SECRET
 basepython =
     docs: python3.6
     py36: python3.6


### PR DESCRIPTION
### What was wrong?
web3.py doesn't support python3.8.


### How was it fixed?
Add support for python 3.8. 
### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/hx6b030722t31.jpg)
