### PR TITLE
add ExtraDataLengthError

### DIFF
--- a/newsfragments/1666.feature.rst
+++ b/newsfragments/1666.feature.rst
@@ -1,0 +1,1 @@
+Introduce a more specific validation error, ``ExtraDataLengthError``. This enables tools to detect when someone may be connected to a POA network, for example, and provide a smoother developer experience.

--- a/tests/core/eth-module/test_poa.py
+++ b/tests/core/eth-module/test_poa.py
@@ -1,7 +1,7 @@
 import pytest
 
 from web3.exceptions import (
-    ValidationError,
+    ExtraDataLengthError,
 )
 from web3.middleware import (
     construct_fixture_middleware,
@@ -15,7 +15,7 @@ def test_long_extra_data(web3):
         'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 33},
     })
     web3.middleware_onion.inject(return_block_with_long_extra_data, layer=0)
-    with pytest.raises(ValidationError):
+    with pytest.raises(ExtraDataLengthError):
         web3.eth.getBlock('latest')
 
 

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -100,6 +100,13 @@ class ValidationError(Exception):
     pass
 
 
+class ExtraDataLengthError(ValidationError):
+    """
+    Raised when an RPC call returns >32 bytes of extraData.
+    """
+    pass
+
+
 class NoABIFunctionsFound(AttributeError):
     """
     Raised when an ABI is present, but doesn't contain any functions.

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -24,6 +24,7 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.exceptions import (
+    ExtraDataLengthError,
     ValidationError,
 )
 from web3.middleware.formatting import (
@@ -61,10 +62,10 @@ def check_extradata_length(val: Any) -> Any:
         return val
     result = HexBytes(val)
     if len(result) > MAX_EXTRADATA_LENGTH:
-        raise ValidationError(
+        raise ExtraDataLengthError(
             "The field extraData is %d bytes, but should be %d. "
             "It is quite likely that you are connected to a POA chain. "
-            "Refer "
+            "Refer to "
             "http://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority "
             "for more details. The full extraData is: %r" % (
                 len(result), MAX_EXTRADATA_LENGTH, result


### PR DESCRIPTION
### What was wrong?
When a POA network returns >32 bytes of `extraData` a `ValidationError` is raised.  Because this exception is also used for other errors, it is difficult to specifically target and handle the issue.

Originally discussed on [Gitter](https://gitter.im/ethereum/web3.py?at=5ed7723d225dc25f54c2b38c).

### How was it fixed?
 To more effectively handle this specific situation, I had added a new exception `ExtraDataLengthError` which is only raised in this case.  The new exception is a subclass of `ValidationError` so this shouldn't break any existing code.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/83647230-b9a59b80-a5c5-11ea-9e4a-a009121a8b50.png)
