### PR TITLE
Fix bug in contract caller

### DIFF
--- a/newsfragments/1552.bugfix.rst
+++ b/newsfragments/1552.bugfix.rst
@@ -1,0 +1,1 @@
+Minor bugfix in how ContractCaller looks up abi functions.

--- a/tests/core/contracts/test_contract_caller_interface.py
+++ b/tests/core/contracts/test_contract_caller_interface.py
@@ -82,9 +82,19 @@ def test_caller_with_empty_abi(web3):
         contract.caller.thisFunctionDoesNotExist()
 
 
+def test_caller_raw_getattr_with_missing_element(math_contract):
+    with pytest.raises(MismatchedABI, match="not found in this contract's ABI"):
+        math_contract.caller.__getattr__('notafunction')
+
+
+def test_caller_raw_getattr_with_present_element(math_contract):
+    attr = math_contract.caller.__getattr__('return13')
+    assert attr
+
+
 def test_caller_with_a_nonexistent_function(math_contract):
     contract = math_contract
-    with pytest.raises(MismatchedABI):
+    with pytest.raises(MismatchedABI, match="not found in this contract's ABI"):
         contract.caller.thisFunctionDoesNotExist()
 
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1351,8 +1351,7 @@ class ContractCaller:
                 "The ABI for this contract contains no function definitions. ",
                 "Are you sure you provided the correct contract ABI?"
             )
-        # type ignore b/c bug: fix coming in future pr
-        elif function_name not in self._functions:  # type: ignore
+        elif function_name not in set(fn['name'] for fn in self._functions):
             functions_available = ', '.join([fn['name'] for fn in self._functions])
             raise MismatchedABI(
                 "The function '{}' was not found in this contract's ABI. ".format(function_name),


### PR DESCRIPTION
### What was wrong?
Minor bug in `ContractCaller` fn lookup.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/70718881-59f2c580-1cf1-11ea-87ea-f2b0ff64fa38.png)

