### PR TITLE
Correct eth-tester upgrade notes

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,7 +12,7 @@ v5.10.0 (2020-05-18)
 Features
 ~~~~~~~~
 
-- An update of ``eth-tester`` includes a change of the default fork from Constantinople to Istanbul.  `#1636 <https://github.com/ethereum/web3.py/issues/1636>`__
+- An update of ``eth-tester`` includes a change of the default fork from Constantinople to Muir Glacier.  `#1636 <https://github.com/ethereum/web3.py/issues/1636>`__
 
 
 Bugfixes


### PR DESCRIPTION
### What was wrong?
Oop - pulled the latest default fork notes from the eth-tester changelog, but that didn't reflect the latest default fork update to muir glacier.

#### Cute Animal Picture
![](https://i.kym-cdn.com/entries/icons/original/000/030/710/dd0.png)
