### PR TITLE
tests return values against different geth versions

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ extras_require = {
         "towncrier>=19.2.0,<20",
         "urllib3",
         "web3>=2.1.0",
-        "wheel"
+        "wheel",
     ],
     'dev': [
         "bumpversion",
@@ -46,7 +46,7 @@ extras_require = {
         "tox>=1.8.0",
         "tqdm>4.32,<5",
         "twine>=1.13,<2",
-        "when-changed>=0.3.0,<0.4"
+        "when-changed>=0.3.0,<0.4",
     ]
 }
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -785,7 +785,7 @@ class EthModuleTest:
             if v in web3.clientVersion:
                 assert block['hash'] is None
                 return
-        assert block['hash'] == current_block_number
+        assert block['hash'] == current_block_number + 1
 
     def test_eth_getBlockByNumber_with_integer(
         self, web3: "Web3", empty_block: BlockData

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -775,11 +775,29 @@ class EthModuleTest:
         with pytest.raises(BlockNotFound):
             web3.eth.getBlock(UNKNOWN_HASH)
 
+    def test_eth_getBlockByHash_pending(
+            self, web3: "Web3", empty_block: BlockData
+    ) -> None:
+        null_versions = ('1.9.8', '1.9.9', '1.9.10', '1.9.11')
+        current_block_number = web3.eth.blockNumber
+        block = web3.eth.getBlock('pending')
+        for v in null_versions:
+            if v in web3.clientVersion:
+                assert block['hash'] is None
+                return
+        assert block['hash'] == current_block_number
+
     def test_eth_getBlockByNumber_with_integer(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
         block = web3.eth.getBlock(empty_block['number'])
         assert block['number'] == empty_block['number']
+
+    def test_eth_getBlockByNumber_not_found(
+            self, web3: "Web3", empty_block: BlockData
+    ) -> None:
+        with pytest.raises(BlockNotFound):
+            web3.eth.getBlock(BlockNumber(12345))
 
     def test_eth_getBlockByNumber_latest(
         self, web3: "Web3", empty_block: BlockData
@@ -788,18 +806,20 @@ class EthModuleTest:
         block = web3.eth.getBlock('latest')
         assert block['number'] == current_block_number
 
-    def test_eth_getBlockByNumber_not_found(
-        self, web3: "Web3", empty_block: BlockData
-    ) -> None:
-        with pytest.raises(BlockNotFound):
-            web3.eth.getBlock(BlockNumber(12345))
-
     def test_eth_getBlockByNumber_pending(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
+        null_versions = ('1.9.8', '1.9.9', '1.9.10', '1.9.11')
         current_block_number = web3.eth.blockNumber
         block = web3.eth.getBlock('pending')
+        for v in null_versions:
+            if v in web3.clientVersion:
+                assert block['number'] is None
+                return
         assert block['number'] == current_block_number + 1
+
+
+
 
     def test_eth_getBlockByNumber_earliest(
         self, web3: "Web3", empty_block: BlockData


### PR DESCRIPTION
### What was wrong?

Related to Issue #1572

### How was it fixed?
In order to be compatible with geth versions v1.7.0 to v1.9.12+, tests were added to check that web3 can handle both null and number return values from getBlockByHash and getBlockByNumber. The version return value details are based on the following from [this comment](https://github.com/ethereum/web3.py/issues/1572#issuecomment-603694142) on Issue #1572:

```
>= 1.9.11 : returns number
>= 1.9.7 and < 1.9.11: returns null
< 1.9.7 : returns number
```

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://townsquare.media/site/832/files/2018/10/ThinkstockPhotos-475488041-e1539191570199.jpg?w=980&q=75)
