### PR TITLE
Accept string type as Provider arg

### DIFF
--- a/newsfragments/1669.bugfix.rst
+++ b/newsfragments/1669.bugfix.rst
@@ -1,0 +1,1 @@
+Fix type annotation warning when using string URI to instantiate an HTTP or WebsocketProvider.

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -4,7 +4,9 @@ from typing import (
     Any,
     Dict,
     Iterable,
+    Optional,
     Tuple,
+    Union,
 )
 
 from eth_typing import (
@@ -49,11 +51,13 @@ class HTTPProvider(JSONBaseProvider):
     # type ignored b/c conflict with _middlewares attr on BaseProvider
     _middlewares: Tuple[Middleware, ...] = NamedElementOnion([(http_retry_request_middleware, 'http_retry_request')])  # type: ignore # noqa: E501
 
-    def __init__(self, endpoint_uri: URI=None, request_kwargs: Any=None) -> None:
+    def __init__(
+        self, endpoint_uri: Optional[Union[URI, str]] = None, request_kwargs: Any = None
+    ) -> None:
         if endpoint_uri is None:
             self.endpoint_uri = get_default_endpoint()
         else:
-            self.endpoint_uri = endpoint_uri
+            self.endpoint_uri = URI(endpoint_uri)
         self._request_kwargs = request_kwargs or {}
         super().__init__()
 

--- a/web3/providers/websocket.py
+++ b/web3/providers/websocket.py
@@ -10,7 +10,9 @@ from types import (
 )
 from typing import (
     Any,
+    Optional,
     Type,
+    Union,
 )
 
 from eth_typing import (
@@ -84,11 +86,11 @@ class WebsocketProvider(JSONBaseProvider):
 
     def __init__(
         self,
-        endpoint_uri: URI=None,
-        websocket_kwargs: Any=None,
-        websocket_timeout: int=DEFAULT_WEBSOCKET_TIMEOUT,
+        endpoint_uri: Optional[Union[URI, str]] = None,
+        websocket_kwargs: Any = None,
+        websocket_timeout: int = DEFAULT_WEBSOCKET_TIMEOUT,
     ) -> None:
-        self.endpoint_uri = endpoint_uri
+        self.endpoint_uri = URI(endpoint_uri)
         self.websocket_timeout = websocket_timeout
         if self.endpoint_uri is None:
             self.endpoint_uri = get_default_endpoint()


### PR DESCRIPTION
### What was wrong?

When instantiating Providers, URI strings appear to be a typical usage pattern, including in our own [docs](https://web3py.readthedocs.io/en/stable/overview.html#providers). mypy warns against this though:

```python
w3 = Web3(Web3.HTTPProvider('https://127.0.0.1:8545'))
# or:
w3 = Web3(Web3.WebsocketProvider('ws://127.0.0.1:8546'))

# produces warning:
# Argument 1 has incompatible type "str"; expected "Optional[URI]"
```

### How was it fixed?
`URI` -> `Optional[Union[URI, str]]`

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://data.whicdn.com/images/42560218/original.jpg)
