### PR TITLE
Tiffany/snake case

### DIFF
--- a/docs/web3.geth.rst
+++ b/docs/web3.geth.rst
@@ -211,7 +211,7 @@ GethPersonal API
 
 The following methods are available on the ``web3.geth.personal`` namespace.
 
-.. py:method:: listAccounts
+.. py:method:: list_accounts()
 
     * Delegates to ``personal_listAccounts`` RPC Method
 
@@ -219,11 +219,17 @@ The following methods are available on the ``web3.geth.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.geth.personal.listAccounts()
+        >>> web3.geth.personal.list_accounts()
         ['0xd3CdA913deB6f67967B99D67aCDFa1712C293601']
 
 
-.. py:method:: importRawKey(self, private_key, passphrase)
+.. py:method:: listAccounts()
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.geth.personal.list_accounts()`
+
+
+.. py:method:: import_raw_key(self, private_key, passphrase)
 
     * Delegates to ``personal_importRawKey`` RPC Method
 
@@ -232,11 +238,17 @@ The following methods are available on the ``web3.geth.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.geth.personal.importRawKey(some_private_key, 'the-passphrase')
+        >>> web3.geth.personal.import_raw_key(some_private_key, 'the-passphrase')
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 
 
-.. py:method:: newAccount(self, password)
+.. py:method:: importRawKey()
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.geth.personal.import_raw_key()`
+
+
+.. py:method:: new_account(self, password)
 
     * Delegates to ``personal_newAccount`` RPC Method
 
@@ -249,7 +261,13 @@ The following methods are available on the ``web3.geth.personal`` namespace.
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 
 
-.. py:method:: lockAccount(self, account)
+.. py:method:: newAccount()
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.geth.personal.newAccount()`
+
+
+.. py:method:: lock_account(self, account)
 
     * Delegates to ``personal_lockAccount`` RPC Method
 
@@ -257,31 +275,49 @@ The following methods are available on the ``web3.geth.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.geth.personal.lockAccount('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
+        >>> web3.geth.personal.lock_account('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
 
 
-.. py:method:: unlockAccount(self, account, passphrase, duration=None)
+.. py:method:: lockAccount()
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.geth.personal.lockAccount()`
+
+
+.. py:method:: unlock_account(self, account, passphrase, duration=None)
 
     * Delegates to ``personal_unlockAccount`` RPC Method
 
-    Unlocks the given ``account`` for ``duration`` seconds. If ``duration`` is 
-	``None`` then the account will remain unlocked for 300 seconds (which is current default by Geth v1.9.5), 
-	if ``duration`` is set to ``0``, the account will remain unlocked indefinitely.  
+    Unlocks the given ``account`` for ``duration`` seconds. If ``duration`` is
+	``None`` then the account will remain unlocked for 300 seconds (which is current default by Geth v1.9.5),
+	if ``duration`` is set to ``0``, the account will remain unlocked indefinitely.
 	Returns boolean as to whether the account was successfully unlocked.
 
     .. code-block:: python
 
-        >>> web3.geth.personal.unlockAccount('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'wrong-passphrase')
+        >>> web3.geth.personal.unlock_account('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'wrong-passphrase')
         False
-        >>> web3.geth.personal.unlockAccount('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'the-passphrase')
+        >>> web3.geth.personal.unlock_account('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'the-passphrase')
         True
 
 
-.. py:method:: sendTransaction(self, transaction, passphrase)
+.. py:method:: unlockAccount()
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.geth.personal.unlockAccount()`
+
+
+.. py:method:: send_transaction(self, transaction, passphrase)
 
     * Delegates to ``personal_sendTransaction`` RPC Method
 
     Sends the transaction.
+
+
+.. py:method:: sendTransaction()
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.geth.personal.sendTransaction()`
 
 
 .. py:module:: web3.geth.txpool

--- a/docs/web3.parity.rst
+++ b/docs/web3.parity.rst
@@ -5,12 +5,14 @@ Parity API
 
 The ``web3.parity`` object exposes modules that enable you to interact with the JSON-RPC endpoints supported by `Parity <https://wiki.parity.io/JSONRPC>`_ that are not defined in the standard set of Ethereum JSONRPC endpoints according to `EIP 1474 <https://github.com/ethereum/EIPs/pull/1474>`_.
 
+.. py:module:: web3.parity.personal
+
 ParityPersonal
 --------------
 
 The following methods are available on the ``web3.parity.personal`` namespace.
 
-.. py:method:: listAccounts
+.. py:method:: list_accounts()
 
     * Delegates to ``personal_listAccounts`` RPC Method
 
@@ -18,11 +20,15 @@ The following methods are available on the ``web3.parity.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.parity.personal.listAccounts()
+        >>> web3.parity.personal.list_accounts()
         ['0xd3CdA913deB6f67967B99D67aCDFa1712C293601']
 
+.. py:method:: listAccounts
 
-.. py:method:: importRawKey(self, private_key, passphrase)
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.parity.personal.list_accounts()`
+
+.. py:method:: import_raw_key(self, private_key, passphrase)
 
     * Delegates to ``personal_importRawKey`` RPC Method
 
@@ -31,11 +37,15 @@ The following methods are available on the ``web3.parity.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.parity.personal.importRawKey(some_private_key, 'the-passphrase')
+        >>> web3.parity.personal.import_raw_key(some_private_key, 'the-passphrase')
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 
+.. py:method:: importRawKey(self, private_key, passphrase)
 
-.. py:method:: newAccount(self, password)
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.parity.personal.import_raw_key()`
+
+.. py:method:: new_account(self, password)
 
     * Delegates to ``personal_newAccount`` RPC Method
 
@@ -44,11 +54,15 @@ The following methods are available on the ``web3.parity.personal`` namespace.
 
     .. code-block:: python
 
-        >>> web3.parity.personal.newAccount('the-passphrase')
+        >>> web3.parity.personal.new_account('the-passphrase')
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 
+.. py:method:: newAccount(self, password)
 
-.. py:method:: unlockAccount(self, account, passphrase, duration=None)
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.parity.personal.new_account()`
+
+.. py:method:: unlock_account(self, account, passphrase, duration=None)
 
     * Delegates to ``personal_unlockAccount`` RPC Method
 
@@ -59,20 +73,28 @@ The following methods are available on the ``web3.parity.personal`` namespace.
     .. code-block:: python
 
         # Invalid call to personal_unlockAccount on Parity currently returns True, due to Parity bug
-        >>> web3.parity.personal.unlockAccount('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'wrong-passphrase')
+        >>> web3.parity.personal.unlock_account('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'wrong-passphrase')
         True
-        >>> web3.parity.personal.unlockAccount('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'the-passphrase')
+        >>> web3.parity.personal.unlock_account('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'the-passphrase')
         True
 
+.. py:method:: unlockAccount(self, account, passphrase, duration=None)
 
-.. py:method:: sendTransaction(self, transaction, passphrase)
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.parity.personal.unlock_account()`
+
+.. py:method:: send_transaction(self, transaction, passphrase)
 
     * Delegates to ``personal_sendTransaction`` RPC Method
 
     Sends the transaction.
 
+.. py:method:: sendTransaction(self, account, passphrase, duration=None)
 
-.. py:method:: signTypedData(self, jsonMessage, account, passphrase)
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.parity.personal.send_transaction()`
+
+.. py:method:: sign_typed_data(self, jsonMessage, account, passphrase)
 
     * Delegates to ``personal_signTypedData`` RPC Method
 
@@ -81,6 +103,10 @@ The following methods are available on the ``web3.parity.personal`` namespace.
 
     Signs the ``Structured Data`` (or ``Typed Data``) with the passphrase of the given ``account``
 
+.. py:method:: signTypedData(self, jsonMessage, account, passphrase)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.parity.personal.sign_typed_data()`
 
 ParityShh
 ---------

--- a/newsfragments/1589.feature.rst
+++ b/newsfragments/1589.feature.rst
@@ -1,0 +1,3 @@
+Add snake_case methods to Geth and Parity Personal Modules.
+
+Deprecate camelCase methods.

--- a/tests/generate_go_ethereum_fixture.py
+++ b/tests/generate_go_ethereum_fixture.py
@@ -317,7 +317,7 @@ def mine_block(web3):
 
 
 def deploy_contract(web3, name, factory):
-    web3.geth.personal.unlockAccount(web3.eth.coinbase, KEYFILE_PW)
+    web3.geth.personal.unlock_account(web3.eth.coinbase, KEYFILE_PW)
     deploy_txn_hash = factory.constructor().transact({'from': web3.eth.coinbase})
     print('{0}_CONTRACT_DEPLOY_HASH: '.format(name.upper()), deploy_txn_hash)
     deploy_receipt = mine_transaction_hash(web3, deploy_txn_hash)
@@ -376,7 +376,7 @@ def setup_chain_state(web3):
     #
     # Block with Transaction
     #
-    web3.geth.personal.unlockAccount(coinbase, KEYFILE_PW)
+    web3.geth.personal.unlock_account(coinbase, KEYFILE_PW)
     web3.geth.miner.start(1)
     mined_txn_hash = web3.eth.sendTransaction({
         'from': coinbase,

--- a/tests/integration/generate_fixtures/common.py
+++ b/tests/integration/generate_fixtures/common.py
@@ -228,7 +228,7 @@ def mine_transaction_hash(web3, txn_hash):
 
 
 def deploy_contract(web3, name, factory):
-    web3.geth.personal.unlockAccount(web3.eth.coinbase, KEYFILE_PW)
+    web3.geth.personal.unlock_account(web3.eth.coinbase, KEYFILE_PW)
     deploy_txn_hash = factory.constructor().transact({'from': web3.eth.coinbase})
     print('{0}_CONTRACT_DEPLOY_HASH: '.format(name.upper()), deploy_txn_hash)
     deploy_receipt = mine_transaction_hash(web3, deploy_txn_hash)

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -120,7 +120,7 @@ def setup_chain_state(web3):
     #
     # Block with Transaction
     #
-    web3.geth.personal.unlockAccount(coinbase, common.KEYFILE_PW)
+    web3.geth.personal.unlock_account(coinbase, common.KEYFILE_PW)
     web3.geth.miner.start(1)
     mined_txn_hash = web3.eth.sendTransaction({
         'from': coinbase,

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -136,3 +136,7 @@ class CommonGoEthereumShhModuleTest(GoEthereumShhModuleTest):
 
 class GoEthereumAdminModuleTest(GoEthereumAdminModuleTest):
     pass
+
+
+class GoEthereumPersonalModuleTest(GoEthereumPersonalModuleTest):
+    pass

--- a/tests/integration/go_ethereum/conftest.py
+++ b/tests/integration/go_ethereum/conftest.py
@@ -170,9 +170,9 @@ def emitter_contract_address(emitter_contract, address_conversion_func):
 
 @pytest.fixture
 def unlocked_account(web3, unlockable_account, unlockable_account_pw):
-    web3.geth.personal.unlockAccount(unlockable_account, unlockable_account_pw)
+    web3.geth.personal.unlock_account(unlockable_account, unlockable_account_pw)
     yield unlockable_account
-    web3.geth.personal.lockAccount(unlockable_account)
+    web3.geth.personal.lock_account(unlockable_account)
 
 
 @pytest.fixture(scope='module')
@@ -192,9 +192,9 @@ def unlockable_account_dual_type(unlockable_account, address_conversion_func):
 
 @pytest.yield_fixture
 def unlocked_account_dual_type(web3, unlockable_account_dual_type, unlockable_account_pw):
-    web3.geth.personal.unlockAccount(unlockable_account_dual_type, unlockable_account_pw)
+    web3.geth.personal.unlock_account(unlockable_account_dual_type, unlockable_account_pw)
     yield unlockable_account_dual_type
-    web3.geth.personal.lockAccount(unlockable_account_dual_type)
+    web3.geth.personal.lock_account(unlockable_account_dual_type)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -25,8 +25,6 @@ from web3.providers.eth_tester import (
     EthereumTesterProvider,
 )
 
-pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
-
 
 @pytest.fixture(scope="module")
 def eth_tester():
@@ -147,7 +145,7 @@ def unlockable_account_pw(web3):
 
 @pytest.fixture(scope='module')
 def unlockable_account(web3, unlockable_account_pw):
-    account = web3.geth.personal.importRawKey(UNLOCKABLE_PRIVATE_KEY, unlockable_account_pw)
+    account = web3.geth.personal.import_raw_key(UNLOCKABLE_PRIVATE_KEY, unlockable_account_pw)
     web3.eth.sendTransaction({
         'from': web3.eth.coinbase,
         'to': account,
@@ -158,9 +156,9 @@ def unlockable_account(web3, unlockable_account_pw):
 
 @pytest.fixture
 def unlocked_account(web3, unlockable_account, unlockable_account_pw):
-    web3.geth.personal.unlockAccount(unlockable_account, unlockable_account_pw)
+    web3.geth.personal.unlock_account(unlockable_account, unlockable_account_pw)
     yield unlockable_account
-    web3.geth.personal.lockAccount(unlockable_account)
+    web3.geth.personal.lock_account(unlockable_account)
 
 
 @pytest.fixture()
@@ -170,9 +168,9 @@ def unlockable_account_dual_type(unlockable_account, address_conversion_func):
 
 @pytest.fixture
 def unlocked_account_dual_type(web3, unlockable_account_dual_type, unlockable_account_pw):
-    web3.geth.personal.unlockAccount(unlockable_account_dual_type, unlockable_account_pw)
+    web3.geth.personal.unlock_account(unlockable_account_dual_type, unlockable_account_pw)
     yield unlockable_account_dual_type
-    web3.geth.personal.lockAccount(unlockable_account_dual_type)
+    web3.geth.personal.lock_account(unlockable_account_dual_type)
 
 
 @pytest.fixture(scope="module")
@@ -317,10 +315,22 @@ class TestEthereumTesterPersonalModule(GoEthereumPersonalModuleTest):
         GoEthereumPersonalModuleTest.test_personal_sign_and_ecrecover,
         ValueError,
     )
+    test_personal_sign_and_ecrecover_deprecated = not_implemented(
+        GoEthereumPersonalModuleTest.test_personal_sign_and_ecrecover,
+        ValueError,
+    )
 
     # Test overridden here since eth-tester returns False rather than None for failed unlock
-    def test_personal_unlockAccount_failure(self,
-                                            web3,
-                                            unlockable_account_dual_type):
-        result = web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
+    def test_personal_unlock_account_failure(self,
+                                             web3,
+                                             unlockable_account_dual_type):
+        result = web3.geth.personal.unlock_account(unlockable_account_dual_type, 'bad-password')
         assert result is False
+
+    def test_personal_unlockAccount_failure_deprecated(self,
+                                                       web3,
+                                                       unlockable_account_dual_type):
+        with pytest.warns(DeprecationWarning,
+                          match="unlockAccount is deprecated in favor of unlock_account"):
+            result = web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
+            assert result is False

--- a/web3/_utils/module_testing/personal_module.py
+++ b/web3/_utils/module_testing/personal_module.py
@@ -26,8 +26,10 @@ if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
 
 PRIVATE_KEY_HEX = '0x56ebb41875ceedd42e395f730e03b5c44989393c9f0484ee6bc05f933673458f'
+SECOND_PRIVATE_KEY_HEX = '0x56ebb41875ceedd42e395f730e03b5c44989393c9f0484ee6bc05f9336712345'
 PASSWORD = 'web3-testing'
 ADDRESS = '0x844B417c0C58B02c2224306047B9fb0D3264fE8c'
+SECOND_ADDRESS = '0xB96b6B21053e67BA59907E252D990C71742c41B8'
 
 
 PRIVATE_KEY_FOR_UNLOCK = '0x392f63a79b1ff8774845f3fa69de4a13800a59e7083f5187f1558f0797ad0f01'
@@ -35,12 +37,17 @@ ACCOUNT_FOR_UNLOCK = '0x12efDc31B1a8FA1A1e756DFD8A1601055C971E13'
 
 
 class GoEthereumPersonalModuleTest:
-    def test_personal_importRawKey(self, web3: "Web3") -> None:
-        actual = web3.geth.personal.importRawKey(PRIVATE_KEY_HEX, PASSWORD)
+    def test_personal_import_raw_key(self, web3: "Web3") -> None:
+        actual = web3.geth.personal.import_raw_key(PRIVATE_KEY_HEX, PASSWORD)
         assert actual == ADDRESS
 
-    def test_personal_listAccounts(self, web3: "Web3") -> None:
-        accounts = web3.geth.personal.listAccounts()
+    def test_personal_importRawKey_deprecated(self, web3: "Web3") -> None:
+        with pytest.warns(DeprecationWarning):
+            actual = web3.geth.personal.importRawKey(SECOND_PRIVATE_KEY_HEX, PASSWORD)
+            assert actual == SECOND_ADDRESS
+
+    def test_personal_list_accounts(self, web3: "Web3") -> None:
+        accounts = web3.geth.personal.list_accounts()
         assert is_list_like(accounts)
         assert len(accounts) > 0
         assert all((
@@ -49,35 +56,78 @@ class GoEthereumPersonalModuleTest:
             in accounts
         ))
 
-    def test_personal_lockAccount(
+    def test_personal_listAccounts_deprecated(self, web3: "Web3") -> None:
+        with pytest.warns(DeprecationWarning):
+            accounts = web3.geth.personal.listAccounts()
+            assert is_list_like(accounts)
+            assert len(accounts) > 0
+            assert all((
+                is_checksum_address(item)
+                for item
+                in accounts
+            ))
+
+    def test_personal_lock_account(
         self, web3: "Web3", unlockable_account_dual_type: ChecksumAddress
     ) -> None:
         # TODO: how do we test this better?
-        web3.geth.personal.lockAccount(unlockable_account_dual_type)
+        web3.geth.personal.lock_account(unlockable_account_dual_type)
 
-    def test_personal_unlockAccount_success(
+    def test_personal_lockAccount_deprecated(
+        self, web3: "Web3", unlockable_account_dual_type: ChecksumAddress
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            # TODO: how do we test this better?
+            web3.geth.personal.lockAccount(unlockable_account_dual_type)
+
+    def test_personal_unlock_account_success(
         self,
         web3: "Web3",
         unlockable_account_dual_type: ChecksumAddress,
         unlockable_account_pw: str,
     ) -> None:
-        result = web3.geth.personal.unlockAccount(
+        result = web3.geth.personal.unlock_account(
             unlockable_account_dual_type,
             unlockable_account_pw
         )
         assert result is True
 
-    def test_personal_unlockAccount_failure(
+    def test_personal_unlockAccount_success_deprecated(
+        self,
+        web3: "Web3",
+        unlockable_account_dual_type: ChecksumAddress,
+        unlockable_account_pw: str,
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            result = web3.geth.personal.unlockAccount(
+                unlockable_account_dual_type,
+                unlockable_account_pw
+            )
+            assert result is True
+
+    def test_personal_unlock_account_failure(
         self, web3: "Web3", unlockable_account_dual_type: ChecksumAddress
     ) -> None:
         with pytest.raises(ValueError):
-            web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
+            web3.geth.personal.unlock_account(unlockable_account_dual_type, 'bad-password')
 
-    def test_personal_newAccount(self, web3: "Web3") -> None:
-        new_account = web3.geth.personal.newAccount(PASSWORD)
+    def test_personal_unlockAccount_failure_deprecated(
+        self, web3: "Web3", unlockable_account_dual_type: ChecksumAddress
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            with pytest.raises(ValueError):
+                web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
+
+    def test_personal_new_account(self, web3: "Web3") -> None:
+        new_account = web3.geth.personal.new_account(PASSWORD)
         assert is_checksum_address(new_account)
 
-    def test_personal_sendTransaction(
+    def test_personal_newAccount_deprecated(self, web3: "Web3") -> None:
+        with pytest.warns(DeprecationWarning):
+            new_account = web3.geth.personal.newAccount(PASSWORD)
+            assert is_checksum_address(new_account)
+
+    def test_personal_send_transaction(
         self,
         web3: "Web3",
         unlockable_account_dual_type: ChecksumAddress,
@@ -91,7 +141,7 @@ class GoEthereumPersonalModuleTest:
             'value': Wei(1),
             'gasPrice': web3.toWei(1, 'gwei'),
         }
-        txn_hash = web3.geth.personal.sendTransaction(txn_params, unlockable_account_pw)
+        txn_hash = web3.geth.personal.send_transaction(txn_params, unlockable_account_pw)
         assert txn_hash
         transaction = web3.eth.getTransaction(txn_hash)
 
@@ -100,6 +150,31 @@ class GoEthereumPersonalModuleTest:
         assert transaction['gas'] == txn_params['gas']
         assert transaction['value'] == txn_params['value']
         assert transaction['gasPrice'] == txn_params['gasPrice']
+
+    def test_personal_sendTransaction_deprecated(
+        self,
+        web3: "Web3",
+        unlockable_account_dual_type: ChecksumAddress,
+        unlockable_account_pw: str,
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            assert web3.eth.getBalance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
+            txn_params: TxParams = {
+                'from': unlockable_account_dual_type,
+                'to': unlockable_account_dual_type,
+                'gas': Wei(21000),
+                'value': Wei(1),
+                'gasPrice': web3.toWei(1, 'gwei'),
+            }
+            txn_hash = web3.geth.personal.sendTransaction(txn_params, unlockable_account_pw)
+            assert txn_hash
+            transaction = web3.eth.getTransaction(txn_hash)
+
+            assert is_same_address(transaction['from'], cast(ChecksumAddress, txn_params['from']))
+            assert is_same_address(transaction['to'], cast(ChecksumAddress, txn_params['to']))
+            assert transaction['gas'] == txn_params['gas']
+            assert transaction['value'] == txn_params['value']
+            assert transaction['gasPrice'] == txn_params['gasPrice']
 
     def test_personal_sign_and_ecrecover(
         self,
@@ -113,10 +188,28 @@ class GoEthereumPersonalModuleTest:
             unlockable_account_dual_type,
             unlockable_account_pw
         )
-        signer = web3.geth.personal.ecRecover(message, signature)
+        signer = web3.geth.personal.ec_recover(message, signature)
         assert is_same_address(signer, unlockable_account_dual_type)
 
-    @pytest.mark.xfail(reason="personal_signTypedData JSON RPC call has not been released in geth")
+    def test_personal_sign_and_ecrecover_deprecated(
+        self,
+        web3: "Web3",
+        unlockable_account_dual_type: ChecksumAddress,
+        unlockable_account_pw: str,
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            message = 'test-web3-geth-personal-sign'
+            signature = web3.geth.personal.sign(
+                message,
+                unlockable_account_dual_type,
+                unlockable_account_pw
+            )
+            signer = web3.geth.personal.ecRecover(message, signature)
+            assert is_same_address(signer, unlockable_account_dual_type)
+
+    @pytest.mark.xfail(
+        reason="personal_sign_typed_data JSON RPC call has not been released in geth"
+    )
     def test_personal_sign_typed_data(
         self,
         web3: "Web3",
@@ -162,7 +255,7 @@ class GoEthereumPersonalModuleTest:
                 }
             }
         '''
-        signature = HexBytes(web3.geth.personal.signTypedData(
+        signature = HexBytes(web3.geth.personal.sign_typed_data(
             json.loads(typed_message),
             unlockable_account_dual_type,
             unlockable_account_pw
@@ -176,10 +269,72 @@ class GoEthereumPersonalModuleTest:
         assert signature == expected_signature
         assert len(signature) == 32 + 32 + 1
 
+    @pytest.mark.xfail(reason="personal_signTypedData JSON RPC call has not been released in geth")
+    def test_personal_sign_typed_data_deprecated(
+        self,
+        web3: "Web3",
+        unlockable_account_dual_type: ChecksumAddress,
+        unlockable_account_pw: str,
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            typed_message = '''
+                {
+                    "types": {
+                        "EIP712Domain": [
+                            {"name": "name", "type": "string"},
+                            {"name": "version", "type": "string"},
+                            {"name": "chainId", "type": "uint256"},
+                            {"name": "verifyingContract", "type": "address"}
+                        ],
+                        "Person": [
+                            {"name": "name", "type": "string"},
+                            {"name": "wallet", "type": "address"}
+                        ],
+                        "Mail": [
+                            {"name": "from", "type": "Person"},
+                            {"name": "to", "type": "Person"},
+                            {"name": "contents", "type": "string"}
+                        ]
+                    },
+                    "primaryType": "Mail",
+                    "domain": {
+                        "name": "Ether Mail",
+                        "version": "1",
+                        "chainId": "0x01",
+                        "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+                    },
+                    "message": {
+                        "from": {
+                            "name": "Cow",
+                            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+                        },
+                        "to": {
+                            "name": "Bob",
+                            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+                        },
+                        "contents": "Hello, Bob!"
+                    }
+                }
+            '''
+            signature = HexBytes(web3.geth.personal.signTypedData(
+                json.loads(typed_message),
+                unlockable_account_dual_type,
+                unlockable_account_pw
+            ))
+
+            expected_signature = HexBytes(
+                "0xc8b56aaeefd10ab4005c2455daf28d9082af661ac347cd"
+                "b612d5b5e11f339f2055be831bf57a6e6cb5f6d93448fa35"
+                "c1bd56fe1d745ffa101e74697108668c401c"
+            )
+            assert signature == expected_signature
+            assert len(signature) == 32 + 32 + 1
+
 
 class ParityPersonalModuleTest():
-    def test_personal_listAccounts(self, web3: "Web3") -> None:
-        accounts = web3.parity.personal.listAccounts()
+
+    def test_personal_list_accounts(self, web3: "Web3") -> None:
+        accounts = web3.parity.personal.list_accounts()
         assert is_list_like(accounts)
         assert len(accounts) > 0
         assert all((
@@ -188,49 +343,107 @@ class ParityPersonalModuleTest():
             in accounts
         ))
 
-    def test_personal_unlockAccount_success(
+    def test_personal_listAccounts_deprecated(self, web3: "Web3") -> None:
+        with pytest.warns(DeprecationWarning):
+            accounts = web3.parity.personal.listAccounts()
+            assert is_list_like(accounts)
+            assert len(accounts) > 0
+            assert all((
+                is_checksum_address(item)
+                for item
+                in accounts
+            ))
+
+    def test_personal_unlock_account_success(
         self,
         web3: "Web3",
         unlockable_account_dual_type: ChecksumAddress,
         unlockable_account_pw: str,
     ) -> None:
-        result = web3.parity.personal.unlockAccount(
+        result = web3.parity.personal.unlock_account(
             unlockable_account_dual_type,
             unlockable_account_pw,
             None
         )
         assert result is True
 
+    def test_personal_unlockAccount_success_deprecated(
+        self,
+        web3: "Web3",
+        unlockable_account_dual_type: ChecksumAddress,
+        unlockable_account_pw: str,
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            result = web3.parity.personal.unlockAccount(
+                unlockable_account_dual_type,
+                unlockable_account_pw,
+                None
+            )
+            assert result is True
+
     # Seems to be an issue with Parity since this should return False
-    def test_personal_unlockAccount_failure(
+    def test_personal_unlock_account_failure(
         self,
         web3: "Web3",
         unlockable_account_dual_type: ChecksumAddress,
     ) -> None:
-        result = web3.parity.personal.unlockAccount(
+        result = web3.parity.personal.unlock_account(
             unlockable_account_dual_type,
             'bad-password',
             None
         )
         assert result is True
 
-    def test_personal_newAccount(self, web3: "Web3") -> None:
-        new_account = web3.parity.personal.newAccount(PASSWORD)
+    # Seems to be an issue with Parity since this should return False
+    def test_personal_unlockAccount_failure_deprecated(
+        self,
+        web3: "Web3",
+        unlockable_account_dual_type: ChecksumAddress,
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            result = web3.parity.personal.unlockAccount(
+                unlockable_account_dual_type,
+                'bad-password',
+                None
+            )
+            assert result is True
+
+    def test_personal_new_account(self, web3: "Web3") -> None:
+        new_account = web3.parity.personal.new_account(PASSWORD)
         assert is_checksum_address(new_account)
 
+    def test_personal_newAccount_deprecated(self, web3: "Web3") -> None:
+        with pytest.warns(DeprecationWarning):
+            new_account = web3.parity.personal.newAccount(PASSWORD)
+            assert is_checksum_address(new_account)
+
     @pytest.mark.xfail(reason='this non-standard json-rpc method is not implemented on parity')
-    def test_personal_lockAccount(
+    def test_personal_lock_account(
         self, web3: "Web3", unlocked_account: ChecksumAddress
     ) -> None:
         # method undefined in superclass
-        super().test_personal_lockAccount(web3, unlocked_account)  # type: ignore
+        super().test_personal_lock_account(web3, unlocked_account)  # type: ignore
 
     @pytest.mark.xfail(reason='this non-standard json-rpc method is not implemented on parity')
-    def test_personal_importRawKey(self, web3: "Web3") -> None:
-        # method undefined in superclass
-        super().test_personal_importRawKey(web3)  # type: ignore
+    def test_personal_lockAccount_deprecated(
+        self, web3: "Web3", unlocked_account: ChecksumAddress
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            # method undefined in superclass
+            super().test_personal_lockAccount(web3, unlocked_account)  # type: ignore
 
-    def test_personal_sendTransaction(
+    @pytest.mark.xfail(reason='this non-standard json-rpc method is not implemented on parity')
+    def test_personal_import_raw_key(self, web3: "Web3") -> None:
+        # method undefined in superclass
+        super().test_personal_import_raw_key(web3)  # type: ignore
+
+    @pytest.mark.xfail(reason='this non-standard json-rpc method is not implemented on parity')
+    def test_personal_importRawKey_deprecated(self, web3: "Web3") -> None:
+        with pytest.warns(DeprecationWarning):
+            # method undefined in superclass
+            super().test_personal_importRawKey_deprecated(web3)  # type: ignore
+
+    def test_personal_send_transaction(
         self,
         web3: "Web3",
         unlockable_account_dual_type: ChecksumAddress,
@@ -244,7 +457,7 @@ class ParityPersonalModuleTest():
             'value': Wei(1),
             'gasPrice': web3.toWei(1, 'gwei'),
         }
-        txn_hash = web3.parity.personal.sendTransaction(txn_params, unlockable_account_pw)
+        txn_hash = web3.parity.personal.send_transaction(txn_params, unlockable_account_pw)
         assert txn_hash
         transaction = web3.eth.getTransaction(txn_hash)
 
@@ -253,6 +466,31 @@ class ParityPersonalModuleTest():
         assert transaction['gas'] == txn_params['gas']
         assert transaction['value'] == txn_params['value']
         assert transaction['gasPrice'] == txn_params['gasPrice']
+
+    def test_personal_sendTransaction_deprecated(
+        self,
+        web3: "Web3",
+        unlockable_account_dual_type: ChecksumAddress,
+        unlockable_account_pw: str,
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            assert web3.eth.getBalance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
+            txn_params: TxParams = {
+                'from': unlockable_account_dual_type,
+                'to': unlockable_account_dual_type,
+                'gas': Wei(21000),
+                'value': Wei(1),
+                'gasPrice': web3.toWei(1, 'gwei'),
+            }
+            txn_hash = web3.parity.personal.sendTransaction(txn_params, unlockable_account_pw)
+            assert txn_hash
+            transaction = web3.eth.getTransaction(txn_hash)
+
+            assert is_same_address(transaction['from'], cast(ChecksumAddress, txn_params['from']))
+            assert is_same_address(transaction['to'], cast(ChecksumAddress, txn_params['to']))
+            assert transaction['gas'] == txn_params['gas']
+            assert transaction['value'] == txn_params['value']
+            assert transaction['gasPrice'] == txn_params['gasPrice']
 
     def test_personal_sign_and_ecrecover(
         self,
@@ -266,8 +504,24 @@ class ParityPersonalModuleTest():
             unlockable_account_dual_type,
             unlockable_account_pw
         )
-        signer = web3.parity.personal.ecRecover(message, signature)
+        signer = web3.parity.personal.ec_recover(message, signature)
         assert is_same_address(signer, unlockable_account_dual_type)
+
+    def test_personal_sign_and_ecrecover_deprecated(
+        self,
+        web3: "Web3",
+        unlockable_account_dual_type: ChecksumAddress,
+        unlockable_account_pw: str,
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            message = 'test-web3-parity-personal-sign'
+            signature = web3.parity.personal.sign(
+                message,
+                unlockable_account_dual_type,
+                unlockable_account_pw
+            )
+            signer = web3.parity.personal.ecRecover(message, signature)
+            assert is_same_address(signer, unlockable_account_dual_type)
 
     def test_personal_sign_typed_data(
         self,
@@ -314,7 +568,7 @@ class ParityPersonalModuleTest():
                 }
             }
         '''
-        signature = HexBytes(web3.parity.personal.signTypedData(
+        signature = HexBytes(web3.parity.personal.sign_typed_data(
             json.loads(typed_message),
             unlockable_account_dual_type,
             unlockable_account_pw
@@ -327,6 +581,66 @@ class ParityPersonalModuleTest():
         )
         assert signature == expected_signature
         assert len(signature) == 32 + 32 + 1
+
+    def test_personal_sign_typed_data_deprecated(
+        self,
+        web3: "Web3",
+        unlockable_account_dual_type: ChecksumAddress,
+        unlockable_account_pw: str,
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            typed_message = '''
+                {
+                    "types": {
+                        "EIP712Domain": [
+                            {"name": "name", "type": "string"},
+                            {"name": "version", "type": "string"},
+                            {"name": "chainId", "type": "uint256"},
+                            {"name": "verifyingContract", "type": "address"}
+                        ],
+                        "Person": [
+                            {"name": "name", "type": "string"},
+                            {"name": "wallet", "type": "address"}
+                        ],
+                        "Mail": [
+                            {"name": "from", "type": "Person"},
+                            {"name": "to", "type": "Person"},
+                            {"name": "contents", "type": "string"}
+                        ]
+                    },
+                    "primaryType": "Mail",
+                    "domain": {
+                        "name": "Ether Mail",
+                        "version": "1",
+                        "chainId": "0x01",
+                        "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+                    },
+                    "message": {
+                        "from": {
+                            "name": "Cow",
+                            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+                        },
+                        "to": {
+                            "name": "Bob",
+                            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+                        },
+                        "contents": "Hello, Bob!"
+                    }
+                }
+            '''
+            signature = HexBytes(web3.parity.personal.signTypedData(
+                json.loads(typed_message),
+                unlockable_account_dual_type,
+                unlockable_account_pw
+            ))
+
+            expected_signature = HexBytes(
+                "0xc8b56aaeefd10ab4005c2455daf28d9082af661ac347cd"
+                "b612d5b5e11f339f2055be831bf57a6e6cb5f6d93448fa35"
+                "c1bd56fe1d745ffa101e74697108668c401c"
+            )
+            assert signature == expected_signature
+            assert len(signature) == 32 + 32 + 1
 
     def test_invalid_personal_sign_typed_data(
         self,
@@ -375,8 +689,63 @@ class ParityPersonalModuleTest():
         '''
         with pytest.raises(ValueError,
                            match=r".*Expected 2 items for array type Person\[2\], got 1 items.*"):
-            web3.parity.personal.signTypedData(
+            web3.parity.personal.sign_typed_data(
                 json.loads(invalid_typed_message),
                 unlockable_account_dual_type,
                 unlockable_account_pw
             )
+
+    def test_invalid_personal_sign_typed_data_deprecated(
+        self,
+        web3: "Web3",
+        unlockable_account_dual_type: ChecksumAddress,
+        unlockable_account_pw: str,
+    ) -> None:
+        with pytest.warns(DeprecationWarning):
+            invalid_typed_message = '''
+                {
+                    "types": {
+                        "EIP712Domain": [
+                            {"name": "name", "type": "string"},
+                            {"name": "version", "type": "string"},
+                            {"name": "chainId", "type": "uint256"},
+                            {"name": "verifyingContract", "type": "address"}
+                        ],
+                        "Person": [
+                            {"name": "name", "type": "string"},
+                            {"name": "wallet", "type": "address"}
+                        ],
+                        "Mail": [
+                            {"name": "from", "type": "Person"},
+                            {"name": "to", "type": "Person[2]"},
+                            {"name": "contents", "type": "string"}
+                        ]
+                    },
+                    "primaryType": "Mail",
+                    "domain": {
+                        "name": "Ether Mail",
+                        "version": "1",
+                        "chainId": "0x01",
+                        "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+                    },
+                    "message": {
+                        "from": {
+                            "name": "Cow",
+                            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+                        },
+                        "to": [{
+                            "name": "Bob",
+                            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+                        }],
+                        "contents": "Hello, Bob!"
+                    }
+                }
+            '''
+            with pytest.raises(ValueError,
+                               match=r".*Expected 2 items for array type Person\[2\], got 1 items.*"
+                               ):
+                web3.parity.personal.signTypedData(
+                    json.loads(invalid_typed_message),
+                    unlockable_account_dual_type,
+                    unlockable_account_pw
+                )

--- a/web3/_utils/personal.py
+++ b/web3/_utils/personal.py
@@ -21,6 +21,7 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.method import (
+    DeprecatedMethod,
     Method,
     default_root_munger,
 )
@@ -28,31 +29,31 @@ from web3.types import (
     TxParams,
 )
 
-importRawKey: Method[Callable[[str, str], ChecksumAddress]] = Method(
+import_raw_key: Method[Callable[[str, str], ChecksumAddress]] = Method(
     RPC.personal_importRawKey,
     mungers=[default_root_munger],
 )
 
 
-newAccount: Method[Callable[[str], ChecksumAddress]] = Method(
+new_account: Method[Callable[[str], ChecksumAddress]] = Method(
     RPC.personal_newAccount,
     mungers=[default_root_munger],
 )
 
 
-listAccounts: Method[Callable[[], List[ChecksumAddress]]] = Method(
+list_accounts: Method[Callable[[], List[ChecksumAddress]]] = Method(
     RPC.personal_listAccounts,
     mungers=None,
 )
 
 
-sendTransaction: Method[Callable[[TxParams, str], HexBytes]] = Method(
+send_transaction: Method[Callable[[TxParams, str], HexBytes]] = Method(
     RPC.personal_sendTransaction,
     mungers=[default_root_munger],
 )
 
 
-lockAccount: Method[Callable[[ChecksumAddress], bool]] = Method(
+lock_account: Method[Callable[[ChecksumAddress], bool]] = Method(
     RPC.personal_lockAccount,
     mungers=[default_root_munger],
 )
@@ -63,7 +64,7 @@ class UnlockAccountWrapper(Protocol):
         pass
 
 
-unlockAccount: Method[UnlockAccountWrapper] = Method(
+unlock_account: Method[UnlockAccountWrapper] = Method(
     RPC.personal_unlockAccount,
     mungers=[default_root_munger],
 )
@@ -75,13 +76,25 @@ sign: Method[Callable[[str, ChecksumAddress, Optional[str]], HexStr]] = Method(
 )
 
 
-signTypedData: Method[Callable[[Dict[str, Any], ChecksumAddress, str], HexStr]] = Method(
+sign_typed_data: Method[Callable[[Dict[str, Any], ChecksumAddress, str], HexStr]] = Method(
     RPC.personal_signTypedData,
     mungers=[default_root_munger],
 )
 
 
-ecRecover: Method[Callable[[str, HexStr], ChecksumAddress]] = Method(
+ec_recover: Method[Callable[[str, HexStr], ChecksumAddress]] = Method(
     RPC.personal_ecRecover,
     mungers=[default_root_munger],
 )
+
+#
+# Deprecated Methods
+#
+importRawKey = DeprecatedMethod(import_raw_key, 'importRawKey', 'import_raw_key')
+newAccount = DeprecatedMethod(new_account, 'newAccount', 'new_account')
+listAccounts = DeprecatedMethod(list_accounts, 'listAccounts', 'list_accounts')
+sendTransaction = DeprecatedMethod(send_transaction, 'sendTransaction', 'send_transaction')
+lockAccount = DeprecatedMethod(lock_account, 'lockAccount', 'lock_account')
+unlockAccount = DeprecatedMethod(unlock_account, 'unlockAccount', 'unlock_account')
+signTypedData = DeprecatedMethod(sign_typed_data, 'signTypedData', 'sign_typed_data')
+ecRecover = DeprecatedMethod(ec_recover, 'ecRecover', 'ec_recover')

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -34,14 +34,22 @@ from web3._utils.miner import (
     stopAutoDag,
 )
 from web3._utils.personal import (
+    ec_recover,
     ecRecover,
+    import_raw_key,
     importRawKey,
+    list_accounts,
     listAccounts,
+    lock_account,
     lockAccount,
+    new_account,
     newAccount,
+    send_transaction,
     sendTransaction,
     sign,
+    sign_typed_data,
     signTypedData,
+    unlock_account,
     unlockAccount,
 )
 from web3._utils.txpool import (
@@ -59,13 +67,22 @@ class GethPersonal(ModuleV2):
     """
     https://github.com/ethereum/go-ethereum/wiki/management-apis#personal
     """
+    ec_recover = ec_recover
+    import_raw_key = import_raw_key
+    list_accounts = list_accounts
+    lock_account = lock_account
+    new_account = new_account
+    send_transaction = send_transaction
+    sign = sign
+    sign_typed_data = sign_typed_data
+    unlock_account = unlock_account
+    # deprecated
     ecRecover = ecRecover
     importRawKey = importRawKey
     listAccounts = listAccounts
     lockAccount = lockAccount
     newAccount = newAccount
     sendTransaction = sendTransaction
-    sign = sign
     signTypedData = signTypedData
     unlockAccount = unlockAccount
 

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -23,13 +23,20 @@ from web3._utils.compat import (
     Literal,
 )
 from web3._utils.personal import (
+    ec_recover,
     ecRecover,
+    import_raw_key,
     importRawKey,
+    list_accounts,
     listAccounts,
+    new_account,
     newAccount,
+    send_transaction,
     sendTransaction,
     sign,
+    sign_typed_data,
     signTypedData,
+    unlock_account,
     unlockAccount,
 )
 from web3._utils.rpc_abi import (
@@ -91,12 +98,20 @@ class ParityPersonal(ModuleV2):
     """
     https://wiki.parity.io/JSONRPC-personal-module
     """
+    ec_recover = ec_recover
+    import_raw_key = import_raw_key
+    list_accounts = list_accounts
+    new_account = new_account
+    send_transaction = send_transaction
+    sign = sign
+    sign_typed_data = sign_typed_data
+    unlock_account = unlock_account
+    # deprecated
     ecRecover = ecRecover
     importRawKey = importRawKey
     listAccounts = listAccounts
     newAccount = newAccount
     sendTransaction = sendTransaction
-    sign = sign
     signTypedData = signTypedData
     unlockAccount = unlockAccount
 

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -398,6 +398,23 @@ API_ENDPOINTS = {
         'stopAutoDAG': not_implemented,
     },
     'personal': {
+        'ec_recover': not_implemented,
+        'import_raw_key': call_eth_tester('add_account'),
+        'list_accounts': call_eth_tester('get_accounts'),
+        'lock_account': excepts(
+            ValidationError,
+            compose(static_return(True), call_eth_tester('lock_account')),
+            static_return(False),
+        ),
+        'new_account': create_new_account,
+        'unlock_account': excepts(
+            ValidationError,
+            compose(static_return(True), call_eth_tester('unlock_account')),
+            static_return(False),
+        ),
+        'send_transaction': personal_send_transaction,
+        'sign': not_implemented,
+        # deprecated
         'ecRecover': not_implemented,
         'importRawKey': call_eth_tester('add_account'),
         'listAccounts': call_eth_tester('get_accounts'),
@@ -413,7 +430,6 @@ API_ENDPOINTS = {
             static_return(False),
         ),
         'sendTransaction': personal_send_transaction,
-        'sign': not_implemented,
     },
     'testing': {
         'timeTravel': call_eth_tester('time_travel'),


### PR DESCRIPTION
### What was wrong?
Parity Personal methods were camelCased rather than snake_cased

Related to Issue #
1429

### How was it fixed?
Parity Personal method names were changed from camelCase to snake_case. Deprecation warnings and tests for the snake_cased methods were also added. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.perthnow.com.au/publication/B881368345Z/1572419887806_G422FPENT.1-3.jpg?imwidth=668&impolicy=pn_v3)
