### PR TITLE
Update mainnet ENS registrar address

### DIFF
--- a/ens/constants.py
+++ b/ens/constants.py
@@ -1,4 +1,5 @@
 from eth_typing import (
+    ChecksumAddress,
     HexAddress,
     HexStr,
 )
@@ -15,3 +16,5 @@ EMPTY_SHA3_BYTES = HexBytes(b'\0' * 32)
 EMPTY_ADDR_HEX = HexAddress(HexStr('0x' + '00' * 20))
 
 REVERSE_REGISTRAR_DOMAIN = 'addr.reverse'
+
+ENS_MAINNET_ADDR = ChecksumAddress(HexAddress(HexStr('0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e')))

--- a/ens/main.py
+++ b/ens/main.py
@@ -11,7 +11,6 @@ from eth_typing import (
     Address,
     ChecksumAddress,
     HexAddress,
-    HexStr,
 )
 from eth_utils import (
     is_binary_address,
@@ -25,6 +24,7 @@ from hexbytes import (
 from ens import abis
 from ens.constants import (
     EMPTY_ADDR_HEX,
+    ENS_MAINNET_ADDR,
     REVERSE_REGISTRAR_DOMAIN,
 )
 from ens.exceptions import (
@@ -57,9 +57,6 @@ if TYPE_CHECKING:
     from web3.types import (  # noqa: F401
         TxParams,
     )
-
-
-ENS_MAINNET_ADDR = ChecksumAddress(HexAddress(HexStr('0x314159265dD8dbb310642f98f50C066173C1259b')))
 
 
 class ENS:

--- a/newsfragments/1573.feature.rst
+++ b/newsfragments/1573.feature.rst
@@ -1,0 +1,3 @@
+ENS had to release a new registry to push a bugfix. See
+`this article <https://medium.com/the-ethereum-name-service/ens-registry-migration-bug-fix-new-features-64379193a5a>`_
+for background information. Web3.py uses the new registry for all default ENS interactions, now.


### PR DESCRIPTION
### What was wrong?

Original announcement about ENS registry location change:
https://medium.com/the-ethereum-name-service/ens-registry-migration-bug-fix-new-features-64379193a5a

For the updated address, see: https://docs.ens.domains/ens-migration/guide-for-dapp-developers

### How was it fixed?

Changed the address, as documented.

Also, moved the address into the constants module.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/6bLlRjDug7A/maxresdefault.jpg)