### PR TITLE
Pass kwargs to HTTPAdapter, removing pool size constraints

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -214,8 +214,10 @@ HTTPProvider
       ``'https://localhost:8545'``.  For RPC servers behind HTTP connections
       running on port 80 and HTTPS connections running on port 443 the port can
       be omitted from the URI.
-    * ``request_kwargs`` this should be a dictionary of keyword arguments which
-      will be passed onto the http/https request.
+    * ``request_kwargs`` should be a dictionary of keyword arguments which
+      will be passed onto each http/https POST request made to your node.
+    * ``session`` allows you to pass a ``requests.Session`` object initialized
+      as desired.
 
     .. code-block:: python
 
@@ -236,6 +238,18 @@ HTTPProvider
 
         >>> from web3 import Web3
         >>> w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545", request_kwargs={'timeout': 60}))
+
+
+    To tune the connection pool size, you can pass your own ``requests.Session``.
+
+    .. code-block:: python
+
+        >>> from web3 import Web3
+        >>> adapter = requests.adapters.HTTPAdapter(pool_connections=20, pool_maxsize=20)
+        >>> session = requests.Session()
+        >>> session.mount('http://', adapter)
+        >>> session.mount('https://', adapter)
+        >>> w3 = Web3(Web3.HTTPProvider("http://127.0.0.1:8545", session=session))
 
 
 IPCProvider

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -206,7 +206,7 @@ local and remote JSON-RPC servers.
 HTTPProvider
 ~~~~~~~~~~~~
 
-.. py:class:: web3.providers.rpc.HTTPProvider(endpoint_uri[, request_kwargs])
+.. py:class:: web3.providers.rpc.HTTPProvider(endpoint_uri[, request_kwargs, session])
 
     This provider handles interactions with an HTTP or HTTPS based JSON-RPC server.
 

--- a/newsfragments/1469.feature.rst
+++ b/newsfragments/1469.feature.rst
@@ -1,0 +1,1 @@
+Pass `kwargs` to `HttpAdapter` when using `HttpProvider`, allowing consumer to tune the connection pool.

--- a/newsfragments/1469.feature.rst
+++ b/newsfragments/1469.feature.rst
@@ -1,1 +1,1 @@
-Pass `kwargs` to `HttpAdapter` when using `HttpProvider`, allowing consumer to tune the connection pool.
+Allow consumer to initialize `HttpProvider` with their own `requests.Session`.  This allows the `HttpAdapter` connection pool to be tuned as desired.

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -145,12 +145,11 @@ def test_web3_auto_infura_with_secret(monkeypatch, caplog, environ_name):
     monkeypatch.setenv(environ_name, 'test')
     monkeypatch.setenv('WEB3_INFURA_API_SECRET', 'secret')
 
-    with pytest.raises(DeprecationWarning):
-        importlib.reload(infura)
+    importlib.reload(infura)
 
-        w3 = infura.w3
-        assert isinstance(w3.provider, HTTPProvider)
-        expected_url = 'https://%s/v3/test' % (infura.INFURA_MAINNET_DOMAIN)
-        expected_auth_value = ('', 'secret')
-        assert getattr(w3.provider, 'endpoint_uri') == expected_url
-        assert w3.provider.get_request_kwargs()['auth'] == expected_auth_value
+    w3 = infura.w3
+    assert isinstance(w3.provider, HTTPProvider)
+    expected_url = 'https://%s/v3/test' % (infura.INFURA_MAINNET_DOMAIN)
+    expected_auth_value = ('', 'secret')
+    assert getattr(w3.provider, 'endpoint_uri') == expected_url
+    assert w3.provider.get_request_kwargs()['auth'] == expected_auth_value

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -145,11 +145,12 @@ def test_web3_auto_infura_with_secret(monkeypatch, caplog, environ_name):
     monkeypatch.setenv(environ_name, 'test')
     monkeypatch.setenv('WEB3_INFURA_API_SECRET', 'secret')
 
-    importlib.reload(infura)
+    with pytest.raises(DeprecationWarning):
+        importlib.reload(infura)
 
-    w3 = infura.w3
-    assert isinstance(w3.provider, HTTPProvider)
-    expected_url = 'https://%s/v3/test' % (infura.INFURA_MAINNET_DOMAIN)
-    expected_auth_value = ('', 'secret')
-    assert getattr(w3.provider, 'endpoint_uri') == expected_url
-    assert w3.provider.get_request_kwargs()['auth'] == expected_auth_value
+        w3 = infura.w3
+        assert isinstance(w3.provider, HTTPProvider)
+        expected_url = 'https://%s/v3/test' % (infura.INFURA_MAINNET_DOMAIN)
+        expected_auth_value = ('', 'secret')
+        assert getattr(w3.provider, 'endpoint_uri') == expected_url
+        assert w3.provider.get_request_kwargs()['auth'] == expected_auth_value

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -21,15 +21,15 @@ URI = "http://mynode.local:8545"
 
 def test_no_args():
     provider = HTTPProvider()
-    web3: Web3(provider)
-
+    web3 = Web3(provider)
+    assert web3.manager.provider == provider
 
 def test_init_kwargs():
     with pytest.raises(DeprecationWarning):
         provider = HTTPProvider(endpoint_uri=URI,
                                 request_kwargs={'timeout': 60})
-        web3: Web3(provider)
-
+        web3 = Web3(provider)
+        assert web3.manager.provider == provider
 
 def test_user_provided_session():
     adapter = HTTPAdapter(pool_connections=20, pool_maxsize=20)
@@ -38,7 +38,8 @@ def test_user_provided_session():
     session.mount('https://', adapter)
 
     provider = HTTPProvider(endpoint_uri=URI, session=session)
-    web3: Web3(provider)
+    web3 = Web3(provider)
+    assert web3.manager.provider == provider
 
     session = request._get_session(URI)
     adapter = session.get_adapter(URI)

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -1,5 +1,3 @@
-import pytest
-
 from requests import (
     Session,
 )

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -24,12 +24,14 @@ def test_no_args():
     web3 = Web3(provider)
     assert web3.manager.provider == provider
 
+
 def test_init_kwargs():
     with pytest.raises(DeprecationWarning):
         provider = HTTPProvider(endpoint_uri=URI,
                                 request_kwargs={'timeout': 60})
         web3 = Web3(provider)
         assert web3.manager.provider == provider
+
 
 def test_user_provided_session():
     adapter = HTTPAdapter(pool_connections=20, pool_maxsize=20)

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -25,11 +25,10 @@ def test_no_args():
 
 
 def test_init_kwargs():
-    with pytest.raises(DeprecationWarning):
-        provider = HTTPProvider(endpoint_uri=URI,
-                                request_kwargs={'timeout': 60})
-        web3 = Web3(provider)
-        assert web3.manager.provider == provider
+    provider = HTTPProvider(endpoint_uri=URI,
+                            request_kwargs={'timeout': 60})
+    web3 = Web3(provider)
+    assert web3.manager.provider == provider
 
 
 def test_user_provided_session():

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -1,4 +1,5 @@
 import pytest
+
 from requests import (
     Session,
 )

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -1,14 +1,12 @@
 import pytest
 from requests import (
-    Session
+    Session,
 )
 from requests.adapters import (
-    HTTPAdapter
+    HTTPAdapter,
 )
 
-from web3 import (
-    Web3,
-)
+from web3 import Web3
 from web3._utils import (
     request,
 )

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -1,0 +1,47 @@
+import pytest
+from requests import (
+    Session
+)
+from requests.adapters import (
+    HTTPAdapter
+)
+
+from web3 import (
+    Web3,
+)
+from web3._utils import (
+    request,
+)
+from web3.providers import (
+    HTTPProvider,
+)
+
+URI = "http://mynode.local:8545"
+
+
+def test_no_args():
+    provider = HTTPProvider()
+    web3: Web3(provider)
+
+
+def test_init_kwargs():
+    with pytest.raises(DeprecationWarning):
+        provider = HTTPProvider(endpoint_uri=URI,
+                                request_kwargs={'timeout': 60})
+        web3: Web3(provider)
+
+
+def test_user_provided_session():
+    adapter = HTTPAdapter(pool_connections=20, pool_maxsize=20)
+    session = Session()
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+
+    provider = HTTPProvider(endpoint_uri=URI, session=session)
+    web3: Web3(provider)
+
+    session = request._get_session(URI)
+    adapter = session.get_adapter(URI)
+    assert isinstance(adapter, HTTPAdapter)
+    assert adapter._pool_connections == 20
+    assert adapter._pool_maxsize == 20

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -1,0 +1,75 @@
+from web3._utils import request
+from requests import Session, Response
+from requests.adapters import (
+    DEFAULT_POOLSIZE,
+    HTTPAdapter
+)
+
+
+class MockedResponse:
+    def __init__(self, text="", status_code=200):
+        assert (isinstance(text, str))
+        assert (isinstance(status_code, int))
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 400
+        self.text = text
+        self.reason = None
+        self.content = "content"
+
+    def raise_for_status(self):
+        pass
+
+
+uri = "http://mynode.local:8545"
+
+
+def check_adapters_mounted(session: Session):
+    assert isinstance(session, Session)
+    print(session.adapters)
+    assert len(session.adapters) == 2
+    assert isinstance(session.adapters['http://'], HTTPAdapter)
+    assert isinstance(session.adapters['https://'], HTTPAdapter)
+    assert session.adapters['http://'] == session.adapters['https://']
+
+
+def test_make_post_request_no_args(mocker):
+    mocker.patch("requests.Session.post", return_value=MockedResponse())
+
+    # Submit a first request to create a session with default parameters
+    assert len(request._session_cache) == 0
+    response = request.make_post_request(uri, b'request')
+    assert response == "content"
+    assert len(request._session_cache) == 1
+    session = request._session_cache.values()[0]
+    session.post.assert_called_once_with(uri, data=b'request', timeout=10)
+
+    # Ensure the adapter was created with default values
+    check_adapters_mounted(session)
+    adapter = session.get_adapter(uri)
+    assert isinstance(adapter, HTTPAdapter)
+    assert adapter._pool_connections == DEFAULT_POOLSIZE
+    assert adapter._pool_maxsize == DEFAULT_POOLSIZE
+
+
+def test_make_post_request_with_pool_size(mocker):
+    mocker.patch("requests.Session.post", return_value=MockedResponse())
+
+    # Submit a second request with different arguments
+    assert len(request._session_cache) == 1
+    request_kwargs = {"timeout": 60, "pool_connections": 100, "pool_maxsize": 100}
+    response = request.make_post_request(uri, b'request', **request_kwargs)
+    assert response == "content"
+
+    # Ensure a new session was cached with the alternate args
+    assert len(request._session_cache) == 2
+    session = request._get_session(**request_kwargs)
+
+    # Ensure the timeout was passed to the request
+    session.post.assert_called_once_with(uri, data=b'request', timeout=60)
+
+    # Ensure the pool size was passed to the adapter
+    check_adapters_mounted(session)
+    adapter = session.get_adapter(uri)
+    assert isinstance(adapter, HTTPAdapter)
+    assert adapter._pool_connections == 100
+    assert adapter._pool_maxsize == 100

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -25,12 +25,11 @@ class MockedResponse:
         pass
 
 
-uri = "http://mynode.local:8545"
+URI = "http://mynode.local:8545"
 
 
 def check_adapters_mounted(session: Session):
     assert isinstance(session, Session)
-    print(session.adapters)
     assert len(session.adapters) == 2
     assert isinstance(session.adapters['http://'], HTTPAdapter)
     assert isinstance(session.adapters['https://'], HTTPAdapter)
@@ -42,15 +41,15 @@ def test_make_post_request_no_args(mocker):
 
     # Submit a first request to create a session with default parameters
     assert len(request._session_cache) == 0
-    response = request.make_post_request(uri, b'request')
+    response = request.make_post_request(URI, b'request')
     assert response == "content"
     assert len(request._session_cache) == 1
     session = request._session_cache.values()[0]
-    session.post.assert_called_once_with(uri, data=b'request', timeout=10)
+    session.post.assert_called_once_with(URI, data=b'request', timeout=10)
 
     # Ensure the adapter was created with default values
     check_adapters_mounted(session)
-    adapter = session.get_adapter(uri)
+    adapter = session.get_adapter(URI)
     assert isinstance(adapter, HTTPAdapter)
     assert adapter._pool_connections == DEFAULT_POOLSIZE
     assert adapter._pool_maxsize == DEFAULT_POOLSIZE
@@ -62,7 +61,7 @@ def test_make_post_request_with_pool_size(mocker):
     # Submit a second request with different arguments
     assert len(request._session_cache) == 1
     request_kwargs = {"timeout": 60, "pool_connections": 100, "pool_maxsize": 100}
-    response = request.make_post_request(uri, b'request', **request_kwargs)
+    response = request.make_post_request(URI, b'request', **request_kwargs)
     assert response == "content"
 
     # Ensure a new session was cached with the alternate args
@@ -70,11 +69,11 @@ def test_make_post_request_with_pool_size(mocker):
     session = request._get_session(**request_kwargs)
 
     # Ensure the timeout was passed to the request
-    session.post.assert_called_once_with(uri, data=b'request', timeout=60)
+    session.post.assert_called_once_with(URI, data=b'request', timeout=60)
 
     # Ensure the pool size was passed to the adapter
     check_adapters_mounted(session)
-    adapter = session.get_adapter(uri)
+    adapter = session.get_adapter(URI)
     assert isinstance(adapter, HTTPAdapter)
     assert adapter._pool_connections == 100
     assert adapter._pool_maxsize == 100

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -1,5 +1,9 @@
-from web3._utils import request
-from requests import Session
+from web3._utils import (
+    request
+)
+from requests import (
+    Session
+)
 from requests.adapters import (
     DEFAULT_POOLSIZE,
     HTTPAdapter

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -1,12 +1,12 @@
-from web3._utils import (
-    request
-)
 from requests import (
-    Session
+    Session,
 )
 from requests.adapters import (
     DEFAULT_POOLSIZE,
-    HTTPAdapter
+    HTTPAdapter,
+)
+from web3._utils import (
+    request,
 )
 
 

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -36,6 +36,7 @@ def check_adapters_mounted(session: Session):
 
 def test_make_post_request_no_args(mocker):
     mocker.patch("requests.Session.post", return_value=MockedResponse())
+    request._session_cache.clear()
 
     # Submit a first request to create a session with default parameters
     assert len(request._session_cache) == 0

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -1,5 +1,5 @@
 from web3._utils import request
-from requests import Session, Response
+from requests import Session
 from requests.adapters import (
     DEFAULT_POOLSIZE,
     HTTPAdapter

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -1,6 +1,6 @@
 from requests import (
-    adapters,
     Session,
+    adapters,
 )
 from requests.adapters import (
     DEFAULT_POOLSIZE,

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -5,6 +5,7 @@ from requests.adapters import (
     DEFAULT_POOLSIZE,
     HTTPAdapter,
 )
+
 from web3._utils import (
     request,
 )

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -1,5 +1,6 @@
 from typing import (
     Any,
+    Dict,
 )
 
 from eth_typing import (
@@ -43,12 +44,12 @@ def make_post_request(endpoint_uri: URI, data: bytes, *args: Any, **kwargs: Any)
     return response.content
 
 
-def extract_adapter_kwargs(**kwargs: Any) -> dict:
+def extract_adapter_kwargs(**kwargs: Any) -> Dict[str, Any]:
     adapter_args = ['pool_connections', 'pool_maxsize', 'max_retries', 'pool_block']
     return {key: value for key, value in kwargs.items() if key in adapter_args}
 
 
-def extract_request_kwargs(**kwargs: Any) -> dict:
+def extract_request_kwargs(**kwargs: Any) -> Dict[str, Any]:
     request_args = ['params', 'params', 'headers', 'cookies', 'files',
                     'auth', 'timeout', 'allow_redirects', 'proxies',
                     'hooks', 'stream', 'verify', 'cert', 'json']

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -13,7 +13,7 @@ from web3._utils.caching import (
 )
 
 
-def cache_session(endpoint_uri: URI, session: requests.Session):
+def cache_session(endpoint_uri: URI, session: requests.Session) -> None:
     cache_key = generate_cache_key(endpoint_uri)
     _session_cache[cache_key] = session
 

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -49,7 +49,7 @@ def extract_adapter_kwargs(**kwargs: Any):
 
 
 def extract_request_kwargs(**kwargs: Any):
-    request_args = ['params', 'params', 'data', 'headers', 'cookies', 'files',
+    request_args = ['params', 'params', 'headers', 'cookies', 'files',
                     'auth', 'timeout', 'allow_redirects', 'proxies',
                     'hooks', 'stream', 'verify', 'cert', 'json']
     return {key: value for key, value in kwargs.items() if key in request_args}

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -38,7 +38,8 @@ def make_post_request(endpoint_uri: URI, data: bytes, *args: Any, **kwargs: Any)
     kwargs.setdefault('timeout', 10)
     session = _get_session(endpoint_uri, **kwargs)
     # https://github.com/python/mypy/issues/2582
-    response = session.post(endpoint_uri, data=data, *args, **extract_request_kwargs(**kwargs))
+    response = session.post(endpoint_uri, data=data, *args,
+                            **extract_request_kwargs(**kwargs))  # type: ignore
     response.raise_for_status()
 
     return response.content

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -24,10 +24,10 @@ def _get_session(*args: Any, **kwargs: Any) -> requests.Session:
     cache_key = generate_cache_key((args, kwargs))
     if cache_key not in _session_cache:
         session = requests.Session()
-        print(f"adapter kwargs are: {extract_adapter_kwargs(**kwargs)}")
         adapter = requests.adapters.HTTPAdapter(**extract_adapter_kwargs(**kwargs))
-        session.mount('https://', adapter)
+
         session.mount('http://', adapter)
+        session.mount('https://', adapter)
 
         _session_cache[cache_key] = session
     return _session_cache[cache_key]
@@ -35,7 +35,6 @@ def _get_session(*args: Any, **kwargs: Any) -> requests.Session:
 
 def make_post_request(endpoint_uri: URI, data: bytes, *args: Any, **kwargs: Any) -> bytes:
     kwargs.setdefault('timeout', 10)
-    # print(f"passed kwargs are: {kwargs}")
     session = _get_session(endpoint_uri, **kwargs)
     # https://github.com/python/mypy/issues/2582
     response = session.post(endpoint_uri, data=data, *args, **extract_request_kwargs(**kwargs))  # type: ignore

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -23,15 +23,34 @@ _session_cache = lru.LRU(8, callback=_remove_session)
 def _get_session(*args: Any, **kwargs: Any) -> requests.Session:
     cache_key = generate_cache_key((args, kwargs))
     if cache_key not in _session_cache:
-        _session_cache[cache_key] = requests.Session()
+        session = requests.Session()
+        print(f"adapter kwargs are: {extract_adapter_kwargs(**kwargs)}")
+        adapter = requests.adapters.HTTPAdapter(**extract_adapter_kwargs(**kwargs))
+        session.mount('https://', adapter)
+        session.mount('http://', adapter)
+
+        _session_cache[cache_key] = session
     return _session_cache[cache_key]
 
 
 def make_post_request(endpoint_uri: URI, data: bytes, *args: Any, **kwargs: Any) -> bytes:
     kwargs.setdefault('timeout', 10)
-    session = _get_session(endpoint_uri)
+    # print(f"passed kwargs are: {kwargs}")
+    session = _get_session(endpoint_uri, **kwargs)
     # https://github.com/python/mypy/issues/2582
-    response = session.post(endpoint_uri, data=data, *args, **kwargs)  # type: ignore
+    response = session.post(endpoint_uri, data=data, *args, **extract_request_kwargs(**kwargs))  # type: ignore
     response.raise_for_status()
 
     return response.content
+
+
+def extract_adapter_kwargs(**kwargs: Any):
+    adapter_args = ['pool_connections', 'pool_maxsize', 'max_retries', 'pool_block']
+    return {key: value for key, value in kwargs.items() if key in adapter_args}
+
+
+def extract_request_kwargs(**kwargs: Any):
+    request_args = ['params', 'params', 'data', 'headers', 'cookies', 'files',
+            'auth', 'timeout', 'allow_redirects', 'proxies',
+            'hooks', 'stream', 'verify', 'cert', 'json']
+    return {key: value for key, value in kwargs.items() if key in request_args}

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -51,7 +51,7 @@ def extract_adapter_kwargs(**kwargs: Any) -> Dict[str, Any]:
 
 
 def extract_request_kwargs(**kwargs: Any) -> Dict[str, Any]:
-    request_args = ['params', 'params', 'headers', 'cookies', 'files',
+    request_args = ['params', 'headers', 'cookies', 'files',
                     'auth', 'timeout', 'allow_redirects', 'proxies',
                     'hooks', 'stream', 'verify', 'cert', 'json']
     return {key: value for key, value in kwargs.items() if key in request_args}

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -43,12 +43,12 @@ def make_post_request(endpoint_uri: URI, data: bytes, *args: Any, **kwargs: Any)
     return response.content
 
 
-def extract_adapter_kwargs(**kwargs: Any):
+def extract_adapter_kwargs(**kwargs: Any) -> dict:
     adapter_args = ['pool_connections', 'pool_maxsize', 'max_retries', 'pool_block']
     return {key: value for key, value in kwargs.items() if key in adapter_args}
 
 
-def extract_request_kwargs(**kwargs: Any):
+def extract_request_kwargs(**kwargs: Any) -> dict:
     request_args = ['params', 'params', 'headers', 'cookies', 'files',
                     'auth', 'timeout', 'allow_redirects', 'proxies',
                     'hooks', 'stream', 'verify', 'cert', 'json']

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -37,7 +37,7 @@ def make_post_request(endpoint_uri: URI, data: bytes, *args: Any, **kwargs: Any)
     kwargs.setdefault('timeout', 10)
     session = _get_session(endpoint_uri, **kwargs)
     # https://github.com/python/mypy/issues/2582
-    response = session.post(endpoint_uri, data=data, *args, **extract_request_kwargs(**kwargs))  # type: ignore
+    response = session.post(endpoint_uri, data=data, *args, **extract_request_kwargs(**kwargs))
     response.raise_for_status()
 
     return response.content
@@ -50,6 +50,6 @@ def extract_adapter_kwargs(**kwargs: Any):
 
 def extract_request_kwargs(**kwargs: Any):
     request_args = ['params', 'params', 'data', 'headers', 'cookies', 'files',
-            'auth', 'timeout', 'allow_redirects', 'proxies',
-            'hooks', 'stream', 'verify', 'cert', 'json']
+                    'auth', 'timeout', 'allow_redirects', 'proxies',
+                    'hooks', 'stream', 'verify', 'cert', 'json']
     return {key: value for key, value in kwargs.items() if key in request_args}

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -20,6 +20,7 @@ from web3._utils.http import (
     construct_user_agent,
 )
 from web3._utils.request import (
+    cache_session,
     make_post_request,
 )
 from web3.datastructures import (
@@ -53,13 +54,18 @@ class HTTPProvider(JSONBaseProvider):
 
     def __init__(
         self, endpoint_uri: Optional[Union[URI, str]] = None,
-        request_kwargs: Optional[Any] = None
+            request_kwargs: Optional[Any] = None,
+            session: Optional[Any] = None
     ) -> None:
         if endpoint_uri is None:
             self.endpoint_uri = get_default_endpoint()
         else:
             self.endpoint_uri = URI(endpoint_uri)
         self._request_kwargs = request_kwargs or {}
+
+        if session:
+            cache_session(self.endpoint_uri, session)
+
         super().__init__()
 
     def __str__(self) -> str:

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -61,6 +61,7 @@ class HTTPProvider(JSONBaseProvider):
             self.endpoint_uri = get_default_endpoint()
         else:
             self.endpoint_uri = URI(endpoint_uri)
+
         self._request_kwargs = request_kwargs or {}
 
         if session:


### PR DESCRIPTION
### What was wrong?

Related to Issue #1469 
`HTTPAdapter` connection pool size was not tunable.  As a result, applications which submit transactions (or make on-chain method calls) from multiple threads can easily reach the queue limit, restricting flow of data to an Ethereum node which could otherwise handle it.

### How was it fixed?

Since the `requests` library's `Session` object doesn't allow these parameters to be passed either, `request.py` was modified to explicitly reassign a new `HTTPAdapter` with the desired parameters.  To prevent changing the interface, `kwargs` passed to `HTTPProvider` are categorized based upon whether they are for the _request_ (`timeout` for example), or for the _adapter_ (`pool_maxsize` for example).

One downside with this implementation is that the categorization of arguments must be explicitly maintained with new releases of `requests`.  Discussion of alternate implementations is welcomed.

#### Cute Animal Picture

![three baby ducklings](https://www.cacklehatchery.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/s/h/shutterstock_191412071.jpg)
