### PR TITLE
[ethpm] Allow registry uri to namespace package assets

### DIFF
--- a/newsfragments/1576.misc.rst
+++ b/newsfragments/1576.misc.rst
@@ -1,0 +1,1 @@
+Update ethpm URI to support namespaced assets

--- a/tests/ethpm/_utils/test_registry_utils.py
+++ b/tests/ethpm/_utils/test_registry_utils.py
@@ -39,6 +39,7 @@ from ethpm.validation.uri import (
         ("erc1319://0xd3CdA913deB6f67967B99D67aCDFa1712C293601/erc20@1.0.0"),
         ("erc1319://0xd3CdA913deB6f67967B99D67aCDFa1712C293601:1/erc20@1.0.0"),
         ("erc1319://0xd3CdA913deB6f67967B99D67aCDFa1712C293601:1/erc20@1.0.0/"),
+        ("erc1319://0xd3CdA913deB6f67967B99D67aCDFa1712C293601:1/erc20@1.0.0/deployments/ERC139")
     ),
 )
 def test_is_registry_uri_validates(uri):

--- a/tests/ethpm/test_uri.py
+++ b/tests/ethpm/test_uri.py
@@ -75,63 +75,86 @@ def test_create_github_uri():
     (
         (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", None, None, None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", None, None, None, None],
         ),
         (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:3",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "3", None, None, None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "3", None, None, None, None],
         ),
         (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:5/owned",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "5", "owned", None, None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "5", "owned", None, None, None],
         ),
         (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/owned@1.0.0",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "owned", "1.0.0", None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "owned", "1.0.0", None, None],
         ),
         (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/wallet@2.8.0/",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", None, None],
         ),
         # ethpm scheme
         (
             "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/wallet@2.8.0",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", None, None],
         ),
         # w/o chain_id
         (
             "erc1319://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/owned",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "owned", None, None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "owned", None, None, None],
         ),
         (
             "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/wallet@2.8.0",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", None, None],
         ),
         (
             "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/wallet@8%400",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "8@0", None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "8@0", None, None],
         ),
         # escaped chars
         (
             "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/wallet@8%400",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "8@0", None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "8@0", None, None],
         ),
         (
             "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/wallet@%250",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "%0", None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "%0", None, None],
         ),
         (
             "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1/wallet@8%400/",
-            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "8@0", None],
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "8@0", None, None],
+        ),
+        # with namespaced manifest contents
+        (
+            "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/wallet@2.8.0/deployments",
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", "deployments", None],  # noqa: E501
+        ),
+        (
+            "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/wallet@2.8.0/deployments/",
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", "deployments", None],  # noqa: E501
+        ),
+        (
+            "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/wallet@2.8.0/deployments/WalletContract",  # noqa: E501
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", "deployments/WalletContract", None],  # noqa: E501
+        ),
+        (
+            "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/wallet@2.8.0/deployments/WalletContract/",  # noqa: E501
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "2.8.0", "deployments/WalletContract", None],  # noqa: E501
+        ),
+        # unescaped chars & namespaced assets
+        (
+            "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/wallet@20%26/deployments/WalletContract/",  # noqa: E501
+            ["0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", "1", "wallet", "20&", "deployments/WalletContract", None],  # noqa: E501
         ),
     ),
 )
 def test_parse_registry_uri(uri, expected):
-    address, chain_id, pkg_name, pkg_version, ens = parse_registry_uri(uri)
+    address, chain_id, pkg_name, pkg_version, namespaced_asset, ens = parse_registry_uri(uri)
     assert address == expected[0]
     assert chain_id == expected[1]
     assert pkg_name == expected[2]
     assert pkg_version == expected[3]
+    assert namespaced_asset == expected[4]
 
 
 @pytest.mark.parametrize(
@@ -148,6 +171,9 @@ def test_parse_registry_uri(uri, expected):
         "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/ab@@1.0.0",
         "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/!bc@1.0.0",
         "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/!bc@1.0.0/",
+        # namespaced asset and missing version
+        "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/wallet/deployments/WalletContract",
+        "ethpm://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/wallet@/deployments/WalletContract",
     )
 )
 def test_invalid_registry_uris(uri):


### PR DESCRIPTION
### What was wrong?
Updated the ethpm uri parsing functions to support namespaced assets.
`ethpm://compound.ethpm.eth:1/compound@1.0.0/deployments/cDai`

This will be useful in the ethpm widget - so that all the data needed to fetch the contract address of a deployment is in a single url.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/74027095-c9123080-49a7-11ea-85fb-fcb47f2e0027.png)
