### PR TITLE
Update typing-extensions imports to compatible version

### DIFF
--- a/newsfragments/1554.bugfix.rst
+++ b/newsfragments/1554.bugfix.rst
@@ -1,0 +1,1 @@
+Update modules to use compatible typing-extensions import.

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -16,10 +16,10 @@ from eth_utils.toolz import (
 from hexbytes import (
     HexBytes,
 )
-from typing_extensions import (
+
+from web3._utils.compat import (
     Literal,
 )
-
 from web3._utils.threads import (
     Timeout,
 )

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -13,13 +13,13 @@ from typing import (
 )
 
 import lru
-from typing_extensions import (
-    Literal,
-    TypedDict,
-)
 
 from web3._utils.caching import (
     generate_cache_key,
+)
+from web3._utils.compat import (
+    Literal,
+    TypedDict,
 )
 from web3.types import (  # noqa: F401
     BlockData,


### PR DESCRIPTION
### What was wrong?
re @veox in the web3 gitter channel - `typing_extensions` was incorrectly used instead of the imported version from `web3._utils.compat`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/70980718-0519cb00-20b4-11ea-898b-0a9fd6b3a1bc.png)

