### PR TITLE
Add Matomo Tracking

### DIFF
--- a/docs/_static/js/matomo.js
+++ b/docs/_static/js/matomo.js
@@ -1,0 +1,11 @@
+var _paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="https://matomo.ethereum.org/piwik/";
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '18']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,7 +149,10 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
+
+def setup(app):
+    app.add_js_file("js/matomo.js")
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/newsfragments/1541.doc.rst
+++ b/newsfragments/1541.doc.rst
@@ -1,0 +1,7 @@
+Add Matomo Tracking to Docs site.
+
+Matomo is an Open Source web analytics platform that allows us
+to get better insights and optimize for our audience without
+the negative consequences of other compareable platforms.
+
+Read more: https://matomo.org/why-matomo/


### PR DESCRIPTION
### What was wrong?

Currently we do not have a good insight into our target group. In order to improve both web3.py itself and the documentation, it makes sense to aggregate some data.

### How was it fixed?

Add Matomo Tracking to Docs site.

Matomo is an Open Source web analytics platform that allows us
to get better insights and optimize for our audience without
the negative consequences of other compareable platforms.

Read more: https://matomo.org/why-matomo/

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![put a cute animal picture link inside the parentheses](http://sacramento.cbslocal.com/wp-content/uploads/sites/15909776/2013/04/baby-sea-turtles.jpg)

