### PR TITLE
Add condition to check for secret key and return correct uri

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,6 @@ jobs:
       TOXENV: py36-ethpm
       # Please don't use this key for any shenanigans
       WEB3_INFURA_PROJECT_ID: 7707850c2fb7465ebe6f150d67182e22
-      WEB3_INFURA_API_SECRET: 1955838f22ac4d858434f41498557130
 
   py36-integration-goethereum-ipc-1.7.2:
     <<: *geth_steps
@@ -290,7 +289,6 @@ jobs:
       TOXENV: py37-ethpm
       # Please don't use this key for any shenanigans
       WEB3_INFURA_PROJECT_ID: 7707850c2fb7465ebe6f150d67182e22
-      WEB3_INFURA_API_SECRET: 1955838f22ac4d858434f41498557130
 
   py37-integration-goethereum-ipc-1.7.2:
     <<: *geth_steps
@@ -399,7 +397,6 @@ jobs:
       TOXENV: py38-ethpm
       # Please don't use this key for any shenanigans
       WEB3_INFURA_PROJECT_ID: 7707850c2fb7465ebe6f150d67182e22
-      WEB3_INFURA_API_SECRET: 1955838f22ac4d858434f41498557130
 
   py38-integration-goethereum-ipc-1.7.2:
     <<: *geth_steps

--- a/newsfragments/1501.bugfix.rst
+++ b/newsfragments/1501.bugfix.rst
@@ -1,0 +1,1 @@
+Infura websocket provider works when no secret key is present

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -107,7 +107,7 @@ def test_web3_auto_infura_websocket_default(monkeypatch, caplog, environ_name):
     monkeypatch.setenv('WEB3_INFURA_SCHEME', 'wss')
     API_KEY = 'aoeuhtns'
     monkeypatch.setenv(environ_name, API_KEY)
-    expected_url = 'wss://:@%s/ws/v3/%s' % (infura.INFURA_MAINNET_DOMAIN, API_KEY)
+    expected_url = 'wss://%s/ws/v3/%s' % (infura.INFURA_MAINNET_DOMAIN, API_KEY)
 
     importlib.reload(infura)
     assert len(caplog.record_tuples) == 0

--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -46,8 +46,10 @@ def build_infura_url(domain):
     key = load_api_key()
     secret = load_secret()
 
-    if scheme == WEBSOCKET_SCHEME:
+    if scheme == WEBSOCKET_SCHEME and secret != '':
         return "%s://:%s@%s/ws/v3/%s" % (scheme, secret, domain, key)
+    elif scheme == WEBSOCKET_SCHEME and secret == '':
+        return "%s://%s/ws/v3/%s" % (scheme, domain, key)
     elif scheme == HTTP_SCHEME:
         return "%s://%s/v3/%s" % (scheme, domain, key)
     else:


### PR DESCRIPTION
### What was wrong?
The Infura auto websocket provider started throwing an error with a uri of `wss://:@mainnet.infura.com/v3/<key>` with the upgrade to websockets v8.

Related to Issue #1500 

### How was it fixed?
Added a new condition in the url builder to check if the secret key is present, and build a url based on the presence of the key. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="347" alt="image" src="https://user-images.githubusercontent.com/6540608/68809695-afbc4b00-0629-11ea-9da8-62f2f05b3275.png">
