### PR TITLE
Remove warnings from asyncio version module specs

### DIFF
--- a/newsfragments/1476.misc.rst
+++ b/newsfragments/1476.misc.rst
@@ -1,0 +1,1 @@
+Remove warnings from asyncio version module tests

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ extras_require = {
         "flaky>=3.3.0",
         "hypothesis>=3.31.2",
         "pytest>=4.4.0,<5.0.0",
+        "pytest-asyncio>=0.10.0,<0.11",
         "pytest-mock>=1.10,<2",
         "pytest-pythonpath>=0.3",
         "pytest-watch>=4.2,<5",

--- a/tests/core/version-module/test_version_module.py
+++ b/tests/core/version-module/test_version_module.py
@@ -4,6 +4,9 @@ from web3 import (
     EthereumTesterProvider,
     Web3,
 )
+from web3.eth import (
+    Eth,
+)
 from web3.providers.eth_tester.main import (
     AsyncEthereumTesterProvider,
 )
@@ -24,6 +27,7 @@ def blocking_w3():
         modules={
             "blocking_version": (BlockingVersion,),
             "legacy_version": (Version,),
+            "eth": (Eth,),
         })
 
 
@@ -46,11 +50,7 @@ def test_legacy_version_deprecation(blocking_w3):
 
 @pytest.mark.asyncio
 async def test_async_blocking_version(async_w3, blocking_w3):
-    assert async_w3.async_version.api == blocking_w3.legacy_version.api
+    assert async_w3.async_version.api == blocking_w3.api
 
-    assert await async_w3.async_version.node == blocking_w3.legacy_version.node
-    with pytest.raises(
-        ValueError,
-        message="RPC Endpoint has not been implemented: eth_protocolVersion"
-    ):
-        assert await async_w3.async_version.ethereum == blocking_w3.legacy_version.ethereum
+    assert await async_w3.async_version.node == blocking_w3.clientVersion
+    assert await async_w3.async_version.ethereum == int(blocking_w3.eth.protocolVersion)


### PR DESCRIPTION
### What was wrong?
Pytest was skipping one of the version-module tests because it didn't know what `pytest.mark.asyncio` is. 

### How was it fixed?
Installed pytest-asyncio, added to `setup.py`, and updated the tests so they aren't failing.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="400" alt="image" src="https://user-images.githubusercontent.com/6540608/67229022-ad364f00-f3f7-11e9-862a-5c5c83d18549.png">

