### PR TITLE
Add typing-extensions lib

### DIFF
--- a/newsfragments/1544.bugfix.rst
+++ b/newsfragments/1544.bugfix.rst
@@ -1,0 +1,1 @@
+Add required typing-extensions library to setup.py

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         "pypiwin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
         "websockets>=8.1.0,<9.0.0",
+        "typing-extensions>=3.7.4.1,<4",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.6,<4',


### PR DESCRIPTION
### What was wrong?
We need to require typing-extensions and we don't.

Related to Issue #1540

### How was it fixed?
Added it!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
<img width="350" alt="image" src="https://user-images.githubusercontent.com/6540608/70340784-b3995280-180e-11ea-9f42-5e84f5a95cd0.png">


