### PR TITLE
fixed error when accessing blocks by blocknumber using eth_tester

### DIFF
--- a/newsfragments/1660.bugfix.rst
+++ b/newsfragments/1660.bugfix.rst
@@ -1,1 +1,1 @@
-- Added formatter rules for eth_tester middleware to allow getBalance by using integer block numbers
+Added formatter rules for eth_tester middleware to allow :meth:`~web3.eth.Eth.getBalance` by using integer block numbers

--- a/newsfragments/1660.bugfix.rst
+++ b/newsfragments/1660.bugfix.rst
@@ -1,0 +1,1 @@
+- Added formatter rules for eth_tester middleware to allow getBalance by using integer block numbers

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -126,6 +126,17 @@ class EthModuleTest:
         assert is_integer(balance)
         assert balance >= 0
 
+    def test_eth_getBalance_with_block_identifier(self, web3: "Web3") -> None:
+        coinbase = web3.eth.coinbase
+
+        with pytest.raises(InvalidAddress):
+            web3.eth.getBalance(ChecksumAddress(HexAddress(HexStr(coinbase.lower()))))
+
+        balance = web3.eth.getBalance(coinbase, 0)
+
+        assert is_integer(balance)
+        assert balance >= 0
+
     def test_eth_getStorageAt(
         self, web3: "Web3", emitter_contract_address: ChecksumAddress
     ) -> None:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -127,15 +127,13 @@ class EthModuleTest:
         assert balance >= 0
 
     def test_eth_getBalance_with_block_identifier(self, web3: "Web3") -> None:
-        coinbase = web3.eth.coinbase
+        miner_address = web3.eth.getBlock(1)['miner']
+        genesis_balance = web3.eth.getBalance(miner_address, 0)
+        later_balance = web3.eth.getBalance(miner_address, 1)
 
-        with pytest.raises(InvalidAddress):
-            web3.eth.getBalance(ChecksumAddress(HexAddress(HexStr(coinbase.lower()))))
-
-        balance = web3.eth.getBalance(coinbase, 0)
-
-        assert is_integer(balance)
-        assert balance >= 0
+        assert is_integer(genesis_balance)
+        assert is_integer(later_balance)
+        assert later_balance > genesis_balance
 
     def test_eth_getStorageAt(
         self, web3: "Web3", emitter_contract_address: ChecksumAddress

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -225,6 +225,10 @@ ethereum_tester_middleware = construct_formatting_middleware(
             identity,
             apply_formatter_if(is_not_named_block, to_integer_if_hex),
         ),
+        RPCEndpoint('eth_getBalance'): apply_formatters_to_args(
+            identity,
+            apply_formatter_if(is_not_named_block, to_integer_if_hex),
+        ),
         # EVM
         RPCEndpoint('evm_revert'): apply_formatters_to_args(hex_to_integer),
         # Personal

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -225,10 +225,10 @@ ethereum_tester_middleware = construct_formatting_middleware(
             identity,
             apply_formatter_if(is_not_named_block, to_integer_if_hex),
         ),
-        RPCEndpoint('eth_getBalance'): apply_formatters_to_args(
-            identity,
-            apply_formatter_if(is_not_named_block, to_integer_if_hex),
-        ),
+        #  RPCEndpoint('eth_getBalance'): apply_formatters_to_args(
+            #  identity,
+            #  apply_formatter_if(is_not_named_block, to_integer_if_hex),
+        #  ),
         # EVM
         RPCEndpoint('evm_revert'): apply_formatters_to_args(hex_to_integer),
         # Personal

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -225,10 +225,10 @@ ethereum_tester_middleware = construct_formatting_middleware(
             identity,
             apply_formatter_if(is_not_named_block, to_integer_if_hex),
         ),
-        #  RPCEndpoint('eth_getBalance'): apply_formatters_to_args(
-            #  identity,
-            #  apply_formatter_if(is_not_named_block, to_integer_if_hex),
-        #  ),
+        RPCEndpoint('eth_getBalance'): apply_formatters_to_args(
+            identity,
+            apply_formatter_if(is_not_named_block, to_integer_if_hex),
+        ),
         # EVM
         RPCEndpoint('evm_revert'): apply_formatters_to_args(hex_to_integer),
         # Personal

--- a/web3/types.py
+++ b/web3/types.py
@@ -44,7 +44,7 @@ TParams = TypeVar("TParams")
 TValue = TypeVar("TValue")
 
 BlockParams = Literal["latest", "earliest", "pending"]
-BlockIdentifier = Union[BlockParams, BlockNumber, Hash32, HexStr, HexBytes]
+BlockIdentifier = Union[BlockParams, BlockNumber, Hash32, HexStr, HexBytes, int]
 LatestBlockParam = Literal["latest"]
 
 FunctionIdentifier = Union[str, Type[FallbackFn], Type[ReceiveFn]]


### PR DESCRIPTION
### What was wrong?

When accessing a block by its block number using eth_tester, e.g. 3, the following error occured:
```
Block number must be a positive integer or one of the strings 'latest', 'earliest', or 'pending'. Got: 0x3
```

### How was it fixed?

With this pull request, the ethereum_tester_middleware is extended by typing instructions for `eth_getBalance`.

#### Cute Animal Picture

Too tired for searching for a cat picture. Meow.
