### PR TITLE
address local_filter_middleware bug

### DIFF
--- a/newsfragments/1514.bugfix.rst
+++ b/newsfragments/1514.bugfix.rst
@@ -1,0 +1,1 @@
+Fix local_filter_middleware new entries bug

--- a/tests/core/middleware/test_filter_middleware.py
+++ b/tests/core/middleware/test_filter_middleware.py
@@ -101,6 +101,18 @@ def test_block_ranges(start, stop, expected):
         (1, 19),
         (20, 55),
     ]),
+    (0, None, [10], [
+        (0, 10),
+    ]),
+    (0, 10, [12], [
+        (None, None),
+    ]),
+    (12, 10, [12], [
+        (None, None),
+    ]),
+    (12, 10, [None], [
+        (None, None),
+    ]),
 ])
 def test_iter_latest_block_ranges(
         w3,


### PR DESCRIPTION
### What was wrong?
FIlters are unable to parse for new log events with `local_filter_middleware` registered. (Closes #1514)

### How was it fixed?
The `iter_latest_block` method in the middleware threw a `StopIteration` exception when the latest block was beyond the `to_block`. Devoid of context, this seems appropriate, but there seemed to be no advantage to this implementation practically. I updated this 'out of bounds' query to return None instead, which makes upstream methods happy without additional code changes. If this is egregiously unpythonic and another solution is recommended, let me know.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.pinimg.com/474x/79/d0/17/79d017ba4bae7102ae157aa082f0925a.jpg)
