### PR TITLE
Some fixes to type definitions

### DIFF
--- a/web3/types.py
+++ b/web3/types.py
@@ -161,7 +161,7 @@ TxData = TypedDict("TxData", {
     "gasPrice": Wei,
     "hash": HexBytes,
     "input": HexStr,
-    "nonce": int,
+    "nonce": Nonce,
     "r": HexBytes,
     "s": HexBytes,
     "to": ChecksumAddress,
@@ -191,7 +191,7 @@ GasPriceStrategy = Callable[["Web3", TxParams], Wei]
 # syntax b/c "from" keyword not allowed w/ class construction
 TxReceipt = TypedDict("TxReceipt", {
     "blockHash": HexBytes,
-    "blockNumber": int,
+    "blockNumber": BlockNumber,
     "contractAddress": Optional[ChecksumAddress],
     "cumulativeGasUsed": int,
     "gasUsed": Wei,
@@ -222,7 +222,7 @@ class MerkleProof(TypedDict):
     accountProof: Sequence[HexStr]
     balance: int
     codeHash: HexBytes
-    nonce: int
+    nonce: Nonce
     storageHash: HexBytes
     storageProof: Sequence[StorageProof]
 


### PR DESCRIPTION
### What was wrong?

Some type definitions were not a strict as they could be.

### How was it fixed?

Tighten type definitions.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.telegraph.co.uk/content/dam/Travel/leadAssets/34/97/comedy-hamster_3497562a.jpg?imwidth=450)
