### PR TITLE
Net module v2

### DIFF
--- a/docs/web3.net.rst
+++ b/docs/web3.net.rst
@@ -1,10 +1,7 @@
 Net API
-===========
+=======
 
 .. py:module:: web3.net
-.. py:currentmodule:: web3.net
-
-.. py:class:: Net
 
 The ``web3.net`` object exposes methods to interact with the RPC APIs under
 the ``net_`` namespace.
@@ -15,17 +12,49 @@ Properties
 
 The following properties are available on the ``web3.net`` namespace.
 
-.. py:method:: Net.chainId(self)	
-    This method is deprecated as of EIP 1474.
+.. py:method:: chainId
+  :property:
 
-.. py:method:: Net.version(self)
+    .. warning:: Deprecated: This property is deprecated as of EIP 1474.
+
+.. py:method:: listening
+  :property:
+
+    * Delegates to ``net_listening`` RPC method
+
+    Returns true if client is actively listening for network connections.
+
+    .. code-block:: python
+
+        >>> web3.net.listening
+        True
+
+.. py:method:: peer_count
+  :property:
+
+    * Delegates to ``net_peerCount`` RPC method
+
+    Returns number of peers currently connected to the client.
+
+    .. code-block:: python
+
+        >>> web3.net.peer_count
+        1
+
+.. py:method:: peerCount
+  :property:
+
+    .. warning:: Deprecated: This property is deprecated in favor of
+      :attr:`~web3.geth.admin.peer_count`
+
+.. py:method:: version
+  :property:
 
     * Delegates to ``net_version`` RPC Method
 
-    Returns the current network chainId/version.
+    Returns the current network id.
 
     .. code-block:: python
 
         >>> web3.net.version
-        1
-
+        '8996'

--- a/newsfragments/1592.feature.rst
+++ b/newsfragments/1592.feature.rst
@@ -1,0 +1,3 @@
+Add snake_case methods for the net module
+
+Also moved net module to use ModuleV2 instead of Module

--- a/web3/_utils/net.py
+++ b/web3/_utils/net.py
@@ -20,6 +20,7 @@ peer_count: Method[Callable[[], int]] = Method(
     RPC.net_peerCount,
     mungers=[default_root_munger],
 )
+
 version: Method[Callable[[], str]] = Method(
     RPC.net_version,
     mungers=[default_root_munger],

--- a/web3/_utils/net.py
+++ b/web3/_utils/net.py
@@ -1,0 +1,32 @@
+from typing import (
+    Callable,
+)
+
+from web3._utils.rpc_abi import (
+    RPC,
+)
+from web3.method import (
+    DeprecatedMethod,
+    Method,
+    default_root_munger,
+)
+
+listening: Method[Callable[[], bool]] = Method(
+    RPC.net_listening,
+    mungers=[default_root_munger],
+)
+
+peer_count: Method[Callable[[], int]] = Method(
+    RPC.net_peerCount,
+    mungers=[default_root_munger],
+)
+version: Method[Callable[[], str]] = Method(
+    RPC.net_version,
+    mungers=[default_root_munger],
+)
+
+
+#
+# Deprecated Methods
+#
+peerCount = DeprecatedMethod(peer_count, 'peerCount', 'peer_count')

--- a/web3/net.py
+++ b/web3/net.py
@@ -1,36 +1,39 @@
 from typing import (
     NoReturn,
 )
-import warnings
 
-from web3._utils.rpc_abi import (
-    RPC,
+from web3._utils.net import (
+    listening,
+    peer_count,
+    peerCount,
+    version,
 )
 from web3.module import (
-    Module,
+    ModuleV2,
 )
 
 
-class Net(Module):
+class Net(ModuleV2):
     """
         https://github.com/ethereum/wiki/wiki/JSON-RPC
     """
 
+    _listening = listening
+    _peer_count = peer_count
+    _peerCount = peerCount
+    _version = version
+
     @property
     def listening(self) -> bool:
-        return self.web3.manager.request_blocking(RPC.net_listening, [])
+        return self._listening()
 
     @property
     def peer_count(self) -> int:
-        return self.web3.manager.request_blocking(RPC.net_peerCount, [])
+        return self._peer_count()
 
     @property
     def peerCount(self) -> int:
-        warnings.warn(
-            "peerCount is deprecated in favor of peer_count",
-            category=DeprecationWarning,
-        )
-        return self.peer_count
+        return self._peerCount()
 
     @property
     def chainId(self) -> NoReturn:
@@ -38,4 +41,4 @@ class Net(Module):
 
     @property
     def version(self) -> str:
-        return self.web3.manager.request_blocking(RPC.net_version, [])
+        return self._version()

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -200,7 +200,6 @@ API_ENDPOINTS = {
         'version': static_return('1'),
         'listening': static_return(False),
         'peerCount': static_return(0),
-
     },
     'eth': {
         'protocolVersion': static_return(63),


### PR DESCRIPTION
### What was wrong?

Related to Issue #1429 

This is a cleanup of the Net module, after changing to snake case methods/properties

### How was it fixed?
+ Documentation has been changed to look the same as the other modules.
+ Documentation shows the properties instead of method calls
+ Better documentation examples
+ The net module as been moved to `ModuleV2' 
+ The methods are now in _utils folder in the net.py module

