### PR TITLE
Fix SyntaxWarning

### DIFF
--- a/newsfragments/1498.misc.rst
+++ b/newsfragments/1498.misc.rst
@@ -1,0 +1,1 @@
+Fix Syntax warnings: use `==` instead of `is` where appropriate, and similarly `!=` instead of `is not`

--- a/tests/ethpm/test_deployments.py
+++ b/tests/ethpm/test_deployments.py
@@ -138,7 +138,7 @@ def test_get_linked_deployments(escrow_package):
     assert actual_linked_deployments == {"Escrow": all_deployments["Escrow"]}
     # integration via package.deployments
     deployments = escrow_package.deployments
-    assert len(deployments.contract_instances) is 2
+    assert len(deployments.contract_instances) == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -296,7 +296,7 @@ class TestEthereumTesterEthModule(EthModuleTest):
     def test_eth_chainId(self, web3):
         chain_id = web3.eth.chainId
         assert is_integer(chain_id)
-        assert chain_id is 61
+        assert chain_id == 61
 
 
 class TestEthereumTesterVersionModule(VersionModuleTest):

--- a/web3/_utils/module_testing/shh_module.py
+++ b/web3/_utils/module_testing/shh_module.py
@@ -378,17 +378,17 @@ class GoEthereumShhModuleTest():
 
     def test_shh_info(self, web3):
         pre_info = web3.geth.shh.info()
-        assert pre_info["maxMessageSize"] != 1024
-        assert pre_info["minPow"] != 0.5
+        assert pre_info["maxMessageSize"] != 2048
+        assert pre_info["minPow"] != 0.6
 
-        web3.geth.shh.set_max_message_size(1024)
-        web3.geth.shh.set_min_pow(0.5)
+        web3.geth.shh.set_max_message_size(2048)
+        web3.geth.shh.set_min_pow(0.6)
 
         info = web3.geth.shh.info()
 
         assert len(info) == 4
-        assert info["maxMessageSize"] == 1024
-        assert info["minPow"] == 0.5
+        assert info["maxMessageSize"] == 2048
+        assert info["minPow"] == 0.6
 
     def test_shh_info_deprecated(self, web3):
         with pytest.warns(DeprecationWarning):

--- a/web3/_utils/module_testing/shh_module.py
+++ b/web3/_utils/module_testing/shh_module.py
@@ -378,8 +378,8 @@ class GoEthereumShhModuleTest():
 
     def test_shh_info(self, web3):
         pre_info = web3.geth.shh.info()
-        assert pre_info["maxMessageSize"] is not 1024
-        assert pre_info["minPow"] is not 0.5
+        assert pre_info["maxMessageSize"] != 1024
+        assert pre_info["minPow"] != 0.5
 
         web3.geth.shh.set_max_message_size(1024)
         web3.geth.shh.set_min_pow(0.5)
@@ -393,8 +393,8 @@ class GoEthereumShhModuleTest():
     def test_shh_info_deprecated(self, web3):
         with pytest.warns(DeprecationWarning):
             pre_info = web3.geth.shh.info()
-            assert pre_info["maxMessageSize"] is not 1024
-            assert pre_info["minPow"] is not 0.5
+            assert pre_info["maxMessageSize"] != 1024
+            assert pre_info["minPow"] != 0.5
 
             web3.geth.shh.setMaxMessageSize(1024)
             web3.geth.shh.setMinPoW(0.5)

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -172,7 +172,7 @@ def abi_ens_resolver(w3, type_str, val):
                 "Could not look up name %r because ENS is"
                 " set to None" % (val)
             )
-        elif int(w3.net.version) is not 1 and not isinstance(w3.ens, StaticENS):
+        elif int(w3.net.version) != 1 and not isinstance(w3.ens, StaticENS):
             raise InvalidAddress(
                 "Could not look up name %r because web3 is"
                 " not connected to mainnet" % (val)

--- a/web3/middleware/filter.py
+++ b/web3/middleware/filter.py
@@ -110,7 +110,7 @@ def iter_latest_block(w3, to_block=None):
 
     is_bounded_range = (
         to_block is not None and
-        to_block is not 'latest'
+        to_block != 'latest'
     )
 
     while True:


### PR DESCRIPTION
### What was wrong?

Python is complaining with a SyntaxWarning when comparing with literals using `is`/`is not`

`is` and `is not` are identity operators, that check if they are the
same objects, which is not what we want when comparing on these cases.

### How was it fixed?

Change to use `==` and `!=` where appropriate

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](http://4.bp.blogspot.com/-N0Mp-4V6xZM/UH_3rmZuNFI/AAAAAAAAlDI/wJNY9bNywGI/s1600/Cute+Animal+Pics+(10).jpg)
