### PR TITLE
add quickest infura instructions

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -40,14 +40,16 @@ To use the web3 library you will need to initialize the
     
     $ export WEB3_INFURA_PROJECT_ID=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-Use the ``auto`` module to :ref:`guess at common node connection options
-<automatic_provider_detection>`. Or specify to use the Infura node by importing from ``web3.auto.infura``.
+Use the ``web3.auto.infura`` module to connect to the Infura node.
 
 .. code-block:: python
 
     >>> from web3.auto import w3
     >>> w3.eth.blockNumber
     4000000
+    
+.. NOTE:: Use the ``auto`` module to :ref:`guess at common node connection options
+<automatic_provider_detection>`.
 
 This ``w3`` instance will now allow you to interact with the Ethereum
 blockchain.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -34,25 +34,36 @@ Using Web3
 ----------
 
 To use the web3 library you will need to initialize the
-:class:`~web3.Web3` class and connecting to an Ethereum node. The quickest way to do so for free is by setting up an account on `Infura https://infura.io/>`. On Infura, create a project and copy the Project ID. Then set the environment variable ``WEB3_INFURA_PROJECT_ID``.
+:class:`~web3.Web3` class and connecting to an Ethereum node.
+The quickest way to do so for free is by setting up an account on
+`Infura https://infura.io/>`. On Infura, create a project and copy
+the Project ID. Then set the environment variable ``WEB3_INFURA_PROJECT_ID``.
 
 .. code-block:: shell
-    
+
     $ export WEB3_INFURA_PROJECT_ID=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 Use the ``web3.auto.infura`` module to connect to the Infura node.
 
 .. code-block:: python
 
-    >>> from web3.auto import w3
+    >>> from web3.auto.infura import w3
     >>> w3.eth.blockNumber
     4000000
-    
-.. NOTE:: 
-    Use the ``auto`` module to :ref:`guess at common node connection options <automatic_provider_detection>`.
 
 This ``w3`` instance will now allow you to interact with the Ethereum
 blockchain.
+
+.. NOTE::
+    If you don't want to use Infura, the ``web3.auto`` module is
+    available and will :ref:`guess at common node connection
+    options <automatic_provider_detection>`.
+
+      .. code-block:: python
+
+          >>> from web3.auto import w3
+          >>> w3.eth.blockNumber
+          4000000
 
 .. NOTE:: If you get the result ``UnhandledRequest: No providers responded to the RPC request``
     then you are not connected to a node. See :ref:`why_need_connection` and

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -34,7 +34,7 @@ Using Web3
 ----------
 
 To use the web3 library you will need to initialize the
-:class:`~web3.Web3` class by connecting to an Ethereum node. The quickest way to do so for free is by setting up an account on `Infura https://infura.io/>`. On Infura, create a project and copy the Project ID. Then set the environment variable ``WEB3_INFURA_PROJECT_ID``.
+:class:`~web3.Web3` class and connecting to an Ethereum node. The quickest way to do so for free is by setting up an account on `Infura https://infura.io/>`. On Infura, create a project and copy the Project ID. Then set the environment variable ``WEB3_INFURA_PROJECT_ID``.
 
 .. code-block:: shell
     
@@ -45,7 +45,7 @@ Use the ``auto`` module to :ref:`guess at common node connection options
 
 .. code-block:: python
 
-    >>> from web3.auto.infura import w3
+    >>> from web3.auto import w3
     >>> w3.eth.blockNumber
     4000000
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -48,8 +48,8 @@ Use the ``web3.auto.infura`` module to connect to the Infura node.
     >>> w3.eth.blockNumber
     4000000
     
-.. NOTE:: Use the ``auto`` module to :ref:`guess at common node connection options
-<automatic_provider_detection>`.
+.. NOTE:: 
+    Use the ``auto`` module to :ref:`guess at common node connection options <automatic_provider_detection>`.
 
 This ``w3`` instance will now allow you to interact with the Ethereum
 blockchain.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -34,14 +34,18 @@ Using Web3
 ----------
 
 To use the web3 library you will need to initialize the
-:class:`~web3.Web3` class.
+:class:`~web3.Web3` class by connecting to an Ethereum node. The quickest way to do so for free is by setting up an account on `Infura https://infura.io/>`. On Infura, create a project and copy the Project ID. Then set the environment variable ``WEB3_INFURA_PROJECT_ID``.
+
+.. code-block:: shell
+    
+    $ export WEB3_INFURA_PROJECT_ID=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 Use the ``auto`` module to :ref:`guess at common node connection options
-<automatic_provider_detection>`.
+<automatic_provider_detection>`. Or specify to use the Infura node by importing from ``web3.auto.infura``.
 
 .. code-block:: python
 
-    >>> from web3.auto import w3
+    >>> from web3.auto.infura import w3
     >>> w3.eth.blockNumber
     4000000
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -34,9 +34,9 @@ Using Web3
 ----------
 
 To use the web3 library you will need to initialize the
-:class:`~web3.Web3` class and connecting to an Ethereum node.
+:class:`~web3.Web3` class and connect to an Ethereum node.
 The quickest way to do so for free is by setting up an account on
-`Infura https://infura.io/>`. On Infura, create a project and copy
+`Infura <https://infura.io/>`_. On Infura, create a project and copy
 the Project ID. Then set the environment variable ``WEB3_INFURA_PROJECT_ID``.
 
 .. code-block:: shell

--- a/newsfragments/1482.doc.rst
+++ b/newsfragments/1482.doc.rst
@@ -1,0 +1,1 @@
+Update Quickstart instructions to use the auto Infura module instead of the more complicated web3 auto module


### PR DESCRIPTION
### What was wrong?
The quick start was not quick enough. Several python developers I recommended it to were stuck on connecting a node. The quick start example required users to look through docs elsewhere (bad user experience, most will quit at this step) in order to connect to a provider.

Related to Issue #1481

### How was it fixed?
Added explanation of Infura and setting Infura global variable to quick start docs.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture (my puppy Stella)
![1021191535_HDR](https://user-images.githubusercontent.com/9449596/67681033-e7a56c00-f962-11e9-9421-4cec439f08ef.jpg)
