### PR TITLE
permit pathlib.Path type as IPCProvider input

### DIFF
--- a/newsfragments/1647.bugfix.rst
+++ b/newsfragments/1647.bugfix.rst
@@ -1,0 +1,1 @@
+IPCProvider correctly handled Path input, but warned against its type. Fixed to permit Path objects in addition to strings.

--- a/newsfragments/1647.bugfix.rst
+++ b/newsfragments/1647.bugfix.rst
@@ -1,1 +1,1 @@
-IPCProvider correctly handled Path input, but warned against its type. Fixed to permit Path objects in addition to strings.
+IPCProvider correctly handled ``pathlib.Path`` input, but warned against its type. Fixed to permit Path objects in addition to strings.

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -15,6 +15,7 @@ from types import (
 from typing import (
     Any,
     Type,
+    Union,
 )
 
 from web3._utils.threads import (
@@ -203,7 +204,13 @@ class IPCProvider(JSONBaseProvider):
     logger = logging.getLogger("web3.providers.IPCProvider")
     _socket = None
 
-    def __init__(self, ipc_path: str=None, timeout: int=10, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        ipc_path: Union[str, Path] = None,
+        timeout: int = 10,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         if ipc_path is None:
             self.ipc_path = get_default_ipc_path()
         elif isinstance(ipc_path, str) or isinstance(ipc_path, Path):


### PR DESCRIPTION
### What was wrong?
"IPCProvider correctly handles a pathlib.Path as its ipc_path argument, but the type annotation says it only accepts str." - @carver 

### How was it fixed?
`str` -> `Union[str, Path]`
Closes #1647

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://images.unsplash.com/photo-1535930749574-1399327ce78f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&w=1000&q=80)
