### PR TITLE
Eth to method 4

### DIFF
--- a/newsfragments/1741.misc.rst
+++ b/newsfragments/1741.misc.rst
@@ -1,0 +1,9 @@
+A few new methods use the Method class:
+- RPC.eth_getBlockByNumber
+- RPC.eth_getBlockTransactionCountByHash
+- RPC.eth_getBlockTransactionCountByNumber
+- RPC.eth_getUncleCountByBlockHash
+- RPC.eth_getUncleCountByBlockNumber
+- RPC.eth_getUncleByBlockHashAndIndex
+- RPC.eth_getUncleByBlockNumberAndIndex
+- RPC.eth_getTransactionByHash

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -92,6 +92,7 @@ def bytes_to_ascii(value: bytes) -> str:
 to_ascii_if_bytes = apply_formatter_if(is_bytes, bytes_to_ascii)
 to_integer_if_hex = apply_formatter_if(is_string, hex_to_integer)
 block_number_formatter = apply_formatter_if(is_integer, integer_to_hex)
+to_hex_if_integer = apply_formatter_if(is_integer, integer_to_hex)
 
 
 is_false = partial(operator.is_, False)
@@ -365,7 +366,7 @@ PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getUncleCountByBlockNumber: apply_formatter_at_index(block_number_formatter, 0),
     RPC.eth_getUncleByBlockNumberAndIndex: compose(
         apply_formatter_at_index(block_number_formatter, 0),
-        apply_formatter_at_index(block_number_formatter, 1),
+        apply_formatter_at_index(to_hex_if_integer, 1),
     ),
     RPC.eth_getUncleByBlockHashAndIndex: apply_formatter_at_index(integer_to_hex, 1),
     RPC.eth_newFilter: apply_formatter_at_index(filter_params_formatter, 0),

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -506,8 +506,10 @@ def raise_block_not_found(params: Tuple[BlockIdentifier, bool]) -> NoReturn:
 
 
 NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
-    RPC.eth_getBlockByNumber: raise_block_not_found,
     RPC.eth_getBlockByHash: raise_block_not_found,
+    RPC.eth_getBlockByNumber: raise_block_not_found,
+    RPC.eth_getBlockTransactionCountByHash: raise_block_not_found,
+    RPC.eth_getBlockTransactionCountByNumber: raise_block_not_found,
 }
 
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -75,11 +75,13 @@ from web3.datastructures import (
 )
 from web3.exceptions import (
     BlockNotFound,
+    TransactionNotFound,
 )
 from web3.types import (
     BlockIdentifier,
     RPCEndpoint,
     TReturn,
+    _Hash32,
 )
 
 
@@ -518,6 +520,11 @@ def raise_block_not_found_for_uncle_at_index(
     )
 
 
+def raise_transaction_not_found(params: Tuple[_Hash32]) -> NoReturn:
+    transaction_hash = params[0]
+    raise TransactionNotFound(f"Transaction with hash: {transaction_hash} not found.")
+
+
 NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getBlockByHash: raise_block_not_found,
     RPC.eth_getBlockByNumber: raise_block_not_found,
@@ -527,6 +534,7 @@ NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getUncleCountByBlockNumber: raise_block_not_found,
     RPC.eth_getUncleByBlockHashAndIndex: raise_block_not_found_for_uncle_at_index,
     RPC.eth_getUncleByBlockNumberAndIndex: raise_block_not_found_for_uncle_at_index,
+    RPC.eth_getTransactionByHash: raise_transaction_not_found,
 }
 
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -11,6 +11,9 @@ from typing import (
     Union,
 )
 
+from eth_typing import (
+    HexStr,
+)
 from eth_utils.curried import (
     apply_formatter_at_index,
     apply_formatter_if,
@@ -360,7 +363,7 @@ PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getUncleCountByBlockNumber: apply_formatter_at_index(block_number_formatter, 0),
     RPC.eth_getUncleByBlockNumberAndIndex: compose(
         apply_formatter_at_index(block_number_formatter, 0),
-        apply_formatter_at_index(integer_to_hex, 1),
+        apply_formatter_at_index(block_number_formatter, 1),
     ),
     RPC.eth_getUncleByBlockHashAndIndex: apply_formatter_at_index(integer_to_hex, 1),
     RPC.eth_newFilter: apply_formatter_at_index(filter_params_formatter, 0),
@@ -505,6 +508,16 @@ def raise_block_not_found(params: Tuple[BlockIdentifier, bool]) -> NoReturn:
     raise BlockNotFound(f"Block with id: {block_identifier} not found.")
 
 
+def raise_block_not_found_for_uncle_at_index(
+    params: Tuple[BlockIdentifier, Union[HexStr, int]]
+) -> NoReturn:
+    block_identifier = params[0]
+    uncle_index = to_integer_if_hex(params[1])
+    raise BlockNotFound(
+        f"Uncle at index: {uncle_index} of block with id: {block_identifier} not found."
+    )
+
+
 NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getBlockByHash: raise_block_not_found,
     RPC.eth_getBlockByNumber: raise_block_not_found,
@@ -512,6 +525,8 @@ NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getBlockTransactionCountByNumber: raise_block_not_found,
     RPC.eth_getUncleCountByBlockHash: raise_block_not_found,
     RPC.eth_getUncleCountByBlockNumber: raise_block_not_found,
+    RPC.eth_getUncleByBlockHashAndIndex: raise_block_not_found_for_uncle_at_index,
+    RPC.eth_getUncleByBlockNumberAndIndex: raise_block_not_found_for_uncle_at_index,
 }
 
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -510,6 +510,8 @@ NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getBlockByNumber: raise_block_not_found,
     RPC.eth_getBlockTransactionCountByHash: raise_block_not_found,
     RPC.eth_getBlockTransactionCountByNumber: raise_block_not_found,
+    RPC.eth_getUncleCountByBlockHash: raise_block_not_found,
+    RPC.eth_getUncleCountByBlockNumber: raise_block_not_found,
 }
 
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -283,24 +283,37 @@ class Eth(ModuleV2, Module):
     )
 
 
-    def getUncleCount(self, block_identifier: BlockIdentifier) -> int:
-        """
-        `eth_getUncleCountByBlockHash`
-        `eth_getUncleCountByBlockNumber`
-        """
-        method = select_method_for_block_identifier(
-            block_identifier,
+    # def getUncleCount(self, block_identifier: BlockIdentifier) -> int:
+    #     """
+    #     `eth_getUncleCountByBlockHash`
+    #     `eth_getUncleCountByBlockNumber`
+    #     """
+    #     method = select_method_for_block_identifier(
+    #         block_identifier,
+    #         if_predefined=RPC.eth_getUncleCountByBlockNumber,
+    #         if_hash=RPC.eth_getUncleCountByBlockHash,
+    #         if_number=RPC.eth_getUncleCountByBlockNumber,
+    #     )
+    #     result = self.web3.manager.request_blocking(
+    #         method,
+    #         [block_identifier],
+    #     )
+    #     if result is None:
+    #         raise BlockNotFound(f"Block with id: {block_identifier} not found.")
+    #     return result
+
+    """
+    `eth_getUncleCountByBlockHash`
+    `eth_getUncleCountByBlockNumber`
+    """
+    getUncleCount: Method[Callable[[BlockIdentifier], int]] = Method(
+        method_choice_depends_on_args=select_method_for_block_identifier(
             if_predefined=RPC.eth_getUncleCountByBlockNumber,
             if_hash=RPC.eth_getUncleCountByBlockHash,
             if_number=RPC.eth_getUncleCountByBlockNumber,
-        )
-        result = self.web3.manager.request_blocking(
-            method,
-            [block_identifier],
-        )
-        if result is None:
-            raise BlockNotFound(f"Block with id: {block_identifier} not found.")
-        return result
+        ),
+        mungers=[default_root_munger]
+    )
 
     def getUncleByBlock(self, block_identifier: BlockIdentifier, uncle_index: int) -> Uncle:
         """

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -282,26 +282,6 @@ class Eth(ModuleV2, Module):
         mungers=[default_root_munger]
     )
 
-
-    # def getUncleCount(self, block_identifier: BlockIdentifier) -> int:
-    #     """
-    #     `eth_getUncleCountByBlockHash`
-    #     `eth_getUncleCountByBlockNumber`
-    #     """
-    #     method = select_method_for_block_identifier(
-    #         block_identifier,
-    #         if_predefined=RPC.eth_getUncleCountByBlockNumber,
-    #         if_hash=RPC.eth_getUncleCountByBlockHash,
-    #         if_number=RPC.eth_getUncleCountByBlockNumber,
-    #     )
-    #     result = self.web3.manager.request_blocking(
-    #         method,
-    #         [block_identifier],
-    #     )
-    #     if result is None:
-    #         raise BlockNotFound(f"Block with id: {block_identifier} not found.")
-    #     return result
-
     """
     `eth_getUncleCountByBlockHash`
     `eth_getUncleCountByBlockNumber`
@@ -315,26 +295,18 @@ class Eth(ModuleV2, Module):
         mungers=[default_root_munger]
     )
 
-    def getUncleByBlock(self, block_identifier: BlockIdentifier, uncle_index: int) -> Uncle:
-        """
-        `eth_getUncleByBlockHashAndIndex`
-        `eth_getUncleByBlockNumberAndIndex`
-        """
-        method = select_method_for_block_identifier(
-            block_identifier,
+    """
+    `eth_getUncleByBlockHashAndIndex`
+    `eth_getUncleByBlockNumberAndIndex`
+    """
+    getUncleByBlock: Method[Callable[[BlockIdentifier, int], Uncle]] = Method(
+        method_choice_depends_on_args = select_method_for_block_identifier(
             if_predefined=RPC.eth_getUncleByBlockNumberAndIndex,
             if_hash=RPC.eth_getUncleByBlockHashAndIndex,
             if_number=RPC.eth_getUncleByBlockNumberAndIndex,
-        )
-        result = self.web3.manager.request_blocking(
-            method,
-            [block_identifier, uncle_index],
-        )
-        if result is None:
-            raise BlockNotFound(
-                f"Uncle at index: {uncle_index} of block with id: {block_identifier} not found."
-            )
-        return result
+        ),
+        mungers=[default_root_munger]
+    )
 
     def getTransaction(self, transaction_hash: _Hash32) -> TxData:
         result = self.web3.manager.request_blocking(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -75,7 +75,6 @@ from web3.contract import (
     ContractCaller,
 )
 from web3.exceptions import (
-    BlockNotFound,
     TimeExhausted,
     TransactionNotFound,
 )
@@ -300,7 +299,7 @@ class Eth(ModuleV2, Module):
     `eth_getUncleByBlockNumberAndIndex`
     """
     getUncleByBlock: Method[Callable[[BlockIdentifier, int], Uncle]] = Method(
-        method_choice_depends_on_args = select_method_for_block_identifier(
+        method_choice_depends_on_args=select_method_for_block_identifier(
             if_predefined=RPC.eth_getUncleByBlockNumberAndIndex,
             if_hash=RPC.eth_getUncleByBlockHashAndIndex,
             if_number=RPC.eth_getUncleByBlockNumberAndIndex,
@@ -308,14 +307,10 @@ class Eth(ModuleV2, Module):
         mungers=[default_root_munger]
     )
 
-    def getTransaction(self, transaction_hash: _Hash32) -> TxData:
-        result = self.web3.manager.request_blocking(
-            RPC.eth_getTransactionByHash,
-            [transaction_hash],
-        )
-        if result is None:
-            raise TransactionNotFound(f"Transaction with hash: {transaction_hash} not found.")
-        return result
+    getTransaction: Method[Callable[[_Hash32], TxData]] = Method(
+        RPC.eth_getTransactionByHash,
+        mungers=[default_root_munger]
+    )
 
     def getTransactionFromBlock(
         self, block_identifier: BlockIdentifier, transaction_index: int

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -269,24 +269,19 @@ class Eth(ModuleV2, Module):
         mungers=[get_block_munger],
     )
 
-    def getBlockTransactionCount(self, block_identifier: BlockIdentifier) -> int:
-        """
-        `eth_getBlockTransactionCountByHash`
-        `eth_getBlockTransactionCountByNumber`
-        """
-        method = select_method_for_block_identifier(
-            block_identifier,
+    """
+    `eth_getBlockTransactionCountByHash`
+    `eth_getBlockTransactionCountByNumber`
+    """
+    getBlockTransactionCount: Method[Callable[[BlockIdentifier], int]] = Method(
+        method_choice_depends_on_args=select_method_for_block_identifier(
             if_predefined=RPC.eth_getBlockTransactionCountByNumber,
             if_hash=RPC.eth_getBlockTransactionCountByHash,
             if_number=RPC.eth_getBlockTransactionCountByNumber,
-        )
-        result = self.web3.manager.request_blocking(
-            method,
-            [block_identifier],
-        )
-        if result is None:
-            raise BlockNotFound(f"Block with id: {block_identifier} not found.")
-        return result
+        ),
+        mungers=[default_root_munger]
+    )
+
 
     def getUncleCount(self, block_identifier: BlockIdentifier) -> int:
         """


### PR DESCRIPTION
### What was wrong?
The Eth module needs to be moved to use Method. Part 4 includes changes to:
- RPC.eth_getBlockTransactionCountByHash
- RPC.eth_getBlockTransactionCountByNumber
- RPC.eth_getUncleCountByBlockHash
- RPC.eth_getUncleCountByBlockNumber
- RPC.eth_getUncleByBlockHashAndIndex
- RPC.eth_getUncleByBlockNumberAndIndex
- RPC.eth_getTransactionByHash

Related to Issue #1568

### How was it fixed?

Updated eth.py to use Method for the above methods


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Manually test

#### Cute Animal Picture

<img width="387" alt="image" src="https://user-images.githubusercontent.com/6540608/93393521-e8234b80-f82f-11ea-9570-996da909207b.png">

