### PR TITLE
Parity to method class

### DIFF
--- a/newsfragments/1602.misc.rst
+++ b/newsfragments/1602.misc.rst
@@ -1,0 +1,1 @@
+Move Parity Module to use Method class.

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -54,38 +54,9 @@ class ParityEthModuleTest(EthModuleTest):
         pytest.xfail('eth_uninstallFilter calls to parity always return true')
         super().test_eth_uninstallFilter(web3)
 
-    def test_eth_replaceTransaction(self, web3, unlocked_account):
-        super().test_eth_replaceTransaction(web3, unlocked_account)
-
     @pytest.mark.xfail(reason='Parity is not setup to auto mine')
     def test_eth_replaceTransaction_already_mined(self, web3, unlocked_account):
         super().test_eth_replaceTransaction_already_mined(web3, unlocked_account)
-
-    def test_eth_replaceTransaction_incorrect_nonce(self, web3, unlocked_account):
-        super().test_eth_replaceTransaction_incorrect_nonce(web3, unlocked_account)
-
-    def test_eth_replaceTransaction_gas_price_too_low(self, web3, unlocked_account):
-        super().test_eth_replaceTransaction_gas_price_too_low(web3, unlocked_account)
-
-    def test_eth_replaceTransaction_gas_price_defaulting_minimum(self, web3, unlocked_account):
-        super().test_eth_replaceTransaction_gas_price_defaulting_minimum(web3, unlocked_account)
-
-    def test_eth_replaceTransaction_gas_price_defaulting_strategy_higher(self,
-                                                                         web3,
-                                                                         unlocked_account):
-        super().test_eth_replaceTransaction_gas_price_defaulting_strategy_higher(
-            web3, unlocked_account
-        )
-
-    def test_eth_replaceTransaction_gas_price_defaulting_strategy_lower(self,
-                                                                        web3,
-                                                                        unlocked_account):
-        super().test_eth_replaceTransaction_gas_price_defaulting_strategy_lower(
-            web3, unlocked_account
-        )
-
-    def test_eth_modifyTransaction(self, web3, unlocked_account):
-        super().test_eth_modifyTransaction(web3, unlocked_account)
 
     @flaky(max_runs=MAX_FLAKY_RUNS)
     def test_eth_getTransactionReceipt_unmined(self, web3, unlocked_account):

--- a/tests/integration/parity/test_parity_http.py
+++ b/tests/integration/parity/test_parity_http.py
@@ -15,7 +15,9 @@ from web3._utils.module_testing import (
 
 from .common import (
     ParityEthModuleTest,
+    ParityModuleTest,
     ParityPersonalModuleTest,
+    ParitySetModuleTest,
     ParityTraceModuleTest,
     ParityWeb3ModuleTest,
 )
@@ -86,6 +88,10 @@ class TestParityEthModuleTest(ParityEthModuleTest):
     pass
 
 
+class TestParityModuleTest(ParityModuleTest):
+    pass
+
+
 class TestParityVersionModule(VersionModuleTest):
     pass
 
@@ -99,4 +105,8 @@ class TestParityPersonalModuleTest(ParityPersonalModuleTest):
 
 
 class TestParityTraceModuleTest(ParityTraceModuleTest):
+    pass
+
+
+class TestParitySetModuleTest(ParitySetModuleTest):
     pass

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -82,6 +82,7 @@ from web3.datastructures import (
 from web3.exceptions import (
     BlockNotFound,
     ContractLogicError,
+    InvalidParityMode,
     TransactionNotFound,
 )
 from web3.types import (
@@ -527,9 +528,16 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
     return response
 
 
+def raise_invalid_parity_mode(response: RPCResponse) -> NoReturn:
+    # eth-tester sends back an invalid RPCError, which makes mypy complain
+    error_message = response['error'].get('message')  # type: ignore
+    raise InvalidParityMode(error_message)
+
+
 ERROR_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_estimateGas: raise_solidity_error_on_revert,
     RPC.eth_call: raise_solidity_error_on_revert,
+    RPC.parity_setMode: raise_invalid_parity_mode,
 }
 
 

--- a/web3/_utils/module_testing/parity_module.py
+++ b/web3/_utils/module_testing/parity_module.py
@@ -15,6 +15,9 @@ from eth_utils import (
 from web3._utils.formatters import (
     hex_to_integer,
 )
+from web3.exceptions import (
+    InvalidParityMode,
+)
 from web3.types import (
     BlockData,
     EnodeURI,
@@ -154,11 +157,14 @@ class ParitySetModuleTest:
         assert web3.parity.setMode(mode) is True
 
     def test_set_mode_with_bad_string(self, web3: "Web3") -> None:
-        with pytest.raises(ValueError, match="Couldn't parse parameters: mode"):
+        with pytest.raises(InvalidParityMode, match="Couldn't parse parameters: mode"):
             # type ignored b/c it's an invalid literal ParityMode
             web3.parity.setMode('not a mode')  # type: ignore
 
     def test_set_mode_with_no_argument(self, web3: "Web3") -> None:
-        with pytest.raises(TypeError, match='missing 1 required positional argument'):
+        with pytest.raises(
+            InvalidParityMode,
+            match='Invalid params: invalid length 0, expected a tuple of size 1.'
+        ):
             # type ignored b/c setMode expects arguments
             web3.parity.setMode()  # type: ignore

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -208,4 +208,11 @@ class ContractLogicError(SolidityError, ValueError):
     """
     Raised on a contract revert error
     """
+
+
+class InvalidParityMode(TypeError, ValueError):
+    # Inherits from TypeError for backwards compatibility
+    """
+    Raised when web3.parity.setMode() is called with no or invalid args
+    """
     pass

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -95,16 +95,15 @@ class EthereumTesterProvider(BaseProvider):
         try:
             delegator = self.api_endpoints[namespace][endpoint]
         except KeyError:
-            return RPCResponse({
-                "error": "Unknown RPC Endpoint: {0}".format(method),
-            })
-
+            return RPCResponse(
+                {"error": f"Unknown RPC Endpoint: {method}"}
+            )
         try:
             response = delegator(self.ethereum_tester, params)
         except NotImplementedError:
-            return RPCResponse({
-                "error": "RPC Endpoint has not been implemented: {0}".format(method),
-            })
+            return RPCResponse(
+                {"error": f"RPC Endpoint has not been implemented: {method}"}
+            )
         except TransactionFailed as e:
             try:
                 reason = decode_single('(string)', e.args[0].args[0][4:])[0]


### PR DESCRIPTION
### What was wrong?
The Parity class needed to move over to use the `Method` class and `ModuleV2` class. 


### How was it fixed?
Started using `Method` and `ModuleV2`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Think about how to get rid of self.web3 = web3 in Module
- [x] Check that all parity tests have all modules running
- [x] Typing
- [x] Cleanup commits

#### Cute Animal Picture

<img width="226" alt="image" src="https://user-images.githubusercontent.com/6540608/76665354-15273680-654d-11ea-896e-6a0642c82773.png">

