### PR TITLE
adopt trinity's newsfragment validation

### DIFF
--- a/newsfragments/1690.misc.rst
+++ b/newsfragments/1690.misc.rst
@@ -1,0 +1,1 @@
+Adopt Trinity's newsfragment validation script.

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -12,6 +12,7 @@ ALLOWED_EXTENSIONS = {
     '.doc.rst',
     '.feature.rst',
     '.misc.rst',
+    '.removal.rst',
 }
 
 ALLOWED_FILES = {

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -5,12 +5,12 @@
 
 import os
 import pathlib
+import sys
 
 ALLOWED_EXTENSIONS = {
-    '.feature.rst',
     '.bugfix.rst',
     '.doc.rst',
-    '.removal.rst',
+    '.feature.rst',
     '.misc.rst',
 }
 
@@ -21,11 +21,20 @@ ALLOWED_FILES = {
 
 THIS_DIR = pathlib.Path(__file__).parent
 
+num_args = len(sys.argv) - 1
+assert num_args in {0, 1}
+if num_args == 1:
+    assert sys.argv[1] in ('is-empty', )
+
 for fragment_file in THIS_DIR.iterdir():
 
     if fragment_file.name in ALLOWED_FILES:
         continue
-
-    full_extension = "".join(fragment_file.suffixes)
-    if full_extension not in ALLOWED_EXTENSIONS:
+    elif num_args == 0:
+        full_extension = "".join(fragment_file.suffixes)
+        if full_extension not in ALLOWED_EXTENSIONS:
+            raise Exception(f"Unexpected file: {fragment_file}")
+    elif sys.argv[1] == 'is-empty':
         raise Exception(f"Unexpected file: {fragment_file}")
+    else:
+        raise RuntimeError("Strange: arguments {sys.argv} were validated, but not found")


### PR DESCRIPTION
### What was wrong?
Updated the `make docs` and `make release` commands to line up with Trinity's, but didn't realize the `/newsfragments/validate_files.py` file also diverged. 

`./newsfragments/validate_files.py is-empty` is called in the `make release` command, but the `is-empty` arg goes unhandled in web3 at the moment.

### How was it fixed?
Borrowed Trinity's `validate_files.py`. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.pinimg.com/originals/b7/ab/73/b7ab7389ae6dfa9cbf4a53fd7f6986c7.jpg)
