### PR TITLE
Fix return type of `rpc_gas_price_strategy`

### DIFF
--- a/newsfragments/1612.bugfix.rst
+++ b/newsfragments/1612.bugfix.rst
@@ -1,0 +1,1 @@
+Change return type of rpc_gas_price_strategy from int to Wei

--- a/web3/gas_strategies/rpc.py
+++ b/web3/gas_strategies/rpc.py
@@ -4,10 +4,11 @@ from web3._utils.rpc_abi import (
 )
 from web3.types import (
     TxParams,
+    Wei,
 )
 
 
-def rpc_gas_price_strategy(web3: Web3, transaction_params: TxParams=None) -> int:
+def rpc_gas_price_strategy(web3: Web3, transaction_params: TxParams=None) -> Wei:
     """
     A simple gas price strategy deriving it's value from the eth_gasPrice JSON-RPC call.
     """


### PR DESCRIPTION
### What was wrong?

The return type of `rpc_gas_price_strategy` was wrong: `int` instead if `Wei`

### How was it fixed?

Changed the return type.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/4a6c04ea-2c06-434f-82c2-482329362993/d89hr71-9abc7efa-36dd-4d3d-8df2-7409f9a1560b.jpg/v1/fill/w_1024,h_664,q_75,strp/cute_baby_octopus_in_a_glow_shell_by_shadydarkgirl-d89hr71.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwic3ViIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsImF1ZCI6WyJ1cm46c2VydmljZTppbWFnZS5vcGVyYXRpb25zIl0sIm9iaiI6W1t7InBhdGgiOiIvZi80YTZjMDRlYS0yYzA2LTQzNGYtODJjMi00ODIzMjkzNjI5OTMvZDg5aHI3MS05YWJjN2VmYS0zNmRkLTRkM2QtOGRmMi03NDA5ZjlhMTU2MGIuanBnIiwid2lkdGgiOiI8PTEwMjQiLCJoZWlnaHQiOiI8PTY2NCJ9XV19.6yaAM377h5ga_1iPFo-dn9v8LD7TzI06rfsS25od2FE)
