### PR TITLE
Add Web3Exception to all exception classes

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -215,7 +215,7 @@ Each Contract Factory exposes the following methods.
 
 .. py:classmethod:: Contract.constructor(*args, **kwargs).build_transaction(transaction=None)
     :noindex:
-    
+
     Construct the contract deploy transaction bytecode data.
 
     If the contract takes constructor parameters they should be provided as
@@ -435,7 +435,7 @@ and the arguments are ambiguous.
         }
         """
         # fast forward all the steps of compiling and deploying the contract.
-        >>> ambiguous_contract.functions.identity(1, True) # raises ValidationError
+        >>> ambiguous_contract.functions.identity(1, True) # raises Web3ValidationError
 
         >>> identity_func = ambiguous_contract.get_function_by_signature('identity(uint256,bool)')
         >>> identity_func(1, True)
@@ -654,7 +654,7 @@ Taking the following contract code as an example:
     >>> array_contract.functions.setBytes2Value([b'a']).transact()
     Traceback (most recent call last):
        ...
-    ValidationError:
+    Web3ValidationError:
     Could not identify the intended function with name `setBytes2Value`
 
 

--- a/ens/exceptions.py
+++ b/ens/exceptions.py
@@ -1,7 +1,15 @@
 import idna
 
 
-class AddressMismatch(ValueError):
+class ENSError(Exception):
+    """
+    Base class for all ENS Errors
+    """
+
+    pass
+
+
+class AddressMismatch(ENSError):
     """
     In order to set up reverse resolution correctly, the ENS name should first
     point to the address. This exception is raised if the name does
@@ -11,7 +19,7 @@ class AddressMismatch(ValueError):
     pass
 
 
-class InvalidName(idna.IDNAError):
+class InvalidName(idna.IDNAError, ENSError):
     """
     This exception is raised if the provided name does not meet
     the syntax standards specified in `EIP 137 name syntax
@@ -23,7 +31,7 @@ class InvalidName(idna.IDNAError):
     pass
 
 
-class UnauthorizedError(Exception):
+class UnauthorizedError(ENSError):
     """
     Raised if the sending account is not the owner of the name
     you are trying to modify. Make sure to set ``from`` in the
@@ -33,7 +41,7 @@ class UnauthorizedError(Exception):
     pass
 
 
-class UnownedName(Exception):
+class UnownedName(ENSError):
     """
     Raised if you are trying to modify a name that no one owns.
 
@@ -44,7 +52,7 @@ class UnownedName(Exception):
     pass
 
 
-class ResolverNotFound(Exception):
+class ResolverNotFound(ENSError):
     """
     Raised if no resolver was found for the name you are trying to resolve.
     """
@@ -52,7 +60,7 @@ class ResolverNotFound(Exception):
     pass
 
 
-class UnsupportedFunction(Exception):
+class UnsupportedFunction(ENSError):
     """
     Raised if a resolver does not support a particular method.
     """
@@ -60,7 +68,7 @@ class UnsupportedFunction(Exception):
     pass
 
 
-class BidTooLow(ValueError):
+class BidTooLow(ENSError):
     """
     Raised if you bid less than the minimum amount
     """
@@ -68,7 +76,7 @@ class BidTooLow(ValueError):
     pass
 
 
-class InvalidBidHash(ValueError):
+class InvalidBidHash(ENSError):
     """
     Raised if you supply incorrect data to generate the bid hash.
     """
@@ -76,7 +84,7 @@ class InvalidBidHash(ValueError):
     pass
 
 
-class InvalidLabel(ValueError):
+class InvalidLabel(ENSError):
     """
     Raised if you supply an invalid label
     """
@@ -84,7 +92,7 @@ class InvalidLabel(ValueError):
     pass
 
 
-class OversizeTransaction(ValueError):
+class OversizeTransaction(ENSError):
     """
     Raised if a transaction you are trying to create would cost so
     much gas that it could not fit in a block.
@@ -95,7 +103,7 @@ class OversizeTransaction(ValueError):
     pass
 
 
-class UnderfundedBid(ValueError):
+class UnderfundedBid(ENSError):
     """
     Raised if you send less wei with your bid than you declared
     as your intent to bid.

--- a/ens/exceptions.py
+++ b/ens/exceptions.py
@@ -1,3 +1,6 @@
+from eth_utils import (
+    ValidationError,
+)
 import idna
 
 
@@ -110,3 +113,9 @@ class UnderfundedBid(ENSException):
     """
 
     pass
+
+
+class ENSValidationError(ENSException, ValidationError):
+    """
+    Raised if there is a validation error
+    """

--- a/ens/exceptions.py
+++ b/ens/exceptions.py
@@ -1,7 +1,7 @@
 import idna
 
 
-class ENSError(Exception):
+class ENSException(Exception):
     """
     Base class for all ENS Errors
     """
@@ -9,7 +9,7 @@ class ENSError(Exception):
     pass
 
 
-class AddressMismatch(ENSError):
+class AddressMismatch(ENSException):
     """
     In order to set up reverse resolution correctly, the ENS name should first
     point to the address. This exception is raised if the name does
@@ -19,7 +19,7 @@ class AddressMismatch(ENSError):
     pass
 
 
-class InvalidName(idna.IDNAError, ENSError):
+class InvalidName(idna.IDNAError, ENSException):
     """
     This exception is raised if the provided name does not meet
     the syntax standards specified in `EIP 137 name syntax
@@ -31,7 +31,7 @@ class InvalidName(idna.IDNAError, ENSError):
     pass
 
 
-class UnauthorizedError(ENSError):
+class UnauthorizedError(ENSException):
     """
     Raised if the sending account is not the owner of the name
     you are trying to modify. Make sure to set ``from`` in the
@@ -41,7 +41,7 @@ class UnauthorizedError(ENSError):
     pass
 
 
-class UnownedName(ENSError):
+class UnownedName(ENSException):
     """
     Raised if you are trying to modify a name that no one owns.
 
@@ -52,7 +52,7 @@ class UnownedName(ENSError):
     pass
 
 
-class ResolverNotFound(ENSError):
+class ResolverNotFound(ENSException):
     """
     Raised if no resolver was found for the name you are trying to resolve.
     """
@@ -60,7 +60,7 @@ class ResolverNotFound(ENSError):
     pass
 
 
-class UnsupportedFunction(ENSError):
+class UnsupportedFunction(ENSException):
     """
     Raised if a resolver does not support a particular method.
     """
@@ -68,7 +68,7 @@ class UnsupportedFunction(ENSError):
     pass
 
 
-class BidTooLow(ENSError):
+class BidTooLow(ENSException):
     """
     Raised if you bid less than the minimum amount
     """
@@ -76,7 +76,7 @@ class BidTooLow(ENSError):
     pass
 
 
-class InvalidBidHash(ENSError):
+class InvalidBidHash(ENSException):
     """
     Raised if you supply incorrect data to generate the bid hash.
     """
@@ -84,7 +84,7 @@ class InvalidBidHash(ENSError):
     pass
 
 
-class InvalidLabel(ENSError):
+class InvalidLabel(ENSException):
     """
     Raised if you supply an invalid label
     """
@@ -92,7 +92,7 @@ class InvalidLabel(ENSError):
     pass
 
 
-class OversizeTransaction(ENSError):
+class OversizeTransaction(ENSException):
     """
     Raised if a transaction you are trying to create would cost so
     much gas that it could not fit in a block.
@@ -103,7 +103,7 @@ class OversizeTransaction(ENSError):
     pass
 
 
-class UnderfundedBid(ENSError):
+class UnderfundedBid(ENSException):
     """
     Raised if you send less wei with your bid than you declared
     as your intent to bid.

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -24,7 +24,6 @@ from eth_typing import (
     HexStr,
 )
 from eth_utils import (
-    ValidationError,
     is_same_address,
     remove_0x_prefix,
     to_bytes,
@@ -47,6 +46,7 @@ from ens.constants import (
     REVERSE_REGISTRAR_DOMAIN,
 )
 from ens.exceptions import (
+    ENSValidationError,
     InvalidName,
 )
 
@@ -142,7 +142,9 @@ def ens_encode_name(name: str) -> bytes:
     # raises if len(label) > 255:
     for index, label in enumerate(labels):
         if len(label) > 255:
-            raise ValidationError(f"Label at position {index} too long after encoding.")
+            raise ENSValidationError(
+                f"Label at position {index} too long after encoding."
+            )
 
     # concat label size in bytes to each label:
     dns_prepped_labels = [to_bytes(len(label)) + label for label in labels_as_bytes]

--- a/ethpm/exceptions.py
+++ b/ethpm/exceptions.py
@@ -53,3 +53,11 @@ class ManifestBuildingError(PyEthPMException):
     """
 
     pass
+
+
+class ManifestValidationError(PyEthPMException):
+    """
+    Raised when a provided manifest cannot be published, since it's invalid.
+    """
+
+    pass

--- a/ethpm/exceptions.py
+++ b/ethpm/exceptions.py
@@ -1,3 +1,8 @@
+from eth_utils import (
+    ValidationError,
+)
+
+
 class EthPMException(Exception):
     """
     Base class for all Py-EthPM errors.
@@ -15,7 +20,7 @@ class InsufficientAssetsError(EthPMException):
     pass
 
 
-class EthPMValidationError(EthPMException):
+class EthPMValidationError(EthPMException, ValidationError):
     """
     Raised when something does not pass a validation check.
     """

--- a/ethpm/exceptions.py
+++ b/ethpm/exceptions.py
@@ -1,4 +1,4 @@
-class PyEthPMError(Exception):
+class PyEthPMException(Exception):
     """
     Base class for all Py-EthPM errors.
     """
@@ -6,7 +6,7 @@ class PyEthPMError(Exception):
     pass
 
 
-class InsufficientAssetsError(PyEthPMError):
+class InsufficientAssetsError(PyEthPMException):
     """
     Raised when a Manifest or Package does not contain the required
     assets to do something.
@@ -15,7 +15,7 @@ class InsufficientAssetsError(PyEthPMError):
     pass
 
 
-class EthPMValidationError(PyEthPMError):
+class EthPMValidationError(PyEthPMException):
     """
     Raised when something does not pass a validation check.
     """
@@ -23,7 +23,7 @@ class EthPMValidationError(PyEthPMError):
     pass
 
 
-class CannotHandleURI(PyEthPMError):
+class CannotHandleURI(PyEthPMException):
     """
     Raised when the given URI cannot be served by any of the available backends.
     """
@@ -31,7 +31,7 @@ class CannotHandleURI(PyEthPMError):
     pass
 
 
-class FailureToFetchIPFSAssetsError(PyEthPMError):
+class FailureToFetchIPFSAssetsError(PyEthPMException):
     """
     Raised when an attempt to fetch a Package's assets via IPFS failed.
     """
@@ -39,7 +39,7 @@ class FailureToFetchIPFSAssetsError(PyEthPMError):
     pass
 
 
-class BytecodeLinkingError(PyEthPMError):
+class BytecodeLinkingError(PyEthPMException):
     """
     Raised when an attempt to link a contract factory's bytecode failed.
     """
@@ -47,7 +47,7 @@ class BytecodeLinkingError(PyEthPMError):
     pass
 
 
-class ManifestBuildingError(PyEthPMError):
+class ManifestBuildingError(PyEthPMException):
     """
     Raised when an attempt to build a manifest failed.
     """

--- a/ethpm/exceptions.py
+++ b/ethpm/exceptions.py
@@ -1,4 +1,4 @@
-class PyEthPMException(Exception):
+class EthPMException(Exception):
     """
     Base class for all Py-EthPM errors.
     """
@@ -6,7 +6,7 @@ class PyEthPMException(Exception):
     pass
 
 
-class InsufficientAssetsError(PyEthPMException):
+class InsufficientAssetsError(EthPMException):
     """
     Raised when a Manifest or Package does not contain the required
     assets to do something.
@@ -15,7 +15,7 @@ class InsufficientAssetsError(PyEthPMException):
     pass
 
 
-class EthPMValidationError(PyEthPMException):
+class EthPMValidationError(EthPMException):
     """
     Raised when something does not pass a validation check.
     """
@@ -23,7 +23,7 @@ class EthPMValidationError(PyEthPMException):
     pass
 
 
-class CannotHandleURI(PyEthPMException):
+class CannotHandleURI(EthPMException):
     """
     Raised when the given URI cannot be served by any of the available backends.
     """
@@ -31,7 +31,7 @@ class CannotHandleURI(PyEthPMException):
     pass
 
 
-class FailureToFetchIPFSAssetsError(PyEthPMException):
+class FailureToFetchIPFSAssetsError(EthPMException):
     """
     Raised when an attempt to fetch a Package's assets via IPFS failed.
     """
@@ -39,7 +39,7 @@ class FailureToFetchIPFSAssetsError(PyEthPMException):
     pass
 
 
-class BytecodeLinkingError(PyEthPMException):
+class BytecodeLinkingError(EthPMException):
     """
     Raised when an attempt to link a contract factory's bytecode failed.
     """
@@ -47,7 +47,7 @@ class BytecodeLinkingError(PyEthPMException):
     pass
 
 
-class ManifestBuildingError(PyEthPMException):
+class ManifestBuildingError(EthPMException):
     """
     Raised when an attempt to build a manifest failed.
     """
@@ -55,7 +55,7 @@ class ManifestBuildingError(PyEthPMException):
     pass
 
 
-class ManifestValidationError(PyEthPMException):
+class ManifestValidationError(EthPMException):
     """
     Raised when a provided manifest cannot be published, since it's invalid.
     """

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -56,7 +56,7 @@ from ethpm.exceptions import (
     EthPMValidationError,
     FailureToFetchIPFSAssetsError,
     InsufficientAssetsError,
-    PyEthPMError,
+    PyEthPMException,
 )
 from ethpm.uri import (
     resolve_uri_contents,
@@ -338,7 +338,7 @@ class Package(object):
             try:
                 validate_build_dependency(name, uri)
                 dependency_package = Package.from_uri(uri, self.w3)
-            except PyEthPMError as e:
+            except PyEthPMException as e:
                 raise FailureToFetchIPFSAssetsError(
                     f"Failed to retrieve build dependency: {name} from URI: {uri}.\n"
                     f"Got error: {e}."

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -53,10 +53,10 @@ from ethpm.deployments import (
 )
 from ethpm.exceptions import (
     BytecodeLinkingError,
+    EthPMException,
     EthPMValidationError,
     FailureToFetchIPFSAssetsError,
     InsufficientAssetsError,
-    PyEthPMException,
 )
 from ethpm.uri import (
     resolve_uri_contents,
@@ -338,7 +338,7 @@ class Package(object):
             try:
                 validate_build_dependency(name, uri)
                 dependency_package = Package.from_uri(uri, self.w3)
-            except PyEthPMException as e:
+            except EthPMException as e:
                 raise FailureToFetchIPFSAssetsError(
                     f"Failed to retrieve build dependency: {name} from URI: {uri}.\n"
                     f"Got error: {e}."

--- a/newsfragments/1478.breaking.rst
+++ b/newsfragments/1478.breaking.rst
@@ -1,0 +1,1 @@
+All exceptions inherit from a custom class. EthPM exceptions inherit from PyEthPMError, ENS exceptions inherit from ENS Error, and all other web3.py exceptions inherit from Web3Exception

--- a/newsfragments/1478.breaking.rst
+++ b/newsfragments/1478.breaking.rst
@@ -1,1 +1,1 @@
-All exceptions inherit from a custom class. EthPM exceptions inherit from PyEthPMException, ENS exceptions inherit from ENSException, and all other web3.py exceptions inherit from Web3Exception
+All exceptions inherit from a custom class. EthPM exceptions inherit from EthPMException, ENS exceptions inherit from ENSException, and all other web3.py exceptions inherit from Web3Exception

--- a/newsfragments/1478.breaking.rst
+++ b/newsfragments/1478.breaking.rst
@@ -1,1 +1,1 @@
-All exceptions inherit from a custom class. EthPM exceptions inherit from PyEthPMError, ENS exceptions inherit from ENS Error, and all other web3.py exceptions inherit from Web3Exception
+All exceptions inherit from a custom class. EthPM exceptions inherit from PyEthPMException, ENS exceptions inherit from ENSException, and all other web3.py exceptions inherit from Web3Exception

--- a/tests/core/contracts/test_contract_build_transaction.py
+++ b/tests/core/contracts/test_contract_build_transaction.py
@@ -5,7 +5,7 @@ from eth_utils.toolz import (
 )
 
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 
 
@@ -28,7 +28,7 @@ def test_build_transaction_not_paying_to_nonpayable_function(
 def test_build_transaction_paying_to_nonpayable_function(
     w3, payable_tester_contract, build_transaction
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         build_transaction(
             contract=payable_tester_contract,
             contract_function="doNoValueCall",
@@ -277,7 +277,7 @@ async def test_async_build_transaction_not_paying_to_nonpayable_function(
 async def test_async_build_transaction_paying_to_nonpayable_function(
     async_w3, async_payable_tester_contract, async_build_transaction
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         await async_build_transaction(
             contract=async_payable_tester_contract,
             contract_function="doNoValueCall",

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -32,7 +32,7 @@ from web3.exceptions import (
     NameNotFound,
     NoABIFound,
     NoABIFunctionsFound,
-    ValidationError,
+    Web3ValidationError,
 )
 
 MULTIPLE_FUNCTIONS = json.loads(
@@ -317,7 +317,7 @@ def test_set_strict_byte_array(strict_arrays_contract, call, transact, args, exp
 def test_set_strict_byte_array_with_invalid_args(
     strict_arrays_contract, transact, args
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         transact(
             contract=strict_arrays_contract,
             contract_function="setByteValue",
@@ -644,13 +644,13 @@ def test_no_functions_match_identifier(arrays_contract):
 
 def test_function_1_match_identifier_wrong_number_of_args(arrays_contract):
     regex = message_regex + diagnosis_arg_regex
-    with pytest.raises(ValidationError, match=regex):
+    with pytest.raises(Web3ValidationError, match=regex):
         arrays_contract.functions.setBytes32Value().call()
 
 
 def test_function_1_match_identifier_wrong_args_encoding(arrays_contract):
     regex = message_regex + diagnosis_encoding_regex
-    with pytest.raises(ValidationError, match=regex):
+    with pytest.raises(Web3ValidationError, match=regex):
         arrays_contract.functions.setBytes32Value("dog").call()
 
 
@@ -665,7 +665,7 @@ def test_function_1_match_identifier_wrong_args_encoding(arrays_contract):
 def test_function_multiple_error_diagnoses(w3, arg1, arg2, diagnosis):
     Contract = w3.eth.contract(abi=MULTIPLE_FUNCTIONS)
     regex = message_regex + diagnosis
-    with pytest.raises(ValidationError, match=regex):
+    with pytest.raises(Web3ValidationError, match=regex):
         if arg2:
             Contract.functions.a(arg1, arg2).call()
         else:
@@ -683,7 +683,7 @@ def test_function_wrong_args_for_tuple_collapses_args_in_message(
     address,
     tuple_contract,
 ):
-    with pytest.raises(ValidationError) as e:
+    with pytest.raises(Web3ValidationError) as e:
         tuple_contract.functions.method(
             (1, [2, 3], [(4, [True, [False]], [address])])
         ).call()
@@ -711,7 +711,7 @@ def test_function_wrong_args_for_tuple_collapses_args_in_message(
 def test_function_wrong_args_for_tuple_collapses_kwargs_in_message(
     address, tuple_contract
 ):
-    with pytest.raises(ValidationError) as e:
+    with pytest.raises(Web3ValidationError) as e:
         tuple_contract.functions.method(
             a=(1, [2, 3], [(4, [True, [False]], [address])])  # noqa: E501
         ).call()
@@ -747,7 +747,7 @@ def test_call_not_sending_ether_to_nonpayable_function(payable_tester_contract, 
 
 
 def test_call_sending_ether_to_nonpayable_function(payable_tester_contract, call):
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         call(
             contract=payable_tester_contract,
             contract_function="doNoValueCall",
@@ -817,7 +817,7 @@ def test_invalid_fixed_value_reflections(
     fixed_reflection_contract, function, value, error
 ):
     contract_func = fixed_reflection_contract.functions[function]
-    with pytest.raises(ValidationError, match=error):
+    with pytest.raises(Web3ValidationError, match=error):
         contract_func(value).call({"gas": 420000})
 
 
@@ -1154,7 +1154,7 @@ async def test_async_set_strict_byte_array(
 async def test_async_set_strict_byte_array_with_invalid_args(
     async_strict_arrays_contract, async_transact, args
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         await async_transact(
             contract=async_strict_arrays_contract,
             contract_function="setByteValue",
@@ -1514,7 +1514,7 @@ async def test_async_function_1_match_identifier_wrong_number_of_args(
     async_arrays_contract,
 ):
     regex = message_regex + diagnosis_arg_regex
-    with pytest.raises(ValidationError, match=regex):
+    with pytest.raises(Web3ValidationError, match=regex):
         await async_arrays_contract.functions.setBytes32Value().call()
 
 
@@ -1523,7 +1523,7 @@ async def test_async_function_1_match_identifier_wrong_args_encoding(
     async_arrays_contract,
 ):
     regex = message_regex + diagnosis_encoding_regex
-    with pytest.raises(ValidationError, match=regex):
+    with pytest.raises(Web3ValidationError, match=regex):
         await async_arrays_contract.functions.setBytes32Value("dog").call()
 
 
@@ -1539,7 +1539,7 @@ async def test_async_function_1_match_identifier_wrong_args_encoding(
 async def test_async_function_multiple_diagnoses(async_w3, arg1, arg2, diagnosis):
     Contract = async_w3.eth.contract(abi=MULTIPLE_FUNCTIONS)
     regex = message_regex + diagnosis
-    with pytest.raises(ValidationError, match=regex):
+    with pytest.raises(Web3ValidationError, match=regex):
         if arg2:
             await Contract.functions.a(arg1, arg2).call()
         else:
@@ -1574,7 +1574,7 @@ async def test_async_call_not_sending_ether_to_nonpayable_function(
 async def test_async_call_sending_ether_to_nonpayable_function(
     async_payable_tester_contract, async_call
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         await async_call(
             contract=async_payable_tester_contract,
             contract_function="doNoValueCall",
@@ -1648,7 +1648,7 @@ async def test_async_invalid_fixed_value_reflections(
     async_fixed_reflection_contract, function, value, error
 ):
     contract_func = async_fixed_reflection_contract.functions[function]
-    with pytest.raises(ValidationError, match=error):
+    with pytest.raises(Web3ValidationError, match=error):
         await contract_func(value).call({"gas": 420000})
 
 

--- a/tests/core/contracts/test_contract_estimate_gas.py
+++ b/tests/core/contracts/test_contract_estimate_gas.py
@@ -1,7 +1,7 @@
 import pytest
 
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 
 
@@ -63,7 +63,7 @@ def test_estimate_gas_not_sending_ether_to_nonpayable_function(
 def test_estimate_gas_sending_ether_to_nonpayable_function(
     w3, payable_tester_contract, estimate_gas
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         estimate_gas(
             contract=payable_tester_contract,
             contract_function="doNoValueCall",
@@ -169,7 +169,7 @@ async def test_async_estimate_gas_not_sending_ether_to_nonpayable_function(
 async def test_async_estimate_gas_sending_ether_to_nonpayable_function(
     async_w3, async_payable_tester_contract, async_estimate_gas
 ):
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         await async_estimate_gas(
             contract=async_payable_tester_contract,
             contract_function="doNoValueCall",

--- a/tests/core/contracts/test_contract_method_abi_encoding.py
+++ b/tests/core/contracts/test_contract_method_abi_encoding.py
@@ -5,7 +5,7 @@ from web3 import (
     constants,
 )
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 
 ABI_A = json.loads(
@@ -112,7 +112,7 @@ def test_contract_abi_encoding_kwargs(w3):
 )
 def test_contract_abi_encoding_strict_with_error(w3_strict_abi, arguments):
     contract = w3_strict_abi.eth.contract(abi=ABI_C)
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         contract.encodeABI("a", arguments, data=None)
 
 

--- a/tests/core/contracts/test_contract_method_to_argument_matching.py
+++ b/tests/core/contracts/test_contract_method_to_argument_matching.py
@@ -9,7 +9,7 @@ from web3._utils.function_identifiers import (
     ReceiveFn,
 )
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 
 SINGLE_FN_NO_ARGS = json.loads(
@@ -137,7 +137,7 @@ def test_finds_receive_function(w3):
 def test_error_when_no_function_name_match(w3):
     Contract = w3.eth.contract(abi=SINGLE_FN_NO_ARGS)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         Contract._find_matching_fn_abi("no_function_name", [1234])
 
 
@@ -176,7 +176,7 @@ def test_finds_function_with_matching_args_deprecation_warning(w3):
 def test_error_when_duplicate_match(w3):
     Contract = w3.eth.contract(abi=MULTIPLE_FUNCTIONS)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         Contract._find_matching_fn_abi("a", [100])
 
 
@@ -184,7 +184,7 @@ def test_error_when_duplicate_match(w3):
 def test_strict_errors_if_type_is_wrong(w3_strict_abi, arguments):
     Contract = w3_strict_abi.eth.contract(abi=MULTIPLE_FUNCTIONS)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         Contract._find_matching_fn_abi("a", arguments)
 
 

--- a/tests/core/contracts/test_contract_transact_interface.py
+++ b/tests/core/contracts/test_contract_transact_interface.py
@@ -8,7 +8,7 @@ from web3._utils.empty import (
     empty,
 )
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 
 
@@ -51,7 +51,7 @@ def test_transact_sending_ether_to_nonpayable_function(
     )
 
     assert initial_value is False
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         txn_hash = transact(
             contract=payable_tester_contract,
             contract_function="doNoValueCall",
@@ -314,7 +314,7 @@ async def test_async_transact_sending_ether_to_nonpayable_function(
     )
 
     assert initial_value is False
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         txn_hash = await async_transact(
             contract=async_payable_tester_contract,
             contract_function="doNoValueCall",

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -13,7 +13,7 @@ from web3._utils.events import (
 )
 from web3.exceptions import (
     LogTopicError,
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.logs import (
     DISCARD,
@@ -282,7 +282,7 @@ def test_event_data_extraction_bytes_with_warning(
 )
 def test_event_data_extraction_bytes_strict_with_errors(strict_emitter, call_args):
     emitter_fn = strict_emitter.functions.logListArgs
-    with pytest.raises(ValidationError):
+    with pytest.raises(Web3ValidationError):
         emitter_fn(*call_args).transact()
 
 

--- a/tests/core/contracts/test_offchain_lookup.py
+++ b/tests/core/contracts/test_offchain_lookup.py
@@ -18,7 +18,7 @@ from web3._utils.type_conversion import (
 from web3.exceptions import (
     OffchainLookup,
     TooManyRequests,
-    ValidationError,
+    Web3ValidationError,
 )
 
 # "test offchain lookup" as an abi-encoded string
@@ -139,7 +139,7 @@ def test_offchain_lookup_raises_for_improperly_formatted_rest_request_response(
         mocked_json_data=WEB3PY_AS_HEXBYTES,
         json_data_field="not_data",
     )
-    with pytest.raises(ValidationError, match="missing 'data' field"):
+    with pytest.raises(Web3ValidationError, match="missing 'data' field"):
         offchain_lookup_contract.caller.testOffchainLookup(OFFCHAIN_LOOKUP_TEST_DATA)
 
 

--- a/tests/core/eth-module/test_eth_contract.py
+++ b/tests/core/eth-module/test_eth_contract.py
@@ -7,6 +7,10 @@ from eth_utils import (
     to_bytes,
 )
 
+from web3.exceptions import (
+    InvalidAddress,
+)
+
 ABI = [{}]
 ADDRESS = "0xd3CdA913deB6f67967B99D67aCDFa1712C293601"
 BYTES_ADDRESS = to_bytes(hexstr=ADDRESS)
@@ -19,11 +23,11 @@ INVALID_CHECKSUM_ADDRESS = "0xd3CDA913deB6f67967B99D67aCDFa1712C293601"
     (
         ((ADDRESS,), {}, None),
         ((BYTES_ADDRESS,), {}, None),
-        ((INVALID_CHECKSUM_ADDRESS,), {}, ValueError),
-        ((NON_CHECKSUM_ADDRESS,), {}, ValueError),
+        ((INVALID_CHECKSUM_ADDRESS,), {}, InvalidAddress),
+        ((NON_CHECKSUM_ADDRESS,), {}, InvalidAddress),
         ((), {"address": ADDRESS}, None),
-        ((), {"address": INVALID_CHECKSUM_ADDRESS}, ValueError),
-        ((), {"address": NON_CHECKSUM_ADDRESS}, ValueError),
+        ((), {"address": INVALID_CHECKSUM_ADDRESS}, InvalidAddress),
+        ((), {"address": NON_CHECKSUM_ADDRESS}, InvalidAddress),
     ),
 )
 def test_contract_address_validation(w3, args, kwargs, expected):

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -7,7 +7,7 @@ from web3.exceptions import (
     NameNotFound,
     TimeExhausted,
     TransactionNotFound,
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.middleware.simulate_unmined_transaction import (
     unmined_receipt_simulator_middleware,
@@ -91,7 +91,7 @@ def test_send_transaction_with_valid_chain_id(w3, make_chain_id, expect_success)
         receipt = w3.eth.wait_for_transaction_receipt(txn_hash, timeout=RECEIPT_TIMEOUT)
         assert receipt.get("blockNumber") is not None
     else:
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(Web3ValidationError) as exc_info:
             w3.eth.send_transaction(transaction)
 
         assert "chain ID" in str(exc_info.value)

--- a/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
+++ b/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
@@ -5,7 +5,7 @@ from web3 import (
     constants,
 )
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.gas_strategies.time_based import (
     construct_time_based_gas_price_strategy,
@@ -231,7 +231,7 @@ def test_time_based_gas_price_strategy(strategy_params, expected):
 def test_time_based_gas_price_strategy_zero_sample(
     strategy_params_zero, expected_exception_message
 ):
-    with pytest.raises(ValidationError) as excinfo:
+    with pytest.raises(Web3ValidationError) as excinfo:
         fixture_middleware = construct_result_generator_middleware(
             {
                 "eth_getBlockByHash": _get_block_by_something,

--- a/tests/core/middleware/test_transaction_signing.py
+++ b/tests/core/middleware/test_transaction_signing.py
@@ -11,11 +11,9 @@ from eth_tester.exceptions import (
     ValidationError,
 )
 from eth_utils import (
+    ValidationError as EthUtilsValidationError,
     to_bytes,
     to_hex,
-)
-from eth_utils.exceptions import (
-    ValidationError as EthUtilsValidationError,
 )
 from eth_utils.toolz import (
     assoc,

--- a/tests/core/pm-module/test_pm_init.py
+++ b/tests/core/pm-module/test_pm_init.py
@@ -5,8 +5,8 @@ from ethpm import (
     Package,
 )
 from ethpm.exceptions import (
+    EthPMException,
     InsufficientAssetsError,
-    PyEthPMException,
 )
 from ethpm.tools import (
     get_ethpm_local_manifest,
@@ -121,10 +121,10 @@ def test_get_local_package(w3, tmp_ethpmdir):
 def test_get_local_package_with_invalid_ethpmdir(w3, tmp_path):
     invalid_ethpmdir = tmp_path / "invalid"
     invalid_ethpmdir.mkdir()
-    with pytest.raises(PyEthPMException, match="not a valid ethPM packages directory."):
+    with pytest.raises(EthPMException, match="not a valid ethPM packages directory."):
         w3.pm.get_local_package("owned", invalid_ethpmdir)
 
 
 def test_get_local_package_with_uninstalled_package(w3, tmp_ethpmdir):
-    with pytest.raises(PyEthPMException, match="Package: safe-math not found in "):
+    with pytest.raises(EthPMException, match="Package: safe-math not found in "):
         w3.pm.get_local_package("safe-math", tmp_ethpmdir)

--- a/tests/core/pm-module/test_pm_init.py
+++ b/tests/core/pm-module/test_pm_init.py
@@ -6,13 +6,11 @@ from ethpm import (
 )
 from ethpm.exceptions import (
     InsufficientAssetsError,
+    PyEthPMException,
 )
 from ethpm.tools import (
     get_ethpm_local_manifest,
     get_ethpm_spec_manifest,
-)
-from web3.exceptions import (
-    PMError,
 )
 
 
@@ -123,10 +121,10 @@ def test_get_local_package(w3, tmp_ethpmdir):
 def test_get_local_package_with_invalid_ethpmdir(w3, tmp_path):
     invalid_ethpmdir = tmp_path / "invalid"
     invalid_ethpmdir.mkdir()
-    with pytest.raises(PMError, match="not a valid ethPM packages directory."):
+    with pytest.raises(PyEthPMException, match="not a valid ethPM packages directory."):
         w3.pm.get_local_package("owned", invalid_ethpmdir)
 
 
 def test_get_local_package_with_uninstalled_package(w3, tmp_ethpmdir):
-    with pytest.raises(PMError, match="Package: safe-math not found in "):
+    with pytest.raises(PyEthPMException, match="Package: safe-math not found in "):
         w3.pm.get_local_package("safe-math", tmp_ethpmdir)

--- a/tests/core/pm-module/test_registry_integration.py
+++ b/tests/core/pm-module/test_registry_integration.py
@@ -12,7 +12,7 @@ from ethpm.contract import (
     LinkableContract,
 )
 from ethpm.exceptions import (
-    PyEthPMException,
+    EthPMException,
 )
 from web3 import Web3
 from web3.pm import (
@@ -60,25 +60,25 @@ def test_pm_set_custom_registry(empty_sol_registry, fresh_w3):
 
 @pytest.mark.xfail(reason="Need to properly add authorization as of 8/10/2022")
 def test_pm_must_set_registry_before_all_registry_interaction_functions(fresh_w3):
-    with pytest.raises(PyEthPMException):
+    with pytest.raises(EthPMException):
         fresh_w3.pm.release_package(
             "package", "1.0.0", "ipfs://QmcxvhkJJVpbxEAa6cgW3B6XwPJb79w9GpNUv2P2THUzZR"
         )
-    with pytest.raises(PyEthPMException):
+    with pytest.raises(EthPMException):
         fresh_w3.pm.get_release_id_data(b"invalid_release_id")
-    with pytest.raises(PyEthPMException):
+    with pytest.raises(EthPMException):
         fresh_w3.pm.get_release_id("package", "1.0.0")
-    with pytest.raises(PyEthPMException):
+    with pytest.raises(EthPMException):
         fresh_w3.pm.get_release_data("package", "1.0.0")
-    with pytest.raises(PyEthPMException):
+    with pytest.raises(EthPMException):
         fresh_w3.pm.get_package("package", "1.0.0")
-    with pytest.raises(PyEthPMException):
+    with pytest.raises(EthPMException):
         fresh_w3.pm.get_all_package_names()
-    with pytest.raises(PyEthPMException):
+    with pytest.raises(EthPMException):
         fresh_w3.pm.get_all_package_releases("package")
-    with pytest.raises(PyEthPMException):
+    with pytest.raises(EthPMException):
         fresh_w3.pm.get_release_count("package")
-    with pytest.raises(PyEthPMException):
+    with pytest.raises(EthPMException):
         fresh_w3.pm.get_package_count()
 
 

--- a/tests/core/pm-module/test_registry_integration.py
+++ b/tests/core/pm-module/test_registry_integration.py
@@ -11,10 +11,10 @@ from ethpm import (
 from ethpm.contract import (
     LinkableContract,
 )
-from web3 import Web3
-from web3.exceptions import (
-    PMError,
+from ethpm.exceptions import (
+    PyEthPMException,
 )
+from web3 import Web3
 from web3.pm import (
     SimpleRegistry,
     get_simple_registry_manifest,
@@ -60,25 +60,25 @@ def test_pm_set_custom_registry(empty_sol_registry, fresh_w3):
 
 @pytest.mark.xfail(reason="Need to properly add authorization as of 8/10/2022")
 def test_pm_must_set_registry_before_all_registry_interaction_functions(fresh_w3):
-    with pytest.raises(PMError):
+    with pytest.raises(PyEthPMException):
         fresh_w3.pm.release_package(
             "package", "1.0.0", "ipfs://QmcxvhkJJVpbxEAa6cgW3B6XwPJb79w9GpNUv2P2THUzZR"
         )
-    with pytest.raises(PMError):
+    with pytest.raises(PyEthPMException):
         fresh_w3.pm.get_release_id_data(b"invalid_release_id")
-    with pytest.raises(PMError):
+    with pytest.raises(PyEthPMException):
         fresh_w3.pm.get_release_id("package", "1.0.0")
-    with pytest.raises(PMError):
+    with pytest.raises(PyEthPMException):
         fresh_w3.pm.get_release_data("package", "1.0.0")
-    with pytest.raises(PMError):
+    with pytest.raises(PyEthPMException):
         fresh_w3.pm.get_package("package", "1.0.0")
-    with pytest.raises(PMError):
+    with pytest.raises(PyEthPMException):
         fresh_w3.pm.get_all_package_names()
-    with pytest.raises(PMError):
+    with pytest.raises(PyEthPMException):
         fresh_w3.pm.get_all_package_releases("package")
-    with pytest.raises(PMError):
+    with pytest.raises(PyEthPMException):
         fresh_w3.pm.get_release_count("package")
-    with pytest.raises(PMError):
+    with pytest.raises(PyEthPMException):
         fresh_w3.pm.get_package_count()
 
 

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -12,7 +12,7 @@ from tests.utils import (
 )
 from web3 import Web3
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.providers.websocket import (
     WebsocketProvider,
@@ -69,5 +69,5 @@ def test_websocket_provider_timeout(w3):
 def test_restricted_websocket_kwargs():
     invalid_kwargs = {"uri": "ws://127.0.0.1:8546"}
     re_exc_message = f".*found: {set(invalid_kwargs)!r}*"
-    with pytest.raises(ValidationError, match=re_exc_message):
+    with pytest.raises(Web3ValidationError, match=re_exc_message):
         WebsocketProvider(websocket_kwargs=invalid_kwargs)

--- a/tests/core/utilities/test_attach_modules.py
+++ b/tests/core/utilities/test_attach_modules.py
@@ -12,7 +12,7 @@ from web3._utils.module import (
     attach_modules,
 )
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.module import (
     Module,
@@ -90,7 +90,7 @@ def test_attach_modules_with_wrong_module_format():
     mods = {"eth": (MockEth, MockGeth, MockGethPersonal)}
     w3 = Web3(EthereumTesterProvider, modules={})
     with pytest.raises(
-        ValidationError, match="Module definitions can only have 1 or 2 elements"
+        Web3ValidationError, match="Module definitions can only have 1 or 2 elements"
     ):
         attach_modules(w3, mods)
 

--- a/tests/core/utilities/test_select_filter_method.py
+++ b/tests/core/utilities/test_select_filter_method.py
@@ -5,7 +5,7 @@ from web3._utils.filters import (
     select_filter_method,
 )
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 
 
@@ -30,8 +30,8 @@ def test_select_filter_method(value, expected):
     "value, error",
     (
         ("0x0", _UseExistingFilter),
-        ("disallowed string", ValidationError),
-        (1, ValidationError),  # filter id needs to be a hexstr
+        ("disallowed string", Web3ValidationError),
+        (1, Web3ValidationError),  # filter id needs to be a hexstr
     ),
 )
 def test_select_filter_method_raises_error(value, error):

--- a/tests/ens/test_get_text.py
+++ b/tests/ens/test_get_text.py
@@ -1,7 +1,7 @@
 import pytest
 
-from eth_utils.exceptions import (
-    ValidationError,
+from eth_utils import (
+    ValidationError as EthUtilsValidationError,
 )
 
 from ens.exceptions import (
@@ -29,7 +29,7 @@ def test_set_text_fails_with_bad_address(ens):
     address = ens.w3.eth.accounts[2]
     ens.setup_address("tester.eth", address)
     zero_address = "0x" + "00" * 20
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthUtilsValidationError):
         ens.set_text(
             "tester.eth", "url", "http://example.com", transact={"from": zero_address}
         )
@@ -97,7 +97,7 @@ async def test_async_set_text_fails_with_bad_address(async_ens):
     address = accounts[2]
     await async_ens.setup_address("tester.eth", address)
     zero_address = "0x" + "00" * 20
-    with pytest.raises(ValidationError):
+    with pytest.raises(EthUtilsValidationError):
         await async_ens.set_text(
             "tester.eth", "url", "http://example.com", transact={"from": zero_address}
         )

--- a/tests/ens/test_offchain_resolution.py
+++ b/tests/ens/test_offchain_resolution.py
@@ -10,7 +10,7 @@ from ens.utils import (
 )
 from web3.exceptions import (
     OffchainLookup,
-    ValidationError,
+    Web3ValidationError,
 )
 
 # the encoded calldata for the initiating ``addr(namehash(name))`` call
@@ -155,7 +155,7 @@ def test_offchain_resolution_with_improperly_formatted_http_response(ens, monkey
 
     monkeypatch.setattr(requests.Session, "get", mock_get)
     with pytest.raises(
-        ValidationError,
+        Web3ValidationError,
         match=(
             "Improperly formatted response for offchain lookup HTTP request "
             "- missing 'data' field."
@@ -225,7 +225,7 @@ async def test_async_offchain_resolution_with_improperly_formatted_http_response
 
     monkeypatch.setattr(ClientSession, "get", mock_get)
     with pytest.raises(
-        ValidationError,
+        Web3ValidationError,
         match=(
             "Improperly formatted response for offchain lookup HTTP request "
             "- missing 'data' field."

--- a/tests/ens/test_utils.py
+++ b/tests/ens/test_utils.py
@@ -1,11 +1,13 @@
 import pytest
 
 from eth_utils import (
-    ValidationError,
     is_integer,
     to_bytes,
 )
 
+from ens.exceptions import (
+    ENSValidationError,
+)
 from ens.utils import (
     ens_encode_name,
     init_async_web3,
@@ -113,7 +115,7 @@ def test_ens_encode_name_raises_ValidationError_on_label_lengths_over_63(
     name, invalid_label_index
 ):
     with pytest.raises(
-        ValidationError, match=f"Label at position {invalid_label_index} too long"
+        ENSValidationError, match=f"Label at position {invalid_label_index} too long"
     ):
         ens_encode_name(name)
 

--- a/web3/_utils/async_transactions.py
+++ b/web3/_utils/async_transactions.py
@@ -34,7 +34,7 @@ from web3.constants import (
     DYNAMIC_FEE_TXN_PARAMS,
 )
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.types import (
     BlockIdentifier,
@@ -154,7 +154,7 @@ async def async_handle_offchain_lookup(
     formatted_data = to_hex_if_bytes(offchain_lookup_payload["callData"]).lower()
 
     if formatted_sender != to_hex_if_bytes(transaction["to"]).lower():
-        raise ValidationError(
+        raise Web3ValidationError(
             "Cannot handle OffchainLookup raised inside nested call. Returned `sender` "
             "value does not equal `to` address in transaction."
         )
@@ -175,7 +175,7 @@ async def async_handle_offchain_lookup(
                     data={"data": formatted_data, "sender": formatted_sender},
                 )
             else:
-                raise ValidationError("url not formatted properly.")
+                raise Web3ValidationError("url not formatted properly.")
         except Exception:
             continue  # try next url if timeout or issues making the request
 
@@ -189,7 +189,7 @@ async def async_handle_offchain_lookup(
         result = await async_get_json_from_client_response(response)
 
         if "data" not in result.keys():
-            raise ValidationError(
+            raise Web3ValidationError(
                 "Improperly formatted response for offchain lookup HTTP request "
                 "- missing 'data' field."
             )

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -65,7 +65,7 @@ from web3._utils.normalizers import (
     abi_string_to_text,
 )
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.types import (
     ABI,
@@ -190,7 +190,7 @@ def find_matching_fn_abi(
             f"the name `{fn_identifier}`: {matching_function_signatures}{diagnosis}"
         )
 
-        raise ValidationError(message)
+        raise Web3ValidationError(message)
 
 
 def encode_abi(
@@ -356,13 +356,13 @@ def get_function_info(
 
 
 def validate_payable(transaction: TxParams, abi: ABIFunction) -> None:
-    """Raise ValidationError if non-zero ether
+    """Raise Web3ValidationError if non-zero ether
     is sent to a non-payable function.
     """
     if "value" in transaction:
         if to_integer_if_hex(transaction["value"]) != 0:
             if "payable" in abi and not abi["payable"]:
-                raise ValidationError(
+                raise Web3ValidationError(
                     "Sending non-zero ether to a contract function "
                     "with payable=False. Please ensure that "
                     "transaction's value is 0."

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -50,7 +50,7 @@ from web3._utils.validation import (
     validate_address,
 )
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.types import (
     ABIEvent,
@@ -386,7 +386,7 @@ def select_filter_method(
         elif is_hex(value):
             raise _UseExistingFilter(value)
         else:
-            raise ValidationError(
+            raise Web3ValidationError(
                 "Filter argument needs to be either 'latest',"
                 " 'pending', or a hex-encoded filter_id. Filter argument"
                 f" is: {value}"
@@ -394,7 +394,7 @@ def select_filter_method(
     elif isinstance(value, dict):
         return if_new_filter
     else:
-        raise ValidationError(
+        raise Web3ValidationError(
             "Filter argument needs to be either the string "
             "'pending' or 'latest', a filter_id, "
             f"or a filter params dictionary. Filter argument is: {value}"

--- a/web3/_utils/module.py
+++ b/web3/_utils/module.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.module import (
     Module,
@@ -82,6 +82,6 @@ def attach_modules(
                 module = getattr(parent_module, module_name)
                 attach_modules(module, submodule_definitions, w3)
             elif len(module_info) != 1:
-                raise ValidationError(
+                raise Web3ValidationError(
                     "Module definitions can only have 1 or 2 elements."
                 )

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -64,7 +64,7 @@ from web3.exceptions import (
     TooManyRequests,
     TransactionNotFound,
     TransactionTypeMismatch,
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.middleware import (
     async_geth_poa_middleware,
@@ -309,7 +309,7 @@ class AsyncEthModuleTest:
             "chainId": wrong_chain_id,
         }
         with pytest.raises(
-            ValidationError,
+            Web3ValidationError,
             match=f"The transaction declared chain ID {wrong_chain_id}, "
             f"but the connected node is on {actual_chain_id}",
         ):
@@ -945,7 +945,7 @@ class AsyncEthModuleTest:
             mocked_json_data=WEB3PY_AS_HEXBYTES,
             json_data_field="not_data",
         )
-        with pytest.raises(ValidationError, match="missing 'data' field"):
+        with pytest.raises(Web3ValidationError, match="missing 'data' field"):
             await async_offchain_lookup_contract.caller().testOffchainLookup(
                 OFFCHAIN_LOOKUP_TEST_DATA
             )
@@ -2279,7 +2279,7 @@ class EthModuleTest:
             "chainId": wrong_chain_id,
         }
         with pytest.raises(
-            ValidationError,
+            Web3ValidationError,
             match=f"The transaction declared chain ID {wrong_chain_id}, "
             f"but the connected node is on {actual_chain_id}",
         ):
@@ -2850,7 +2850,7 @@ class EthModuleTest:
             mocked_json_data=WEB3PY_AS_HEXBYTES,
             json_data_field="not_data",
         )
-        with pytest.raises(ValidationError, match="missing 'data' field"):
+        with pytest.raises(Web3ValidationError, match="missing 'data' field"):
             offchain_lookup_contract.functions.testOffchainLookup(
                 OFFCHAIN_LOOKUP_TEST_DATA
             ).call()

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -125,7 +125,7 @@ from web3.exceptions import (
     NoABIEventsFound,
     NoABIFound,
     NoABIFunctionsFound,
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.logs import (
     DISCARD,
@@ -1499,7 +1499,7 @@ class BaseContractEvent:
         blkhash_set = blockHash is not None
         blknum_set = fromBlock is not None or toBlock is not None
         if blkhash_set and blknum_set:
-            raise ValidationError(
+            raise Web3ValidationError(
                 "blockHash cannot be set at the same time as fromBlock or toBlock"
             )
 

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -201,22 +201,6 @@ class TimeExhausted(Web3Exception):
     pass
 
 
-class PMError(Web3Exception):
-    """
-    Raised when an error occurs in the PM module.
-    """
-
-    pass
-
-
-class ManifestValidationError(PMError):
-    """
-    Raised when a provided manifest cannot be published, since it's invalid.
-    """
-
-    pass
-
-
 class TransactionNotFound(Web3Exception):
     """
     Raised when a tx hash used to lookup a tx in a jsonrpc call cannot be found.

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -5,6 +5,10 @@ from typing import (
     Dict,
 )
 
+from eth_utils import (
+    ValidationError,
+)
+
 from web3.types import (
     BlockData,
 )
@@ -143,7 +147,7 @@ class FallbackNotFound(Web3Exception):
     pass
 
 
-class ValidationError(Web3Exception):
+class Web3ValidationError(Web3Exception, ValidationError):
     """
     Raised when a supplied value is invalid.
     """
@@ -151,7 +155,7 @@ class ValidationError(Web3Exception):
     pass
 
 
-class ExtraDataLengthError(ValidationError):
+class ExtraDataLengthError(Web3ValidationError):
     """
     Raised when an RPC call returns >32 bytes of extraData.
     """

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -10,7 +10,22 @@ from web3.types import (
 )
 
 
-class BadFunctionCallOutput(Exception):
+class Web3Exception(Exception):
+    """
+    Exception mixin inherited by all exceptions of web3.py
+
+    This allows::
+
+        try:
+            some_call()
+        except Web3Exception:
+            # deal with web3 exception
+        except:
+            # deal with other exceptions
+    """
+
+
+class BadFunctionCallOutput(Web3Exception):
     """
     We failed to decode ABI output.
 
@@ -20,7 +35,7 @@ class BadFunctionCallOutput(Exception):
     pass
 
 
-class BlockNumberOutofRange(Exception):
+class BlockNumberOutofRange(Web3Exception):
     """
     block_identifier passed does not match known block.
     """
@@ -28,7 +43,7 @@ class BlockNumberOutofRange(Exception):
     pass
 
 
-class CannotHandleRequest(Exception):
+class CannotHandleRequest(Web3Exception):
     """
     Raised by a provider to signal that it cannot handle an RPC request and
     that the manager should proceed to the next provider.
@@ -37,7 +52,7 @@ class CannotHandleRequest(Exception):
     pass
 
 
-class TooManyRequests(Exception):
+class TooManyRequests(Web3Exception):
     """
     Raised by a provider to signal that too many requests have been made consecutively.
     """
@@ -45,7 +60,7 @@ class TooManyRequests(Exception):
     pass
 
 
-class MultipleFailedRequests(Exception):
+class MultipleFailedRequests(Web3Exception):
     """
     Raised by a provider to signal that multiple requests to retrieve the same
     (or similar) data have failed.
@@ -54,7 +69,7 @@ class MultipleFailedRequests(Exception):
     pass
 
 
-class InvalidAddress(ValueError):
+class InvalidAddress(Web3Exception):
     """
     The supplied address does not have a valid checksum, as defined in EIP-55
     """
@@ -62,7 +77,7 @@ class InvalidAddress(ValueError):
     pass
 
 
-class NameNotFound(ValueError):
+class NameNotFound(Web3Exception):
     """
     Raised when a caller provides an Ethereum Name Service name that
     does not resolve to an address.
@@ -71,7 +86,7 @@ class NameNotFound(ValueError):
     pass
 
 
-class StaleBlockchain(Exception):
+class StaleBlockchain(Web3Exception):
     """
     Raised by the stalecheck_middleware when the latest block is too old.
     """
@@ -93,7 +108,7 @@ class StaleBlockchain(Exception):
         return self.args[0]
 
 
-class MismatchedABI(Exception):
+class MismatchedABI(Web3Exception):
     """
     Raised when an ABI does not match with supplied parameters, or when an
     attempt is made to access a function/event that does not exist in the ABI.
@@ -120,7 +135,7 @@ class ABIFunctionNotFound(AttributeError, MismatchedABI):
     pass
 
 
-class FallbackNotFound(Exception):
+class FallbackNotFound(Web3Exception):
     """
     Raised when fallback function doesn't exist in contract.
     """
@@ -128,7 +143,7 @@ class FallbackNotFound(Exception):
     pass
 
 
-class ValidationError(Exception):
+class ValidationError(Web3Exception):
     """
     Raised when a supplied value is invalid.
     """
@@ -144,7 +159,7 @@ class ExtraDataLengthError(ValidationError):
     pass
 
 
-class NoABIFunctionsFound(AttributeError):
+class NoABIFunctionsFound(Web3Exception):
     """
     Raised when an ABI is present, but doesn't contain any functions.
     """
@@ -152,7 +167,7 @@ class NoABIFunctionsFound(AttributeError):
     pass
 
 
-class NoABIFound(AttributeError):
+class NoABIFound(Web3Exception):
     """
     Raised when no ABI is present.
     """
@@ -160,7 +175,7 @@ class NoABIFound(AttributeError):
     pass
 
 
-class NoABIEventsFound(AttributeError):
+class NoABIEventsFound(Web3Exception):
     """
     Raised when an ABI doesn't contain any events.
     """
@@ -168,7 +183,7 @@ class NoABIEventsFound(AttributeError):
     pass
 
 
-class InsufficientData(Exception):
+class InsufficientData(Web3Exception):
     """
     Raised when there are insufficient data points to
     complete a calculation
@@ -177,7 +192,7 @@ class InsufficientData(Exception):
     pass
 
 
-class TimeExhausted(Exception):
+class TimeExhausted(Web3Exception):
     """
     Raised when a method has not retrieved the desired
     result within a specified timeout.
@@ -186,7 +201,7 @@ class TimeExhausted(Exception):
     pass
 
 
-class PMError(Exception):
+class PMError(Web3Exception):
     """
     Raised when an error occurs in the PM module.
     """
@@ -202,7 +217,7 @@ class ManifestValidationError(PMError):
     pass
 
 
-class TransactionNotFound(Exception):
+class TransactionNotFound(Web3Exception):
     """
     Raised when a tx hash used to lookup a tx in a jsonrpc call cannot be found.
     """
@@ -210,7 +225,7 @@ class TransactionNotFound(Exception):
     pass
 
 
-class BlockNotFound(Exception):
+class BlockNotFound(Web3Exception):
     """
     Raised when the block id used to lookup a block in a jsonrpc call cannot be found.
     """
@@ -218,7 +233,7 @@ class BlockNotFound(Exception):
     pass
 
 
-class InfuraProjectIdNotFound(Exception):
+class InfuraProjectIdNotFound(Web3Exception):
     """
     Raised when there is no Infura Project Id set.
     """
@@ -226,24 +241,23 @@ class InfuraProjectIdNotFound(Exception):
     pass
 
 
-class LogTopicError(ValueError):
-    # Inherits from ValueError for backwards compatibility
+class LogTopicError(Web3Exception):
     """
     Raised when the number of log topics is mismatched.
     """
+
     pass
 
 
-class InvalidEventABI(ValueError):
-    # Inherits from ValueError for backwards compatibility
+class InvalidEventABI(Web3Exception):
     """
     Raised when the event ABI is invalid.
     """
+
     pass
 
 
-class ContractLogicError(ValueError):
-    # Inherits from ValueError for backwards compatibility
+class ContractLogicError(Web3Exception):
     """
     Raised on a contract revert error
     """
@@ -259,7 +273,7 @@ class OffchainLookup(ContractLogicError):
         super().__init__()
 
 
-class InvalidTransaction(Exception):
+class InvalidTransaction(Web3Exception):
     """
     Raised when a transaction includes an invalid combination of arguments.
     """
@@ -279,9 +293,9 @@ class TransactionTypeMismatch(InvalidTransaction):
         super().__init__(message)
 
 
-class BadResponseFormat(ValueError, KeyError):
-    # Inherits from KeyError and ValueError for backwards compatibility
+class BadResponseFormat(Web3Exception):
     """
     Raised when a JSON-RPC response comes back in an unexpected format
     """
+
     pass

--- a/web3/gas_strategies/time_based.py
+++ b/web3/gas_strategies/time_based.py
@@ -28,7 +28,7 @@ from web3._utils.math import (
 )
 from web3.exceptions import (
     InsufficientData,
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.types import (
     BlockNumber,
@@ -48,7 +48,7 @@ def _get_avg_block_time(w3: Web3, sample_size: int) -> float:
 
     constrained_sample_size = min(sample_size, latest["number"])
     if constrained_sample_size == 0:
-        raise ValidationError("Constrained sample size is 0")
+        raise Web3ValidationError("Constrained sample size is 0")
 
     oldest = w3.eth.get_block(BlockNumber(latest["number"] - constrained_sample_size))
     return (latest["timestamp"] - oldest["timestamp"]) / constrained_sample_size
@@ -58,8 +58,7 @@ def _get_weighted_avg_block_time(w3: Web3, sample_size: int) -> float:
     latest_block_number = w3.eth.get_block("latest")["number"]
     constrained_sample_size = min(sample_size, latest_block_number)
     if constrained_sample_size == 0:
-        raise ValidationError("Constrained sample size is 0")
-
+        raise Web3ValidationError("Constrained sample size is 0")
     oldest_block = w3.eth.get_block(
         BlockNumber(latest_block_number - constrained_sample_size)
     )

--- a/web3/method.py
+++ b/web3/method.py
@@ -15,9 +15,6 @@ from typing import (
 )
 import warnings
 
-from eth_utils import (
-    ValidationError,
-)
 from eth_utils.curried import (
     to_tuple,
 )
@@ -33,6 +30,9 @@ from web3._utils.method_formatters import (
 )
 from web3._utils.rpc_abi import (
     RPC,
+)
+from web3.exceptions import (
+    Web3ValidationError,
 )
 from web3.types import (
     RPCEndpoint,
@@ -69,7 +69,7 @@ def _set_mungers(
     mungers: Optional[Sequence[Munger]], is_property: bool
 ) -> Sequence[Any]:
     if is_property and mungers:
-        raise ValidationError("Mungers cannot be used with a property.")
+        raise Web3ValidationError("Mungers cannot be used with a property.")
 
     return (
         mungers
@@ -82,7 +82,7 @@ def _set_mungers(
 
 def default_munger(_module: "Module", *args: Any, **kwargs: Any) -> Tuple[()]:
     if args or kwargs:
-        raise ValidationError("Parameters cannot be passed to a property.")
+        raise Web3ValidationError("Parameters cannot be passed to a property.")
     return ()
 
 

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -30,7 +30,7 @@ from web3._utils.rpc_abi import (
 )
 from web3.exceptions import (
     ExtraDataLengthError,
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.middleware.formatting import (
     async_construct_web3_formatting_middleware,
@@ -59,7 +59,7 @@ def _validate_chain_id(web3_chain_id: int, chain_id: int) -> int:
     if chain_id_int == web3_chain_id:
         return chain_id
     else:
-        raise ValidationError(
+        raise Web3ValidationError(
             f"The transaction declared chain ID {chain_id_int!r}, "
             f"but the connected node is on {web3_chain_id!r}"
         )

--- a/web3/pm.py
+++ b/web3/pm.py
@@ -39,8 +39,8 @@ from ethpm import (
     Package,
 )
 from ethpm.exceptions import (
+    EthPMException,
     ManifestValidationError,
-    PyEthPMException,
 )
 from ethpm.uri import (
     is_supported_content_addressed_uri,
@@ -362,13 +362,13 @@ class PM(Module):
             ethpm_dir = Path.cwd() / "_ethpm_packages"
 
         if not ethpm_dir.name == "_ethpm_packages" or not ethpm_dir.is_dir():
-            raise PyEthPMException(
+            raise EthPMException(
                 f"{ethpm_dir} is not a valid ethPM packages directory."
             )
 
         local_packages = [pkg.name for pkg in ethpm_dir.iterdir() if pkg.is_dir()]
         if package_name not in local_packages:
-            raise PyEthPMException(
+            raise EthPMException(
                 f"Package: {package_name} not found in {ethpm_dir}. "
                 f"Available packages include: {local_packages}."
             )
@@ -406,7 +406,7 @@ class PM(Module):
                 )
             self.registry = SimpleRegistry(addr_lookup, self.w3)
         else:
-            raise PyEthPMException(
+            raise EthPMException(
                 "Expected a canonical/checksummed address or ENS name for the address, "
                 f"instead received {type(address)}."
             )
@@ -559,14 +559,14 @@ class PM(Module):
         try:
             self.registry
         except AttributeError:
-            raise PyEthPMException(
+            raise EthPMException(
                 "web3.pm does not have a set registry. "
                 "Please set registry with either: "
                 "web3.pm.set_registry(address) or "
                 "web3.pm.deploy_and_set_registry()"
             )
         if not isinstance(self.registry, ERC1319Registry):
-            raise PyEthPMException(
+            raise EthPMException(
                 "web3.pm requires an instance of a subclass of ERC1319Registry "
                 "to be set as the web3.pm.registry attribute. Instead found: "
                 f"{type(self.registry)}."

--- a/web3/pm.py
+++ b/web3/pm.py
@@ -38,6 +38,10 @@ from ethpm import (
     ASSETS_DIR,
     Package,
 )
+from ethpm.exceptions import (
+    ManifestValidationError,
+    PyEthPMException,
+)
 from ethpm.uri import (
     is_supported_content_addressed_uri,
     resolve_uri_contents,
@@ -56,9 +60,7 @@ from web3._utils.ens import (
 )
 from web3.exceptions import (
     InvalidAddress,
-    ManifestValidationError,
     NameNotFound,
-    PMError,
 )
 from web3.module import (
     Module,
@@ -360,11 +362,13 @@ class PM(Module):
             ethpm_dir = Path.cwd() / "_ethpm_packages"
 
         if not ethpm_dir.name == "_ethpm_packages" or not ethpm_dir.is_dir():
-            raise PMError(f"{ethpm_dir} is not a valid ethPM packages directory.")
+            raise PyEthPMException(
+                f"{ethpm_dir} is not a valid ethPM packages directory."
+            )
 
         local_packages = [pkg.name for pkg in ethpm_dir.iterdir() if pkg.is_dir()]
         if package_name not in local_packages:
-            raise PMError(
+            raise PyEthPMException(
                 f"Package: {package_name} not found in {ethpm_dir}. "
                 f"Available packages include: {local_packages}."
             )
@@ -402,7 +406,7 @@ class PM(Module):
                 )
             self.registry = SimpleRegistry(addr_lookup, self.w3)
         else:
-            raise PMError(
+            raise PyEthPMException(
                 "Expected a canonical/checksummed address or ENS name for the address, "
                 f"instead received {type(address)}."
             )
@@ -555,14 +559,14 @@ class PM(Module):
         try:
             self.registry
         except AttributeError:
-            raise PMError(
+            raise PyEthPMException(
                 "web3.pm does not have a set registry. "
                 "Please set registry with either: "
                 "web3.pm.set_registry(address) or "
                 "web3.pm.deploy_and_set_registry()"
             )
         if not isinstance(self.registry, ERC1319Registry):
-            raise PMError(
+            raise PyEthPMException(
                 "web3.pm requires an instance of a subclass of ERC1319Registry "
                 "to be set as the web3.pm.registry attribute. Instead found: "
                 f"{type(self.registry)}."

--- a/web3/providers/websocket.py
+++ b/web3/providers/websocket.py
@@ -26,7 +26,7 @@ from websockets.legacy.client import (
 )
 
 from web3.exceptions import (
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.providers.base import (
     JSONBaseProvider,
@@ -105,7 +105,7 @@ class WebsocketProvider(JSONBaseProvider):
                 RESTRICTED_WEBSOCKET_KWARGS
             )
             if found_restricted_keys:
-                raise ValidationError(
+                raise Web3ValidationError(
                     f"{RESTRICTED_WEBSOCKET_KWARGS} are not allowed "
                     f"in websocket_kwargs, found: {found_restricted_keys}"
                 )

--- a/web3/utils/async_exception_handling.py
+++ b/web3/utils/async_exception_handling.py
@@ -21,7 +21,7 @@ from web3._utils.type_conversion import (
 )
 from web3.exceptions import (
     MultipleFailedRequests,
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.types import (
     TxParams,
@@ -36,7 +36,7 @@ async def async_handle_offchain_lookup(
     formatted_data = to_hex_if_bytes(offchain_lookup_payload["callData"]).lower()
 
     if formatted_sender != to_hex_if_bytes(transaction["to"]).lower():
-        raise ValidationError(
+        raise Web3ValidationError(
             "Cannot handle OffchainLookup raised inside nested call. Returned "
             "`sender` value does not equal `to` address in transaction."
         )
@@ -57,7 +57,7 @@ async def async_handle_offchain_lookup(
                     data={"data": formatted_data, "sender": formatted_sender},
                 )
             else:
-                raise ValidationError("url not formatted properly.")
+                raise Web3ValidationError("url not formatted properly.")
         except Exception:
             continue  # try next url if timeout or issues making the request
 
@@ -71,7 +71,7 @@ async def async_handle_offchain_lookup(
         result = await async_get_json_from_client_response(response)
 
         if "data" not in result.keys():
-            raise ValidationError(
+            raise Web3ValidationError(
                 "Improperly formatted response for offchain lookup HTTP request"
                 " - missing 'data' field."
             )

--- a/web3/utils/exception_handling.py
+++ b/web3/utils/exception_handling.py
@@ -20,7 +20,7 @@ from web3._utils.type_conversion import (
 )
 from web3.exceptions import (
     MultipleFailedRequests,
-    ValidationError,
+    Web3ValidationError,
 )
 from web3.types import (
     TxParams,
@@ -35,7 +35,7 @@ def handle_offchain_lookup(
     formatted_data = to_hex_if_bytes(offchain_lookup_payload["callData"]).lower()
 
     if formatted_sender != to_hex_if_bytes(transaction["to"]).lower():
-        raise ValidationError(
+        raise Web3ValidationError(
             "Cannot handle OffchainLookup raised inside nested call. "
             "Returned `sender` value does not equal `to` address in transaction."
         )
@@ -59,7 +59,7 @@ def handle_offchain_lookup(
                     },
                 )
             else:
-                raise ValidationError("url not formatted properly.")
+                raise Web3ValidationError("url not formatted properly.")
         except Exception:
             continue  # try next url if timeout or issues making the request
 
@@ -73,7 +73,7 @@ def handle_offchain_lookup(
         result = response.json()
 
         if "data" not in result.keys():
-            raise ValidationError(
+            raise Web3ValidationError(
                 "Improperly formatted response for offchain lookup HTTP request"
                 " - missing 'data' field."
             )


### PR DESCRIPTION
Exception mixin inherited by all exceptions of web3.py

This allows:

    try:
        some_call()
    except Web3Exception as e:
        # deal with web3 exception
    except:
        # deal with other exceptions

### What was wrong?

I currently have this code:

```
        try:    
            result = something_that_calls_web3()
        except (    
            web3.exceptions.BadFunctionCallOutput    
            web3.exceptions.BlockNotFound    
            web3.exceptions.BlockNumberOutofRange    
            web3.exceptions.CannotHandleRequest    
            web3.exceptions.FallbackNotFound    
            web3.exceptions.InfuraKeyNotFound    
            web3.exceptions.InsufficientData    
            web3.exceptions.InvalidAddress    
            web3.exceptions.InvalidEventABI    
            web3.exceptions.LogTopicError    
            web3.exceptions.ManifestValidationError    
            web3.exceptions.MismatchedABI    
            web3.exceptions.NameNotFound    
            web3.exceptions.NoABIEventsFound    
            web3.exceptions.NoABIFound    
            web3.exceptions.NoABIFunctionsFound    
            web3.exceptions.PMError    
            web3.exceptions.StaleBlockchain    
            web3.exceptions.TimeExhausted    
            web3.exceptions.TransactionNotFound    
            web3.exceptions.ValidationError    
        ) as e:    
            deal_with_web3_exception()
```

This has readability problem, and also not forward-compatible with new exceptions, and also will break if an exception is removed from web3 package.

### How was it fixed?

With this patch, I could replace the above with:

```
        try:    
            result = something_that_calls_web3()
        except web3.exceptions.Web3Exception as e:    
            deal_with_web3_exception()
```

This fixes readability and forward-compatibility.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.standard.co.uk/s3fs-public/thumbnails/image/2018/10/26/19/lion2610.jpg?w968)
