### PR TITLE
Correct type of FilterParams.address

### DIFF
--- a/newsfragments/1664.bugfix.rst
+++ b/newsfragments/1664.bugfix.rst
@@ -1,0 +1,1 @@
+Correct the type annotations of `FilterParams.address`

--- a/web3/types.py
+++ b/web3/types.py
@@ -136,7 +136,7 @@ class FormattersDict(TypedDict, total=False):
 
 
 class FilterParams(TypedDict, total=False):
-    address: Union[Address, ChecksumAddress, List[ChecksumAddress]]
+    address: Union[Address, ChecksumAddress, List[Address], List[ChecksumAddress]]
     blockHash: HexBytes
     fromBlock: BlockIdentifier
     toBlock: BlockIdentifier


### PR DESCRIPTION
### What was wrong?

The type annotations of `FilterParams.address` were not complete.

### How was it fixed?

Added the missing type.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/FrNGyMgfpzY/maxresdefault.jpg)
