### PR TITLE
add transaction options to docs

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -705,6 +705,9 @@ Taking the following contract code as an example:
     ValidationError:
     Could not identify the intended function with name `setBytes2Value`
 
+
+.. _contract-functions:
+
 Contract Functions
 ------------------
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -133,6 +133,36 @@ Web3 can help you convert between denominations.  The following denominations ar
     Decimal('1.23456789E-10')
 
 
+Making transactions
+-------------------
+
+There are a few options for making transactions:
+
+- :meth:`~web3.eth.Eth.sendTransaction`
+
+  Use this method if:
+    - you want to send Ether from one account to another.
+
+- :meth:`~web3.eth.Eth.sendRawTransaction`
+
+  Use this method if:
+    - you want to sign the transaction elsewhere, e.g., a hardware wallet.
+    - you want to broadcast a transaction through another provider, e.g., Infura.
+    - you have some other advanced use case that requires more flexibility.
+
+- :ref:`contract-functions`
+
+  Use these methods if:
+    - you want to interact with a contract. Web3.py parses the contract ABI and makes those functions available via the ``functions`` property.
+
+- :meth:`~web3.middleware.construct_sign_and_send_raw_middleware`
+
+  Use this middleware if:
+    - you want to automate signing when using ``w3.eth.sendTransaction`` or ``ContractFunctions``.
+
+.. NOTE:: The location of your keys (e.g., local or hosted) will have implications on these methods. Read about the differences :ref:`here <eth-account>`.
+
+
 Looking up transactions
 -----------------------
 

--- a/newsfragments/1610.doc.rst
+++ b/newsfragments/1610.doc.rst
@@ -1,0 +1,1 @@
+Add documentation for when to use each transaction method.


### PR DESCRIPTION
### What was wrong?
There's a few ways to send transactions with web3.py, which may be confusing for newcomers in particular.

Closes #1610 

### How was it fixed?
Added some notes about when to use each method/middleware in the Examples page:

<img width="741" alt="Screen Shot 2020-04-13 at 1 25 18 PM" src="https://user-images.githubusercontent.com/3621728/79154050-2651a600-7d8c-11ea-93a2-a4394ab44d53.png">

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/564x/d8/ba/83/d8ba83804ec252be888f75cffa6bcdd1.jpg)
