### PR TITLE
Add tuple decoder for events

### DIFF
--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -11,6 +11,7 @@ from eth_abi import (
 from eth_typing import (
     TypeStr,
 )
+from eth_utils.abi import collapse_if_tuple
 from eth_utils import (
     encode_hex,
     event_abi_to_log_topic,
@@ -152,7 +153,7 @@ def get_event_abi_types_for_decoding(event_inputs):
         if input_abi['indexed'] and is_dynamic_sized_type(input_abi['type']):
             yield 'bytes32'
         else:
-            yield input_abi['type']
+            yield collapse_if_tuple(input_abi)
 
 
 @curry


### PR DESCRIPTION
### What was wrong?

Struct in events can't be decoded.

### How was it fixed?

Struct is mapped to tuple, and there's existing function to
convert it to decodable structure.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [ ] Add unittest

#### Cute Animal Picture


![image](https://user-images.githubusercontent.com/1130984/67733031-1e00eb00-fa38-11e9-9ae5-a72d3f0c6b2e.png)

