### PR TITLE
providers/ipc: fix Trinity IPC path to include 'ipcs-eth1' sub-dir

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -244,7 +244,7 @@ IPCProvider
     This provider handles interaction with an IPC Socket based JSON-RPC
     server.
 
-    *  ``ipc_path`` is the filesystem path to the IPC socket.:56
+    *  ``ipc_path`` is the filesystem path to the IPC socket:
 
     .. code-block:: python
 
@@ -258,10 +258,12 @@ IPCProvider
 
       - ``~/.ethereum/geth.ipc``
       - ``~/.local/share/io.parity.ethereum/jsonrpc.ipc``
+      - ``~/.local/share/trinity/mainnet/ipcs-eth1/jsonrpc.ipc``
     - On Mac OS:
 
       - ``~/Library/Ethereum/geth.ipc``
       - ``~/Library/Application Support/io.parity.ethereum/jsonrpc.ipc``
+      - ``~/.local/share/trinity/mainnet/ipcs-eth1/jsonrpc.ipc``
     - On Windows:
 
       - ``\\\.\pipe\geth.ipc``

--- a/newsfragments/1563.bugfix.rst
+++ b/newsfragments/1563.bugfix.rst
@@ -1,0 +1,1 @@
+Use local Trinity's IPC socket if it is available, for newer versions of Trinity.

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -100,7 +100,7 @@ def get_default_ipc_path() -> str:  # type: ignore
             return ipc_path
 
         base_trinity_path = Path('~').expanduser() / '.local' / 'share' / 'trinity'
-        ipc_path = str(base_trinity_path / 'mainnet' / 'jsonrpc.ipc')
+        ipc_path = str(base_trinity_path / 'mainnet' / 'ipcs-eth1' / 'jsonrpc.ipc')
         if Path(ipc_path).exists():
             return str(ipc_path)
 
@@ -124,7 +124,7 @@ def get_default_ipc_path() -> str:  # type: ignore
             return ipc_path
 
         base_trinity_path = Path('~').expanduser() / '.local' / 'share' / 'trinity'
-        ipc_path = str(base_trinity_path / 'mainnet' / 'jsonrpc.ipc')
+        ipc_path = str(base_trinity_path / 'mainnet' / 'ipcs-eth1' / 'jsonrpc.ipc')
         if Path(ipc_path).exists():
             return str(ipc_path)
 


### PR DESCRIPTION
### What was wrong?

Trinity's `jsonrpc.ipc` socket has moved to a sub-dir quite some time ago. I believe the change was made in https://github.com/ethereum/trinity/pull/8, >1y ago, and landed in [`trinity-v0.1.0-alpha.21`](https://github.com/ethereum/trinity/releases/tag/trinity-v0.1.0-alpha.21).

This has not been updated (or documented), probably because Trinity's JSON-RPC support is still limited.

### How was it fixed?

Point towards the new socket location now, and mention the fact in docs.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.pixabay.com/photo/2019/04/02/21/44/stork-4098979_960_720.jpg)

Source: [satinek@Pixabay](https://pixabay.com/photos/stork-bird-socket-spring-4098979/)