### PR TITLE
address the use of multiple providers in docs

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -7,6 +7,12 @@ The provider is how web3 talks to the blockchain.  Providers take JSON-RPC
 requests and return the response.  This is normally done by submitting the
 request to an HTTP or IPC socket based server.
 
+.. note::
+
+   Web3.py supports one provider per instance. If you have an advanced use case
+   that requires multiple providers, create and configure a new web3 instance
+   per connection.
+
 If you are already happily connected to your Ethereum node, then you
 can skip the rest of the Providers section.
 

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -24,11 +24,6 @@ Providers
 
     Convenience API to access :py:class:`web3.providers.ipc.IPCProvider`
 
-.. py:method:: Web3.setProviders(provider)
-
-    Updates the current web3 instance with the new list of providers. It
-    also accepts a single provider.
-
 
 Attributes
 ~~~~~~~~~~

--- a/newsfragments/1701.bugfix.rst
+++ b/newsfragments/1701.bugfix.rst
@@ -1,0 +1,1 @@
+Address the use of multiple providers in the docs


### PR DESCRIPTION
### What was wrong?

- Removes stale `setProviders` method from docs
- Adds a note to the providers page to clarify only one provider is supported per web3 instance

Closes #1701 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.pinimg.com/originals/6a/5b/a3/6a5ba3264f05e859286961e9b7fdab27.jpg)
