### PR TITLE
Add context to index.rst and docs categories

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,32 +1,63 @@
-Web3.py
-=======
+Introduction
+============
 
-Web3.py is a python library for interacting with Ethereum.  Its API is derived
-from the `Web3.js`_ Javascript API and should be familiar to anyone who has
-used ``web3.js``.
+Web3.py is a Python library for interacting with Ethereum.
 
+It's commonly found in `decentralized apps (dapps)`_ to help with
+sending transactions, interacting with smart contracts, reading
+block data, and a variety of other use cases.
 
-Contents
---------
+The original API was derived from the `Web3.js`_ Javascript API,
+but has since evolved toward the needs and creature comforts of
+Python developers.
+
+Getting Started
+---------------
+
+Your next steps depend on where you're standing:
+
+- Unfamiliar with Ethereum? `ethereum.org`_
+- Looking for Ethereum Python tutorials? `ethereum.org/python`_
+- Ready to code? :ref:`quickstart`
+- Need help debugging? `StackExchange`_
+- Want to chat? `Gitter`_
+
+Table of Contents
+-----------------
 
 .. toctree::
     :maxdepth: 1
+    :caption: Intro
 
     quickstart
     overview
+    releases
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Guides
+
     node
     providers
     examples
     troubleshooting
-    v5_migration
-    v4_migration
+    web3.eth.account
     filters
     contracts
-    ens_overview
     middleware
+    internals
+    abi_types
+    ethpm
+    ens_overview
+    v5_migration
+    v4_migration
+
+.. toctree::
+    :maxdepth: 1
+    :caption: API
+
     web3.main
     web3.eth
-    web3.eth.account
     web3.pm
     web3.net
     web3.miner
@@ -34,10 +65,6 @@ Contents
     web3.parity
     gas_price
     ens
-    ethpm
-    internals
-    abi_types
-    releases
 
 Indices and tables
 ------------------
@@ -47,4 +74,9 @@ Indices and tables
 * :ref:`search`
 
 
-.. _Web3.js: https://github.com/ethereum/wiki/wiki/JavaScript-API
+.. _decentralized apps (dapps): https://ethereum.org/dapps/
+.. _Web3.js: https://web3js.readthedocs.io/
+.. _ethereum.org: https://ethereum.org/what-is-ethereum/
+.. _ethereum.org/python: https://ethereum.org/python/
+.. _StackExchange: https://ethereum.stackexchange.com/questions/tagged/web3.py
+.. _Gitter: https://gitter.im/ethereum/web3.py

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,3 +1,5 @@
+.. _quickstart:
+
 Quickstart
 ==========
 

--- a/newsfragments/1671.doc.rst
+++ b/newsfragments/1671.doc.rst
@@ -1,0 +1,1 @@
+Breaks up links into three categories (Intro, Guides, and API) and adds content to the index page: a lib introduction and some "Getting Started" links.


### PR DESCRIPTION
### What was wrong?

The index page of the docs is (naturally) the most visited page in the documentation, but it does little for our cause as an unstructured table of contents dump.

### How was it fixed?

Added some introductory text, next step links, and broke the pages into three categories.

This content is a starting point. Opinions desired. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://external-preview.redd.it/QeB3pCOknx8oVcySGcYletPO_VsqtwdNeyJrHQMHI1A.jpg?width=960&crop=smart&auto=webp&s=53bbe95084f5772fc70b93398d9164e1c50a72b7)
