### PR TITLE
[ethpm] Support ENS in Registry URIs

### DIFF
--- a/ethpm/backends/registry.py
+++ b/ethpm/backends/registry.py
@@ -8,7 +8,11 @@ from urllib import (
 from eth_typing import (
     URI,
 )
+from eth_utils import (
+    is_address,
+)
 
+from ens import ENS
 from ethpm._utils.registry import (
     fetch_standard_registry_abi,
 )
@@ -25,7 +29,7 @@ from ethpm.validation.uri import (
 
 # TODO: Update registry ABI once ERC is finalized.
 REGISTRY_ABI = fetch_standard_registry_abi()
-RegistryURI = namedtuple("RegistryURI", ["address", "chain_id", "name", "version"])
+RegistryURI = namedtuple("RegistryURI", ["address", "chain_id", "name", "version", "ens"])
 
 
 class RegistryURIBackend(BaseURIBackend):
@@ -49,7 +53,7 @@ class RegistryURIBackend(BaseURIBackend):
         """
         Return content-addressed URI stored at registry URI.
         """
-        address, chain_id, pkg_name, pkg_version = parse_registry_uri(uri)
+        address, chain_id, pkg_name, pkg_version, _ = parse_registry_uri(uri)
         if chain_id != '1':
             # todo: support all testnets
             raise CannotHandleURI(
@@ -78,11 +82,23 @@ def parse_registry_uri(uri: str) -> RegistryURI:
     """
     Validate and return (authority, pkg name, version) from a valid registry URI
     """
+    from web3.auto.infura import w3
     validate_registry_uri(uri)
     parsed_uri = parse.urlparse(uri)
-    address, chain_id = parsed_uri.netloc.split(":")
+    address_or_ens, chain_id = parsed_uri.netloc.split(":")
+    ns = ENS.fromWeb3(w3)
+    if is_address(address_or_ens):
+        address = address_or_ens
+        ens = None
+    elif ns.address(address_or_ens):
+        address = ns.address(address_or_ens)
+        ens = address_or_ens
+    else:
+        raise CannotHandleURI(
+            f"Invalid address or ENS domain found in uri: {uri}."
+        )
     parsed_name = parsed_uri.path.strip("/")
     parsed_version = parsed_uri.query.lstrip("version=").strip("/")
     pkg_name = parsed_name if parsed_name else None
     pkg_version = parsed_version if parsed_version else None
-    return RegistryURI(address, chain_id, pkg_name, pkg_version)
+    return RegistryURI(address, chain_id, pkg_name, pkg_version, ens)

--- a/newsfragments/1489.feature.rst
+++ b/newsfragments/1489.feature.rst
@@ -1,0 +1,1 @@
+Support handling ENS domains in ERC1319 URIs.

--- a/tests/ethpm/backends/test_registry_backend.py
+++ b/tests/ethpm/backends/test_registry_backend.py
@@ -3,6 +3,7 @@ import pytest
 
 from ethpm.backends.registry import (
     RegistryURIBackend,
+    parse_registry_uri,
 )
 from ethpm.exceptions import (
     CannotHandleURI,
@@ -21,6 +22,21 @@ def test_registry_uri_backend(backend):
     assert backend.can_translate_uri(valid_uri) is True
     assert backend.can_resolve_uri(valid_uri) is False
     assert backend.fetch_uri_contents(valid_uri) == expected_uri
+
+
+@pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
+def test_registry_uri_supports_ens_domains(backend):
+    valid_uri = "erc1319://defi.snakecharmers.eth:1/compound?version=1.0.0"
+    parsed = parse_registry_uri(valid_uri)
+    expected_uri = 'ipfs://QmYvsyuxjj9mKmCvn3jrdfnaHYwFsyHXUu7kETrN4dBhE6'
+    assert backend.can_translate_uri(valid_uri) is True
+    assert backend.can_resolve_uri(valid_uri) is False
+    assert backend.fetch_uri_contents(valid_uri) == expected_uri
+    assert parsed.address == "0xA635F17288187daE5b424D343E21FF44a79ce922"
+    assert parsed.ens == "defi.snakecharmers.eth"
+    assert parsed.chain_id == '1'
+    assert parsed.name == "compound"
+    assert parsed.version == "1.0.0"
 
 
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')

--- a/tests/ethpm/test_uri.py
+++ b/tests/ethpm/test_uri.py
@@ -72,24 +72,24 @@ def test_create_github_uri():
     (
         (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", None, None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", None, None, None],
         ),
         (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/owned",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "owned", None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "owned", None, None],
         ),
         (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/owned?version=1.0.0",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "owned", "1.0.0"],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "owned", "1.0.0", None],
         ),
         (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/wallet?version=2.8.0/",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0"],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", None],
         ),
     ),
 )
 def test_parse_registry_uri(uri, expected):
-    address, chain_id, pkg_name, pkg_version = parse_registry_uri(uri)
+    address, chain_id, pkg_name, pkg_version, ens = parse_registry_uri(uri)
     assert address == expected[0]
     assert chain_id == expected[1]
     assert pkg_name == expected[2]


### PR DESCRIPTION
### What was wrong?
ENS support was needed in ERC1319 URIs.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/68036099-69670380-fc9b-11e9-9544-d066aa92bba7.png)

