### PR TITLE
add eth-tester breaking change release notes

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -9,6 +9,12 @@ v5 Breaking Changes Summary
 v5.10.0 (2020-05-18)
 --------------------
 
+Features
+~~~~~~~~
+
+- An update of ``eth-tester`` includes a change of the default fork from Constantinople to Istanbul.  `#1636 <https://github.com/ethereum/web3.py/issues/1636>`__
+
+
 Bugfixes
 ~~~~~~~~
 


### PR DESCRIPTION
### What was wrong?
The `eth-tester` version bump included a breaking change that was not included in the release notes by default.

#### Cute Animal Picture

🦨
