### PR TITLE
Requesting to Add QuikNode as a Web3 Provider in web3.py Documentation.

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -182,6 +182,27 @@ an optional secret key, set the environment variable ``WEB3_INFURA_API_SECRET``:
     # confirm that the connection succeeded
     >>> w3.isConnected()
     True
+    
+QuikNode
+~~~~~~~~~~~~~~
+
+To get your QuikNode Mainnet endpoint for free, log on to https://www.quiknode.io/ .
+
+Then set the environment variable ``QuikNode_Node_URL`` with your Node URL::
+
+    $ export QuikNode_Node_URL=yourNodeURL
+    
+The network can be selected while making a new node and the Node URL will be generated
+according to the selection, below is for Mainnet:
+
+.. code-block:: python
+
+    >>> from web3.auto.QuikNode import w3
+
+    # confirm if connected
+    >>> w3.isConnected()
+    True
+    # network ID must be added if Network other then Mainnetlike '3' for Ropsten, '4' for Rinkeby etc
 
 Geth dev Proof of Authority
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -13,7 +13,7 @@ Local Node
   When you run ``geth`` or ``parity`` on your machine, you are running a local node.
 
 Hosted Node
-  A hosted node is controlled by someone else. When you connect to Infura, you are
+  A hosted node is controlled by someone else. When you connect providers like Infura, QuikNode, etc you are
   connected to a hosted node.
 
 Local vs Hosted Keys

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -13,7 +13,7 @@ Local Node
   When you run ``geth`` or ``parity`` on your machine, you are running a local node.
 
 Hosted Node
-  A hosted node is controlled by someone else. When you connect providers like Infura, QuikNode, etc you are
+  A hosted node is controlled by someone else. When you connect to providers like Infura, QuikNode, etc you are
   connected to a hosted node.
 
 Local vs Hosted Keys

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -1,21 +1,9 @@
 import importlib
-import logging
 import os
 import pytest
 
 from eth_utils import (
     ValidationError,
-)
-
-from web3.auto import   (
-    QuikNode,
-)
-
-from web3.auto.QuikNode import  (
-    kovan,
-    mainnet,
-    rinkeby,
-    ropsten,
 )
 
 from web3.exceptions import (
@@ -136,36 +124,6 @@ def test_web3_auto_infura_raises_error_with_nonexistent_scheme(monkeypatch):
     error_msg = "Cannot connect to Infura with scheme 'not-a-scheme'"
     with pytest.raises(ValidationError, match=error_msg):
         importlib.reload(infura)
-        
-def test_web3_auto_QuikNode_wrong_url(monkeypatch, caplog):
-    importlib.reload(QuikNode)
-    assert len(caplog.record_tuples) == 1
-    logger, level, msg = caplog.record_tuples[0]
-    assert 'QuikNode_Node_URL' in msg
-    assert level == logging.ERROR
-
-
-@pytest.mark.parametrize(
-    'network', [
-        (kovan, 'kovan'),
-        (mainnet, 'mainnet'),
-        (rinkeby, 'rinkeby'),
-        (ropsten, 'ropsten')
-    ])
-def test_web3_auto_QuikNode_different_networks(monkeypatch, network):
-
-    network_module = network[0]
-    network_name = network[1]
-    API_KEY = 'ns_python'
-    monkeypatch.setenv('QuikNode_Node_URL', API_KEY)
-    expected_url = 'https://%s.quiknode.pro/%s/' % \
-                   (network_name, API_KEY)
-
-    importlib.reload(network_module)
-
-    w3 = network_module.w3
-    assert isinstance(w3.provider, HTTPProvider)
-    assert getattr(w3.provider, 'endpoint_uri') == expected_url
 
 
 @pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])

--- a/web3/auto/QuikNode/__init__.py
+++ b/web3/auto/QuikNode/__init__.py
@@ -1,0 +1,13 @@
+from web3 import Web3
+from web3.providers.auto import (
+  load_provider_from_uri,
+)
+
+from .endpoints import(
+  build_QuikNode_url,
+)
+
+#By default, connect to mainnet endpoint
+_QuikNode_url = build_QuikNode_url("mainnet")
+
+w3 = Web3(load_provider_from_uri(_QuikNode_url))

--- a/web3/auto/QuikNode/endpoints.py
+++ b/web3/auto/QuikNode/endpoints.py
@@ -1,0 +1,19 @@
+import logging
+import os
+
+QuikNode_URL_format = 'https://%s.quiknode.pro/%s/'
+
+def check_endpoint_URL():
+  key = os.environ.get('QuikNode_Node_URL','')
+  if key == '':
+    logging.getLogger('web3.auto.QuikNode').error(
+      "Your node's URL is wrong or invalid. Add environment variable QuikNode_Node_URL"
+      "with your endpoint URL. Get a free QuikNode endpoint at https://quiknode.io/"
+    )
+  return key
+  
+  
+  def build_QuikNode_url(network):
+    key = check_endpoint_URL()
+    url = QuikNode_URL_format % (network, key)
+    return url

--- a/web3/auto/QuikNode/kovan.py
+++ b/web3/auto/QuikNode/kovan.py
@@ -1,0 +1,12 @@
+from web3 import Web3
+from web3.providers.auto import(
+  load_provider_from_uri,
+)
+
+from .endpoints import(
+  build_QuikNode_url,
+)
+
+_QuikNode_url = build_QuikNode_url("kovan")
+
+w3 = Web3(load_provider_from_uri(_QuikNode_url))

--- a/web3/auto/QuikNode/mainnet.py
+++ b/web3/auto/QuikNode/mainnet.py
@@ -1,0 +1,12 @@
+from web3 import Web3
+from web3.providers.auto import (
+  load_provider_from_uri,
+)
+
+from .endpoints import(
+  build_Quiknode_url,
+)
+
+_QuikNode_url = build_QuikNode_url("mainnet")
+
+w3 = Web3(load_provider_from_uri(_QuikNode_url))

--- a/web3/auto/QuikNode/rinkeby.py
+++ b/web3/auto/QuikNode/rinkeby.py
@@ -1,0 +1,17 @@
+from web3 import Web3
+from web3.middleware import (
+  geth_poa_middleware,
+)
+
+from web3.providers.auto import(
+  load_provider_from_uri,
+)
+
+from .endpoints import  (
+  build_QuikNode_url,
+)
+
+_QuikNode_url = build_QuikNode_url("rinkeby")
+
+w3 = Web3(load_provider_from_uri(_QuikNode_url))
+w3.middleware_onion.inject(geth-poa_middleware, layer=0)

--- a/web3/auto/QuikNode/ropsten.py
+++ b/web3/auto/QuikNode/ropsten.py
@@ -1,0 +1,12 @@
+from web3 import Web3
+from web3.providers.auto import (
+  load_provider_from_uri,
+)
+
+from .endpoints import  (
+  build_QuikNode_url,
+)
+
+_QuikNode_url = build_QuikNode_url("ropsten")
+
+w3 = Web3(load_provider_from_uri(_QuikNode_url))


### PR DESCRIPTION
### What was wrong?

A lot of our users use web3.py as their backend library for dApp development, So we're trying to add [QuikNode](https://www.quiknode.io/)  as a web3 provider, QuikNode Provides nodes as a service as well as API plans.

Related to Issue #

### How was it fixed?

Added QuikNode as a web3 provider in docs.

### Todo:
- [] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ibb.co/zfXMHHx/daniel-lincoln-UNGYOAr0w5k-unsplash.jpg)
