### PR TITLE
Upgrade Websockets to v8

### DIFF
--- a/newsfragments/1477.misc.rst
+++ b/newsfragments/1477.misc.rst
@@ -1,0 +1,1 @@
+Remove warnings stemming from using an older version of Websockets

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "protobuf>=3.0.0,<4",
         "pypiwin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
-        "websockets>=7.0.0,<8.0.0",
+        "websockets>=8.0.0,<9.0.0",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.6,<4',


### PR DESCRIPTION
### What was wrong?
Tests were showing a deprecation warning that should be fixed with a `websocket` dependency upgrade to v8.


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="168" alt="image" src="https://user-images.githubusercontent.com/6540608/67234184-e83d8000-f401-11e9-9f98-359176713dc3.png">

