### PR TITLE
fixed deprecation warning

### DIFF
--- a/newsfragments/1474.misc.rst
+++ b/newsfragments/1474.misc.rst
@@ -1,0 +1,1 @@
+Removed last eth-account method that was issuing a DeprecationWarning

--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -75,7 +75,7 @@ def _(val):
 
 def private_key_to_account(val):
     normalized_key = key_normalizer(val)
-    return Account.privateKeyToAccount(normalized_key)
+    return Account.from_key(normalized_key)
 
 
 to_account.register(PrivateKey, private_key_to_account)


### PR DESCRIPTION
### What was wrong?

#1468 was a great Pull Request to fix deprecation warnings. However, I think they missed something.

### How was it fixed?

Searching for `privateKeyToAccount` in the whole project and replaced with `from_key`. One single match, which causes deprecation warnings in my project.

### Todo:
- [x] Add entry to the [release notes] -- actually, there's already an entry in #1468. Should I add some more?

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/781926/67070919-92f33b80-f181-11e9-93a6-bd454114945a.png)

