### PR TITLE
Add quik node as web3 provider in docs

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -161,6 +161,10 @@ To setup QuikNode, then set the following environment variable::
 
     $ export WEB3_PROVIDER_URI=https://young-early-dawn.quiknode.pro/<your-token-here>/
     
+Now, let's check if this actaully worked, first we'll import the web3 instance(we'll add
+.auto as we already supplied the node URL to the environment variable) and then check if we're
+connected to the node or not
+    
 .. code-block:: python
 
     >>> from web3.auto import w3

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -161,9 +161,7 @@ To setup QuikNode, then set the following environment variable::
 
     $ export WEB3_PROVIDER_URI=https://young-early-dawn.quiknode.pro/<your-token-here>/
     
-Now, let's check if this actaully worked, first we'll import the web3 instance(we'll add
-.auto as we already supplied the node URL to the environment variable) and then check if we're
-connected to the node or not
+By doing the above step we are now able to take advantage of web3.py's auto-initialization.
     
 .. code-block:: python
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -152,6 +152,22 @@ Valid formats for this environment variable are:
 - ``https://node.ontheweb.com``
 - ``ws://127.0.0.1:8546``
 
+QuikNode
+~~~~~~~~~~~~~~
+
+If you want to use QuikNode, grab a free Node URL from https://quiknode.io.
+
+To setup QuikNode, then set the following environment variable::
+
+    $ export WEB3_PROVIDER_URI=https://young-early-dawn.quiknode.pro/<your-token-here>/
+    
+.. code-block:: python
+
+    >>> from web3.auto import w3
+
+    # confirm that the connection succeeded
+    >>> w3.isConnected()
+    True
 
 .. _custom_auto_providers:
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -152,6 +152,13 @@ Valid formats for this environment variable are:
 - ``https://node.ontheweb.com``
 - ``ws://127.0.0.1:8546``
 
+.. _custom_auto_providers:
+
+Auto-initialization Provider Shortcuts
+--------------------------------------
+
+There are a couple auto-initialization shortcuts for common providers.
+
 QuikNode
 ~~~~~~~~~~~~~~
 
@@ -171,12 +178,6 @@ By doing the above step we are now able to take advantage of web3.py's auto-init
     >>> w3.isConnected()
     True
 
-.. _custom_auto_providers:
-
-Auto-initialization Provider Shortcuts
---------------------------------------
-
-There are a couple auto-initialization shortcuts for common providers.
 
 Infura Mainnet
 ~~~~~~~~~~~~~~
@@ -200,6 +201,7 @@ an optional secret key, set the environment variable ``WEB3_INFURA_API_SECRET``:
     # confirm that the connection succeeded
     >>> w3.isConnected()
     True
+  
 
 Geth dev Proof of Authority
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
### What was wrong?
QuikNode provides ETH nodes, which allows users to connect to blockchain in a hassle free manner(eliminating a need to host a node locally).

### How was it fixed?
Added QuikNode Support in the docs

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![slothsarefar](https://user-images.githubusercontent.com/41318044/88125729-88bd0c80-cbed-11ea-95a8-fc786c6bdffd.jpg)

