### PR TITLE
Use eth-utils methods instead of custom web3 methods

### DIFF
--- a/newsfragments/1479.misc.rst
+++ b/newsfragments/1479.misc.rst
@@ -1,0 +1,1 @@
+Use formatting functions from eth-utils instead of web3

--- a/tests/core/utilities/test_formatters.py
+++ b/tests/core/utilities/test_formatters.py
@@ -1,8 +1,11 @@
 
 import pytest
 
-from web3._utils.formatters import (
+from eth_utils.curried import (
     apply_formatters_to_dict,
+)
+
+from web3._utils.formatters import (
     map_collection,
     recursive_map,
 )

--- a/web3/_utils/datatypes.py
+++ b/web3/_utils/datatypes.py
@@ -1,8 +1,9 @@
+from eth_utils import (
+    apply_formatters_to_dict,
+)
 from eth_utils.toolz import (
     concat,
 )
-
-import web3._utils.formatters
 
 
 def verify_attr(class_name, key, namespace):
@@ -28,7 +29,7 @@ class PropertyCheckingFactory(type):
             verify_attr(name, key, all_keys)
 
         if normalizers:
-            processed_namespace = web3._utils.formatters.apply_formatters_to_dict(
+            processed_namespace = apply_formatters_to_dict(
                 normalizers,
                 namespace,
             )

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -20,6 +20,9 @@ from eth_utils import (
     to_hex,
     to_tuple,
 )
+from eth_utils.curried import (
+    apply_formatter_if,
+)
 from eth_utils.toolz import (
     complement,
     compose,
@@ -33,9 +36,6 @@ from web3._utils.encoding import (
     encode_single_packed,
     hexstr_if_str,
     to_bytes,
-)
-from web3._utils.formatters import (
-    apply_formatter_if,
 )
 from web3._utils.normalizers import (
     BASE_RETURN_NORMALIZERS,

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -6,6 +6,9 @@ from eth_utils import (
     is_string,
     is_text,
 )
+from eth_utils.curried import (
+    apply_formatter_if,
+)
 from eth_utils.toolz import (
     complement,
     curry,
@@ -14,9 +17,6 @@ from hexbytes import (
     HexBytes,
 )
 
-from web3._utils.formatters import (
-    apply_formatter_if,
-)
 from web3._utils.threads import (
     TimerClass,
 )

--- a/web3/_utils/formatters.py
+++ b/web3/_utils/formatters.py
@@ -10,6 +10,9 @@ from eth_utils import (
     to_dict,
     to_list,
 )
+from eth_utils.curried import (
+    apply_formatter_at_index,
+)
 from eth_utils.toolz import (
     compose,
     curry,
@@ -28,21 +31,6 @@ def hex_to_integer(value):
 integer_to_hex = hex
 
 
-@curry
-@to_list
-def apply_formatter_at_index(formatter, at_index, value):
-    if at_index + 1 > len(value):
-        raise IndexError(
-            "Not enough values in iterable to apply formatter.  Got: {0}. "
-            "Need: {1}".format(len(value), at_index + 1)
-        )
-    for index, item in enumerate(value):
-        if index == at_index:
-            yield formatter(item)
-        else:
-            yield item
-
-
 def apply_formatters_to_args(*formatters):
     return compose(*(
         apply_formatter_at_index(formatter, index)
@@ -52,40 +40,10 @@ def apply_formatters_to_args(*formatters):
 
 
 @curry
-def apply_formatter_if(condition, formatter, value):
-    if condition(value):
-        return formatter(value)
-    else:
-        return value
-
-
-@curry
-@to_dict
-def apply_formatters_to_dict(formatters, value):
-    for key, item in value.items():
-        if key in formatters:
-            try:
-                yield key, formatters[key](item)
-            except (TypeError, ValueError) as exc:
-                raise type(exc)("Could not format value %r as field %r" % (item, key)) from exc
-        else:
-            yield key, item
-
-
-@curry
 @to_list
 def apply_formatter_to_array(formatter, value):
     for item in value:
         yield formatter(item)
-
-
-@curry
-def apply_one_of_formatters(formatter_condition_pairs, value):
-    for formatter, condition in formatter_condition_pairs:
-        if condition(value):
-            return formatter(value)
-    else:
-        raise ValueError("The provided value did not satisfy any of the formatter conditions")
 
 
 def map_collection(func, collection):

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -1,15 +1,15 @@
 from eth_utils import (
     to_dict,
 )
+from eth_utils.curried import (
+    apply_formatter_at_index,
+)
 from eth_utils.toolz import (
     curry,
 )
 
 from web3._utils.abi import (
     map_abi_data,
-)
-from web3._utils.formatters import (
-    apply_formatter_at_index,
 )
 
 TRANSACTION_PARAMS_ABIS = {

--- a/web3/_utils/validation.py
+++ b/web3/_utils/validation.py
@@ -13,6 +13,9 @@ from eth_utils import (
     is_list_like,
     is_string,
 )
+from eth_utils.curried import (
+    apply_formatter_to_array,
+)
 from eth_utils.hexadecimal import (
     encode_hex,
 )
@@ -36,9 +39,6 @@ from web3._utils.abi import (
     is_uint_type,
     length_of_array_type,
     sub_type_of_array_type,
-)
-from web3._utils.formatters import (
-    apply_formatter_to_array,
 )
 from web3.exceptions import (
     InvalidAddress,

--- a/web3/middleware/normalize_request_parameters.py
+++ b/web3/middleware/normalize_request_parameters.py
@@ -1,8 +1,7 @@
 from eth_utils import (
     is_string,
 )
-
-from web3._utils.formatters import (
+from eth_utils.curried import (
     apply_formatter_at_index,
     apply_formatter_if,
     apply_formatters_to_dict,

--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -15,13 +15,13 @@ from eth_keys.datatypes import (
 from eth_utils import (
     to_dict,
 )
+from eth_utils.curried import (
+    apply_formatter_if,
+)
 from eth_utils.toolz import (
     compose,
 )
 
-from web3._utils.formatters import (
-    apply_formatter_if,
-)
 from web3._utils.rpc_abi import (
     TRANSACTION_PARAMS_ABIS,
     apply_abi_formatters_to_dict,

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -14,14 +14,13 @@ from eth_utils import (
     is_null,
     keccak,
 )
+from eth_utils.curried import (
+    apply_formatter_if,
+)
 from eth_utils.toolz import (
     compose,
     curry,
     excepts,
-)
-
-from web3._utils.formatters import (
-    apply_formatter_if,
 )
 
 

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -5,6 +5,10 @@ from eth_utils import (
     is_hex,
     is_string,
 )
+from eth_utils.curried import (
+    apply_formatter_if,
+    apply_formatters_to_dict,
+)
 from eth_utils.toolz import (
     assoc,
     complement,
@@ -16,10 +20,8 @@ from eth_utils.toolz import (
 )
 
 from web3._utils.formatters import (
-    apply_formatter_if,
     apply_formatter_to_array,
     apply_formatters_to_args,
-    apply_formatters_to_dict,
     apply_key_map,
     hex_to_integer,
     integer_to_hex,


### PR DESCRIPTION
### What was wrong?
There were a couple duplicate functions in both eth-utils and web3. We want to standardize on eth-utils.

Related to Issue #1197 

### How was it fixed?

Took out the duplicate methods from web3, and added a note to the v6 breaking changes for apply_formatters_to_array which is very close but not quite the same between the two libraries. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="254" alt="image" src="https://user-images.githubusercontent.com/6540608/67531106-876eab80-f67e-11e9-8b06-83454a2de8ef.png">

