### PR TITLE
Upgrade eth account to >= 0.5.2

### DIFF
--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -60,7 +60,7 @@ Extract private key from geth keyfile
 
 .. NOTE::
   The amount of available ram should be greater than 1GB.
-  
+
 .. code-block:: python
 
     with open('~/.ethereum/keystore/UTC--...--5ce9454909639D2D17A3F753ce7d93fa0b9aB12E') as keyfile:
@@ -91,11 +91,11 @@ is provided by :meth:`w3.eth.sign() <web3.eth.Eth.sign>`.
     >>> message = encode_defunct(text=msg)
     >>> signed_message = w3.eth.account.sign_message(message, private_key=private_key)
     >>> signed_message
-    AttrDict({'messageHash': HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
-     'r': 104389933075820307925104709181714897380569894203213074526835978196648170704563,
-     's': 28205917190874851400050446352651915501321657673772411533993420917949420456142,
-     'v': 28,
-     'signature': HexBytes('0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb33e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce1c')})
+    SignedMessage(messageHash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
+     r=104389933075820307925104709181714897380569894203213074526835978196648170704563,
+     s=28205917190874851400050446352651915501321657673772411533993420917949420456142,
+     v=28,
+     signature=HexBytes('0xe6ca9bba58c88611fad66a6ce8f996908195593807c4b38bd528d2cff09d4eb33e5bfbbf4d3e39b1a2fd816a7680c19ebebaf3a141b239934ad43cb33fcec8ce1c'))
 
 Verify a Message
 ------------------------------------------------
@@ -265,7 +265,7 @@ To sign a transaction locally that will invoke a smart contract:
 .. testsetup::
 
     import json
-    
+
     nonce = 0
 
     EIP20_ABI = json.loads('[{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_spender","type":"address"},{"name":"_value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_from","type":"address"},{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"name":"_owner","type":"address"},{"name":"_spender","type":"address"}],"name":"allowance","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_from","type":"address"},{"indexed":true,"name":"_to","type":"address"},{"indexed":false,"name":"_value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"_owner","type":"address"},{"indexed":true,"name":"_spender","type":"address"},{"indexed":false,"name":"_value","type":"uint256"}],"name":"Approval","type":"event"}]')  # noqa: 501

--- a/newsfragments/1622.feature.rst
+++ b/newsfragments/1622.feature.rst
@@ -1,0 +1,3 @@
+Upgrade eth-account to use v0.5.2+. eth-account 0.5.2 adds support for hd accounts
+
+Also had to pin eth-keys to get dependencies to resolve.

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ from setuptools import (
 
 extras_require = {
     'tester': [
+        # TODO - remove this eth-keys pinning once eth-tester >0.4.0-beta.1 is released
+        # and py-evm v0.3.0-alpha.15 is released
+        "eth-keys>=0.2.1,<0.3",
         "eth-tester[py-evm]==v0.2.0-beta.2",
         "py-geth>=2.2.0,<3",
     ],
@@ -70,7 +73,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-abi>=2.0.0b6,<3.0.0",
-        "eth-account>=0.4.0,<0.5.0",
+        "eth-account>=0.5.2,<0.6.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.8.4,<2.0.0",


### PR DESCRIPTION
### What was wrong?
Want to upgrade eth-account to >=0.5.0 for HD Account features. 


### How was it fixed?
Upgraded `eth-account`, but ran into a dependency resolution problem when running `pip install -e .[dev]` because `eth-keys` >v0.3 isn't compatible with the current released versions of `eth-tester` and `py-evm`. Both `py-evm` and `eth-tester` have the `eth-key` >v0.3 support in their master branches, but they aren't released. We'll need to release `py-evm` first and then upgrade the `py-evm` dependency in `eth-tester` (and make sure everything works okay) before the `eth-keys` pinning can be removed. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/78835819-1b72cc00-79ae-11ea-8459-a5bd4b23bf1c.png)

