### PR TITLE
Format 'from' and 'to' fields to checksum addresses in RECEIPT_FORMAT…

### DIFF
--- a/newsfragments/1562.bugfix.rst
+++ b/newsfragments/1562.bugfix.rst
@@ -1,0 +1,1 @@
+Make 'from' and 'to' fields checksum addresses in returned transaction receipts

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -298,6 +298,10 @@ class TestEthereumTesterEthModule(EthModuleTest):
         assert is_integer(chain_id)
         assert chain_id == 61
 
+    @pytest.mark.xfail(raises=KeyError, reason="ethereum tester doesn't return 'to' key")
+    def test_eth_getTransactionReceipt_mined(self, web3, block_with_txn, mined_txn_hash):
+        super().test_eth_getTransactionReceipt_mined(web3, block_with_txn, mined_txn_hash)
+
 
 class TestEthereumTesterVersionModule(VersionModuleTest):
     pass

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -183,6 +183,8 @@ RECEIPT_FORMATTERS = {
     'contractAddress': apply_formatter_if(is_not_null, to_checksum_address),
     'logs': apply_list_to_array_formatter(log_entry_formatter),
     'logsBloom': to_hexbytes(256),
+    'from': apply_formatter_if(is_not_null, to_checksum_address),
+    'to': apply_formatter_if(is_address, to_checksum_address),
 }
 
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -767,6 +767,9 @@ class EthModuleTest:
         assert receipt['blockHash'] == block_with_txn['hash']
         assert receipt['transactionIndex'] == 0
         assert receipt['transactionHash'] == HexBytes(mined_txn_hash)
+        assert is_checksum_address(receipt['to'])
+        assert receipt['from'] is not None
+        assert is_checksum_address(receipt['from'])
 
     def test_eth_getTransactionReceipt_unmined(
         self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress


### PR DESCRIPTION
### What was wrong?

Receipt formatter was not formatting **from** and **to** addresses to checksum as it does with transaction formatter.

Related to Issue #1547 

### How was it fixed?

Followed @ignition42's instructions.

#### Added **from** and **to** here: https://github.com/ethereum/web3.py/blob/v5.4.0/web3/_utils/method_formatters.py#L174

#### As they were here: https://github.com/ethereum/web3.py/blob/v5.4.0/web3/_utils/method_formatters.py#L119

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.chzbgr.com/full/8761106432/h3D2A21FF/spring-has-sprung-for-chick)
