### PR TITLE
[ethPM] Update registry URI definition

### DIFF
--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -216,13 +216,13 @@ way through the EIP process)
 
 ::
 
-   scheme://address:chain_id/package-name?version=x.x.x
+   scheme://address:chain_id/package-name@version
 
 -  URI must be a string type
--  ``scheme``: ``erc1319``
--  ``address``: Must be a valid ENS domain or a valid checksum address
+-  ``scheme``: (required) ``ethpm`` or ``erc1319``
+-  ``address``: (required) Must be a valid ENS domain or a valid checksum address
    pointing towards a registry contract.
--  ``chain_id``: Chain ID of the chain on which the registry lives. Supported chains include...
+-  ``chain_id``: Chain ID of the chain on which the registry lives. Defaults to Mainnet. Supported chains include...
 
   - 1: Mainnet
   - 3: Ropsten
@@ -236,7 +236,17 @@ way through the EIP process)
 -  ``version``: The URI escaped version string, *should* conform to the
    `semver <http://semver.org/>`__ version numbering specification.
 
-i.e. ``erc1319://packages.zeppelinos.eth:1/owned?version=1.0.0``
+i.e. 
+- ``ethpm://packages.zeppelinos.eth/owned@1.0.0``
+- ``ethpm://0x808B53bF4D70A24bA5cb720D37A4835621A9df00:1/ethregistrar@1.0.0``
+
+To specify a specific asset within a package, you can namespace the target asset.
+
+i.e. 
+- ``ethpm://maker.snakecharmers.eth:1/dai-dai@1.0.0/sources/token.sol``
+- ``ethpm://maker.snakecharmers.eth:1/dai-dai@1.0.0/contract_types/DSToken/abi``
+- ``ethpm://maker.snakecharmers.eth:1/dai-dai@1.0.0/deployments/mainnet/dai``
+
 
 Builder
 -------


### PR DESCRIPTION
### What was wrong?
I've received a request to improve the registry uri definition to allow specific assets within a package to be specified. Also, I think this is a cleaner way to define the target package version.

Old URI definition
`erc1319://snakecharmers.eth/dai?version=1.0.0`

New URI definition
- to specify a package
`erc1319://snakecharmers.eth/dai@1.0.0`

- to specify any specific asset in a package, just namespace it after the version
`erc1319://snakecharmers.eth/dai@1.0.0/contract_types/DSToken/abi`
`erc1319://snakecharmers.eth/dai@1.0.0/sources/token.sol`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/67748424-3ee43300-fa6e-11e9-81f2-126efb311c85.png)

