### PR TITLE
Add __str__ for IPCProvider

### DIFF
--- a/newsfragments/1536.feature.rst
+++ b/newsfragments/1536.feature.rst
@@ -1,0 +1,1 @@
+Add __str__ to IPCProvider

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -218,7 +218,7 @@ class IPCProvider(JSONBaseProvider):
         super().__init__()
 
     def __str__(self) -> str:
-        return "IPC connection {0}".format(self.ipc_path)
+        return f"<{self.__class__.__name__} {self.ipc_path}>"
 
     def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         self.logger.debug("Making request IPC. Path: %s, Method: %s",

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -217,6 +217,9 @@ class IPCProvider(JSONBaseProvider):
         self._socket = PersistantSocket(self.ipc_path)
         super().__init__()
 
+    def __str__(self) -> str:
+        return "IPC connection {0}".format(self.ipc_path)
+
     def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         self.logger.debug("Making request IPC. Path: %s, Method: %s",
                           self.ipc_path, method)


### PR DESCRIPTION
### What was wrong?

IPCProvider is missing a string representation. RPC and websocket providers both have one.

### How was it fixed?

Add \_\_str\_\_() method to IPCProvider.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://www.buzzecolo.com/wp-content/uploads/2013/11/Le-bebe-herisson.jpg)
