### PR TITLE
Update outdated github url reference

### DIFF
--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -202,8 +202,8 @@ A valid content-addressed Github URI *must* conform to the following scheme, as 
 
    >>> from ethpm.uri import create_content_addressed_github_uri
 
-   >>> owned_github_api_uri = "https://api.github.com/repos/ethereum/web3.py/contents/ethpm/assets/owned/1.0.1.json"
-   >>> content_addressed_uri = "https://api.github.com/repos/ethereum/web3.py/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03480"
+   >>> owned_github_api_uri = "https://api.github.com/repos/ethpm/ethpm-spec/contents/examples/owned/1.0.0.json"
+   >>> content_addressed_uri = "https://api.github.com/repos/ethpm/ethpm-spec/git/blobs/8f9dc767d4c8b31fec4a08d9c0858d4f37b83180"
 
    >>> actual_blob_uri = create_content_addressed_github_uri(owned_github_api_uri)
    >>> assert actual_blob_uri == content_addressed_uri

--- a/newsfragments/1680.bugfix.rst
+++ b/newsfragments/1680.bugfix.rst
@@ -1,0 +1,1 @@
+Update outdated reference url in ethpm docs and tests.

--- a/tests/ethpm/test_uri.py
+++ b/tests/ethpm/test_uri.py
@@ -64,8 +64,8 @@ def test_is_valid_content_addressed_github_uri(uri, expected):
 
 
 def test_create_github_uri():
-    api_uri = "https://api.github.com/repos/ethereum/web3.py/contents/ethpm/assets/owned/1.0.1.json"
-    expected_blob_uri = "https://api.github.com/repos/ethereum/web3.py/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03480"  # noqa: E501
+    api_uri = "https://api.github.com/repos/ethpm/ethpm-spec/contents/examples/owned/1.0.0.json"
+    expected_blob_uri = "https://api.github.com/repos/ethpm/ethpm-spec/git/blobs/8f9dc767d4c8b31fec4a08d9c0858d4f37b83180"  # noqa: E501
     actual_blob_uri = create_content_addressed_github_uri(api_uri)
     assert actual_blob_uri == expected_blob_uri
 


### PR DESCRIPTION
### What was wrong?
#1652 had a ref to a file that was deleted upon it's merge (breaking ci on master 😭 ), so I updated the reference to a more stable file url that actually exists and is unlikely to be removed. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/86811279-56cf7600-c043-11ea-88fe-cc80fe5e0002.png)
