### PR TITLE
Fix websocket timeout documentation

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -273,12 +273,14 @@ IPCProvider
 WebsocketProvider
 ~~~~~~~~~~~~~~~~~
 
-.. py:class:: web3.providers.websocket.WebsocketProvider(endpoint_uri[, websocket_kwargs])
+.. py:class:: web3.providers.websocket.WebsocketProvider(endpoint_uri[, websocket_timeout, websocket_kwargs])
 
     This provider handles interactions with an WS or WSS based JSON-RPC server.
 
     * ``endpoint_uri`` should be the full URI to the RPC endpoint such as
       ``'ws://localhost:8546'``.
+    * ``websocket_timeout`` is the timeout in seconds, used when receiving or
+      sending data over the connection. Defaults to 10.
     * ``websocket_kwargs`` this should be a dictionary of keyword arguments which
       will be passed onto the ws/wss websocket connection.
 
@@ -289,14 +291,19 @@ WebsocketProvider
 
     Under the hood, the ``WebsocketProvider`` uses the python websockets library for
     making requests.  If you would like to modify how requests are made, you can
-    use the ``websocket_kwargs`` to do so.  A common use case for this is increasing
-    the timeout for each request.
+    use the ``websocket_kwargs`` to do so.  See the `websockets documentation`_ for
+    available arguments.
+
+    .. _`websockets documentation`: https://websockets.readthedocs.io/en/stable/api.html#websockets.protocol.WebSocketCommonProtocol
+
+    Unlike HTTP connections, the timeout for WS connections is controlled by a
+    separate ``websocket_timeout`` argument, as shown below.
 
 
     .. code-block:: python
 
         >>> from web3 import Web3
-        >>> w3 = Web3(Web3.WebsocketProvider("http://127.0.0.1:8546", websocket_kwargs={'timeout': 60}))
+        >>> w3 = Web3(Web3.WebsocketProvider("ws://127.0.0.1:8546", websocket_timeout=60))
 
 .. py:currentmodule:: web3.providers.eth_tester
 

--- a/newsfragments/1665.doc.rst
+++ b/newsfragments/1665.doc.rst
@@ -1,0 +1,1 @@
+Corrects documentation of websocket timeout configuration.


### PR DESCRIPTION
### What was wrong?

The documentation for WebsocketProvider was incorrect. It described a "timeout" websocket kwarg, which doesn't actually do anything (only timeout-related arguments that websockets takes are ping_timeout and close_timeout), and omitted mentioning the `websocket_timeout` argument, which actually controls the timeout of the WS send and receive calls.

### How was it fixed?

The documentation was updated with information that corresponds to how the code works.

### Todo:
- [ ] Probably nothing else

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/ddnaXEJ.gif)
