### PR TITLE
Increase replacement transaction minimum gas price bump to 12.5%

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -679,7 +679,7 @@ The following methods are available on the ``web3.eth`` namespace.
     If the ``new_transaction`` does not specify a ``gasPrice`` value, the highest of the
     following 2 values will be used:
 
-    * The pending transaction's ``gasPrice`` * 1.1 - This is typically the minimum
+    * The pending transaction's ``gasPrice`` * 1.125 - This is typically the minimum
       ``gasPrice`` increase a node requires before it accepts a replacement transaction.
     * The ``gasPrice`` as calculated by the current gas price strategy(See :ref:`Gas_Price`).
 

--- a/newsfragments/1570.bugfix.rst
+++ b/newsfragments/1570.bugfix.rst
@@ -1,0 +1,5 @@
+Increase replacement tx minimum gas price bump
+
+Parity/OpenEthereum requires a replacement transaction's
+gas to be a minimum of 12.5% higher than the original
+(vs. Geth's 10%).

--- a/tests/core/utilities/test_prepare_transaction_replacement.py
+++ b/tests/core/utilities/test_prepare_transaction_replacement.py
@@ -24,7 +24,7 @@ def test_prepare_transaction_replacement(web3):
     assert replacement_transaction == {
         'value': 1,
         'nonce': 2,
-        'gasPrice': 11,
+        'gasPrice': 12,
     }
 
 
@@ -38,7 +38,7 @@ def test_prepare_transaction_replacement_without_nonce_sets_correct_nonce(web3):
     assert replacement_transaction == {
         'value': 1,
         'nonce': 2,
-        'gasPrice': 11,
+        'gasPrice': 12,
     }
 
 
@@ -83,7 +83,7 @@ def test_prepare_transaction_replacement_gas_price_defaulting(web3):
     replacement_transaction = prepare_replacement_transaction(
         web3, current_transaction, new_transaction)
 
-    assert replacement_transaction['gasPrice'] == 11
+    assert replacement_transaction['gasPrice'] == 12
 
 
 def test_prepare_transaction_replacement_gas_price_defaulting_when_strategy_higer(web3):
@@ -119,4 +119,4 @@ def test_prepare_transaction_replacement_gas_price_defaulting_when_strategy_lowe
     replacement_transaction = prepare_replacement_transaction(
         web3, current_transaction, new_transaction)
 
-    assert replacement_transaction['gasPrice'] == 11
+    assert replacement_transaction['gasPrice'] == 12

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -530,7 +530,7 @@ class EthModuleTest:
         replace_txn_hash = web3.eth.replaceTransaction(txn_hash, txn_params)
         replace_txn = web3.eth.getTransaction(replace_txn_hash)
 
-        assert replace_txn['gasPrice'] == 11  # minimum gas price
+        assert replace_txn['gasPrice'] == 12  # minimum gas price
 
     def test_eth_replaceTransaction_gas_price_defaulting_strategy_higher(
         self, web3: "Web3", unlocked_account: ChecksumAddress
@@ -575,7 +575,7 @@ class EthModuleTest:
         replace_txn_hash = web3.eth.replaceTransaction(txn_hash, txn_params)
         replace_txn = web3.eth.getTransaction(replace_txn_hash)
         # Strategy provices lower gas price - minimum preferred
-        assert replace_txn['gasPrice'] == 11
+        assert replace_txn['gasPrice'] == 12
 
     def test_eth_modifyTransaction(
         self, web3: "Web3", unlocked_account: ChecksumAddress

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -179,7 +179,10 @@ def assert_valid_transaction_params(transaction_params: TxParams) -> None:
 
 
 def prepare_replacement_transaction(
-    web3: "Web3", current_transaction: TxData, new_transaction: TxParams
+    web3: "Web3",
+    current_transaction: TxData,
+    new_transaction: TxParams,
+    gas_multiplier: float = 1.125
 ) -> TxParams:
     if current_transaction['blockHash'] is not None:
         raise ValueError('Supplied transaction with hash {} has already been mined'
@@ -195,7 +198,7 @@ def prepare_replacement_transaction(
             raise ValueError('Supplied gas price must exceed existing transaction gas price')
     else:
         generated_gas_price = web3.eth.generateGasPrice(new_transaction)
-        minimum_gas_price = int(math.ceil(current_transaction['gasPrice'] * 1.125))
+        minimum_gas_price = int(math.ceil(current_transaction['gasPrice'] * gas_multiplier))
         if generated_gas_price and generated_gas_price > minimum_gas_price:
             new_transaction = assoc(new_transaction, 'gasPrice', generated_gas_price)
         else:

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -195,7 +195,7 @@ def prepare_replacement_transaction(
             raise ValueError('Supplied gas price must exceed existing transaction gas price')
     else:
         generated_gas_price = web3.eth.generateGasPrice(new_transaction)
-        minimum_gas_price = int(math.ceil(current_transaction['gasPrice'] * 1.1))
+        minimum_gas_price = int(math.ceil(current_transaction['gasPrice'] * 1.125))
         if generated_gas_price and generated_gas_price > minimum_gas_price:
             new_transaction = assoc(new_transaction, 'gasPrice', generated_gas_price)
         else:


### PR DESCRIPTION
Parity requires a gas price 12.5% higher than the previous one to accept
a replacement transaction in its transaction queue.
The previous value of 10% only worked for Geth.

See https://wiki.parity.io/Transactions-Queue and
https://github.com/paritytech/parity-ethereum/blob/e69539357f50d20bff51df28c556af8663552eec/miner/src/pool/scoring.rs#L38

### How was it fixed?

Increase to 12.5%.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://s3.amazonaws.com/mongabay-images/12/DSC_0595.reticulatedgiraffe.boy.568.jpg)
