### PR TITLE
Requesting to Add QuikNode as a Web3 Provider in web3.py Documentation.

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -182,6 +182,25 @@ an optional secret key, set the environment variable ``WEB3_INFURA_API_SECRET``:
     # confirm that the connection succeeded
     >>> w3.isConnected()
     True
+    
+QuikNode
+~~~~~~~~~~~~~~
+
+To get your QuikNode Mainnet endpoint for free, log on to https://www.quiknode.io/ .
+
+Then set the environment variable ``QuikNode_Node_URL`` with your Node URL::
+
+    $ export QuikNode_Node_URL=yourNodeURL
+    
+The network can be selected while making a new node and the Node URL will be generated
+according to the selection, below is for Mainnet:
+
+.. code-block:: python
+    >>> from web3.auto.QuikNode import w3
+    # confirm if connected
+    >>> w3.isConnected()
+    True
+    # network ID must be added if Network other then Mainnetlike '3' for Ropsten, '4' for Rinkeby etc
 
 Geth dev Proof of Authority
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -13,7 +13,7 @@ Local Node
   When you run ``geth`` or ``parity`` on your machine, you are running a local node.
 
 Hosted Node
-  A hosted node is controlled by someone else. When you connect to Infura, you are
+  A hosted node is controlled by someone else. When you connect to providers like Infura, QuikNode, etc you are
   connected to a hosted node.
 
 Local vs Hosted Keys


### PR DESCRIPTION
### What was wrong?
A lot of our users use web3.py as their backend library for dApp development, So we're trying to add [QuikNode](https://quiknode.io) as a web3 provider, QuikNode Provides nodes as a service as well as API plans.

Related to Issue #1688 

### How was it fixed?
Added QuikNode as a web3 provider in docs.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ibb.co/zfXMHHx/daniel-lincoln-UNGYOAr0w5k-unsplash.jpg)
