### PR TITLE
Use Optional for typing on contract.py

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -292,7 +292,8 @@ class ENS:
             self._claim_ownership(new_owner, unowned, owned, super_owner, transact=transact)
             return new_owner
 
-    def _assert_control(self, account: ChecksumAddress, name: str, parent_owned: str=None) -> None:
+    def _assert_control(self, account: ChecksumAddress, name: str,
+                        parent_owned: Optional[str] = None) -> None:
         if not address_in(account, self.web3.eth.accounts):
             raise UnauthorizedError(
                 "in order to modify %r, you must control account %r, which owns %r" % (

--- a/newsfragments/1668.bugfix.rst
+++ b/newsfragments/1668.bugfix.rst
@@ -1,1 +1,1 @@
-Fix type annotations within the ``eth.py`` module. Several arguments that defaulted to ``None`` were not declared ``Optional``.
+Fix type annotations within the ``eth.py`` and ``contract.py`` modules. Several arguments that defaulted to ``None`` were not declared ``Optional``.

--- a/newsfragments/1668.bugfix.rst
+++ b/newsfragments/1668.bugfix.rst
@@ -1,1 +1,1 @@
-Fix type annotations within the ``eth.py`` and ``contract.py`` modules. Several arguments that defaulted to ``None`` were not declared ``Optional``.
+Fix type annotations within the ``eth.py`` module. Several arguments that defaulted to ``None`` were not declared ``Optional``.

--- a/newsfragments/1670.bugfix.rst
+++ b/newsfragments/1670.bugfix.rst
@@ -1,0 +1,1 @@
+Fix type annotations within the ``web3`` modules. Several arguments that defaulted to ``None`` were not declared ``Optional``.

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -2,6 +2,7 @@ import functools
 from typing import (
     TYPE_CHECKING,
     Any,
+    Optional,
     Sequence,
     Tuple,
     Type,
@@ -73,7 +74,8 @@ if TYPE_CHECKING:
 
 
 def find_matching_event_abi(
-    abi: ABI, event_name: str=None, argument_names: Sequence[str]=None
+    abi: ABI, event_name: Optional[str] = None,
+    argument_names: Optional[Sequence[str]] = None
 ) -> ABIEvent:
 
     filters = [
@@ -101,9 +103,9 @@ def find_matching_event_abi(
 def find_matching_fn_abi(
     abi: ABI,
     abi_codec: ABICodec,
-    fn_identifier: Union[str, Type[FallbackFn], Type[ReceiveFn]]=None,
-    args: Sequence[Any]=None,
-    kwargs: Any=None,
+    fn_identifier: Optional[Union[str, Type[FallbackFn], Type[ReceiveFn]]] = None,
+    args: Optional[Sequence[Any]] = None,
+    kwargs: Optional[Any] = None,
 ) -> ABIFunction:
     args = args or tuple()
     kwargs = kwargs or dict()
@@ -162,7 +164,7 @@ def find_matching_fn_abi(
 
 
 def encode_abi(
-    web3: "Web3", abi: ABIFunction, arguments: Sequence[Any], data: HexStr=None
+    web3: "Web3", abi: ABIFunction, arguments: Sequence[Any], data: Optional[HexStr] = None
 ) -> HexStr:
     argument_types = get_abi_input_types(abi)
 
@@ -200,11 +202,11 @@ def prepare_transaction(
     address: ChecksumAddress,
     web3: "Web3",
     fn_identifier: Union[str, Type[FallbackFn], Type[ReceiveFn]],
-    contract_abi: ABI=None,
-    fn_abi: ABIFunction=None,
-    transaction: TxParams=None,
-    fn_args: Sequence[Any]=None,
-    fn_kwargs: Any=None,
+    contract_abi: Optional[ABI] = None,
+    fn_abi: Optional[ABIFunction] = None,
+    transaction: Optional[TxParams] = None,
+    fn_args: Optional[Sequence[Any]] = None,
+    fn_kwargs: Optional[Any] = None,
 ) -> TxParams:
     """
     :parameter `is_function_abi` is used to distinguish  function abi from contract abi
@@ -242,10 +244,10 @@ def prepare_transaction(
 def encode_transaction_data(
     web3: "Web3",
     fn_identifier: Union[str, Type[FallbackFn], Type[ReceiveFn]],
-    contract_abi: ABI=None,
-    fn_abi: ABIFunction=None,
-    args: Sequence[Any]=None,
-    kwargs: Any=None
+    contract_abi: Optional[ABI] = None,
+    fn_abi: Optional[ABIFunction] = None,
+    args: Optional[Sequence[Any]] = None,
+    kwargs: Optional[Any] = None
 ) -> HexStr:
     if fn_identifier is FallbackFn:
         fn_abi, fn_selector, fn_arguments = get_fallback_function_info(contract_abi, fn_abi)
@@ -263,7 +265,7 @@ def encode_transaction_data(
 
 
 def get_fallback_function_info(
-    contract_abi: ABI=None, fn_abi: ABIFunction=None
+    contract_abi: Optional[ABI] = None, fn_abi: Optional[ABIFunction] = None
 ) -> Tuple[ABIFunction, HexStr, Tuple[Any, ...]]:
     if fn_abi is None:
         fn_abi = get_fallback_func_abi(contract_abi)
@@ -273,7 +275,7 @@ def get_fallback_function_info(
 
 
 def get_receive_function_info(
-    contract_abi: ABI=None, fn_abi: ABIFunction=None
+    contract_abi: Optional[ABI] = None, fn_abi: Optional[ABIFunction] = None
 ) -> Tuple[ABIFunction, HexStr, Tuple[Any, ...]]:
     if fn_abi is None:
         fn_abi = get_receive_func_abi(contract_abi)
@@ -285,10 +287,10 @@ def get_receive_function_info(
 def get_function_info(
     fn_name: str,
     abi_codec: ABICodec,
-    contract_abi: ABI=None,
-    fn_abi: ABIFunction=None,
-    args: Sequence[Any]=None,
-    kwargs: Any=None,
+    contract_abi: Optional[ABI] = None,
+    fn_abi: Optional[ABIFunction] = None,
+    args: Optional[Sequence[Any]] = None,
+    kwargs: Optional[Any] = None,
 ) -> Tuple[ABIFunction, HexStr, Tuple[Any, ...]]:
     if args is None:
         args = tuple()

--- a/web3/_utils/datatypes.py
+++ b/web3/_utils/datatypes.py
@@ -2,6 +2,7 @@ from typing import (
     Any,
     Collection,
     Dict,
+    Optional,
     Tuple,
     Type,
 )
@@ -41,7 +42,7 @@ class PropertyCheckingFactory(type):
         name: str,
         bases: Tuple[type],
         namespace: Dict[str, Any],
-        normalizers: Dict[str, Any]=None
+        normalizers: Optional[Dict[str, Any]] = None
     ) -> Type['PropertyCheckingFactory']:
         all_bases = set(concat(base.__mro__ for base in bases))
         all_keys = set(concat(base.__dict__.keys() for base in all_bases))

--- a/web3/_utils/encoding.py
+++ b/web3/_utils/encoding.py
@@ -6,6 +6,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Optional,
     Sequence,
     Type,
     Union,
@@ -56,7 +57,8 @@ from web3.datastructures import (
 )
 
 
-def hex_encode_abi_type(abi_type: TypeStr, value: Any, force_size: int=None) -> HexStr:
+def hex_encode_abi_type(abi_type: TypeStr, value: Any,
+                        force_size: Optional[int] = None) -> HexStr:
     """
     Encodes value into a hex string in format of abi_type
     """
@@ -198,7 +200,8 @@ class FriendlyJsonSerde:
             except TypeError as exc:
                 yield "%d: because (%s)" % (index, exc)
 
-    def _friendly_json_encode(self, obj: Dict[Any, Any], cls: Type[json.JSONEncoder]=None) -> str:
+    def _friendly_json_encode(self, obj: Dict[Any, Any],
+                              cls: Optional[Type[json.JSONEncoder]] = None) -> str:
         try:
             encoded = json.dumps(obj, cls=cls)
             return encoded
@@ -222,7 +225,8 @@ class FriendlyJsonSerde:
             # so we have to re-raise the same type.
             raise json.decoder.JSONDecodeError(err_msg, exc.doc, exc.pos)
 
-    def json_encode(self, obj: Dict[Any, Any], cls: Type[json.JSONEncoder]=None) -> str:
+    def json_encode(self, obj: Dict[Any, Any],
+                    cls: Optional[Type[json.JSONEncoder]] = None) -> str:
         try:
             return self._friendly_json_encode(obj, cls=cls)
         except TypeError as exc:

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -90,7 +90,8 @@ if TYPE_CHECKING:
 
 
 def construct_event_topic_set(
-    event_abi: ABIEvent, abi_codec: ABICodec, arguments: Union[Sequence[Any], Dict[str, Any]]=None
+    event_abi: ABIEvent, abi_codec: ABICodec,
+    arguments: Optional[Union[Sequence[Any], Dict[str, Any]]] = None
 ) -> List[HexStr]:
     if arguments is None:
         arguments = {}
@@ -132,7 +133,8 @@ def construct_event_topic_set(
 
 
 def construct_event_data_set(
-    event_abi: ABIEvent, abi_codec: ABICodec, arguments: Union[Sequence[Any], Dict[str, Any]]=None
+    event_abi: ABIEvent, abi_codec: ABICodec,
+    arguments: Optional[Union[Sequence[Any], Dict[str, Any]]] = None
 ) -> List[List[Optional[HexStr]]]:
     if arguments is None:
         arguments = {}
@@ -279,7 +281,8 @@ def pop_singlets(seq: Sequence[Any]) -> Iterable[Any]:
 
 
 @curry
-def remove_trailing_from_seq(seq: Sequence[Any], remove_value: Any=None) -> Sequence[Any]:
+def remove_trailing_from_seq(seq: Sequence[Any],
+                             remove_value: Optional[Any] = None) -> Sequence[Any]:
     index = len(seq)
     while index > 0 and seq[index - 1] == remove_value:
         index -= 1
@@ -308,7 +311,8 @@ class EventFilterBuilder:
     _immutable = False
 
     def __init__(
-        self, event_abi: ABIEvent, abi_codec: ABICodec, formatter: EventData=None
+        self, event_abi: ABIEvent, abi_codec: ABICodec,
+        formatter: Optional[EventData] = None
     ) -> None:
         self.event_abi = event_abi
         self.abi_codec = abi_codec

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -68,12 +68,12 @@ if TYPE_CHECKING:
 def construct_event_filter_params(
     event_abi: ABIEvent,
     abi_codec: ABICodec,
-    contract_address: ChecksumAddress=None,
-    argument_filters: Dict[str, Any]=None,
-    topics: Sequence[HexStr]=None,
-    fromBlock: BlockIdentifier=None,
-    toBlock: BlockIdentifier=None,
-    address: ChecksumAddress=None
+    contract_address: Optional[ChecksumAddress] = None,
+    argument_filters: Optional[Dict[str, Any]] = None,
+    topics: Optional[Sequence[HexStr]] = None,
+    fromBlock: Optional[BlockIdentifier] = None,
+    toBlock: Optional[BlockIdentifier] = None,
+    address: Optional[ChecksumAddress] = None
 ) -> Tuple[List[List[Optional[HexStr]]], FilterParams]:
     filter_params: FilterParams = {}
     topic_set: Sequence[HexStr] = construct_event_topic_set(event_abi, abi_codec, argument_filters)
@@ -163,7 +163,8 @@ class Filter:
         log_entries = self._filter_valid_entries(self.web3.eth.getFilterLogs(self.filter_id))
         return self._format_log_entries(log_entries)
 
-    def _format_log_entries(self, log_entries: Iterator[LogReceipt]=None) -> List[LogReceipt]:
+    def _format_log_entries(self,
+                            log_entries: Optional[Iterator[LogReceipt]] = None) -> List[LogReceipt]:
         if log_entries is None:
             return []
 

--- a/web3/_utils/math.py
+++ b/web3/_utils/math.py
@@ -1,4 +1,5 @@
 from typing import (
+    Optional,
     Sequence,
 )
 
@@ -7,7 +8,8 @@ from web3.exceptions import (
 )
 
 
-def percentile(values: Sequence[int]=None, percentile: float=None) -> float:
+def percentile(values: Optional[Sequence[int]] = None,
+               percentile: Optional[float] = None) -> float:
     """Calculates a simplified weighted average percentile
     """
     if values in [None, tuple(), []] or len(values) < 1:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Callable,
     Sequence,
+    Union,
     cast,
 )
 
@@ -629,7 +630,7 @@ class EthModuleTest:
     def test_eth_sendRawTransaction(
         self,
         web3: "Web3",
-        raw_transaction: HexStr,
+        raw_transaction: Union[HexStr, bytes],
         funded_account_for_raw_txn: ChecksumAddress,
         expected_hash: HexStr,
     ) -> None:

--- a/web3/_utils/personal.py
+++ b/web3/_utils/personal.py
@@ -67,7 +67,8 @@ lock_account: Method[Callable[[ChecksumAddress], bool]] = Method(
 
 
 class UnlockAccountWrapper(Protocol):
-    def __call__(self, account: ChecksumAddress, passphrase: str, duration: int=None) -> bool:
+    def __call__(self, account: ChecksumAddress, passphrase: str,
+                 duration: Optional[int] = None) -> bool:
         pass
 
 

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -2,6 +2,7 @@ import math
 from typing import (
     TYPE_CHECKING,
     List,
+    Optional,
     cast,
 )
 
@@ -111,7 +112,7 @@ def wait_for_transaction_receipt(
     return txn_receipt
 
 
-def get_block_gas_limit(web3: "Web3", block_identifier: BlockIdentifier=None) -> Wei:
+def get_block_gas_limit(web3: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
     if block_identifier is None:
         block_identifier = web3.eth.blockNumber
     block = web3.eth.getBlock(block_identifier)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -154,7 +154,7 @@ class ContractFunctions:
     """Class containing contract function objects
     """
 
-    def __init__(self, abi: ABI, web3: 'Web3', address: ChecksumAddress=None) -> None:
+    def __init__(self, abi: ABI, web3: 'Web3', address: Optional[ChecksumAddress] = None) -> None:
         self.abi = abi
         self.web3 = web3
         self.address = address
@@ -228,7 +228,7 @@ class ContractEvents:
 
     """
 
-    def __init__(self, abi: ABI, web3: 'Web3', address: ChecksumAddress=None) -> None:
+    def __init__(self, abi: ABI, web3: 'Web3', address: Optional[ChecksumAddress] = None) -> None:
         if abi:
             self.abi = abi
             self._events = filter_by_type('event', self.abi)
@@ -322,7 +322,7 @@ class Contract:
     src_map_runtime = None
     user_doc = None
 
-    def __init__(self, address: ChecksumAddress=None) -> None:
+    def __init__(self, address: Optional[ChecksumAddress] = None) -> None:
         """Create a new smart contract proxy object.
 
         :param address: Contract address as 0x hex string
@@ -346,7 +346,7 @@ class Contract:
         self.receive = Contract.get_receive_function(self.abi, self.web3, self.address)
 
     @classmethod
-    def factory(cls, web3: 'Web3', class_name: str=None, **kwargs: Any) -> 'Contract':
+    def factory(cls, web3: 'Web3', class_name: Optional[str] = None, **kwargs: Any) -> 'Contract':
 
         kwargs['web3'] = web3
 
@@ -396,7 +396,8 @@ class Contract:
     #  Public API
     #
     @combomethod
-    def encodeABI(cls, fn_name: str, args: Any=None, kwargs: Any=None, data: HexStr=None) -> HexStr:
+    def encodeABI(cls, fn_name: str, args: Optional[Any] = None,
+                  kwargs: Optional[Any] = None, data: Optional[HexStr] = None) -> HexStr:
         """
         Encodes the arguments using the Ethereum ABI for the contract function
         that matches the given name and arguments..
@@ -493,9 +494,9 @@ class Contract:
     @classmethod
     def _prepare_transaction(cls,
                              fn_name: str,
-                             fn_args: Any=None,
-                             fn_kwargs: Any=None,
-                             transaction: TxParams=None) -> TxParams:
+                             fn_args: Optional[Any] = None,
+                             fn_kwargs: Optional[Any] = None,
+                             transaction: Optional[TxParams] = None) -> TxParams:
 
         return prepare_transaction(
             cls.address,
@@ -509,7 +510,8 @@ class Contract:
 
     @classmethod
     def _find_matching_fn_abi(
-        cls, fn_identifier: str=None, args: Any=None, kwargs: Any=None
+        cls, fn_identifier: Optional[str] = None, args: Optional[Any] = None,
+        kwargs: Optional[Any] = None
     ) -> ABIFunction:
         return find_matching_fn_abi(cls.abi,
                                     cls.web3.codec,
@@ -519,7 +521,7 @@ class Contract:
 
     @classmethod
     def _find_matching_event_abi(
-        cls, event_name: str=None, argument_names: Sequence[str]=None
+        cls, event_name: Optional[str] = None, argument_names: Optional[Sequence[str]] = None
     ) -> ABIEvent:
         return find_matching_event_abi(
             abi=cls.abi,
@@ -528,7 +530,7 @@ class Contract:
 
     @staticmethod
     def get_fallback_function(
-        abi: ABI, web3: 'Web3', address: ChecksumAddress=None
+        abi: ABI, web3: 'Web3', address: Optional[ChecksumAddress] = None
     ) -> 'ContractFunction':
         if abi and fallback_func_abi_exists(abi):
             return ContractFunction.factory(
@@ -542,7 +544,7 @@ class Contract:
 
     @staticmethod
     def get_receive_function(
-        abi: ABI, web3: 'Web3', address: ChecksumAddress=None
+        abi: ABI, web3: 'Web3', address: Optional[ChecksumAddress] = None
     ) -> 'ContractFunction':
         if abi and receive_func_abi_exists(abi):
             return ContractFunction.factory(
@@ -555,7 +557,8 @@ class Contract:
         return cast('ContractFunction', NonExistentReceiveFunction())
 
     @combomethod
-    def _encode_constructor_data(cls, args: Any=None, kwargs: Any=None) -> HexStr:
+    def _encode_constructor_data(cls, args: Optional[Any] = None,
+                                 kwargs: Optional[Any] = None) -> HexStr:
         constructor_abi = get_constructor_abi(cls.abi)
 
         if constructor_abi:
@@ -620,7 +623,8 @@ class ContractConstructor:
 
     @combomethod
     def estimateGas(
-        self, transaction: TxParams=None, block_identifier: BlockIdentifier=None
+        self, transaction: Optional[TxParams] = None,
+        block_identifier: Optional[BlockIdentifier] = None
     ) -> int:
         if transaction is None:
             estimate_gas_transaction: TxParams = {}
@@ -640,7 +644,7 @@ class ContractConstructor:
         )
 
     @combomethod
-    def transact(self, transaction: TxParams=None) -> HexBytes:
+    def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
         if transaction is None:
             transact_transaction: TxParams = {}
         else:
@@ -658,7 +662,7 @@ class ContractConstructor:
         return self.web3.eth.sendTransaction(transact_transaction)
 
     @combomethod
-    def buildTransaction(self, transaction: TxParams=None) -> TxParams:
+    def buildTransaction(self, transaction: Optional[TxParams] = None) -> TxParams:
         """
         Build the transaction dictionary without sending
         """
@@ -680,7 +684,7 @@ class ContractConstructor:
 
     @staticmethod
     def check_forbidden_keys_in_transaction(
-        transaction: TxParams, forbidden_keys: Collection[str]=None
+        transaction: TxParams, forbidden_keys: Optional[Collection[str]] = None
     ) -> None:
         keys_found = set(transaction.keys()) & set(forbidden_keys)
         if keys_found:
@@ -691,7 +695,8 @@ class ConciseMethod:
     ALLOWED_MODIFIERS = {'call', 'estimateGas', 'transact', 'buildTransaction'}
 
     def __init__(
-        self, function: 'ContractFunction', normalizers: Tuple[Callable[..., Any], ...]=None
+        self, function: 'ContractFunction',
+        normalizers: Optional[Tuple[Callable[..., Any], ...]] = None
     ) -> None:
         self._function = function
         self._function._return_data_normalizers = normalizers
@@ -852,7 +857,7 @@ class ContractFunction:
     args: Any = None
     kwargs: Any = None
 
-    def __init__(self, abi: ABIFunction=None) -> None:
+    def __init__(self, abi: Optional[ABIFunction] = None) -> None:
         self.abi = abi
         self.fn_name = type(self).__name__
 
@@ -892,7 +897,7 @@ class ContractFunction:
         self.arguments = merge_args_and_kwargs(self.abi, self.args, self.kwargs)
 
     def call(
-        self, transaction: TxParams=None, block_identifier: BlockIdentifier='latest'
+        self, transaction: Optional[TxParams] = None, block_identifier: BlockIdentifier='latest'
     ) -> Any:
         """
         Execute a contract function call using the `eth_call` interface.
@@ -959,7 +964,7 @@ class ContractFunction:
             **self.kwargs
         )
 
-    def transact(self, transaction: TxParams=None) -> HexBytes:
+    def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
         if transaction is None:
             transact_transaction: TxParams = {}
         else:
@@ -997,7 +1002,8 @@ class ContractFunction:
         )
 
     def estimateGas(
-        self, transaction: TxParams=None, block_identifier: BlockIdentifier=None
+        self, transaction: Optional[TxParams] = None,
+        block_identifier: Optional[BlockIdentifier] = None
     ) -> int:
         if transaction is None:
             estimate_gas_transaction: TxParams = {}
@@ -1038,7 +1044,7 @@ class ContractFunction:
             **self.kwargs
         )
 
-    def buildTransaction(self, transaction: TxParams=None) -> TxParams:
+    def buildTransaction(self, transaction: Optional[TxParams] = None) -> TxParams:
         """
         Build the transaction dictionary without sending
         """
@@ -1168,11 +1174,11 @@ class ContractEvent:
     @combomethod
     def createFilter(
             self, *,  # PEP 3102
-            argument_filters: Dict[str, Any]=None,
-            fromBlock: BlockIdentifier=None,
+            argument_filters: Optional[Dict[str, Any]] = None,
+            fromBlock: Optional[BlockIdentifier] = None,
             toBlock: BlockIdentifier="latest",
-            address: ChecksumAddress=None,
-            topics: Sequence[Any]=None) -> LogFilter:
+            address: Optional[ChecksumAddress] = None,
+            topics: Optional[Sequence[Any]] = None) -> LogFilter:
         """
         Create filter object that tracks logs emitted by this contract event.
         :param filter_params: other parameters to limit the events
@@ -1235,10 +1241,10 @@ class ContractEvent:
 
     @combomethod
     def getLogs(self,
-                argument_filters: Dict[str, Any]=None,
-                fromBlock: BlockIdentifier=None,
-                toBlock: BlockIdentifier=None,
-                blockHash: HexBytes=None) -> Iterable[EventData]:
+                argument_filters: Optional[Dict[str, Any]] = None,
+                fromBlock: Optional[BlockIdentifier] = None,
+                toBlock: Optional[BlockIdentifier] = None,
+                blockHash: Optional[HexBytes] = None) -> Iterable[EventData]:
         """Get events for this contract instance using eth_getLogs API.
 
         This is a stateless method, as opposed to createFilter.
@@ -1364,7 +1370,7 @@ class ContractCaller:
                  abi: ABI,
                  web3: 'Web3',
                  address: ChecksumAddress,
-                 transaction: TxParams=None,
+                 transaction: Optional[TxParams] = None,
                  block_identifier: BlockIdentifier='latest') -> None:
         self.web3 = web3
         self.address = address
@@ -1420,7 +1426,7 @@ class ContractCaller:
             return False
 
     def __call__(
-        self, transaction: TxParams=None, block_identifier: BlockIdentifier='latest'
+        self, transaction: Optional[TxParams] = None, block_identifier: BlockIdentifier='latest'
     ) -> 'ContractCaller':
         if transaction is None:
             transaction = {}
@@ -1434,7 +1440,7 @@ class ContractCaller:
     def call_function(
         fn: ContractFunction,
         *args: Any,
-        transaction: TxParams=None,
+        transaction: Optional[TxParams] = None,
         block_identifier: BlockIdentifier='latest',
         **kwargs: Any
     ) -> Any:
@@ -1467,9 +1473,9 @@ def call_contract_function(
         normalizers: Tuple[Callable[..., Any], ...],
         function_identifier: FunctionIdentifier,
         transaction: TxParams,
-        block_id: BlockIdentifier=None,
-        contract_abi: ABI=None,
-        fn_abi: ABIFunction=None,
+        block_id: Optional[BlockIdentifier] = None,
+        contract_abi: Optional[ABI] = None,
+        fn_abi: Optional[ABIFunction] = None,
         *args: Any,
         **kwargs: Any) -> Any:
     """
@@ -1559,10 +1565,10 @@ def parse_block_identifier_int(web3: 'Web3', block_identifier_int: int) -> Block
 def transact_with_contract_function(
         address: ChecksumAddress,
         web3: 'Web3',
-        function_name: FunctionIdentifier=None,
-        transaction: TxParams=None,
-        contract_abi: ABI=None,
-        fn_abi: ABIFunction=None,
+        function_name: Optional[FunctionIdentifier] = None,
+        transaction: Optional[TxParams] = None,
+        contract_abi: Optional[ABI] = None,
+        fn_abi: Optional[ABIFunction] = None,
         *args: Any,
         **kwargs: Any) -> HexBytes:
     """
@@ -1587,11 +1593,11 @@ def transact_with_contract_function(
 def estimate_gas_for_function(
         address: ChecksumAddress,
         web3: 'Web3',
-        fn_identifier: FunctionIdentifier=None,
-        transaction: TxParams=None,
-        contract_abi: ABI=None,
-        fn_abi: ABIFunction=None,
-        block_identifier: BlockIdentifier=None,
+        fn_identifier: Optional[FunctionIdentifier] = None,
+        transaction: Optional[TxParams] = None,
+        contract_abi: Optional[ABI] = None,
+        fn_abi: Optional[ABIFunction] = None,
+        block_identifier: Optional[BlockIdentifier] = None,
         *args: Any,
         **kwargs: Any) -> int:
     """Estimates gas cost a function call would take.
@@ -1616,10 +1622,10 @@ def estimate_gas_for_function(
 def build_transaction_for_function(
         address: ChecksumAddress,
         web3: 'Web3',
-        function_name: FunctionIdentifier=None,
-        transaction: TxParams=None,
-        contract_abi: ABI=None,
-        fn_abi: ABIFunction=None,
+        function_name: Optional[FunctionIdentifier] = None,
+        transaction: Optional[TxParams] = None,
+        contract_abi: Optional[ABI] = None,
+        fn_abi: Optional[ABIFunction] = None,
         *args: Any,
         **kwargs: Any) -> TxParams:
     """Builds a dictionary with the fields required to make the given transaction

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -12,6 +12,7 @@ from typing import (
     List,
     Mapping,
     MutableMapping,
+    Optional,
     Sequence,
     Type,
     TypeVar,
@@ -132,7 +133,7 @@ class NamedElementOnion(Mapping[TKey, TValue]):
             else:
                 self.add(*element)
 
-    def add(self, element: TValue, name: TKey=None) -> None:
+    def add(self, element: TValue, name: Optional[TKey] = None) -> None:
         if name is None:
             name = cast(TKey, element)
 
@@ -144,7 +145,8 @@ class NamedElementOnion(Mapping[TKey, TValue]):
 
         self._queue[name] = element
 
-    def inject(self, element: TValue, name: TKey=None, layer: int=None) -> None:
+    def inject(self, element: TValue, name: Optional[TKey] = None,
+               layer: Optional[int] = None) -> None:
         """
         Inject a named element to an arbitrary layer in the onion.
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -519,7 +519,7 @@ class Eth(Module):
         )
 
     @overload
-    def contract(self, address: None=None, **kwargs: Any) -> Type[Contract]: ...  # noqa: E704,E501
+    def contract(self, address: None = None, **kwargs: Any) -> Type[Contract]: ...  # noqa: E704,E501
 
     @overload  # noqa: F811
     def contract(self, address: Union[Address, ChecksumAddress, ENS], **kwargs: Any) -> Contract: ...  # noqa: E704,E501

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -389,7 +389,7 @@ class Eth(Module):
             [transaction],
         )
 
-    def sendRawTransaction(self, raw_transaction: HexStr) -> HexBytes:
+    def sendRawTransaction(self, raw_transaction: Union[HexStr, bytes]) -> HexBytes:
         return self.web3.manager.request_blocking(
             RPC.eth_sendRawTransaction,
             [raw_transaction],

--- a/web3/gas_strategies/rpc.py
+++ b/web3/gas_strategies/rpc.py
@@ -1,3 +1,7 @@
+from typing import (
+    Optional,
+)
+
 from web3 import Web3
 from web3._utils.rpc_abi import (
     RPC,
@@ -8,7 +12,8 @@ from web3.types import (
 )
 
 
-def rpc_gas_price_strategy(web3: Web3, transaction_params: TxParams=None) -> Wei:
+def rpc_gas_price_strategy(web3: Web3,
+                           transaction_params: Optional[TxParams] = None) -> Wei:
     """
     A simple gas price strategy deriving it's value from the eth_gasPrice JSON-RPC call.
     """

--- a/web3/main.py
+++ b/web3/main.py
@@ -18,7 +18,7 @@ from eth_utils import (
 from hexbytes import (
     HexBytes,
 )
-from typing import Any, cast, Dict, List, Sequence, TYPE_CHECKING
+from typing import Any, cast, Dict, List, Optional, Sequence, TYPE_CHECKING
 
 from eth_typing import HexStr, Primitives
 from eth_typing.abi import TypeStr
@@ -164,9 +164,9 @@ class Web3:
 
     def __init__(
         self,
-        provider: BaseProvider=None,
-        middlewares: Sequence[Any]=None,
-        modules: Dict[str, Sequence[Any]]=None,
+        provider: Optional[BaseProvider] = None,
+        middlewares: Optional[Sequence[Any]] = None,
+        modules: Optional[Dict[str, Sequence[Any]]] = None,
         ens: ENS=cast(ENS, empty)
     ) -> None:
         self.manager = self.RequestManager(self, provider, middlewares)
@@ -204,12 +204,14 @@ class Web3:
     @staticmethod
     @deprecated_for("keccak")
     @apply_to_return_value(HexBytes)
-    def sha3(primitive: Primitives=None, text: str=None, hexstr: HexStr=None) -> bytes:
+    def sha3(primitive: Optional[Primitives] = None, text: Optional[str] = None,
+             hexstr: Optional[HexStr] = None) -> bytes:
         return Web3.keccak(primitive, text, hexstr)
 
     @staticmethod
     @apply_to_return_value(HexBytes)
-    def keccak(primitive: Primitives=None, text: str=None, hexstr: HexStr=None) -> bytes:
+    def keccak(primitive: Optional[Primitives] = None, text: Optional[str] = None,
+               hexstr: Optional[HexStr] = None) -> bytes:
         if isinstance(primitive, (bytes, int, type(None))):
             input_bytes = to_bytes(primitive, hexstr=hexstr, text=text)
             return eth_utils_keccak(input_bytes)

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -69,8 +69,8 @@ class RequestManager:
     def __init__(
         self,
         web3: 'Web3',
-        provider: BaseProvider=None,
-        middlewares: Sequence[Tuple[Middleware, str]]=None
+        provider: Optional[BaseProvider] = None,
+        middlewares: Optional[Sequence[Tuple[Middleware, str]]] = None
     ) -> None:
         self.web3 = web3
         self.pending_requests: Dict[UUID, ThreadWithReturn[RPCResponse]] = {}
@@ -141,7 +141,7 @@ class RequestManager:
         self,
         method: Union[RPCEndpoint, Callable[..., RPCEndpoint]],
         params: Any,
-        error_formatters: Callable[..., Any]=None,
+        error_formatters: Optional[Callable[..., Any]] = None,
     ) -> Any:
         """
         Make a synchronous request using the provider
@@ -158,7 +158,7 @@ class RequestManager:
         self,
         method: Union[RPCEndpoint, Callable[..., RPCEndpoint]],
         params: Any,
-        error_formatters: Callable[..., Any]=None,
+        error_formatters: Optional[Callable[..., Any]] = None,
     ) -> Any:
         """
         Couroutine for making a request using the provider
@@ -184,7 +184,7 @@ class RequestManager:
         )
         return request_id
 
-    def receive_blocking(self, request_id: UUID, timeout: float=None) -> Any:
+    def receive_blocking(self, request_id: UUID, timeout: Optional[float] = None) -> Any:
         try:
             request = self.pending_requests.pop(request_id)
         except KeyError:

--- a/web3/method.py
+++ b/web3/method.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     Generic,
     List,
+    Optional,
     Sequence,
     Tuple,
     Type,
@@ -113,12 +114,12 @@ class Method(Generic[TFunc]):
     """
     def __init__(
             self,
-            json_rpc_method: RPCEndpoint=None,
-            mungers: Sequence[Munger]=None,
-            request_formatters: Callable[..., TReturn]=None,
-            result_formatters: Callable[..., TReturn]=None,
-            error_formatters: Callable[..., TReturn]=None,
-            web3: "Web3"=None):
+            json_rpc_method: Optional[RPCEndpoint] = None,
+            mungers: Optional[Sequence[Munger]] = None,
+            request_formatters: Optional[Callable[..., TReturn]] = None,
+            result_formatters: Optional[Callable[..., TReturn]] = None,
+            error_formatters: Optional[Callable[..., TReturn]] = None,
+            web3: Optional["Web3"] = None):
 
         self.json_rpc_method = json_rpc_method
         self.mungers = mungers or [default_munger]
@@ -126,7 +127,8 @@ class Method(Generic[TFunc]):
         self.result_formatters = result_formatters or get_result_formatters
         self.error_formatters = get_error_formatters
 
-    def __get__(self, obj: "ModuleV2"=None, obj_type: Type["ModuleV2"]=None) -> TFunc:
+    def __get__(self, obj: Optional["ModuleV2"] = None,
+                obj_type: Optional[Type["ModuleV2"]] = None) -> TFunc:
         if obj is None:
             raise TypeError(
                 "Direct calls to methods are not supported. "
@@ -181,7 +183,8 @@ class DeprecatedMethod():
         self.old_name = old_name
         self.new_name = new_name
 
-    def __get__(self, obj: "ModuleV2"=None, obj_type: Type["ModuleV2"]=None) -> Any:
+    def __get__(self, obj: Optional["ModuleV2"] = None,
+                obj_type: Optional[Type["ModuleV2"]] = None) -> Any:
         warnings.warn(
             f"{self.old_name} is deprecated in favor of {self.new_name}",
             category=DeprecationWarning,

--- a/web3/middleware/exception_handling.py
+++ b/web3/middleware/exception_handling.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Optional,
     Tuple,
     Type,
 )
@@ -22,7 +23,8 @@ if TYPE_CHECKING:
 
 
 def construct_exception_handler_middleware(
-    method_handlers: Dict[RPCEndpoint, Tuple[Type[BaseException], Callable[..., None]]]=None
+    method_handlers: Optional[Dict[RPCEndpoint,
+                                   Tuple[Type[BaseException], Callable[..., None]]]] = None
 ) -> Middleware:
     if method_handlers is None:
         method_handlers = {}

--- a/web3/middleware/filter.py
+++ b/web3/middleware/filter.py
@@ -116,7 +116,7 @@ def block_ranges(
 
 
 def iter_latest_block(
-    w3: "Web3", to_block: Union[BlockNumber, LatestBlockParam]=None
+    w3: "Web3", to_block: Optional[Union[BlockNumber, LatestBlockParam]] = None
 ) -> Iterable[BlockNumber]:
     """Returns a generator that dispenses the latest block, if
     any new blocks have been mined since last iteration.
@@ -157,7 +157,7 @@ def iter_latest_block(
 def iter_latest_block_ranges(
     w3: "Web3",
     from_block: BlockNumber,
-    to_block: Union[BlockNumber, LatestBlockParam]=None,
+    to_block: Optional[Union[BlockNumber, LatestBlockParam]] = None,
 ) -> Iterable[Tuple[Optional[BlockNumber], Optional[BlockNumber]]]:
     """Returns an iterator unloading ranges of available blocks
 
@@ -215,10 +215,12 @@ class RequestLogs:
     def __init__(
         self,
         w3: "Web3",
-        from_block: Union[BlockNumber, LatestBlockParam]=None,
-        to_block: Union[BlockNumber, LatestBlockParam]=None,
-        address: Union[Address, ChecksumAddress, List[Union[Address, ChecksumAddress]]]=None,
-        topics: List[Optional[Union[_Hash32, List[_Hash32]]]]=None
+        from_block: Optional[Union[BlockNumber, LatestBlockParam]] = None,
+        to_block: Optional[Union[BlockNumber, LatestBlockParam]] = None,
+        address: Optional[Union[Address,
+                                ChecksumAddress,
+                                List[Union[Address, ChecksumAddress]]]] = None,
+        topics: Optional[List[Optional[Union[_Hash32, List[_Hash32]]]]] = None
     ) -> None:
         self.address = address
         self.topics = topics

--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -2,6 +2,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Optional,
 )
 
 from eth_utils.toolz import (
@@ -23,9 +24,9 @@ if TYPE_CHECKING:
 
 
 def construct_formatting_middleware(
-    request_formatters: Formatters=None,
-    result_formatters: Formatters=None,
-    error_formatters: Formatters=None
+    request_formatters: Optional[Formatters] = None,
+    result_formatters: Optional[Formatters] = None,
+    error_formatters: Optional[Formatters] = None
 ) -> Middleware:
     def ignore_web3_in_standard_formatters(
         w3: "Web3",

--- a/web3/module.py
+++ b/web3/module.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Callable,
     Coroutine,
+    Optional,
     Union,
 )
 
@@ -65,7 +66,7 @@ class Module:
         self.web3 = web3
 
     @classmethod
-    def attach(cls, target: "Web3", module_name: str=None) -> None:
+    def attach(cls, target: "Web3", module_name: Optional[str] = None) -> None:
         if not module_name:
             module_name = cls.__name__.lower()
 

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -1,5 +1,6 @@
 from typing import (
     List,
+    Optional,
     Union,
 )
 
@@ -135,7 +136,7 @@ class Parity(Module):
         address: Union[Address, ChecksumAddress, ENS],
         quantity: int,
         hash_: Hash32,
-        block_identifier: BlockIdentifier=None,
+        block_identifier: Optional[BlockIdentifier] = None,
     ) -> List[Hash32]:
         if block_identifier is None:
             block_identifier = self.defaultBlock
@@ -194,7 +195,7 @@ class Parity(Module):
         self,
         transaction: TxParams,
         mode: ParityTraceMode=['trace'],
-        block_identifier: BlockIdentifier=None
+        block_identifier: Optional[BlockIdentifier] = None
     ) -> ParityBlockTrace:
         # TODO: move to middleware
         if 'from' not in transaction and is_checksum_address(self.web3.eth.defaultAccount):

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -44,7 +44,7 @@ def load_provider_from_environment() -> BaseProvider:
 
 
 def load_provider_from_uri(
-    uri_string: URI, headers: Dict[str, Tuple[str, str]]=None
+    uri_string: URI, headers: Optional[Dict[str, Tuple[str, str]]] = None
 ) -> BaseProvider:
     uri = urlparse(uri_string)
     if uri.scheme == 'file':
@@ -74,7 +74,8 @@ class AutoProvider(BaseProvider):
 
     def __init__(
         self,
-        potential_providers: Sequence[Union[Callable[..., BaseProvider], Type[BaseProvider]]]=None
+        potential_providers: Optional[Sequence[Union[Callable[..., BaseProvider],
+                                      Type[BaseProvider]]]] = None
     ) -> None:
         """
         :param iterable potential_providers: ordered series of provider classes to attempt with
@@ -98,7 +99,8 @@ class AutoProvider(BaseProvider):
         provider = self._get_active_provider(use_cache=True)
         return provider is not None and provider.isConnected()
 
-    def _proxy_request(self, method: RPCEndpoint, params: Any, use_cache: bool=True) -> RPCResponse:
+    def _proxy_request(self, method: RPCEndpoint, params: Any,
+                       use_cache: bool=True) -> RPCResponse:
         provider = self._get_active_provider(use_cache)
         if provider is None:
             raise CannotHandleRequest(

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     List,
     NoReturn,
+    Optional,
     Tuple,
     Type,
 )
@@ -57,7 +58,8 @@ def not_implemented(*args: Any, **kwargs: Any) -> NoReturn:
 
 @curry
 def call_eth_tester(
-    fn_name: str, eth_tester: "EthereumTester", fn_args: Any, fn_kwargs: Any=None
+    fn_name: str, eth_tester: "EthereumTester", fn_args: Any,
+    fn_kwargs: Optional[Any] = None
 ) -> RPCResponse:
     if fn_kwargs is None:
         fn_kwargs = {}

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Optional,
 )
 
 from web3._utils.compat import (
@@ -53,8 +54,8 @@ class EthereumTesterProvider(BaseProvider):
 
     def __init__(
         self,
-        ethereum_tester: "EthereumTester"=None,
-        api_endpoints: Dict[str, Dict[str, Callable[..., RPCResponse]]]=None
+        ethereum_tester: Optional["EthereumTester"] = None,
+        api_endpoints: Optional[Dict[str, Dict[str, Callable[..., RPCResponse]]]] = None
     ) -> None:
         # do not import eth_tester until runtime, it is not a default dependency
         from eth_tester import EthereumTester  # noqa: F811

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -52,7 +52,8 @@ class HTTPProvider(JSONBaseProvider):
     _middlewares: Tuple[Middleware, ...] = NamedElementOnion([(http_retry_request_middleware, 'http_retry_request')])  # type: ignore # noqa: E501
 
     def __init__(
-        self, endpoint_uri: Optional[Union[URI, str]] = None, request_kwargs: Any = None
+        self, endpoint_uri: Optional[Union[URI, str]] = None,
+        request_kwargs: Optional[Any] = None
     ) -> None:
         if endpoint_uri is None:
             self.endpoint_uri = get_default_endpoint()

--- a/web3/providers/websocket.py
+++ b/web3/providers/websocket.py
@@ -87,7 +87,7 @@ class WebsocketProvider(JSONBaseProvider):
     def __init__(
         self,
         endpoint_uri: Optional[Union[URI, str]] = None,
-        websocket_kwargs: Any = None,
+        websocket_kwargs: Optional[Any] = None,
         websocket_timeout: int = DEFAULT_WEBSOCKET_TIMEOUT,
     ) -> None:
         self.endpoint_uri = URI(endpoint_uri)

--- a/web3/testing.py
+++ b/web3/testing.py
@@ -1,3 +1,7 @@
+from typing import (
+    Optional,
+)
+
 from web3._utils.rpc_abi import (
     RPC,
 )
@@ -20,7 +24,7 @@ class Testing(Module):
     def reset(self) -> None:
         return self.web3.manager.request_blocking(RPC.evm_reset, [])
 
-    def revert(self, snapshot_idx: int=None) -> None:
+    def revert(self, snapshot_idx: Optional[int] = None) -> None:
         if snapshot_idx is None:
             revert_target = self.last_snapshot_idx
         else:


### PR DESCRIPTION
### What was wrong?

Mypy complaining about using `None` in functions where typing was set to non `None` values.

### How was it fixed?
- `Optional[type]` is used for nullable arguments
- Fixed formatting of default arguments when using type `argument: type = default`, with spaces around `=`

### Todo:
- Fix another files

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.bestfunnies.com/wp-content/uploads/2015/05/TOP-30-Cute-Animals-Cute-Animal-27.jpg)
