### PR TITLE
Upgrade eth-utils to >=1.9.5

### DIFF
--- a/newsfragments/1722.misc.rst
+++ b/newsfragments/1722.misc.rst
@@ -1,0 +1,1 @@
+Upgrade eth-utils requirement to >= 1.9.5

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "eth-account>=0.5.3,<0.6.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",
-        "eth-utils>=1.9.3,<2.0.0",
+        "eth-utils>=1.9.5,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "ipfshttpclient>=0.4.13,<1",
         "jsonschema>=3.2.0,<4.0.0",


### PR DESCRIPTION
### What was wrong?
eth-utils needed to be updated again to keep the dependency tree happy across projects. 

### How was it fixed?
Added missing overloaded types to eth_utils curried module

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="382" alt="image" src="https://user-images.githubusercontent.com/6540608/91620413-20302080-e94d-11ea-9c2b-2173959ed898.png">

