### PR TITLE
Fix key remapping for eth-tester client

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -453,7 +453,7 @@ The following methods are available on the ``web3.eth`` namespace.
             'nonce': '0x3b05c6d5524209f1',
             'number': 2000000,
             'parentHash': '0x57ebf07eb9ed1137d41447020a25e51d30a0c272b5896571499c82c33ecb7288',
-            'receiptRoot': '0x84aea4a7aad5c5899bd5cfc7f309cc379009d30179316a2a7baa4a2ea4a438ac',
+            'receiptsRoot': '0x84aea4a7aad5c5899bd5cfc7f309cc379009d30179316a2a7baa4a2ea4a438ac',
             'sha3Uncles': '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
             'size': 650,
             'stateRoot': '0x96dbad955b166f5119793815c36f11ffa909859bbfeb64b735cca37cbf10bef1',

--- a/newsfragments/1630.bugfix.rst
+++ b/newsfragments/1630.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``eth-tester`` key remapping for ``logsBloom`` and ``receiptsRoot``

--- a/tests/core/middleware/test_eth_tester_middleware.py
+++ b/tests/core/middleware/test_eth_tester_middleware.py
@@ -1,7 +1,22 @@
 import pytest
 
+from web3.types import (
+    BlockData,
+)
+
 
 @pytest.mark.parametrize("block_number", {0, "0x0", "earliest"})
 def test_get_transaction_count_formatters(w3, block_number):
     tx_counts = w3.eth.get_transaction_count(w3.eth.accounts[-1], block_number)
     assert tx_counts == 0
+
+
+def test_get_block_formatters(w3):
+    latest_block = w3.eth.get_block("latest")
+
+    all_block_keys = set(BlockData.__annotations__.keys())
+    latest_block_keys = set(latest_block.keys())
+
+    keys_diff = all_block_keys.difference(latest_block_keys)
+    assert len(keys_diff) == 1
+    assert keys_diff.pop() == "mixHash"  # mixHash is not implemented in eth-tester

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -207,7 +207,7 @@ RECEIPT_FORMATTERS = {
     "gasUsed": to_integer_if_hex,
     "contractAddress": apply_formatter_if(is_not_null, to_checksum_address),
     "logs": apply_list_to_array_formatter(log_entry_formatter),
-    "logsBloom": to_hexbytes(256),
+    "logsBloom": to_hexbytes(256, variable_length=True),
     "from": apply_formatter_if(is_not_null, to_checksum_address),
     "to": apply_formatter_if(is_address, to_checksum_address),
     "effectiveGasPrice": to_integer_if_hex,
@@ -225,7 +225,9 @@ BLOCK_FORMATTERS = {
     "size": to_integer_if_hex,
     "timestamp": to_integer_if_hex,
     "hash": apply_formatter_if(is_not_null, to_hexbytes(32)),
-    "logsBloom": apply_formatter_if(is_not_null, to_hexbytes(256)),
+    "logsBloom": apply_formatter_if(
+        is_not_null, to_hexbytes(256, variable_length=True)
+    ),
     "miner": apply_formatter_if(is_not_null, to_checksum_address),
     "mixHash": apply_formatter_if(is_not_null, to_hexbytes(32)),
     "nonce": apply_formatter_if(is_not_null, to_hexbytes(8, variable_length=True)),

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -2889,6 +2889,8 @@ class EthModuleTest:
     def test_eth_getBlockByHash(self, w3: "Web3", empty_block: BlockData) -> None:
         block = w3.eth.get_block(empty_block["hash"])
         assert block["hash"] == empty_block["hash"]
+        assert block["receiptsRoot"] == empty_block["receiptsRoot"]
+        assert block["logsBloom"] == empty_block["logsBloom"]
 
     def test_eth_getBlockByHash_not_found(
         self, w3: "Web3", empty_block: BlockData

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -99,6 +99,11 @@ transaction_request_transformer = compose(
     transaction_request_formatter,
 )
 
+BLOCK_FORMATTERS = {
+    "logsBloom": integer_to_hex,
+}
+block_formatter = apply_formatters_to_dict(BLOCK_FORMATTERS)
+
 
 FILTER_REQUEST_KEY_MAPPING = {
     "fromBlock": "from_block",
@@ -172,9 +177,9 @@ BLOCK_RESULT_KEY_MAPPING = {
     "sha3_uncles": "sha3Uncles",
     "transactions_root": "transactionsRoot",
     "parent_hash": "parentHash",
-    "bloom": "logsBloom",
+    "logs_bloom": "logsBloom",
     "state_root": "stateRoot",
-    "receipt_root": "receiptsRoot",
+    "receipts_root": "receiptsRoot",
     "total_difficulty": "totalDifficulty",
     "extra_data": "extraData",
     "gas_used": "gasUsed",
@@ -253,11 +258,11 @@ request_formatters = {
 result_formatters: Optional[Dict[RPCEndpoint, Callable[..., Any]]] = {
     RPCEndpoint("eth_getBlockByHash"): apply_formatter_if(
         is_dict,
-        block_result_remapper,
+        compose(block_result_remapper, block_formatter),
     ),
     RPCEndpoint("eth_getBlockByNumber"): apply_formatter_if(
         is_dict,
-        block_result_remapper,
+        compose(block_result_remapper, block_formatter),
     ),
     RPCEndpoint("eth_getBlockTransactionCountByHash"): apply_formatter_if(
         is_dict,

--- a/web3/types.py
+++ b/web3/types.py
@@ -336,7 +336,7 @@ class BlockData(TypedDict, total=False):
     nonce: HexBytes
     number: BlockNumber
     parentHash: HexBytes
-    receiptRoot: HexBytes
+    receiptsRoot: HexBytes
     sha3Uncles: HexBytes
     size: int
     stateRoot: HexBytes


### PR DESCRIPTION
### What was wrong?

- The key for the receipts root is wrong when using the `EthereumTesterProvider`
- The key for the bloom filter was also wrong
- The standard formatter for `logsBloom` wasn't setup to correctly handle the integer format used by eth-tester.

### How was it fixed?

- Fixed the typo on the key remappings for `logsBloom` and `receiptRoot`
- Adjusted formatter for `logsBloom` to correctly handle integer values that aren't the full bit-length

#### Cute Animal Picture

![cats-dogs-and-human-furniture](https://user-images.githubusercontent.com/824194/80249981-16f61680-8630-11ea-94c9-351e661a6497.jpeg)
