### PR TITLE
Re-fix flaky parity test

### DIFF
--- a/newsfragments/1473.bugfix.rst
+++ b/newsfragments/1473.bugfix.rst
@@ -1,0 +1,1 @@
+Fix flaky Parity whisper module test

--- a/web3/_utils/module_testing/shh_module.py
+++ b/web3/_utils/module_testing/shh_module.py
@@ -504,6 +504,10 @@ class ParityShhModuleTest():
 
         watcher.stop()
 
+    # Sometimes the post fails because PoW is too low.
+    # We don't care if an error or a True response comes back,
+    # we only care that we're interfacing correctly with Parity
+    @pytest.mark.xfail(strict=False, raises=ValueError)
     def test_shh_remove_filter(self, web3):
         receiver = web3.parity.shh.new_key_pair()
         receiver_pub = web3.parity.shh.get_public_key(receiver)
@@ -567,6 +571,11 @@ class ParityShhModuleTest():
     #
     # shh_post
     #
+
+    # Sometimes the post fails because PoW is too low.
+    # We don't care if an error or a True response comes back,
+    # we only care that we're interfacing correctly with Parity
+    @pytest.mark.xfail(strict=False, raises=ValueError)
     def test_shh_post(self, web3):
         sender = web3.parity.shh.new_key_pair()
         assert web3.parity.shh.post({


### PR DESCRIPTION
### What was wrong?
The flaky parity tests have resurfaced. The fix got overwritten in a previous commit. 

### How was it fixed?
Added back the original couple lines from #1447 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="247" alt="image" src="https://user-images.githubusercontent.com/6540608/67050662-3c8ceb00-f0f6-11e9-9061-780d0c23f986.png">

