### PR TITLE
Tiffany/gas pricing

### DIFF
--- a/docs/gas_price.rst
+++ b/docs/gas_price.rst
@@ -78,13 +78,14 @@ Available gas price strategies
 
 .. py:module:: web3.gas_strategies.time_based
 
-.. py:method:: construct_time_based_gas_price_strategy(max_wait_seconds, sample_size, probability)
+.. py:method:: construct_time_based_gas_price_strategy(max_wait_seconds, sample_size=120, probability=98, weighted=False)
 
     Constructs a strategy which will compute a gas price such that the
     transaction will be mined within a number of seconds defined by
     ``max_wait_seconds`` with a probability defined by ``probability``.  The
     gas price is computed by sampling ``sample_size`` of the most recently
-    mined blocks.
+    mined blocks. If ``weighted=True``, the block time will be weighted towards
+    more recently mined blocks.
 
     * ``max_wait_seconds`` The desired maxiumum number of seconds the
       transaction should take to mine.

--- a/newsfragments/1614.feature.rst
+++ b/newsfragments/1614.feature.rst
@@ -1,0 +1,3 @@
+Added new weighted keyword argument to the time based gas price strategy.
+
+If ``True``, it will more give more weight to more recent block times.

--- a/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
+++ b/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
@@ -19,7 +19,8 @@ def _get_block_by_something(method, params):
     block_identifier = params[0]
     if (
         block_identifier == 'latest' or
-        block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000005'
+        block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000005' or
+        block_identifier == 5
     ):
         return {
             'hash': '0x0000000000000000000000000000000000000000000000000000000000000005',
@@ -35,9 +36,12 @@ def _get_block_by_something(method, params):
                 {'gasPrice': 50},
             ],
             'miner': '0xA',
-            'timestamp': 100,
+            'timestamp': 120,
         }
-    elif block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000004':
+    elif (
+        block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000004' or
+        block_identifier == 4
+    ):
         return {
             'hash': '0x0000000000000000000000000000000000000000000000000000000000000004',
             'number': 4,
@@ -48,9 +52,12 @@ def _get_block_by_something(method, params):
                 {'gasPrice': 60},
             ],
             'miner': '0xB',
-            'timestamp': 80,
+            'timestamp': 90,
         }
-    elif block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000003':
+    elif (
+        block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000003' or
+        block_identifier == 3
+    ):
         return {
             'hash': '0x0000000000000000000000000000000000000000000000000000000000000003',
             'number': 3,
@@ -61,7 +68,10 @@ def _get_block_by_something(method, params):
             'miner': '0xC',
             'timestamp': 60,
         }
-    elif block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000002':
+    elif (
+        block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000002' or
+        block_identifier == 2
+    ):
         return {
             'hash': '0x0000000000000000000000000000000000000000000000000000000000000002',
             'number': 2,
@@ -69,9 +79,12 @@ def _get_block_by_something(method, params):
             'transactions': [
             ],
             'miner': '0xB',
-            'timestamp': 40,
+            'timestamp': 30,
         }
-    elif block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000001':
+    elif (
+        block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000001' or
+        block_identifier == 1
+    ):
         return {
             'hash': '0x0000000000000000000000000000000000000000000000000000000000000001',
             'number': 1,
@@ -82,7 +95,7 @@ def _get_block_by_something(method, params):
                 {'gasPrice': 65},
             ],
             'miner': '0xA',
-            'timestamp': 20,
+            'timestamp': 15,
         }
     elif (
         block_identifier == '0x0000000000000000000000000000000000000000000000000000000000000000' or
@@ -116,7 +129,7 @@ def _get_block_by_something(method, params):
 @pytest.mark.parametrize(
     'strategy_params,expected',
     (
-        # 120 second wait times
+        # 80 second wait times
         (dict(max_wait_seconds=80, sample_size=5, probability=98), 70),
         (dict(max_wait_seconds=80, sample_size=5, probability=90), 25),
         (dict(max_wait_seconds=80, sample_size=5, probability=50), 11),
@@ -132,6 +145,10 @@ def _get_block_by_something(method, params):
         (dict(max_wait_seconds=20, sample_size=5, probability=98), 100),
         (dict(max_wait_seconds=20, sample_size=5, probability=90), 100),
         (dict(max_wait_seconds=20, sample_size=5, probability=50), 36),
+        # 80 second wait times, weighted
+        (dict(max_wait_seconds=80, sample_size=5, probability=98, weighted=True), 92),
+        (dict(max_wait_seconds=80, sample_size=5, probability=90, weighted=True), 49),
+        (dict(max_wait_seconds=80, sample_size=5, probability=50, weighted=True), 11),
     ),
 )
 def test_time_based_gas_price_strategy(strategy_params, expected):

--- a/web3/gas_strategies/time_based.py
+++ b/web3/gas_strategies/time_based.py
@@ -23,19 +23,15 @@ from hexbytes import (
 )
 
 from web3 import Web3
-from web3._utils.encoding import (
-    to_hex_with_size,
-)
-
 from web3._utils.math import (
     percentile,
 )
-
 from web3.exceptions import (
     InsufficientData,
     ValidationError,
 )
 from web3.types import (
+    BlockNumber,
     GasPriceStrategy,
     TxParams,
     Wei,
@@ -44,33 +40,33 @@ from web3.types import (
 MinerData = collections.namedtuple(
     'MinerData',
     ['miner', 'num_blocks', 'min_gas_price', 'low_percentile_gas_price'])
-
 Probability = collections.namedtuple('Probability', ['gas_price', 'prob'])
 
 
 def _get_avg_block_time(w3: Web3, sample_size: int) -> float:
     latest = w3.eth.getBlock('latest')
+
     constrained_sample_size = min(sample_size, latest['number'])
     if constrained_sample_size == 0:
         raise ValidationError('Constrained sample size is 0')
+
     oldest = w3.eth.getBlock(BlockNumber(latest['number'] - constrained_sample_size))
     return (latest['timestamp'] - oldest['timestamp']) / constrained_sample_size
 
 
 def _get_weighted_avg_block_time(w3: Web3, sample_size: int) -> float:
-    bit_size = 256
     latest_block_number = w3.eth.getBlock('latest')['number']
     constrained_sample_size = min(sample_size, latest_block_number)
     if constrained_sample_size == 0:
         raise ValidationError('Constrained sample size is 0')
-    oldest_block = w3.eth.getBlock(to_hex_with_size(latest_block_number -
-                                                    constrained_sample_size, bit_size))
+
+    oldest_block = w3.eth.getBlock(BlockNumber(latest_block_number - constrained_sample_size))
     oldest_block_number = oldest_block['number']
     prev_timestamp = oldest_block['timestamp']
     weighted_sum = 0.0
     sum_of_weights = 0.0
     for i in range(oldest_block_number + 1, latest_block_number + 1):
-        curr_timestamp = w3.eth.getBlock(to_hex_with_size(i, bit_size))['timestamp']
+        curr_timestamp = w3.eth.getBlock(BlockNumber(i))['timestamp']
         time = curr_timestamp - prev_timestamp
         weight = (i - oldest_block_number) / constrained_sample_size
         weighted_sum += (time * weight)
@@ -189,30 +185,38 @@ def _compute_gas_price(probabilities: Sequence[Probability], desired_probability
 
 @curry
 def construct_time_based_gas_price_strategy(
-    max_wait_seconds: int, sample_size: int=120, probability: int=98
+    max_wait_seconds: int, sample_size: int=120, probability: int=98, weighted: bool=False
 ) -> GasPriceStrategy:
     """
     A gas pricing strategy that uses recently mined block data to derive a gas
     price for which a transaction is likely to be mined within X seconds with
-    probability P.
+    probability P. If the weighted kwarg is True, more recent block
+    times will be more heavily weighted.
 
-    :param max_wait_seconds: The desired maxiumum number of seconds the
+    :param max_wait_seconds: The desired maximum number of seconds the
         transaction should take to mine.
     :param sample_size: The number of recent blocks to sample
     :param probability: An integer representation of the desired probability
         that the transaction will be mined within ``max_wait_seconds``.  0 means 0%
         and 100 means 100%.
     """
+
     def time_based_gas_price_strategy(web3: Web3, transaction_params: TxParams) -> Wei:
+        if weighted:
+            avg_block_time = _get_weighted_avg_block_time(web3, sample_size=sample_size)
+        else:
+            avg_block_time = _get_avg_block_time(web3, sample_size=sample_size)
+
+        wait_blocks = int(math.ceil(max_wait_seconds / avg_block_time))
         raw_miner_data = _get_raw_miner_data(web3, sample_size=sample_size)
         miner_data = _aggregate_miner_data(raw_miner_data)
-        weighted_avg_block_time = _get_weighted_avg_block_time(web3, sample_size=sample_size)
-        wait_blocks = int(math.ceil(max_wait_seconds / weighted_avg_block_time))
+
         probabilities = _compute_probabilities(
             miner_data,
             wait_blocks=wait_blocks,
             sample_size=sample_size,
         )
+
         gas_price = _compute_gas_price(probabilities, probability / 100)
         return gas_price
     return time_based_gas_price_strategy


### PR DESCRIPTION
### What was wrong?

> construct_time_based_gas_price_strategy is unable to handle cases when network suddenly requires higher gas prices due to many variables such as network congestion. This has resulted in more transactions to revert.

Related to Issue #1463

### How was it fixed?
A recency based weighted average of the block time is calculated. This weighted_avg_block_time is then used to calculate the probabilities required to determine the best gas price. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRog3r6og66jBkv8cFxlBOB9itnZRZQJO5nTSJwF9Rt0uI61MuK)
