### PR TITLE
fix ContractEvent type

### DIFF
--- a/newsfragments/1646.bugfix.rst
+++ b/newsfragments/1646.bugfix.rst
@@ -1,0 +1,1 @@
+``my_contract.events.MyEvent`` was incorrectly annotated so that ``MyEvent`` was marked as a ``ContractEvent`` instance. Fixed to be a class type, i.e., ``Type[ContractEvent]``.

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -243,7 +243,7 @@ class ContractEvents:
                         address=address,
                         event_name=event['name']))
 
-    def __getattr__(self, event_name: str) -> "ContractEvent":
+    def __getattr__(self, event_name: str) -> Type['ContractEvent']:
         if '_events' not in self.__dict__:
             raise NoABIEventsFound(
                 "The abi for this contract contains no event definitions. ",
@@ -257,10 +257,10 @@ class ContractEvents:
         else:
             return super().__getattribute__(event_name)
 
-    def __getitem__(self, event_name: str) -> "ContractEvent":
+    def __getitem__(self, event_name: str) -> Type['ContractEvent']:
         return getattr(self, event_name)
 
-    def __iter__(self) -> Iterable["ContractEvent"]:
+    def __iter__(self) -> Iterable[Type['ContractEvent']]:
         """Iterate over supported
 
         :return: Iterable of :class:`ContractEvent`


### PR DESCRIPTION
### What was wrong?
When calling contract.events.Event(), mypy warns that ContractEvent is not callable.

Related to Issue #1646 

### How was it fixed?
`'ContractEvent'` -> `Type['ContractEvent']`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://www.arf-il.org/wp-content/themes/kreme/assets/imgs/tech_support_1.jpg)
