### PR TITLE
Fixed typo in example for interacting with contract

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -503,7 +503,7 @@ Just remember that you have to sign all transactions locally, as infura does not
     
     transaction = contract.functions.function_Name(params).buildTransaction()
     transaction.update({ 'gas' : appropriate_gas_amount })  
-    transaction.update({ 'nonce' : web3.eth.getTransactionCount('Your_Wallet_Address') })
+    transaction.update({ 'nonce' : w3.eth.getTransactionCount('Your_Wallet_Address') })
     signed_tx = w3.eth.account.signTransaction(transaction, private_key)
     
 P.S : the two updates are done to the transaction dictionary, since a raw transaction might not contain gas & nonce amounts, so you have to add them manually.


### PR DESCRIPTION
### What was wrong?
The web3 instance is called w3 in the example, which means fetching the nonce should be done using w3.eth.getTransactionCount('Your_Wallet_Address'). In the example, however, it is web3.eth.getTransactionCount('Your_Wallet_Address') which would try fetching it with the name of the imported library (which doesn't work).

Related to Issue #

### How was it fixed?
Changed the name of the variable

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
