### PR TITLE
Remove deprecated kwarg in json.loads

### DIFF
--- a/ethpm/validation/manifest.py
+++ b/ethpm/validation/manifest.py
@@ -142,7 +142,7 @@ def validate_raw_manifest_format(raw_manifest: str) -> None:
     - has a trailing newline
     """
     try:
-        manifest_dict = json.loads(raw_manifest, encoding="UTF-8")
+        manifest_dict = json.loads(raw_manifest)
     except json.JSONDecodeError as err:
         raise json.JSONDecodeError(
             "Failed to load package data. File is not a valid JSON document.",


### PR DESCRIPTION
### What was wrong?
In `ethpm/validation/manifest.py`, a call to `json.loads` includes the `encoding` kwarg which has been deprecated since python 3.1 and will be removed in 3.9 ([source](https://github.com/python/cpython/commit/a8abe097c1165db25b429ca02a65c4f8acbc062b)).

### How was it fixed?
Removed the `encoding` kwarg.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

This is such a minor edit, I'm not sure if it's worth including in the release notes?

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/72149021-75a9c400-33a2-11ea-8640-72033eea5101.png)

