### PR TITLE
Update google protobuf dependency

### DIFF
--- a/newsfragments/1493.bugfix.rst
+++ b/newsfragments/1493.bugfix.rst
@@ -1,0 +1,1 @@
+Google protobuf dependency was updated to `3.10.0`

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         "ipfshttpclient>=0.4.12,<1",
         "jsonschema>=3.0.0,<4.0.0",
         "lru-dict>=1.1.6,<2.0.0",
-        "protobuf>=3.0.0,<4",
+        "protobuf>=3.10.0,<4",
         "pypiwin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
         "websockets>=7.0.0,<8.0.0",


### PR DESCRIPTION
### What was wrong?
`protobuf` dependency was throwing a warning when building docs, so updated the dependency to the latest version.


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/68233253-d0065d00-ffcc-11e9-93bf-fc41a43b0740.png)

