### PR TITLE
Include ethpm example solidity files in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,5 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include ethpm/assets/ *
-recursive-include ethpm/ethpm-spec/examples *.json
-recursive-include ethpm/ethpm-spec/spec *.json
+recursive-include ethpm/ethpm-spec/examples *
+recursive-include ethpm/ethpm-spec/spec *

--- a/newsfragments/1686.bugfix.rst
+++ b/newsfragments/1686.bugfix.rst
@@ -1,0 +1,1 @@
+Include ethpm-spec solidity examples in distribution.


### PR DESCRIPTION
### What was wrong?
Ethpm example solidity contracts were not included in distribution. 

### How was it fixed?
Added `ethpm/examples *.sol` to `MANIFEST.in`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/87479151-958ba000-c5f0-11ea-82d4-e5cde1b8debe.png)
