### PR TITLE
Add PEP561 type marker

### DIFF
--- a/newsfragments/1583.feature.rst
+++ b/newsfragments/1583.feature.rst
@@ -1,0 +1,1 @@
+Add PEP561 type marker

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
     zip_safe=False,
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={"web3": ["py.typed"]},
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
### What was wrong?

Related to Issue https://github.com/ethereum/web3.py/issues/1582

### How was it fixed?

This was my first try, but it doesn't seem to work. When running `make dist` I see the following line:
```
...
adding 'web3/net.py'
adding 'web3/parity.py'
adding 'web3/pm.py'
adding 'web3/py.typed'
adding 'web3/testing.py'
adding 'web3/types.py'
...
```

But when I later look into the source package, it's not there.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
