### PR TITLE
bump eth-utils version

### DIFF
--- a/newsfragments/1715.misc.rst
+++ b/newsfragments/1715.misc.rst
@@ -1,0 +1,1 @@
+Bump the minimum version of eth-utils to 1.9.3

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "eth-account>=0.5.2,<0.6.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",
-        "eth-utils>=1.8.4,<1.9.1",
+        "eth-utils>=1.9.3,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "ipfshttpclient>=0.4.13,<1",
         "jsonschema>=3.2.0,<4.0.0",

--- a/web3/_utils/formatters.py
+++ b/web3/_utils/formatters.py
@@ -21,7 +21,7 @@ from eth_utils import (
     to_dict,
     to_list,
 )
-from eth_utils.curried import (
+from eth_utils.curried import (  # type: ignore
     apply_formatter_at_index,
 )
 from eth_utils.toolz import (

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -9,7 +9,7 @@ from typing import (
     Union,
 )
 
-from eth_utils.curried import (
+from eth_utils.curried import (  # type: ignore
     apply_formatter_at_index,
     apply_formatter_if,
     apply_formatter_to_array,

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -13,7 +13,7 @@ from eth_typing import (
 from eth_utils import (
     to_dict,
 )
-from eth_utils.curried import (
+from eth_utils.curried import (  # type: ignore
     apply_formatter_at_index,
 )
 from eth_utils.toolz import (

--- a/web3/_utils/validation.py
+++ b/web3/_utils/validation.py
@@ -21,7 +21,7 @@ from eth_utils import (
     is_list_like,
     is_string,
 )
-from eth_utils.curried import (
+from eth_utils.curried import (  # type: ignore
     apply_formatter_to_array,
 )
 from eth_utils.hexadecimal import (

--- a/web3/method.py
+++ b/web3/method.py
@@ -15,7 +15,7 @@ from typing import (
 )
 import warnings
 
-from eth_utils.curried import (
+from eth_utils.curried import (  # type: ignore
     to_tuple,
 )
 from eth_utils.toolz import (

--- a/web3/middleware/geth_poa.py
+++ b/web3/middleware/geth_poa.py
@@ -1,4 +1,4 @@
-from eth_utils.curried import (
+from eth_utils.curried import (  # type: ignore
     apply_formatters_to_dict,
     apply_key_map,
 )

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -4,7 +4,7 @@ from typing import (
     Callable,
 )
 
-from eth_utils.curried import (
+from eth_utils.curried import (  # type: ignore
     apply_formatter_at_index,
     apply_formatter_if,
     apply_formatters_to_dict,

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -13,7 +13,7 @@ from eth_utils import (
     is_hex,
     is_string,
 )
-from eth_utils.curried import (
+from eth_utils.curried import (  # type: ignore
     apply_formatter_if,
     apply_formatters_to_dict,
 )


### PR DESCRIPTION
### What was wrong?

In order to parse revert messages triggered within eth-tester, the latest version of eth-utils is required. Without it, error messages are swallowed.

The ignored type linting on curried methods is due to a recent type issue in eth-utils. Borrowed Trinity's strategy for now: https://github.com/ethereum/trinity/issues/1982.

Related to PR: https://github.com/ethereum/web3.py/pull/1585

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="446" alt="Screen Shot 2020-08-24 at 11 18 24 AM" src="https://user-images.githubusercontent.com/3621728/91075582-8c342100-e5fb-11ea-9004-28d1a07f839b.png">
)
