### PR TITLE
Update deprecated use of `version.node` from docs

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -335,7 +335,7 @@ The easiest way to connect to a default ``geth --dev`` instance which loads the 
     >>> from web3.auto.gethdev import w3
 
     # confirm that the connection succeeded
-    >>> w3.version.node
+    >>> w3.clientVersion
     'Geth/v1.7.3-stable-4bb3c89d/linux-amd64/go1.9'
 
 This example connects to a local ``geth --dev`` instance on Linux with a
@@ -355,7 +355,7 @@ unique IPC location and loads the middleware:
     >>> w3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     # confirm that the connection succeeded
-    >>> w3.version.node
+    >>> w3.clientVersion
     'Geth/v1.7.3-stable-4bb3c89d/linux-amd64/go1.9'
 
 Why is ``geth_poa_middleware`` necessary?

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -126,10 +126,10 @@ For example, the following retrieves the client enode endpoint for both geth and
 
     connected = w3.isConnected()
 
-    if connected and w3.version.node.startswith('Parity'):
+    if connected and w3.clientVersion.startswith('Parity'):
         enode = w3.parity.enode
 
-    elif connected and w3.version.node.startswith('Geth'):
+    elif connected and w3.clientVersion.startswith('Geth'):
         enode = w3.geth.admin.nodeInfo['enode']
 
     else:


### PR DESCRIPTION
### What was wrong?

Fixes #1524 

### How was it fixed?
Renaming occurrences of `version.node` by `clientVersion` in two separate doc files.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://www.awesomelycute.com/gallery/2013/02/cute-animals-awesomelycute-com-1848-e1480487103258.jpg)
