### PR TITLE
Update eth-utils dependency

### DIFF
--- a/newsfragments/1537.bugfix.rst
+++ b/newsfragments/1537.bugfix.rst
@@ -1,0 +1,1 @@
+Update eth-utils dependency which contains mypy bugfix.

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "eth-account>=0.4.0,<0.5.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",
-        "eth-utils>=1.8.1,<2.0.0",
+        "eth-utils>=1.8.3,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "ipfshttpclient>=0.4.12,<1",
         "jsonschema>=3.0.0,<4.0.0",


### PR DESCRIPTION
### What was wrong?
Most recent `eth-utils` release fixes a linting error.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/70184866-0b3d9e00-16e9-11ea-8f8e-311477c0c252.png)

