### PR TITLE
Upgrade eth-tester requirement

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -692,7 +692,7 @@ Taking the following contract code as an example:
     >>> array_contract.functions.getBytes2Value().call()
     [b'b\x00']
     >>> array_contract.functions.setBytes2Value([b'a']).transact()
-    HexBytes('0x39bc9a0bf5b8ec8e8115ccb20bf02f5570351a20a8fd774da91353f38535bec1')
+    HexBytes('0x977bd66e0ef59433a02c2f71f61ec3ca48bf7a5a19d10aece84570061fe9d4f3')
     >>> array_contract.functions.getBytes2Value().call()
     [b'a\x00']
     >>> w3.enable_strict_bytes_type_checking()
@@ -1055,7 +1055,7 @@ Event Log Object
     assert alice == '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf', alice
     assert bob == '0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF', bob
     tx_hash = my_token_contract.constructor(1000000).transact({'from': alice})
-    assert tx_hash == b'h9\xeb\xdb4\x07\x03y\x92RP`X\xf6\xf7\x9f\xfaT\xed&e\xee*\xc2\rx\xb3\xab\x8c4\xc9\x1f', tx_hash
+    assert tx_hash == b'\x02c\x80Q`\x04\xaeQ@M\xd4V\xa7\xbb\xe9z\xf2,\xfd\xa5\xa4"{v\x07W\xae\x0c\'\x1d\x13\x91', tx_hash
     txn_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
     assert txn_receipt['contractAddress'] == '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b', txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']
@@ -1076,7 +1076,7 @@ Event Log Object
       'event': 'Transfer',
       'logIndex': 0,
       'transactionIndex': 0,
-      'transactionHash': HexBytes('0xc7b96b166506c5a6edf6bccd22195e9f1aac025421b4a3eac159b878eef5e6e7'),
+      'transactionHash': HexBytes('0xb6e1b9f9e282082141991fb9e91e396985e586eb32407034b1a00fb1e3eea577'),
       'address': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
       'blockHash': HexBytes('...'),
       'blockNumber': 2})]
@@ -1091,7 +1091,7 @@ Event Log Object
       'event': 'Transfer',
       'logIndex': 0,
       'transactionIndex': 0,
-      'transactionHash': HexBytes('0xb1cf8541708184daf8c1ea59ce494bbafe0bb45208c09a81bff184907e88e9b9'),
+      'transactionHash': HexBytes('0x870c07e1103fb458931ddf717e35d5a8c1f0856e806ec97cae08c4a1ecda9786'),
       'address': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
       'blockHash': HexBytes('...'),
       'blockNumber': 3})]
@@ -1102,7 +1102,7 @@ Event Log Object
       'event': 'Transfer',
       'logIndex': 0,
       'transactionIndex': 0,
-      'transactionHash': HexBytes('0xc7b96b166506c5a6edf6bccd22195e9f1aac025421b4a3eac159b878eef5e6e7'),
+      'transactionHash': HexBytes('0xb6e1b9f9e282082141991fb9e91e396985e586eb32407034b1a00fb1e3eea577'),
       'address': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
       'blockHash': HexBytes('...'),
       'blockNumber': 2}),
@@ -1112,7 +1112,7 @@ Event Log Object
       'event': 'Transfer',
       'logIndex': 0,
       'transactionIndex': 0,
-      'transactionHash': HexBytes('0xb1cf8541708184daf8c1ea59ce494bbafe0bb45208c09a81bff184907e88e9b9'),
+      'transactionHash': HexBytes('0x870c07e1103fb458931ddf717e35d5a8c1f0856e806ec97cae08c4a1ecda9786'),
       'address': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
       'blockHash': HexBytes('...'),
       'blockNumber': 3})]

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -202,19 +202,19 @@ Given the following solidity source file stored at ``contract.sol``.
 .. code-block:: javascript
 
     contract StoreVar {
-    
+
         uint8 public _myVar;
         event MyEvent(uint indexed _var);
-    
+
         function setVar(uint8 _var) public {
             _myVar = _var;
             MyEvent(_var);
         }
-    
+
         function getVar() public view returns (uint8) {
             return _myVar;
         }
-    
+
     }
 
 The following example demonstrates a few things:
@@ -229,45 +229,45 @@ The following example demonstrates a few things:
     import sys
     import time
     import pprint
-    
+
     from web3.providers.eth_tester import EthereumTesterProvider
     from web3 import Web3
     from solc import compile_source
-    
+
 
     def compile_source_file(file_path):
        with open(file_path, 'r') as f:
           source = f.read()
-    
+
        return compile_source(source)
-    
-    
+
+
     def deploy_contract(w3, contract_interface):
         tx_hash = w3.eth.contract(
             abi=contract_interface['abi'],
             bytecode=contract_interface['bin']).deploy()
-    
+
         address = w3.eth.getTransactionReceipt(tx_hash)['contractAddress']
         return address
-    
-    
+
+
     w3 = Web3(EthereumTesterProvider())
-    
+
     contract_source_path = 'contract.sol'
     compiled_sol = compile_source_file('contract.sol')
-    
+
     contract_id, contract_interface = compiled_sol.popitem()
-    
+
     address = deploy_contract(w3, contract_interface)
     print("Deployed {0} to: {1}\n".format(contract_id, address))
-    
+
     store_var_contract = w3.eth.contract(
        address=address,
        abi=contract_interface['abi'])
-    
+
     gas_estimate = store_var_contract.functions.setVar(255).estimateGas()
     print("Gas estimate to transact with setVar: {0}\n".format(gas_estimate))
-    
+
     if gas_estimate < 100000:
       print("Sending transaction to setVar(255)\n")
       tx_hash = store_var_contract.functions.setVar(255).transact()
@@ -285,13 +285,13 @@ Output:
 .. code-block:: none
 
     Deployed <stdin>:StoreVar to: 0xF2E246BB76DF876Cef8b38ae84130F4F55De395b
-    
+
     Gas estimate to transact with setVar: 32463
-    
+
     Sending transaction to setVar(255)
-    
-    Transaction receipt mined: 
-    
+
+    Transaction receipt mined:
+
     {'blockHash': HexBytes('0x94e07b0b88667da284e914fa44b87d4e7fec39761be51245ef94632a3b5ab9f0'),
      'blockNumber': 2,
      'contractAddress': None,
@@ -320,7 +320,7 @@ contract which conforms to this standard.
     assert alice == '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf', alice
     assert bob == '0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF', bob
     tx_hash = factory.constructor(1000000).transact({'from': alice})
-    assert tx_hash == b'h9\xeb\xdb4\x07\x03y\x92RP`X\xf6\xf7\x9f\xfaT\xed&e\xee*\xc2\rx\xb3\xab\x8c4\xc9\x1f', tx_hash
+    assert tx_hash == b'\x02c\x80Q`\x04\xaeQ@M\xd4V\xa7\xbb\xe9z\xf2,\xfd\xa5\xa4"{v\x07W\xae\x0c\'\x1d\x13\x91', tx_hash
     txn_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
     assert txn_receipt['contractAddress'] == '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b', txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']
@@ -471,7 +471,7 @@ like so:
 .. include::  ../tests/core/contracts/test_contract_example.py
     :code: python
     :start-line: 1
-    
+
 Using Infura Rinkeby Node
 -------------------------
 Import your required libraries
@@ -479,42 +479,42 @@ Import your required libraries
 .. code-block:: python
 
     from web3 import Web3, HTTPProvider
-    
+
 Initialize a web3 instance with an Infura node
 
 .. code-block:: python
-    
+
     w3 = Web3(Web3.HTTPProvider("https://rinkeby.infura.io/v3/YOUR_INFURA_KEY"))
 
- 
+
 Inject the middleware into the middleware onion
 
 .. code-block:: python
 
     from web3.middleware import geth_poa_middleware
     w3.middleware_onion.inject(geth_poa_middleware, layer=0)
-    
+
 Just remember that you have to sign all transactions locally, as infura does not handle any keys from your wallet ( refer to `this`_  )
 
 
 ..  _this: https://web3py.readthedocs.io/en/stable/web3.eth.account.html#local-vs-hosted-nodes
 
 .. code-block:: python
-    
+
     transaction = contract.functions.function_Name(params).buildTransaction()
-    transaction.update({ 'gas' : appropriate_gas_amount })  
+    transaction.update({ 'gas' : appropriate_gas_amount })
     transaction.update({ 'nonce' : web3.eth.getTransactionCount('Your_Wallet_Address') })
     signed_tx = w3.eth.account.signTransaction(transaction, private_key)
-    
+
 P.S : the two updates are done to the transaction dictionary, since a raw transaction might not contain gas & nonce amounts, so you have to add them manually.
-    
+
 And finally, send the transaction
 
 .. code-block:: python
 
     txn_hash = w3.eth.sendRawTransaction(signed_tx.rawTransaction)
     txn_receipt = w3.eth.waitForTransactionReceipt(txn_hash)
-    
+
 Tip : afterwards you can use the value stored in ``txn_hash``, in an explorer like `etherscan`_ to view the transaction's details
 
 .. _etherscan: https://rinkeby.etherscan.io

--- a/newsfragments/1586.misc.rst
+++ b/newsfragments/1586.misc.rst
@@ -1,0 +1,1 @@
+Update eth-tester requirement to v0.4.0-b.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'tester': [
-        "eth-tester[py-evm]==v0.2.0-beta.2",
+        "eth-tester[py-evm]==v0.4.0-beta.1",
         "py-geth>=2.2.0,<3",
     ],
     'linter': [


### PR DESCRIPTION
### What was wrong?
~Solidity has a sort-of new error called `revert` that eth-tester currently turns into a `TransactionFailed` error. I have a PR up in eth-tester to stop changing the error, but wanted to do an incremental update first to minimize variables~
Just a plain old eth-tester upgrade for now

Related to Issue #1585

### How was it fixed?
Updated!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
<img width="149" alt="image" src="https://user-images.githubusercontent.com/6540608/75375574-94e5ad80-588b-11ea-9972-e85d4d4bcd79.png">

