### PR TITLE
Fix return type of web3.eth.getCode

### DIFF
--- a/ethpm/_utils/deployments.py
+++ b/ethpm/_utils/deployments.py
@@ -6,9 +6,6 @@ from typing import (
     Tuple,
 )
 
-from eth_typing import (
-    HexStr,
-)
 from eth_utils import (
     is_same_address,
     to_bytes,
@@ -16,6 +13,9 @@ from eth_utils import (
 )
 from eth_utils.toolz import (
     get_in,
+)
+from hexbytes import (
+    HexBytes,
 )
 
 from ethpm.exceptions import (
@@ -47,7 +47,7 @@ def get_linked_deployments(deployments: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def validate_linked_references(
-    link_deps: Tuple[Tuple[int, bytes], ...], bytecode: HexStr
+    link_deps: Tuple[Tuple[int, bytes], ...], bytecode: HexBytes
 ) -> None:
     """
     Validates that normalized linked_references (offset, expected_bytes)

--- a/newsfragments/1601.bugfix.rst
+++ b/newsfragments/1601.bugfix.rst
@@ -1,0 +1,1 @@
+Fix return type of eth_getCode. Changed from Hexstr to HexBytes.

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -190,7 +190,7 @@ class Eth(Module):
 
     def getCode(
         self, account: Union[Address, ChecksumAddress, ENS], block_identifier: BlockIdentifier=None
-    ) -> HexStr:
+    ) -> HexBytes:
         if block_identifier is None:
             block_identifier = self.defaultBlock
         return self.web3.manager.request_blocking(


### PR DESCRIPTION
### What was wrong?

I just ran into the problem of `eth.getCode` announciong the return type to be `HexStr`, but it really returning `HexBytes`.

```
(Pdb++) blockchain_bytecode = web3.eth.getCode(human_standard_token.address)
(Pdb++) type(blockchain_bytecode)
<class 'hexbytes.main.HexBytes'>
```

### How was it fixed?

Adjusted the return type annotation. A different option would be to fix the type.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.stock-free.org/images/baby-animal-photo-05032016-image-055.jpg)
