### PR TITLE
add support of Solidity 0.6.0 new receive keyword

### DIFF
--- a/tests/core/utilities/test_abi_filter_by_abi_name.py
+++ b/tests/core/utilities/test_abi_filter_by_abi_name.py
@@ -18,7 +18,6 @@ ABI_CONSTRUCTOR = {
 }
 ABI_FALLBACK = {
     "constant": False,
-    #"stateMutability": "nonpayable", # actually this is how 0.6 abi looks like
     "type": "fallback",
 }
 ABI_RECEIVE = {

--- a/tests/core/utilities/test_abi_filter_by_abi_name.py
+++ b/tests/core/utilities/test_abi_filter_by_abi_name.py
@@ -18,7 +18,12 @@ ABI_CONSTRUCTOR = {
 }
 ABI_FALLBACK = {
     "constant": False,
+    #"stateMutability": "nonpayable", # actually this is how 0.6 abi looks like
     "type": "fallback",
+}
+ABI_RECEIVE = {
+    "stateMutability": "payable",
+    "type": "receive"
 }
 ABI_FUNC_2_SIG_A = {
     "constant": False,
@@ -50,6 +55,7 @@ ABI_FUNC_3 = {
 ABI = [
     ABI_CONSTRUCTOR,
     ABI_FALLBACK,
+    ABI_RECEIVE,
     ABI_FUNC_1,
     ABI_FUNC_2_SIG_A,
     ABI_FUNC_2_SIG_B,

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -95,7 +95,7 @@ def filter_by_name(name: str, contract_abi: ABI) -> List[Union[ABIFunction, ABIE
         for abi
         in contract_abi
         if (
-            abi['type'] not in ('fallback', 'constructor') and
+            abi['type'] not in ('fallback', 'constructor', 'receive') and
             abi['name'] == name
         )
     ]


### PR DESCRIPTION
### What was wrong?

Solidity 0.6.0 adds a new "receive" keyword ( https://solidity.readthedocs.io/en/v0.6.1/060-breaking-changes.html#explicitness-requirements )

web3.py 5.4.0 fails to call _any_ function when ^0.6.0 contract contains "receive" payable fallback function as it chokes on missing 'name' in abi due to type == 'receive'

### How was it fixed?

Adding "receive" to _utils/abi.py row 101

### Todo:
there should probably be a few more places to add "receive" for it to be supported properly -- this is just a starting point that fixed my immediate problem at hand

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](AYFS) Are You Serious?
