### PR TITLE
Type hints cleanup

### DIFF
--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -7,6 +7,8 @@ from eth_account.messages import (
 )
 from eth_utils import (
     is_checksum_address,
+    to_bytes,
+    to_hex,
 )
 from eth_utils.toolz import (
     dissoc,
@@ -18,10 +20,6 @@ from hexbytes import (
 from web3 import (
     Account,
     Web3,
-)
-from web3._utils.encoding import (
-    to_bytes,
-    to_hex,
 )
 from web3.providers.eth_tester import (
     EthereumTesterProvider,

--- a/tests/core/utilities/test_encoding.py
+++ b/tests/core/utilities/test_encoding.py
@@ -9,6 +9,7 @@ from unittest.mock import (
 
 from eth_utils import (
     is_hex,
+    to_hex,
 )
 from hypothesis import (
     example,
@@ -21,8 +22,6 @@ from web3._utils.encoding import (
     hex_encode_abi_type,
     hexstr_if_str,
     text_if_str,
-    to_hex,
-    to_int,
 )
 from web3._utils.hypothesis import (
     hexstr_strategy,
@@ -30,38 +29,6 @@ from web3._utils.hypothesis import (
 from web3.providers import (
     JSONBaseProvider,
 )
-
-
-@pytest.mark.parametrize(
-    "value,expected",
-    [
-        (1, '0x1'),
-        (15, '0xf'),
-        (-1, '-0x1'),
-        (-15, '-0xf'),
-        (0, '0x0'),
-        (-0, '0x0'),
-    ]
-)
-def test_to_hex(value, expected):
-    assert to_hex(value) == expected
-
-
-@given(value=st.integers(min_value=-1 * 2**255 + 1, max_value=2**256 - 1))
-def test_conversion_round_trip(value):
-    intermediate_value = to_hex(value)
-    result_value = to_int(hexstr=intermediate_value)
-    error_msg = "Expected: {0!r}, Result: {1!r}, Intermediate: {2!r}".format(
-        value,
-        result_value,
-        intermediate_value,
-    )
-    assert result_value == value, error_msg
-
-
-def test_bytes_that_start_with_0x():
-    sneaky_bytes = b'0x\xde\xad'
-    assert to_hex(sneaky_bytes) == '0x3078dead'
 
 
 @pytest.mark.parametrize(

--- a/web3/_utils/encoding.py
+++ b/web3/_utils/encoding.py
@@ -21,16 +21,12 @@ from eth_typing import (
 )
 from eth_utils import (
     add_0x_prefix,
-    big_endian_to_int,
-    decode_hex,
     encode_hex,
-    int_to_big_endian,
-    is_boolean,
     is_bytes,
     is_hex,
-    is_integer,
     is_list_like,
     remove_0x_prefix,
+    to_bytes,
     to_hex,
 )
 from eth_utils.toolz import (
@@ -52,7 +48,6 @@ from web3._utils.abi import (
     sub_type_of_array_type,
 )
 from web3._utils.validation import (
-    assert_one_val,
     validate_abi_type,
     validate_abi_value,
 )
@@ -131,73 +126,12 @@ def trim_hex(hexstr: HexStr) -> HexStr:
     return hexstr
 
 
-def to_int(value: Primitives=None, hexstr: HexStr=None, text: str=None) -> int:
-    """
-    Converts value to it's integer representation.
-
-    Values are converted this way:
-
-     * value:
-       * bytes: big-endian integer
-       * bool: True => 1, False => 0
-     * hexstr: interpret hex as integer
-     * text: interpret as string of digits, like '12' => 12
-    """
-    assert_one_val(value, hexstr=hexstr, text=text)
-
-    if hexstr is not None:
-        return int(hexstr, 16)
-    elif text is not None:
-        return int(text)
-    elif isinstance(value, bytes):
-        return big_endian_to_int(value)
-    elif isinstance(value, str):
-        raise TypeError("Pass in strings with keyword hexstr or text")
-    else:
-        return int(value)
-
-
 @curry
 def pad_bytes(fill_with: bytes, num_bytes: int, unpadded: bytes) -> bytes:
     return unpadded.rjust(num_bytes, fill_with)
 
 
 zpad_bytes = pad_bytes(b'\0')
-
-
-def to_bytes(primitive: Primitives=None, hexstr: HexStr=None, text: str=None) -> bytes:
-    assert_one_val(primitive, hexstr=hexstr, text=text)
-
-    if is_boolean(primitive):
-        return b'\x01' if primitive else b'\x00'
-    elif isinstance(primitive, bytes):
-        return primitive
-    elif is_integer(primitive):
-        return to_bytes(hexstr=to_hex(primitive))
-    elif hexstr is not None:
-        if len(hexstr) % 2:
-            hexstr = HexStr('0x0' + remove_0x_prefix(hexstr))
-        return decode_hex(hexstr)
-    elif text is not None:
-        return text.encode('utf-8')
-    raise TypeError("expected an int in first arg, or keyword of hexstr or text")
-
-
-def to_text(primitive: Primitives=None, hexstr: HexStr=None, text: str=None) -> str:
-    assert_one_val(primitive, hexstr=hexstr, text=text)
-
-    if hexstr is not None:
-        return to_bytes(hexstr=hexstr).decode('utf-8')
-    elif text is not None:
-        return text
-    elif isinstance(primitive, str):
-        return to_text(hexstr=primitive)
-    elif isinstance(primitive, bytes):
-        return primitive.decode('utf-8')
-    elif is_integer(primitive):
-        byte_encoding = int_to_big_endian(primitive)
-        return to_text(byte_encoding)
-    raise TypeError("Expected an int, bytes or hexstr.")
 
 
 @curry

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -34,6 +34,7 @@ from eth_utils import (
     event_abi_to_log_topic,
     is_list_like,
     keccak,
+    to_bytes,
     to_dict,
     to_hex,
     to_tuple,
@@ -60,7 +61,6 @@ from web3._utils.abi import (
 from web3._utils.encoding import (
     encode_single_packed,
     hexstr_if_str,
-    to_bytes,
 )
 from web3._utils.normalizers import (
     BASE_RETURN_NORMALIZERS,

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -28,7 +28,10 @@ from eth_typing import (
     TypeStr,
 )
 from eth_utils import (
+    to_bytes,
     to_checksum_address,
+    to_hex,
+    to_text,
 )
 from eth_utils.address import (
     is_binary_address,
@@ -44,9 +47,6 @@ from ens import ENS
 from web3._utils.encoding import (
     hexstr_if_str,
     text_if_str,
-    to_bytes,
-    to_hex,
-    to_text,
 )
 from web3._utils.ens import (
     StaticENS,

--- a/web3/main.py
+++ b/web3/main.py
@@ -9,7 +9,10 @@ from eth_utils import (
     is_checksum_address,
     keccak as eth_utils_keccak,
     remove_0x_prefix,
+    to_bytes,
     to_checksum_address,
+    to_int,
+    to_text,
     to_wei,
 )
 from hexbytes import (
@@ -37,10 +40,7 @@ from web3._utils.empty import (
 )
 from web3._utils.encoding import (
     hex_encode_abi_type,
-    to_bytes,
     to_hex,
-    to_int,
-    to_text,
     to_json,
 )
 from web3._utils.rpc_abi import (

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -124,9 +124,8 @@ def get_default_ipc_path() -> str:  # type: ignore
             return ipc_path
 
         base_trinity_path = Path('~').expanduser() / '.local' / 'share' / 'trinity'
-        # type ignored b/c ipc_path is already defined as a str above
-        ipc_path = base_trinity_path / 'mainnet' / 'jsonrpc.ipc'  # type: ignore
-        if ipc_path.exists():  # type: ignore
+        ipc_path = base_trinity_path / 'mainnet' / 'jsonrpc.ipc'
+        if ipc_path.exists():
             return str(ipc_path)
 
     elif sys.platform == 'win32':

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -124,8 +124,8 @@ def get_default_ipc_path() -> str:  # type: ignore
             return ipc_path
 
         base_trinity_path = Path('~').expanduser() / '.local' / 'share' / 'trinity'
-        ipc_path = base_trinity_path / 'mainnet' / 'jsonrpc.ipc'
-        if ipc_path.exists():
+        ipc_path = str(base_trinity_path / 'mainnet' / 'jsonrpc.ipc')
+        if Path(ipc_path).exists():
             return str(ipc_path)
 
     elif sys.platform == 'win32':


### PR DESCRIPTION
### What was wrong?
- Should we deprecate the removed utils? It seems like `eth-utils` is primarily used both inside `web3` and elsewhere.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/70717313-61649f80-1cee-11ea-9aaa-33b3bf719750.png)

