### PR TITLE
Fix buggy support of ethpm-spec submodule

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,5 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include ethpm/assets/ *
+recursive-include ethpm/ethpm-spec/examples *.json
+recursive-include ethpm/ethpm-spec/spec *.json

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read more in the [documentation on ReadTheDocs](http://web3py.readthedocs.io/). 
 ## Developer Setup
 
 ```sh
-git clone git@github.com:ethereum/web3.py.git
+git clone --recursive git@github.com:ethereum/web3.py.git
 cd web3.py
 ```
 

--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -35,11 +35,12 @@ new ``Package`` class for a given package.
 
 .. doctest::
 
-   >>> from ethpm import Package, ETHPM_SPEC_DIR
+   >>> from ethpm import Package, get_ethpm_spec_dir
    >>> from web3 import Web3
 
    >>> w3 = Web3(Web3.EthereumTesterProvider())
-   >>> owned_manifest_path = ETHPM_SPEC_DIR / 'examples' / 'owned' / 'v3.json'
+   >>> ethpm_spec_dir = get_ethpm_spec_dir()
+   >>> owned_manifest_path = ethpm_spec_dir / 'examples' / 'owned' / 'v3.json'
    >>> OwnedPackage = Package.from_file(owned_manifest_path, w3)
    >>> assert isinstance(OwnedPackage, Package)
 
@@ -563,8 +564,9 @@ To inline the source code directly in the manifest, use ``inline_source()`` or `
 .. doctest::
 
    >>> import json
-   >>> from ethpm import ASSETS_DIR, ETHPM_SPEC_DIR
-   >>> owned_dir = ETHPM_SPEC_DIR / "examples" / "owned" / "contracts"
+   >>> from ethpm import ASSETS_DIR, get_ethpm_spec_dir
+   >>> ethpm_spec_dir = get_ethpm_spec_dir()
+   >>> owned_dir = ethpm_spec_dir / "examples" / "owned" / "contracts"
    >>> compiler_output = json.loads((ASSETS_DIR / "owned" / "output_v3.json").read_text())['contracts']
    >>> expected_manifest = {
    ...   "name": "owned",
@@ -601,9 +603,10 @@ To include the source as a content-addressed URI, ``Py-EthPM`` can pin your sour
 .. doctest::
 
    >>> import json
-   >>> from ethpm import ASSETS_DIR, ETHPM_SPEC_DIR
+   >>> from ethpm import ASSETS_DIR, get_ethpm_spec_dir
    >>> from ethpm.backends.ipfs import get_ipfs_backend
-   >>> owned_dir = ETHPM_SPEC_DIR / "examples" / "owned" / "contracts"
+   >>> ethpm_spec_dir = get_ethpm_spec_dir()
+   >>> owned_dir = ethpm_spec_dir / "examples" / "owned" / "contracts"
    >>> compiler_output = json.loads((ASSETS_DIR / "owned" / "output_v3.json").read_text())['contracts']
    >>> ipfs_backend = get_ipfs_backend()
    >>> expected_manifest = {

--- a/ethpm/__init__.py
+++ b/ethpm/__init__.py
@@ -3,7 +3,18 @@ from pathlib import Path
 
 ETHPM_DIR = Path(__file__).parent
 ASSETS_DIR = ETHPM_DIR / "assets"
-ETHPM_SPEC_DIR: Path = ETHPM_DIR / "ethpm-spec"
+
+
+def get_ethpm_spec_dir() -> Path:
+    ethpm_spec_dir = ETHPM_DIR / "ethpm-spec"
+    v3_spec = ethpm_spec_dir / "spec" / "v3.spec.json"
+    if not v3_spec.is_file():
+        raise FileNotFoundError(
+            "The ethpm-spec submodule is not available. "
+            "Please import the submodule with `git submodule update --init`"
+        )
+    return ethpm_spec_dir
+
 
 from .package import Package  # noqa: F401
 from .backends.registry import RegistryURI  # noqa: F401

--- a/ethpm/backends/ipfs.py
+++ b/ethpm/backends/ipfs.py
@@ -18,7 +18,7 @@ from eth_utils import (
 import ipfshttpclient
 
 from ethpm import (
-    ETHPM_SPEC_DIR,
+    get_ethpm_spec_dir,
 )
 from ethpm._utils.ipfs import (
     dummy_ipfs_pin,
@@ -165,12 +165,13 @@ class DummyIPFSBackend(BaseIPFSBackend):
     ---
     `ipfs_uri` can either be:
     - Valid IPFS URI -> safe-math-lib manifest (ALWAYS)
-    - Path to manifest/contract in ETHPM_SPEC_DIR -> defined manifest/contract
+    - Path to manifest/contract in ethpm_spec_dir -> defined manifest/contract
     """
 
     def fetch_uri_contents(self, ipfs_uri: str) -> bytes:
         pkg_name = MANIFEST_URIS[ipfs_uri]
-        pkg_contents = (ETHPM_SPEC_DIR / "examples" / pkg_name / "v3.json").read_text()
+        ethpm_spec_dir = get_ethpm_spec_dir()
+        pkg_contents = (ethpm_spec_dir / "examples" / pkg_name / "v3.json").read_text()
         return to_bytes(text=pkg_contents)
 
     def can_resolve_uri(self, uri: str) -> bool:

--- a/ethpm/tools/get_manifest.py
+++ b/ethpm/tools/get_manifest.py
@@ -6,12 +6,13 @@ from typing import (
 
 from ethpm import (
     ASSETS_DIR,
-    ETHPM_SPEC_DIR,
+    get_ethpm_spec_dir,
 )
 
 
 def get_ethpm_spec_manifest(use_case: str, filename: str) -> Dict[str, Any]:
-    return json.loads((ETHPM_SPEC_DIR / 'examples' / use_case / filename).read_text())
+    ethpm_spec_dir = get_ethpm_spec_dir()
+    return json.loads((ethpm_spec_dir / 'examples' / use_case / filename).read_text())
 
 
 def get_ethpm_local_manifest(use_case: str, filename: str) -> Dict[str, Any]:

--- a/ethpm/validation/manifest.py
+++ b/ethpm/validation/manifest.py
@@ -20,13 +20,11 @@ from jsonschema.validators import (
 )
 
 from ethpm import (
-    ETHPM_SPEC_DIR,
+    get_ethpm_spec_dir,
 )
 from ethpm.exceptions import (
     EthPMValidationError,
 )
-
-V3_SCHEMA_PATH = ETHPM_SPEC_DIR / "spec" / "v3.spec.json"
 
 META_FIELDS = {
     "license": str,
@@ -62,7 +60,9 @@ def validate_meta_object(meta: Dict[str, Any], allow_extra_meta_fields: bool) ->
 
 
 def _load_schema_data() -> Dict[str, Any]:
-    return json.loads(V3_SCHEMA_PATH.read_text())
+    ethpm_spec_dir = get_ethpm_spec_dir()
+    v3_schema_path = ethpm_spec_dir / "spec" / "v3.spec.json"
+    return json.loads(v3_schema_path.read_text())
 
 
 def extract_contract_types_from_deployments(deployment_data: List[Any]) -> Set[str]:
@@ -77,7 +77,7 @@ def extract_contract_types_from_deployments(deployment_data: List[Any]) -> Set[s
 def validate_manifest_against_schema(manifest: Dict[str, Any]) -> None:
     """
     Load and validate manifest against schema
-    located at V3_SCHEMA_PATH.
+    located at v3_schema_path.
     """
     schema_data = _load_schema_data()
     try:

--- a/newsfragments/1682.bugfix.rst
+++ b/newsfragments/1682.bugfix.rst
@@ -1,0 +1,1 @@
+Support ethpm-spec submodule in distributions.

--- a/tests/core/tools/pytest_ethereum/conftest.py
+++ b/tests/core/tools/pytest_ethereum/conftest.py
@@ -4,7 +4,7 @@ from pathlib import (
 import pytest
 
 from ethpm import (
-    ETHPM_SPEC_DIR,
+    get_ethpm_spec_dir,
 )
 from web3 import Web3
 
@@ -22,6 +22,11 @@ def w3():
 
 
 @pytest.fixture
-def escrow_deployer(deployer):
-    escrow_manifest_path = ETHPM_SPEC_DIR / "examples" / "escrow" / "v3.json"
+def ethpm_spec_dir():
+    return get_ethpm_spec_dir()
+
+
+@pytest.fixture
+def escrow_deployer(deployer, ethpm_spec_dir):
+    escrow_manifest_path = ethpm_spec_dir / "examples" / "escrow" / "v3.json"
     return deployer(escrow_manifest_path)

--- a/tests/core/tools/pytest_ethereum/test_deployer.py
+++ b/tests/core/tools/pytest_ethereum/test_deployer.py
@@ -7,7 +7,6 @@ from eth_utils import (
 
 from ethpm import (
     ASSETS_DIR,
-    ETHPM_SPEC_DIR,
 )
 import web3
 from web3.tools.pytest_ethereum.exceptions import (
@@ -68,8 +67,8 @@ def test_standard_token_deployer(standard_token):
 
 # LIBRARY
 @pytest.fixture
-def safe_math(deployer):
-    safe_math_manifest_path = ETHPM_SPEC_DIR / "examples" / "safe-math-lib" / "v3.json"
+def safe_math(deployer, ethpm_spec_dir):
+    safe_math_manifest_path = ethpm_spec_dir / "examples" / "safe-math-lib" / "v3.json"
     safe_math_deployer = deployer(safe_math_manifest_path)
     return safe_math_deployer.deploy("SafeMathLib")
 

--- a/tests/ethpm/conftest.py
+++ b/tests/ethpm/conftest.py
@@ -7,8 +7,8 @@ from eth_utils.toolz import (
 
 from ethpm import (
     ASSETS_DIR,
-    ETHPM_SPEC_DIR,
     Package,
+    get_ethpm_spec_dir,
 )
 from ethpm._utils.chains import (
     create_block_uri,
@@ -40,6 +40,11 @@ def pytest_addoption(parser):
     parser.addoption("--integration", action="store_true", default=False)
 
 
+@pytest.fixture
+def ethpm_spec_dir():
+    return get_ethpm_spec_dir()
+
+
 @pytest.fixture(params=V3_PACKAGE_NAMES)
 def all_strict_manifests(request):
     return (
@@ -63,7 +68,8 @@ def fetch_manifest(name, version):
 
 
 def fetch_manifest_path(name, version):
-    return ETHPM_SPEC_DIR / 'examples' / name / version
+    ethpm_spec_dir = get_ethpm_spec_dir()
+    return ethpm_spec_dir / 'examples' / name / version
 
 
 MANIFESTS_V3 = {name: fetch_manifest(name, version) for name, version in V3_PACKAGE_NAMES}
@@ -138,8 +144,8 @@ def get_factory(get_manifest, escrow_manifest, w3):
 
 
 @pytest.fixture
-def owned_contract():
-    return (ETHPM_SPEC_DIR / "examples" / "owned" / "contracts" / "Owned.sol").read_text()
+def owned_contract(ethpm_spec_dir):
+    return (ethpm_spec_dir / "examples" / "owned" / "contracts" / "Owned.sol").read_text()
 
 
 @pytest.fixture
@@ -163,8 +169,8 @@ def manifest_with_empty_deployments(tmpdir, safe_math_manifest):
 
 
 @pytest.fixture
-def escrow_package(deployer, w3):
-    escrow_manifest = ETHPM_SPEC_DIR / "examples" / "escrow" / "v3.json"
+def escrow_package(deployer, w3, ethpm_spec_dir):
+    escrow_manifest = ethpm_spec_dir / "examples" / "escrow" / "v3.json"
     escrow_deployer = deployer(escrow_manifest)
     escrow_strategy = l.linker(
         l.deploy("SafeSendLib"),

--- a/tests/ethpm/tools/test_builder.py
+++ b/tests/ethpm/tools/test_builder.py
@@ -14,7 +14,6 @@ from eth_utils.toolz import (
 
 from ethpm import (
     ASSETS_DIR,
-    ETHPM_SPEC_DIR,
     Package,
 )
 from ethpm.backends.ipfs import (
@@ -62,14 +61,14 @@ BASE_MANIFEST = {"name": "package", "manifest": "ethpm/3", "version": "1.0.0"}
 
 
 @pytest.fixture
-def owned_package():
+def owned_package(ethpm_spec_dir):
     manifest = get_ethpm_spec_manifest("owned", "v3.json")
     # source_id missing `./` prefix in ethpm-spec ("Owned.sol"/"./Owned.sol" though both are valid)
     source_obj = manifest['sources'].pop('Owned.sol')
     updated_manifest = assoc_in(manifest, ['sources', './Owned.sol'], source_obj)
 
     compiler = get_ethpm_local_manifest("owned", "output_v3.json")["contracts"]
-    contracts_dir = ETHPM_SPEC_DIR / "examples" / "owned" / "contracts"
+    contracts_dir = ethpm_spec_dir / "examples" / "owned" / "contracts"
     return contracts_dir, updated_manifest, compiler
 
 
@@ -77,8 +76,8 @@ def owned_package():
 
 
 @pytest.fixture
-def standard_token_package():
-    standard_token_dir = ETHPM_SPEC_DIR / "examples" / "standard-token"
+def standard_token_package(ethpm_spec_dir):
+    standard_token_dir = ethpm_spec_dir / "examples" / "standard-token"
     manifest = get_ethpm_spec_manifest("standard-token", "v3.json")
     compiler = get_ethpm_local_manifest("standard-token", "output_v3.json")["contracts"]
     contracts_dir = standard_token_dir / "contracts"
@@ -701,8 +700,8 @@ def test_builder_deployment_simple(w3):
 
 
 @pytest.fixture
-def escrow_package(w3, deployer):
-    manifest = ETHPM_SPEC_DIR / "examples" / "escrow" / "v3.json"
+def escrow_package(w3, deployer, ethpm_spec_dir):
+    manifest = ethpm_spec_dir / "examples" / "escrow" / "v3.json"
     escrow_deployer = deployer(manifest)
     escrow_strategy = linker(
         deploy("SafeSendLib"),


### PR DESCRIPTION
### What was wrong?
For developer setup / to run the `ethpm` tests successfully, developers will have to initialize the `ethpm-spec/` submodule.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/87094534-ab6e1f00-c204-11ea-8e29-69a842c925f4.png)
