### PR TITLE
Type hints complete

### DIFF
--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -200,8 +200,8 @@ A valid content-addressed Github URI *must* conform to the following scheme, as 
 
    >>> from ethpm.uri import create_content_addressed_github_uri
 
-   >>> owned_github_api_uri = "https://api.github.com/repos/ethpm/py-ethpm/contents/ethpm/assets/owned/1.0.1.json"
-   >>> content_addressed_uri = "https://api.github.com/repos/ethpm/py-ethpm/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03480"
+   >>> owned_github_api_uri = "https://api.github.com/repos/ethereum/web3.py/contents/ethpm/assets/owned/1.0.1.json"
+   >>> content_addressed_uri = "https://api.github.com/repos/ethereum/web3.py/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03480"
 
    >>> actual_blob_uri = create_content_addressed_github_uri(owned_github_api_uri)
    >>> assert actual_blob_uri == content_addressed_uri

--- a/ens/main.py
+++ b/ens/main.py
@@ -11,6 +11,7 @@ from eth_typing import (
     Address,
     ChecksumAddress,
     HexAddress,
+    HexStr,
 )
 from eth_utils import (
     is_binary_address,
@@ -58,7 +59,7 @@ if TYPE_CHECKING:
     )
 
 
-ENS_MAINNET_ADDR = cast(ChecksumAddress, '0x314159265dD8dbb310642f98f50C066173C1259b')
+ENS_MAINNET_ADDR = ChecksumAddress(HexAddress(HexStr('0x314159265dD8dbb310642f98f50C066173C1259b')))
 
 
 class ENS:

--- a/ens/main.py
+++ b/ens/main.py
@@ -10,14 +10,15 @@ from typing import (
 from eth_typing import (
     Address,
     ChecksumAddress,
-    Hash32,
     HexAddress,
-    HexStr,
 )
 from eth_utils import (
     is_binary_address,
     is_checksum_address,
     to_checksum_address,
+)
+from hexbytes import (
+    HexBytes,
 )
 
 from ens import abis
@@ -57,9 +58,7 @@ if TYPE_CHECKING:
     )
 
 
-ENS_MAINNET_ADDR = ChecksumAddress(
-    HexAddress(HexStr('0x314159265dD8dbb310642f98f50C066173C1259b'))
-)
+ENS_MAINNET_ADDR = cast(ChecksumAddress, '0x314159265dD8dbb310642f98f50C066173C1259b')
 
 
 class ENS:
@@ -130,7 +129,7 @@ class ENS:
         name: str,
         address: Union[Address, ChecksumAddress, HexAddress]=cast(ChecksumAddress, default),
         transact: "TxParams"={}
-    ) -> Hash32:
+    ) -> HexBytes:
         """
         Set up the name to point to the supplied address.
         The sender of the transaction must own the name, or
@@ -169,7 +168,7 @@ class ENS:
     @dict_copy
     def setup_name(
         self, name: str, address: ChecksumAddress=None, transact: "TxParams"={}
-    ) -> Hash32:
+    ) -> HexBytes:
         """
         Set up the address for reverse lookup, aka "caller ID".
         After successful setup, the method :meth:`~ens.main.ENS.name` will return
@@ -354,7 +353,7 @@ class ENS:
     @dict_copy
     def _setup_reverse(
         self, name: str, address: ChecksumAddress, transact: "TxParams"={}
-    ) -> Hash32:
+    ) -> HexBytes:
         if name:
             name = normalize_name(name)
         else:

--- a/ethpm/_utils/chains.py
+++ b/ethpm/_utils/chains.py
@@ -17,6 +17,9 @@ from eth_utils import (
     is_integer,
     remove_0x_prefix,
 )
+from hexbytes import (
+    HexBytes,
+)
 
 from ethpm.constants import (
     SUPPORTED_CHAIN_IDS,
@@ -24,7 +27,7 @@ from ethpm.constants import (
 from web3 import Web3
 
 
-def get_genesis_block_hash(web3: Web3) -> str:
+def get_genesis_block_hash(web3: Web3) -> HexBytes:
     return web3.eth.getBlock(BlockNumber(0))["hash"]
 
 

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -386,7 +386,7 @@ class Package(object):
                     f"{self.contract_types}."
                 )
             contract_instance = self.get_contract_instance(
-                deployment_data['contract_type'],
+                ContractName(deployment_data['contract_type']),
                 deployment_data['address'],
             )
             yield deployment_name, contract_instance

--- a/ethpm/uri.py
+++ b/ethpm/uri.py
@@ -36,6 +36,9 @@ from ethpm.exceptions import (
     CannotHandleURI,
 )
 from web3 import Web3
+from web3.types import (
+    BlockNumber,
+)
 
 
 def resolve_uri_contents(uri: URI, fingerprint: bool = None) -> bytes:
@@ -101,13 +104,13 @@ def create_latest_block_uri(w3: Web3, from_blocks_ago: int = 3) -> URI:
     """
     chain_id = to_hex(get_genesis_block_hash(w3))
     latest_block_tx_receipt = w3.eth.getBlock("latest")
-    target_block_number = latest_block_tx_receipt.number - from_blocks_ago
+    target_block_number = BlockNumber(latest_block_tx_receipt["number"] - from_blocks_ago)
     if target_block_number < 0:
         raise Exception(
-            f"Only {latest_block_tx_receipt.number} blocks avaible on provided w3, "
+            f"Only {latest_block_tx_receipt['number']} blocks avaible on provided w3, "
             f"cannot create latest block uri for {from_blocks_ago} blocks ago."
         )
-    recent_block = to_hex(w3.eth.getBlock(target_block_number).hash)
+    recent_block = to_hex(w3.eth.getBlock(target_block_number)["hash"])
     return create_block_uri(chain_id, recent_block)
 
 

--- a/tests/ethpm/test_uri.py
+++ b/tests/ethpm/test_uri.py
@@ -61,8 +61,8 @@ def test_is_valid_content_addressed_github_uri(uri, expected):
 
 
 def test_create_github_uri():
-    api_uri = "https://api.github.com/repos/ethpm/py-ethpm/contents/ethpm/assets/owned/1.0.1.json"
-    expected_blob_uri = "https://api.github.com/repos/ethpm/py-ethpm/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03480"  # noqa: E501
+    api_uri = "https://api.github.com/repos/ethereum/web3.py/contents/ethpm/assets/owned/1.0.1.json"
+    expected_blob_uri = "https://api.github.com/repos/ethereum/web3.py/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03480"  # noqa: E501
     actual_blob_uri = create_content_addressed_github_uri(api_uri)
     assert actual_blob_uri == expected_blob_uri
 

--- a/tox.ini
+++ b/tox.ini
@@ -63,4 +63,4 @@ extras=linter
 commands=
   flake8 {toxinidir}/web3 {toxinidir}/ens {toxinidir}/ethpm {toxinidir}/tests
   isort --recursive --check-only --diff {toxinidir}/web3/ {toxinidir}/ens/ {toxinidir}/ethpm/ {toxinidir}/tests/
-  mypy -p web3._utils -p web3.providers -p web3.main -p web3.contract -p web3.datastructures -p web3.eth -p web3.exceptions -p web3.geth -p web3.iban -p web3.logs -p web3.manager -p web3.module -p web3.net -p web3.parity -p web3.middleware -p web3.method -p web3.pm -p web3.auto -p web3.gas_strategies -p web3.testing -p web3.tools -p web3.version -p ethpm -p ens --config-file {toxinidir}/mypy.ini
+  mypy -p web3 -p ethpm -p ens --config-file {toxinidir}/mypy.ini

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -105,7 +105,6 @@ def get_abi_input_types(abi: ABIFunction) -> List[str]:
     if 'inputs' not in abi and abi['type'] == 'fallback':
         return []
     else:
-        # https://github.com/python/mypy/issues/4976
         return [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi['inputs']]
 
 
@@ -113,7 +112,6 @@ def get_abi_output_types(abi: ABIFunction) -> List[str]:
     if abi['type'] == 'fallback':
         return []
     else:
-        # https://github.com/python/mypy/issues/4976
         return [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi['outputs']]
 
 
@@ -555,6 +553,7 @@ def get_aligned_abi_inputs(
         args = tuple(args[abi['name']] for abi in input_abis)
 
     return (
+        # typed dict cannot be used w/ a normal Dict
         # https://github.com/python/mypy/issues/4976
         tuple(collapse_if_tuple(abi) for abi in input_abis),  # type: ignore
         # too many arguments for Sequence

--- a/web3/_utils/compat/__init__.py
+++ b/web3/_utils/compat/__init__.py
@@ -1,6 +1,7 @@
+import sys
 # remove once web3 supports python>=3.8
 # TypedDict was added to typing in 3.8
-try:
-    from typing import Literal, Protocol, TypedDict  # type: ignore
-except ImportError:
-    from typing_extensions import Literal, Protocol, TypedDict  # type: ignore # noqa: F401
+if sys.version_info >= (3, 8):
+    from typing import Literal, Protocol, TypedDict
+else:
+    from typing_extensions import Literal, Protocol, TypedDict  # noqa: F401

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -6,6 +6,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 
 from eth_abi.codec import (
@@ -199,7 +200,7 @@ def prepare_transaction(
     transaction: TxParams=None,
     fn_args: Sequence[Any]=None,
     fn_kwargs: Any=None,
-) -> HexStr:
+) -> TxParams:
     """
     :parameter `is_function_abi` is used to distinguish  function abi from contract abi
     Returns a dictionary of the transaction that could be used to call this
@@ -214,7 +215,7 @@ def prepare_transaction(
     if transaction is None:
         prepared_transaction: TxParams = {}
     else:
-        prepared_transaction = dict(**transaction)
+        prepared_transaction = cast(TxParams, dict(**transaction))
 
     if 'data' in prepared_transaction:
         raise ValueError("Transaction parameter may not contain a 'data' key")
@@ -280,7 +281,8 @@ def get_function_info(
     if fn_abi is None:
         fn_abi = find_matching_fn_abi(contract_abi, abi_codec, fn_name, args, kwargs)
 
-    fn_selector = encode_hex(function_abi_to_4byte_selector(fn_abi))
+    # https://github.com/python/mypy/issues/4976
+    fn_selector = encode_hex(function_abi_to_4byte_selector(fn_abi))  # type: ignore
 
     fn_arguments = merge_args_and_kwargs(fn_abi, args, kwargs)
 

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -281,6 +281,7 @@ def get_function_info(
     if fn_abi is None:
         fn_abi = find_matching_fn_abi(contract_abi, abi_codec, fn_name, args, kwargs)
 
+    # typed dict cannot be used w/ a normal Dict
     # https://github.com/python/mypy/issues/4976
     fn_selector = encode_hex(function_abi_to_4byte_selector(fn_abi))  # type: ignore
 

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -112,6 +112,7 @@ def construct_event_topic_set(
         for key, value in arguments.items()  # type: ignore
     }
 
+    # typed dict cannot be used w/ a normal Dict
     # https://github.com/python/mypy/issues/4976
     event_topic = encode_hex(event_abi_to_log_topic(event_abi))  # type: ignore
     indexed_args = get_indexed_event_inputs(event_abi)

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -112,7 +112,8 @@ def construct_event_topic_set(
         for key, value in arguments.items()  # type: ignore
     }
 
-    event_topic = encode_hex(event_abi_to_log_topic(event_abi))
+    # https://github.com/python/mypy/issues/4976
+    event_topic = encode_hex(event_abi_to_log_topic(event_abi))  # type: ignore
     indexed_args = get_indexed_event_inputs(event_abi)
     zipped_abi_and_args = [
         (arg, normalized_args.get(arg['name'], [None]))
@@ -179,7 +180,7 @@ def is_dynamic_sized_type(type_str: TypeStr) -> bool:
 
 
 @to_tuple
-def get_event_abi_types_for_decoding(event_inputs: ABIEventParams) -> Iterable[TypeStr]:
+def get_event_abi_types_for_decoding(event_inputs: Sequence[ABIEventParams]) -> Iterable[TypeStr]:
     """
     Event logs use the `keccak(value)` for indexed inputs of type `bytes` or
     `string`.  Because of this we need to modify the types so that we can
@@ -202,7 +203,8 @@ def get_event_data(abi_codec: ABICodec, event_abi: ABIEvent, log_entry: LogRecei
         log_topics = log_entry['topics']
     elif not log_entry['topics']:
         raise MismatchedABI("Expected non-anonymous event to have 1 or more topics")
-    elif event_abi_to_log_topic(event_abi) != log_entry['topics'][0]:
+    # type ignored b/c event_abi_to_log_topic(event_abi: Dict[str, Any])
+    elif event_abi_to_log_topic(event_abi) != log_entry['topics'][0]:  # type: ignore
         raise MismatchedABI("The event signature did not match the provided ABI")
     else:
         log_topics = log_entry['topics'][1:]
@@ -267,7 +269,7 @@ def get_event_data(abi_codec: ABICodec, event_abi: ABIEvent, log_entry: LogRecei
         'blockNumber': log_entry['blockNumber'],
     }
 
-    return AttributeDict.recursive(event_data)
+    return cast(EventData, AttributeDict.recursive(event_data))
 
 
 @to_tuple
@@ -409,7 +411,8 @@ class EventFilterBuilder:
 
 def initialize_event_topics(event_abi: ABIEvent) -> Union[bytes, List[Any]]:
     if event_abi['anonymous'] is False:
-        return event_abi_to_log_topic(event_abi)
+        # https://github.com/python/mypy/issues/4976
+        return event_abi_to_log_topic(event_abi)  # type: ignore
     else:
         return list()
 

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -39,9 +39,6 @@ from hexbytes import (
     HexBytes,
 )
 
-from web3._utils.compat import (
-    Literal,
-)
 from web3._utils.events import (
     EventFilterBuilder,
     construct_event_data_set,
@@ -89,7 +86,8 @@ def construct_event_filter_params(
         topic_set = topics
 
     if len(topic_set) == 1 and is_list_like(topic_set[0]):
-        filter_params['topics'] = topic_set[0]
+        # type ignored b/c list-like check on line 88
+        filter_params['topics'] = topic_set[0]  # type: ignore
     else:
         filter_params['topics'] = topic_set
 
@@ -141,20 +139,20 @@ class Filter:
     def __str__(self) -> str:
         return "Filter for {0}".format(self.filter_id)
 
-    def format_entry(self, entry: Dict[str, Any]) -> Dict[str, Any]:
+    def format_entry(self, entry: LogReceipt) -> LogReceipt:
         """
         Hook for subclasses to change the format of the value that is passed
         into the callback functions.
         """
         return entry
 
-    def is_valid_entry(self, entry: Dict[str, Any]) -> Literal[True]:
+    def is_valid_entry(self, entry: LogReceipt) -> bool:
         """
         Hook for subclasses to implement additional filtering layers.
         """
         return True
 
-    def _filter_valid_entries(self, entries: Collection[Dict[str, Any]]) -> Iterator[LogReceipt]:
+    def _filter_valid_entries(self, entries: Collection[LogReceipt]) -> Iterator[LogReceipt]:
         return filter(self.is_valid_entry, entries)
 
     def get_new_entries(self) -> List[LogReceipt]:
@@ -214,7 +212,7 @@ class LogFilter(Filter):
         if any(data_filter_set):
             self.data_filter_set_function = match_fn(self.web3, data_filter_set)
 
-    def is_valid_entry(self, entry: Dict[str, Any]) -> bool:
+    def is_valid_entry(self, entry: LogReceipt) -> bool:
         if not self.data_filter_set:
             return True
         return bool(self.data_filter_set_function(entry['data']))

--- a/web3/_utils/formatters.py
+++ b/web3/_utils/formatters.py
@@ -33,6 +33,10 @@ from eth_utils.toolz import (
 from web3._utils.decorators import (
     reject_recursive_repeats,
 )
+from web3.types import (
+    TReturn,
+    TValue,
+)
 
 TReturn = TypeVar("TReturn")
 TValue = TypeVar("TValue")

--- a/web3/_utils/formatters.py
+++ b/web3/_utils/formatters.py
@@ -33,10 +33,6 @@ from eth_utils.toolz import (
 from web3._utils.decorators import (
     reject_recursive_repeats,
 )
-from web3.types import (
-    TReturn,
-    TValue,
-)
 
 TReturn = TypeVar("TReturn")
 TValue = TypeVar("TValue")
@@ -83,7 +79,7 @@ def map_collection(func: Callable[..., TReturn], collection: Any) -> Any:
 
 
 @reject_recursive_repeats
-def recursive_map(func: Callable[..., TReturn], data: Any) -> Any:
+def recursive_map(func: Callable[..., TReturn], data: Any) -> TReturn:
     """
     Apply func to data, and any collection items inside data (using map_collection).
     Define func so that it only applies to the type of value that you want it to apply to.

--- a/web3/_utils/hypothesis.py
+++ b/web3/_utils/hypothesis.py
@@ -1,7 +1,7 @@
 from hypothesis import (
     strategies as st,
 )
-from hypothesis.searchstrategy import (
+from hypothesis.strategies import (
     SearchStrategy,
 )
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -12,6 +12,7 @@ from typing import (
 from eth_typing import (
     BlockNumber,
     ChecksumAddress,
+    HexAddress,
     HexStr,
 )
 from eth_utils import (
@@ -43,7 +44,7 @@ from web3.types import (  # noqa: F401
     Wei,
 )
 
-UNKNOWN_ADDRESS = cast(ChecksumAddress, '0xdEADBEeF00000000000000000000000000000000')
+UNKNOWN_ADDRESS = ChecksumAddress(HexAddress(HexStr('0xdEADBEeF00000000000000000000000000000000')))
 UNKNOWN_HASH = HexStr('0xdeadbeef00000000000000000000000000000000000000000000000000000000')
 
 if TYPE_CHECKING:
@@ -118,7 +119,7 @@ class EthModuleTest:
         coinbase = web3.eth.coinbase
 
         with pytest.raises(InvalidAddress):
-            web3.eth.getBalance(cast(ChecksumAddress, coinbase.lower()))
+            web3.eth.getBalance(ChecksumAddress(HexAddress(HexStr(coinbase.lower()))))
 
         balance = web3.eth.getBalance(coinbase)
 
@@ -134,7 +135,7 @@ class EthModuleTest:
     def test_eth_getStorageAt_invalid_address(self, web3: "Web3") -> None:
         coinbase = web3.eth.coinbase
         with pytest.raises(InvalidAddress):
-            web3.eth.getStorageAt(cast(ChecksumAddress, coinbase.lower()), 0)
+            web3.eth.getStorageAt(ChecksumAddress(HexAddress(HexStr(coinbase.lower()))), 0)
 
     def test_eth_getTransactionCount(
         self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress
@@ -146,7 +147,7 @@ class EthModuleTest:
     def test_eth_getTransactionCount_invalid_address(self, web3: "Web3") -> None:
         coinbase = web3.eth.coinbase
         with pytest.raises(InvalidAddress):
-            web3.eth.getTransactionCount(cast(ChecksumAddress, coinbase.lower()))
+            web3.eth.getTransactionCount(ChecksumAddress(HexAddress(HexStr(coinbase.lower()))))
 
     def test_eth_getBlockTransactionCountByHash_empty_block(
         self, web3: "Web3", empty_block: BlockData
@@ -199,7 +200,7 @@ class EthModuleTest:
 
     def test_eth_getCode_invalid_address(self, web3: "Web3", math_contract: "Contract") -> None:
         with pytest.raises(InvalidAddress):
-            web3.eth.getCode(cast(ChecksumAddress, math_contract.address.lower()))
+            web3.eth.getCode(ChecksumAddress(HexAddress(HexStr(math_contract.address.lower()))))
 
     def test_eth_getCode_with_block_identifier(
         self, web3: "Web3", emitter_contract: "Contract"

--- a/web3/_utils/module_testing/personal_module.py
+++ b/web3/_utils/module_testing/personal_module.py
@@ -2,6 +2,7 @@ import json
 import pytest
 from typing import (
     TYPE_CHECKING,
+    cast,
 )
 
 from eth_typing import (
@@ -14,6 +15,11 @@ from eth_utils import (
 )
 from hexbytes import (
     HexBytes,
+)
+
+from web3.types import (  # noqa: F401
+    TxParams,
+    Wei,
 )
 
 if TYPE_CHECKING:
@@ -78,19 +84,19 @@ class GoEthereumPersonalModuleTest:
         unlockable_account_pw: str,
     ) -> None:
         assert web3.eth.getBalance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
-        txn_params = {
+        txn_params: TxParams = {
             'from': unlockable_account_dual_type,
             'to': unlockable_account_dual_type,
-            'gas': 21000,
-            'value': 1,
+            'gas': Wei(21000),
+            'value': Wei(1),
             'gasPrice': web3.toWei(1, 'gwei'),
         }
         txn_hash = web3.geth.personal.sendTransaction(txn_params, unlockable_account_pw)
         assert txn_hash
         transaction = web3.eth.getTransaction(txn_hash)
 
-        assert is_same_address(transaction['from'], txn_params['from'])
-        assert is_same_address(transaction['to'], txn_params['to'])
+        assert is_same_address(transaction['from'], cast(ChecksumAddress, txn_params['from']))
+        assert is_same_address(transaction['to'], cast(ChecksumAddress, txn_params['to']))
         assert transaction['gas'] == txn_params['gas']
         assert transaction['value'] == txn_params['value']
         assert transaction['gasPrice'] == txn_params['gasPrice']
@@ -231,19 +237,19 @@ class ParityPersonalModuleTest():
         unlockable_account_pw: str,
     ) -> None:
         assert web3.eth.getBalance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
-        txn_params = {
+        txn_params: TxParams = {
             'from': unlockable_account_dual_type,
             'to': unlockable_account_dual_type,
-            'gas': 21000,
-            'value': 1,
+            'gas': Wei(21000),
+            'value': Wei(1),
             'gasPrice': web3.toWei(1, 'gwei'),
         }
         txn_hash = web3.parity.personal.sendTransaction(txn_params, unlockable_account_pw)
         assert txn_hash
         transaction = web3.eth.getTransaction(txn_hash)
 
-        assert is_same_address(transaction['from'], txn_params['from'])
-        assert is_same_address(transaction['to'], txn_params['to'])
+        assert is_same_address(transaction['from'], cast(ChecksumAddress, txn_params['from']))
+        assert is_same_address(transaction['to'], cast(ChecksumAddress, txn_params['to']))
         assert transaction['gas'] == txn_params['gas']
         assert transaction['value'] == txn_params['value']
         assert transaction['gasPrice'] == txn_params['gasPrice']

--- a/web3/_utils/module_testing/shh_module.py
+++ b/web3/_utils/module_testing/shh_module.py
@@ -5,6 +5,9 @@ from typing import (  # noqa: F401
     List,
 )
 
+from eth_typing import (
+    HexStr,
+)
 from eth_utils import (
     is_integer,
 )
@@ -34,7 +37,7 @@ class GoEthereumShhModuleTest():
         receiver = web3.geth.shh.new_key_pair()
         receiver_pub = web3.geth.shh.get_public_key(receiver)
 
-        topic = '0x13370000'
+        topic = HexStr('0x13370000')
         payloads = [web3.toHex(text="test message :)"), web3.toHex(text="2nd test message")]
 
         shh_filter_id = web3.geth.shh.new_message_filter({
@@ -79,7 +82,7 @@ class GoEthereumShhModuleTest():
             receiver = web3.geth.shh.newKeyPair()
             receiver_pub = web3.geth.shh.getPublicKey(receiver)
 
-            topic = '0x13370000'
+            topic = HexStr('0x13370000')
             payloads = [web3.toHex(text="test message :)"), web3.toHex(text="2nd test message")]
 
             shh_filter_id = web3.geth.shh.newMessageFilter({
@@ -125,7 +128,7 @@ class GoEthereumShhModuleTest():
         receiver = web3.geth.shh.new_key_pair()
         receiver_pub = web3.geth.shh.get_public_key(receiver)
 
-        topic = '0x13370000'
+        topic = HexStr('0x13370000')
         payloads = [web3.toHex(text="test message :)"), web3.toHex(text="2nd test message")]
 
         shh_filter_id = web3.geth.shh.new_message_filter({
@@ -175,7 +178,7 @@ class GoEthereumShhModuleTest():
             receiver = web3.geth.shh.newKeyPair()
             receiver_pub = web3.geth.shh.getPublicKey(receiver)
 
-            topic = '0x13370000'
+            topic = HexStr('0x13370000')
             payloads = [web3.toHex(text="test message :)"), web3.toHex(text="2nd test message")]
 
             shh_filter_id = web3.geth.shh.newMessageFilter({
@@ -358,7 +361,7 @@ class GoEthereumShhModuleTest():
     def test_shh_post(self, web3: "Web3") -> None:
         receiver_pub = web3.geth.shh.get_public_key(web3.geth.shh.new_key_pair())
         assert web3.geth.shh.post({
-            "topic": "0x12345678",
+            "topic": HexStr("0x12345678"),
             "powTarget": 2.5,
             "powTime": 2,
             "payload": web3.toHex(text="testing shh on web3.py"),
@@ -369,7 +372,7 @@ class GoEthereumShhModuleTest():
         with pytest.warns(DeprecationWarning):
             receiver_pub = web3.geth.shh.getPublicKey(web3.geth.shh.newKeyPair())
             assert web3.geth.shh.post({
-                "topic": "0x12345678",
+                "topic": HexStr("0x12345678"),
                 "powTarget": 2.5,
                 "powTime": 2,
                 "payload": web3.toHex(text="testing shh on web3.py"),
@@ -427,7 +430,7 @@ class ParityShhModuleTest():
         receiver = web3.parity.shh.new_key_pair()
         receiver_pub = web3.parity.shh.get_public_key(receiver)
 
-        topic = '0x13370000'
+        topic = HexStr('0x13370000')
         payloads = [web3.toHex(text="test message :)"), web3.toHex(text="2nd test message")]
 
         shh_filter_id = web3.parity.shh.new_message_filter({
@@ -474,7 +477,7 @@ class ParityShhModuleTest():
         receiver = web3.parity.shh.new_key_pair()
         receiver_pub = web3.parity.shh.get_public_key(receiver)
 
-        topic = '0x13370000'
+        topic = HexStr('0x13370000')
         payloads = [web3.toHex(text="test message :)"), web3.toHex(text="2nd test message")]
 
         shh_filter_id = web3.parity.shh.new_message_filter({
@@ -523,7 +526,7 @@ class ParityShhModuleTest():
         receiver_pub = web3.parity.shh.get_public_key(receiver)
 
         payload = web3.toHex(text="test message :)")
-        topic = '0x13370000'
+        topic = HexStr('0x13370000')
         shh_filter = web3.parity.shh.new_message_filter({'decryptWith': None, 'topics': [topic]})
 
         assert web3.parity.shh.post({
@@ -589,7 +592,7 @@ class ParityShhModuleTest():
     def test_shh_post(self, web3: "Web3") -> None:
         sender = web3.parity.shh.new_key_pair()
         assert web3.parity.shh.post({
-            "topics": ["0x12345678"],
+            "topics": [HexStr("0x12345678")],
             "payload": web3.toHex(text="testing shh on web3.py"),
             "from": sender,
             "priority": 40,

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -3,12 +3,11 @@ from typing import (
     Any,
     NoReturn,
     Sequence,
+    cast,
 )
 
 from eth_typing import (
     ChecksumAddress,
-    HexAddress,
-    HexStr,
     TypeStr,
 )
 from hexbytes import (
@@ -205,12 +204,8 @@ class Web3ModuleTest:
         self, web3: "Web3", types: Sequence[TypeStr], values: Sequence[str], expected: HexBytes
     ) -> None:
         with ens_addresses(web3, {
-            'one.eth': ChecksumAddress(
-                HexAddress(HexStr("0x49EdDD3769c0712032808D86597B84ac5c2F5614"))
-            ),
-            'two.eth': ChecksumAddress(
-                HexAddress(HexStr("0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5"))
-            ),
+            'one.eth': cast(ChecksumAddress, "0x49EdDD3769c0712032808D86597B84ac5c2F5614"),
+            'two.eth': cast(ChecksumAddress, "0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5"),
         }):
             # when called as class method, any name lookup attempt will fail
             with pytest.raises(InvalidAddress):

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -3,11 +3,12 @@ from typing import (
     Any,
     NoReturn,
     Sequence,
-    cast,
 )
 
 from eth_typing import (
     ChecksumAddress,
+    HexAddress,
+    HexStr,
     TypeStr,
 )
 from hexbytes import (
@@ -204,8 +205,12 @@ class Web3ModuleTest:
         self, web3: "Web3", types: Sequence[TypeStr], values: Sequence[str], expected: HexBytes
     ) -> None:
         with ens_addresses(web3, {
-            'one.eth': cast(ChecksumAddress, "0x49EdDD3769c0712032808D86597B84ac5c2F5614"),
-            'two.eth': cast(ChecksumAddress, "0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5"),
+            'one.eth': ChecksumAddress(
+                HexAddress(HexStr("0x49EdDD3769c0712032808D86597B84ac5c2F5614"))
+            ),
+            'two.eth': ChecksumAddress(
+                HexAddress(HexStr("0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5"))
+            ),
         }):
             # when called as class method, any name lookup attempt will fail
             with pytest.raises(InvalidAddress):

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -11,6 +11,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
+    cast,
 )
 
 import eth_abi
@@ -239,8 +240,8 @@ if LooseVersion(eth_abi.__version__) < LooseVersion("2"):
 def normalize_abi(abi: Union[ABI, str]) -> ABI:
     if isinstance(abi, str):
         abi = json.loads(abi)
-    validate_abi(abi)
-    return abi
+    validate_abi(cast(ABI, abi))
+    return cast(ABI, abi)
 
 
 def normalize_address(ens: ENS, address: ChecksumAddress) -> ChecksumAddress:

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -430,6 +430,7 @@ class Contract:
     @combomethod
     def get_function_by_selector(self, selector: Union[bytes, int, HexStr]) -> 'ContractFunction':
         def callable_check(fn_abi: ABIFunction) -> bool:
+            # typed dict cannot be used w/ a normal Dict
             # https://github.com/python/mypy/issues/4976
             return encode_hex(function_abi_to_4byte_selector(fn_abi)) == to_4byte_hex(selector)  # type: ignore # noqa: E501
 
@@ -1350,7 +1351,8 @@ class ContractCaller:
                 "The ABI for this contract contains no function definitions. ",
                 "Are you sure you provided the correct contract ABI?"
             )
-        elif function_name not in [fn['name'] for fn in self._functions]:
+        # type ignore b/c bug: fix coming in future pr
+        elif function_name not in self._functions:  # type: ignore
             functions_available = ', '.join([fn['name'] for fn in self._functions])
             raise MismatchedABI(
                 "The function '{}' was not found in this contract's ABI. ".format(function_name),

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -50,11 +50,11 @@ class StaleBlockchain(Exception):
     Raised by the stalecheck_middleware when the latest block is too old.
     """
     def __init__(self, block: BlockData, allowable_delay: int) -> None:
-        last_block_date = datetime.datetime.fromtimestamp(block.timestamp).strftime('%c')
+        last_block_date = datetime.datetime.fromtimestamp(block["timestamp"]).strftime('%c')
         message = (
             "The latest block, #%d, is %d seconds old, but is only allowed to be %d s old. "
             "The date of the most recent block is %s. Continue syncing and try again..." %
-            (block.number, time.time() - block.timestamp, allowable_delay, last_block_date)
+            (block["number"], time.time() - block["timestamp"], allowable_delay, last_block_date)
         )
         super().__init__(message, block, allowable_delay)
 

--- a/web3/iban.py
+++ b/web3/iban.py
@@ -14,10 +14,10 @@ from eth_utils import (
     is_string,
     to_checksum_address,
 )
-from typing_extensions import (
+
+from web3._utils.compat import (
     TypedDict,
 )
-
 from web3._utils.validation import (
     validate_address,
 )

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -134,7 +134,7 @@ class RequestManager:
             self.web3,
             self.middleware_onion)
         self.logger.debug("Making request. Method: %s", method)
-        return await request_func(method, params)
+        return await request_func(method, params)  # type: ignore
 
     def request_blocking(
         self,

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -134,6 +134,7 @@ class RequestManager:
             self.web3,
             self.middleware_onion)
         self.logger.debug("Making request. Method: %s", method)
+        # type ignored b/c request_func is an awaitable in async model
         return await request_func(method, params)  # type: ignore
 
     def request_blocking(

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -1,7 +1,7 @@
 import functools
 import threading
 import time
-from typing import (  # noqa: F401
+from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
@@ -9,7 +9,6 @@ from typing import (  # noqa: F401
     Dict,
     Set,
     Type,
-    Union,
     cast,
 )
 

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -88,7 +88,7 @@ def check_if_retry_on_failure(method: RPCEndpoint) -> bool:
 
 
 def exception_retry_middleware(
-    make_request: Callable[[RPCEndpoint, Any], Any],
+    make_request: Callable[[RPCEndpoint, Any], RPCResponse],
     web3: "Web3",
     errors: Collection[Type[BaseException]],
     retries: int=5,
@@ -97,7 +97,7 @@ def exception_retry_middleware(
     Creates middleware that retries failed HTTP requests. Is a default
     middleware for HTTPProvider.
     """
-    def middleware(method: RPCEndpoint, params: Any) -> Callable[[RPCEndpoint, Any], RPCResponse]:
+    def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
         if check_if_retry_on_failure(method):
             for i in range(retries):
                 try:

--- a/web3/middleware/filter.py
+++ b/web3/middleware/filter.py
@@ -31,11 +31,13 @@ from eth_utils.toolz import (
     valfilter,
 )
 
-from web3.types import (
+from web3.types import (  # noqa: F401
+    FilterParams,
     LatestBlockParam,
     LogReceipt,
     RPCEndpoint,
     RPCResponse,
+    _Hash32,
 )
 
 if TYPE_CHECKING:
@@ -94,7 +96,7 @@ def gen_bounded_segments(start: int, stop: int, step: int) -> Iterable[Tuple[int
 
 def block_ranges(
     start_block: BlockNumber, last_block: Optional[BlockNumber], step: int=5
-) -> Iterable[Tuple[int, int]]:
+) -> Iterable[Tuple[BlockNumber, BlockNumber]]:
     """Returns 2-tuple ranges describing ranges of block from start_block to last_block
 
        Ranges do not overlap to facilitate use as ``toBlock``, ``fromBlock``
@@ -107,7 +109,7 @@ def block_ranges(
             "Start must be less than or equal to stop.")
 
     return (
-        (from_block, to_block - 1)
+        (BlockNumber(from_block), BlockNumber(to_block - 1))
         for from_block, to_block
         in segment_count(start_block, last_block + 1, step)
     )
@@ -196,7 +198,7 @@ def get_logs_multipart(
     startBlock: BlockNumber,
     stopBlock: BlockNumber,
     address: Union[Address, ChecksumAddress, List[Union[Address, ChecksumAddress]]],
-    topics: List[Optional[Union[Hash32, List[Hash32]]]],
+    topics: List[Optional[Union[_Hash32, List[_Hash32]]]],
     max_blocks: int
 ) -> Iterable[List[LogReceipt]]:
     """Used to break up requests to ``eth_getLogs``
@@ -212,8 +214,7 @@ def get_logs_multipart(
             "address": address,
             "topics": topics
         }
-        yield w3.eth.getLogs(
-            drop_items_with_none_value(params))
+        yield w3.eth.getLogs(cast(FilterParams, drop_items_with_none_value(params)))
 
 
 class RequestLogs:
@@ -223,7 +224,7 @@ class RequestLogs:
         from_block: Union[BlockNumber, LatestBlockParam]=None,
         to_block: Union[BlockNumber, LatestBlockParam]=None,
         address: Union[Address, ChecksumAddress, List[Union[Address, ChecksumAddress]]]=None,
-        topics: List[Optional[Union[Hash32, List[Hash32]]]]=None
+        topics: List[Optional[Union[_Hash32, List[_Hash32]]]]=None
     ) -> None:
         self.address = address
         self.topics = topics

--- a/web3/middleware/simulate_unmined_transaction.py
+++ b/web3/middleware/simulate_unmined_transaction.py
@@ -3,7 +3,7 @@ import itertools
 from typing import (  # noqa: F401
     Any,
     Callable,
-    DefaultDict,
+    Dict,
 )
 
 from eth_typing import (  # noqa: F401
@@ -25,7 +25,9 @@ INVOCATIONS_BEFORE_RESULT = 5
 def unmined_receipt_simulator_middleware(
     make_request: Callable[[RPCEndpoint, Any], Any], web3: Web3
 ) -> Callable[[RPCEndpoint, Any], RPCResponse]:
-    receipt_counters: DefaultDict[Hash32, TxReceipt] = collections.defaultdict(itertools.count)
+    receipt_counters: DefaultDict[Hash32, TxReceipt] = collections.defaultdict(  # type: ignore
+        itertools.count
+    )
 
     def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
         if method == 'eth_getTransactionReceipt':

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -1,9 +1,10 @@
 import time
-from typing import (
+from typing import (  # noqa: F401
     TYPE_CHECKING,
     Any,
     Callable,
     Collection,
+    Dict,
 )
 
 from web3.exceptions import (
@@ -48,7 +49,7 @@ def make_stalecheck_middleware(
     def stalecheck_middleware(
         make_request: Callable[[RPCEndpoint, Any], Any], web3: "Web3"
     ) -> Callable[[RPCEndpoint, Any], RPCResponse]:
-        cache = {'latest': None}
+        cache: Dict[str, BlockData] = {'latest': None}
 
         def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
             if method not in skip_stalecheck_for_methods:

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -20,6 +20,9 @@ from hexbytes import (
     HexBytes,
 )
 
+from web3._utils.rpc_abi import (
+    RPC,
+)
 from web3.exceptions import (
     ValidationError,
 )
@@ -110,13 +113,13 @@ def chain_id_validator(web3: "Web3") -> Callable[..., Any]:
 def build_validators_with_web3(w3: "Web3") -> FormattersDict:
     return dict(
         request_formatters={
-            'eth_sendTransaction': chain_id_validator(w3),
-            'eth_estimateGas': chain_id_validator(w3),
-            'eth_call': chain_id_validator(w3),
+            RPC.eth_sendTransaction: chain_id_validator(w3),
+            RPC.eth_estimateGas: chain_id_validator(w3),
+            RPC.eth_call: chain_id_validator(w3),
         },
         result_formatters={
-            'eth_getBlockByHash': block_validator,
-            'eth_getBlockByNumber': block_validator,
+            RPC.eth_getBlockByHash: block_validator,
+            RPC.eth_getBlockByNumber: block_validator,
         },
     )
 

--- a/web3/pm.py
+++ b/web3/pm.py
@@ -309,7 +309,7 @@ class SimpleRegistry(ERC1319Registry):
         registry_factory = registry_package.get_contract_factory(ContractName("PackageRegistry"))
         tx_hash = registry_factory.constructor().transact()
         tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
-        return cls(tx_receipt.contractAddress, w3)
+        return cls(tx_receipt["contractAddress"], w3)
 
 
 class PM(Module):

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -5,6 +5,7 @@ from typing import (
     Callable,
     Sequence,
     Tuple,
+    cast,
 )
 
 from eth_utils import (
@@ -85,7 +86,7 @@ class JSONBaseProvider(BaseProvider):
 
     def decode_rpc_response(self, raw_response: bytes) -> RPCResponse:
         text_response = to_text(raw_response)
-        return FriendlyJsonSerde().json_decode(text_response)
+        return cast(RPCResponse, FriendlyJsonSerde().json_decode(text_response))
 
     def encode_rpc_request(self, method: RPCEndpoint, params: Any) -> bytes:
         rpc_dict = {

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -2,7 +2,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Coroutine,
     Dict,
 )
 
@@ -37,9 +36,10 @@ class AsyncEthereumTesterProvider(BaseProvider):
     def __init__(self) -> None:
         self.eth_tester = EthereumTesterProvider()
 
-    async def make_request(
+    # type ignore b/c conflict w/ def in BaseProvider
+    async def make_request(  # type: ignore
         self, method: RPCEndpoint, params: Any
-    ) -> Coroutine[Any, Any, RPCResponse]:
+    ) -> RPCResponse:
         return self.eth_tester.make_request(method, params)
 
 
@@ -86,16 +86,16 @@ class EthereumTesterProvider(BaseProvider):
         try:
             delegator = self.api_endpoints[namespace][endpoint]
         except KeyError:
-            return {
+            return RPCResponse({
                 "error": "Unknown RPC Endpoint: {0}".format(method),
-            }
+            })
 
         try:
             response = delegator(self.ethereum_tester, params)
         except NotImplementedError:
-            return {
+            return RPCResponse({
                 "error": "RPC Endpoint has not been implemented: {0}".format(method),
-            }
+            })
         else:
             return {
                 'result': response,

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -301,7 +301,8 @@ def guess_gas(web3: "Web3", transaction: TxParams) -> Wei:
 def fill_default(
     field: str, guess_func: Callable[..., Any], web3: "Web3", transaction: TxParams
 ) -> TxParams:
-    if field in transaction and transaction[field] is not None:
+    # type ignored b/c TxParams keys must be string literal types
+    if field in transaction and transaction[field] is not None:  # type: ignore
         return transaction
     else:
         guess_val = guess_func(web3, transaction)

--- a/web3/providers/websocket.py
+++ b/web3/providers/websocket.py
@@ -83,10 +83,10 @@ class WebsocketProvider(JSONBaseProvider):
     _loop = None
 
     def __init__(
-            self,
-            endpoint_uri: URI=None,
-            websocket_kwargs: Any=None,
-            websocket_timeout: int=DEFAULT_WEBSOCKET_TIMEOUT,
+        self,
+        endpoint_uri: URI=None,
+        websocket_kwargs: Any=None,
+        websocket_timeout: int=DEFAULT_WEBSOCKET_TIMEOUT,
     ) -> None:
         self.endpoint_uri = endpoint_uri
         self.websocket_timeout = websocket_timeout

--- a/web3/tools/pytest_ethereum/_utils.py
+++ b/web3/tools/pytest_ethereum/_utils.py
@@ -112,8 +112,8 @@ def create_deployment_data(
 ) -> Iterable[Tuple[str, Any]]:
     yield "contract_type", contract_name
     yield "address", new_address
-    yield "transaction", to_hex(tx_receipt.transactionHash)
-    yield "block", to_hex(tx_receipt.blockHash)
+    yield "transaction", to_hex(tx_receipt["transactionHash"])
+    yield "block", to_hex(tx_receipt["blockHash"])
     if link_refs:
         yield "runtime_bytecode", {"link_dependencies": create_link_dep(link_refs)}
 

--- a/web3/tools/pytest_ethereum/linker.py
+++ b/web3/tools/pytest_ethereum/linker.py
@@ -75,7 +75,7 @@ def _deploy(
     latest_block_uri = create_latest_block_uri(package.w3, 0)
     deployment_data = create_deployment_data(
         contract_name,
-        to_checksum_address(tx_receipt.contractAddress),
+        to_checksum_address(tx_receipt["contractAddress"]),
         tx_receipt,
         factory.linked_references,
     )

--- a/web3/types.py
+++ b/web3/types.py
@@ -60,6 +60,8 @@ ABIEvent = TypedDict("ABIEvent", {
 ABIFunctionComponents = TypedDict("ABIFunctionComponents", {
     "name": str,
     "type": str,
+    # better typed as Sequence['ABIFunctionComponents']
+    # https://github.com/python/mypy/issues/731
     "components": Sequence[Any],
 }, total=False)
 


### PR DESCRIPTION
### What was wrong?
Finish type hints in `web3`

The way `TypedDict` was being imported in `web3._utils.compat` was buggy (it seems there is a `typing.TypedDict` pre `3.8`, but it's hardly effective in what it checks). After updating to the correct `TypedDict` implementation, naturally a lot of errors in the type-hints appeared. Those were all fixed. 

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/70525745-4ce6a280-1b48-11ea-9c24-ea8114445738.png)

