### PR TITLE
Unbundle release notes generation from release command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,17 +50,24 @@ validate-docs: build-docs
 linux-docs: build-docs
 	readlink -f docs/_build/html/index.html
 
-release: clean
-	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
-	git config commit.gpgSign true
+notes:
 	# Let UPCOMING_VERSION be the version that is used for the current bump
 	$(eval UPCOMING_VERSION=$(shell bumpversion $(bump) --dry-run --list | grep new_version= | sed 's/new_version=//g'))
 	# Now generate the release notes to have them included in the release commit
 	towncrier --yes --version $(UPCOMING_VERSION)
-	# We need --allow-dirty because of the generated release_notes file but it is safe because the
-	# previous dry-run runs *without* --allow-dirty which ensures it's really just the release notes
-	# file that we are allowing to sit here dirty, waiting to get included in the release commit.
-	bumpversion --allow-dirty $(bump)
+	# Before we bump the version, make sure that the towncrier-generated docs will build
+	make build-docs
+	git commit -m "Compile release notes"
+
+release: clean
+	# require that you be on a branch that's linked to upstream/master
+	git status -s -b | head -1 | grep "\.\.upstream/master"
+	./newsfragments/validate_files.py is-empty
+	# verify that docs build correctly
+	make build-docs
+	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
+	git config commit.gpgSign true
+	bumpversion $(bump)
 	git push upstream && git push upstream --tags
 	python setup.py sdist bdist_wheel
 	twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -156,21 +156,30 @@ $ ipython
 >>> from web3.auto import w3
 >>> w3.isConnected()
 >>> ...
-
-# Preview the upcoming release notes
-$ towncrier --draft
 ```
 
-To release a new version:
+To preview the upcoming documentation:
 
 ```sh
-make release bump=$$VERSION_PART_TO_BUMP$$
+make docs
 ```
 
 To preview the upcoming release notes:
 
 ```sh
 towncrier --draft
+```
+
+To compile and commit the release notes:
+
+```sh
+make notes
+```
+
+When the release notes are ready, release a new version:
+
+```sh
+make release bump=$$VERSION_PART_TO_BUMP$$
 ```
 
 #### How to bumpversion

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ towncrier --draft
 To compile and commit the release notes:
 
 ```sh
-make notes
+make notes bump=$$VERSION_PART_TO_BUMP$$
 ```
 
 When the release notes are ready, release a new version:

--- a/newsfragments/1687.misc.rst
+++ b/newsfragments/1687.misc.rst
@@ -1,0 +1,1 @@
+Unbundle the generation of release notes from the publish script.


### PR DESCRIPTION
### What was wrong?
The `make release` command compiles and publishes release notes as part of the process. Being able to manually update the auto-generated notes before releasing is useful in the case of moving from `beta` to `stable`, for example.

### How was it fixed?
Borrows the scripts from Trinity's [Makefile](https://github.com/ethereum/trinity/blob/master/Makefile#L63-L84).

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://cdn.suwalls.com/wallpapers/animals/sailor-golden-retriever-50601-1920x1200.jpg)
