### PR TITLE
introduce list_wallets method

### DIFF
--- a/docs/web3.geth.rst
+++ b/docs/web3.geth.rst
@@ -229,6 +229,25 @@ The following methods are available on the ``web3.geth.personal`` namespace.
       :meth:`~web3.geth.personal.list_accounts()`
 
 
+.. py:method:: list_wallets()
+
+    * Delegates to ``personal_listWallets`` RPC Method
+
+    Returns the list of wallets managed by Geth.
+
+    .. code-block:: python
+
+        >>> web3.geth.personal.list_wallets()
+        [{
+            accounts: [{
+                address: "0x44f705f3c31017856777f2931c2f09f240dd800b",
+                url: "keystore:///path/to/keystore/UTC--2020-03-30T23-24-43.133883000Z--44f705f3c31017856777f2931c2f09f240dd800b"
+            }],
+            status: "Unlocked",
+            url: "keystore:///path/to/keystore/UTC--2020-03-30T23-24-43.133883000Z--44f705f3c31017856777f2931c2f09f240dd800b"
+        }]
+
+
 .. py:method:: import_raw_key(self, private_key, passphrase)
 
     * Delegates to ``personal_importRawKey`` RPC Method

--- a/newsfragments/1516.feature.rst
+++ b/newsfragments/1516.feature.rst
@@ -1,0 +1,1 @@
+Introduced ``list_wallets`` method to the ``GethPersonal`` class.

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -334,3 +334,7 @@ class TestEthereumTesterPersonalModule(GoEthereumPersonalModuleTest):
                           match="unlockAccount is deprecated in favor of unlock_account"):
             result = web3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
             assert result is False
+
+    @pytest.mark.xfail(raises=ValueError, reason="list_wallets not implemented in eth-tester")
+    def test_personal_list_wallets(self, web3: "Web3") -> None:
+        super().test_personal_list_wallets(web3)

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -316,6 +316,20 @@ FILTER_PARAM_NORMALIZERS = apply_formatters_to_dict({
     'address': apply_formatter_if(is_string, lambda x: [x])
 })
 
+
+GETH_WALLET_FORMATTER = {
+    'address': to_checksum_address
+}
+
+geth_wallet_formatter = apply_formatters_to_dict(GETH_WALLET_FORMATTER)
+
+GETH_WALLETS_FORMATTER = {
+    'accounts': apply_list_to_array_formatter(geth_wallet_formatter),
+}
+
+geth_wallets_formatter = apply_formatters_to_dict(GETH_WALLETS_FORMATTER)
+
+
 PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     # Eth
     RPC.eth_getBalance: apply_formatter_at_index(block_number_formatter, 1),
@@ -417,6 +431,7 @@ PYTHONIC_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     # personal
     RPC.personal_importRawKey: to_checksum_address,
     RPC.personal_listAccounts: apply_list_to_array_formatter(to_checksum_address),
+    RPC.personal_listWallets: apply_list_to_array_formatter(geth_wallets_formatter),
     RPC.personal_newAccount: to_checksum_address,
     RPC.personal_sendTransaction: to_hexbytes(32),
     RPC.personal_signTypedData: HexBytes,

--- a/web3/_utils/module_testing/personal_module.py
+++ b/web3/_utils/module_testing/personal_module.py
@@ -12,6 +12,7 @@ from eth_utils import (
     is_checksum_address,
     is_list_like,
     is_same_address,
+    is_string,
 )
 from hexbytes import (
     HexBytes,
@@ -66,6 +67,15 @@ class GoEthereumPersonalModuleTest:
                 for item
                 in accounts
             ))
+
+    def test_personal_list_wallets(self, web3: "Web3") -> None:
+        wallets = web3.geth.personal.list_wallets()
+        assert is_list_like(wallets)
+        assert len(wallets) > 0
+        assert is_checksum_address(wallets[0]['accounts'][0]['address'])
+        assert is_string(wallets[0]['accounts'][0]['url'])
+        assert is_string(wallets[0]['status'])
+        assert is_string(wallets[0]['url'])
 
     def test_personal_lock_account(
         self, web3: "Web3", unlockable_account_dual_type: ChecksumAddress

--- a/web3/_utils/personal.py
+++ b/web3/_utils/personal.py
@@ -26,6 +26,7 @@ from web3.method import (
     default_root_munger,
 )
 from web3.types import (
+    GethWallet,
     TxParams,
 )
 
@@ -43,6 +44,12 @@ new_account: Method[Callable[[str], ChecksumAddress]] = Method(
 
 list_accounts: Method[Callable[[], List[ChecksumAddress]]] = Method(
     RPC.personal_listAccounts,
+    mungers=None,
+)
+
+
+list_wallets: Method[Callable[[], List[GethWallet]]] = Method(
+    RPC.personal_listWallets,
     mungers=None,
 )
 

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -117,6 +117,7 @@ class RPC:
     personal_ecRecover = RPCEndpoint("personal_ecRecover")
     personal_importRawKey = RPCEndpoint("personal_importRawKey")
     personal_listAccounts = RPCEndpoint("personal_listAccounts")
+    personal_listWallets = RPCEndpoint("personal_listWallets")
     personal_lockAccount = RPCEndpoint("personal_lockAccount")
     personal_newAccount = RPCEndpoint("personal_newAccount")
     personal_sendTransaction = RPCEndpoint("personal_sendTransaction")

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -39,6 +39,7 @@ from web3._utils.personal import (
     import_raw_key,
     importRawKey,
     list_accounts,
+    list_wallets,
     listAccounts,
     lock_account,
     lockAccount,
@@ -70,6 +71,7 @@ class GethPersonal(ModuleV2):
     ec_recover = ec_recover
     import_raw_key = import_raw_key
     list_accounts = list_accounts
+    list_wallets = list_wallets
     lock_account = lock_account
     new_account = new_account
     send_transaction = send_transaction

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -69,6 +69,7 @@ whitelist = [
     'personal_importRawKey',
     'personal_newAccount',
     'personal_listAccounts',
+    'personal_listWallets',
     'personal_lockAccount',
     'personal_unlockAccount',
     'personal_ecRecover',

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -401,6 +401,7 @@ API_ENDPOINTS = {
         'ec_recover': not_implemented,
         'import_raw_key': call_eth_tester('add_account'),
         'list_accounts': call_eth_tester('get_accounts'),
+        'list_wallets': not_implemented,
         'lock_account': excepts(
             ValidationError,
             compose(static_return(True), call_eth_tester('lock_account')),

--- a/web3/types.py
+++ b/web3/types.py
@@ -416,6 +416,17 @@ class TxPoolStatus(TypedDict, total=False):
 
 
 #
+# web3.geth types
+#
+
+
+class GethWallet(TypedDict):
+    accounts: Sequence[Dict[str, str]]
+    status: str
+    url: str
+
+
+#
 # web3.parity types
 #
 


### PR DESCRIPTION
### What was wrong?
`list_wallets` missing from the geth.personal API (closes #1516)

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/474x/fb/ce/74/fbce749b6784ad5af9312ecbf7d042a6.jpg)
