### PR TITLE
Remove py.test from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ tox -e py37-core
 
 If for some reason it is not working, add `--recreate` params.
 
-`tox` is good for testing against the full set of build targets. But if you want to run the tests individually, `py.test` is better for development workflow. For example, to run only the tests in one file:
+`tox` is good for testing against the full set of build targets. But if you want to run the tests individually, `pytest` is better for development workflow. For example, to run only the tests in one file:
 
 ```sh
-py.test tests/core/gas-strategies/test_time_based_gas_price_strategy.py
+pytest tests/core/gas-strategies/test_time_based_gas_price_strategy.py
 ```
 
 ### Release setup

--- a/newsfragments/1483.doc.rst
+++ b/newsfragments/1483.doc.rst
@@ -1,0 +1,1 @@
+Remove outdated py.test command from readme


### PR DESCRIPTION
### What was wrong?
I just noticed an outdated `py.test` in the README

### How was it fixed?
Changed it to `pytest`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
<img width="170" alt="image" src="https://user-images.githubusercontent.com/6540608/67703014-5c36d580-f978-11e9-9bdb-134d847b1b94.png">


