### PR TITLE
Fix ENS.name and ENS.address return types. They can return None

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -101,7 +101,7 @@ class ENS:
         """
         return cls(web3.manager.provider, addr=addr)
 
-    def address(self, name: str) -> ChecksumAddress:
+    def address(self, name: str) -> Optional[ChecksumAddress]:
         """
         Look up the Ethereum address that `name` currently points to.
 
@@ -110,7 +110,7 @@ class ENS:
         """
         return cast(ChecksumAddress, self.resolve(name, 'addr'))
 
-    def name(self, address: ChecksumAddress) -> str:
+    def name(self, address: ChecksumAddress) -> Optional[str]:
         """
         Look up the name that the address points to, using a
         reverse lookup. Reverse lookup is opt-in for name owners.

--- a/newsfragments/1633.bugfix.rst
+++ b/newsfragments/1633.bugfix.rst
@@ -1,0 +1,1 @@
+ENS ``name`` and ENS ``address`` can return ``None``. Fixes return types.


### PR DESCRIPTION
### What was wrong?

ENS.name() and ENS.address() can return `None` in case name doesn't resolve to an address or vice versa. The type annotations do not show this though.

### How was it fixed?
Fixed the type annotations.