### PR TITLE
Eth to method part 1

### DIFF
--- a/newsfragments/1728.misc.rst
+++ b/newsfragments/1728.misc.rst
@@ -1,0 +1,21 @@
+Move Eth module methods to use ``Method`` class:
+- protocolVersion,
+- syncing,
+- coinbase,
+- mining,
+- hashrate,
+- gasPrice,
+- accounts,
+- blockNumber,
+- chainId,
+- getStorageAt,
+- getProof,
+- getTransactionCount,
+- sendRawTransaction,
+- sign,
+- signTransaction,
+- signTypedData,
+- submitHashrate,
+- submitWork,
+- uninstallFilter
+- getWork

--- a/tests/core/contracts/test_contract_init.py
+++ b/tests/core/contracts/test_contract_init.py
@@ -61,12 +61,12 @@ def test_contract_with_name_address_changing(MathContract, math_addr):
     caller = mc.web3.eth.coinbase
     assert mc.address == 'thedao.eth'
 
-    # what happen when name returns no address at all
+    # what happens when name returns no address at all
     with contract_ens_addresses(mc, []):
         with pytest.raises(NameNotFound):
             mc.functions.return13().call({'from': caller})
 
-    # what happen when name returns address to different contract
+    # what happens when name returns address to different contract
     with contract_ens_addresses(mc, [('thedao.eth', '0x' + '11' * 20)]):
         with pytest.raises(BadFunctionCallOutput):
             mc.functions.return13().call({'from': caller})

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -17,6 +17,7 @@ from eth_utils.curried import (
     apply_formatters_to_dict,
     apply_formatters_to_sequence,
     apply_one_of_formatters,
+    is_0x_prefixed,
     is_address,
     is_bytes,
     is_dict,
@@ -425,8 +426,8 @@ PYTHONIC_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getUncleCountByBlockNumber: to_integer_if_hex,
     RPC.eth_hashrate: to_integer_if_hex,
     RPC.eth_protocolVersion: compose(
+        apply_formatter_if(is_0x_prefixed, to_integer_if_hex),
         apply_formatter_if(is_integer, str),
-        to_integer_if_hex,
     ),
     RPC.eth_sendRawTransaction: to_hexbytes(32),
     RPC.eth_sendTransaction: to_hexbytes(32),
@@ -488,7 +489,7 @@ def get_request_formatters(
     request_formatter_maps = (
         METHOD_NORMALIZERS,
         PYTHONIC_REQUEST_FORMATTERS,
-        ABI_REQUEST_FORMATTERS
+        ABI_REQUEST_FORMATTERS,
     )
     formatters = combine_formatters(request_formatter_maps, method_name)
     return compose(*formatters)

--- a/web3/method.py
+++ b/web3/method.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
         ModuleV2,
     )
 
-Munger = Callable[[Union["Module", "ModuleV2"], Any], Any]
+Munger = Callable[..., Any]
 
 
 @to_tuple
@@ -160,7 +160,7 @@ class Method(Generic[TFunc]):
         mungers_iter = iter(self.mungers)
         root_munger = next(mungers_iter)
         munged_inputs = pipe(
-            root_munger(module, *args, **kwargs),  # type: ignore
+            root_munger(module, *args, **kwargs),
             *map(lambda m: _munger_star_apply(functools.partial(m, module)), mungers_iter))
 
         return munged_inputs

--- a/web3/module.py
+++ b/web3/module.py
@@ -99,3 +99,4 @@ class ModuleV2(Module):
             self.retrieve_caller_fn = retrieve_async_method_call_fn(web3, self)
         else:
             self.retrieve_caller_fn = retrieve_blocking_method_call_fn(web3, self)
+        self.web3 = web3


### PR DESCRIPTION
### What was wrong?
The Eth module needs to be moved to use `Method`. These are the "easy" methods that don't require many changes to keep the tests passing. 

Related to Issue #1568

### How was it fixed?
Updated eth.py to use `Method` for selected methods.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Manually run through and test
- [x] Squash commits

#### Cute Animal Picture

<img width="242" alt="image" src="https://user-images.githubusercontent.com/6540608/92290420-3d2a9d80-eed1-11ea-93f2-3470e66e4bff.png">

