### PR TITLE
Eth to method 5

### DIFF
--- a/newsfragments/1746.misc.rst
+++ b/newsfragments/1746.misc.rst
@@ -1,0 +1,1 @@
+eth_getTransactionByBlock, eth_getTransactionReceipt, and eth_signTransaction now use Method class

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -547,6 +547,7 @@ NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getTransactionByHash: raise_transaction_not_found,
     RPC.eth_getTransactionByBlockHashAndIndex: raise_transaction_not_found_with_index,
     RPC.eth_getTransactionByBlockNumberAndIndex: raise_transaction_not_found_with_index,
+    RPC.eth_getTransactionReceipt: raise_transaction_not_found,
 }
 
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -360,7 +360,7 @@ PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getStorageAt: apply_formatter_at_index(block_number_formatter, 2),
     RPC.eth_getTransactionByBlockNumberAndIndex: compose(
         apply_formatter_at_index(block_number_formatter, 0),
-        apply_formatter_at_index(integer_to_hex, 1),
+        apply_formatter_at_index(to_hex_if_integer, 1),
     ),
     RPC.eth_getTransactionCount: apply_formatter_at_index(block_number_formatter, 1),
     RPC.eth_getUncleCountByBlockNumber: apply_formatter_at_index(block_number_formatter, 0),
@@ -526,6 +526,15 @@ def raise_transaction_not_found(params: Tuple[_Hash32]) -> NoReturn:
     raise TransactionNotFound(f"Transaction with hash: {transaction_hash} not found.")
 
 
+def raise_transaction_not_found_with_index(params: Tuple[BlockIdentifier, int]) -> NoReturn:
+    block_identifier = params[0]
+    transaction_index = to_integer_if_hex(params[1])
+    raise TransactionNotFound(
+        f"Transaction index: {transaction_index} "
+        f"on block id: {block_identifier} not found."
+    )
+
+
 NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getBlockByHash: raise_block_not_found,
     RPC.eth_getBlockByNumber: raise_block_not_found,
@@ -536,6 +545,8 @@ NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getUncleByBlockHashAndIndex: raise_block_not_found_for_uncle_at_index,
     RPC.eth_getUncleByBlockNumberAndIndex: raise_block_not_found_for_uncle_at_index,
     RPC.eth_getTransactionByHash: raise_transaction_not_found,
+    RPC.eth_getTransactionByBlockHashAndIndex: raise_transaction_not_found_with_index,
+    RPC.eth_getTransactionByBlockNumberAndIndex: raise_transaction_not_found_with_index,
 }
 
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -499,8 +499,8 @@ def get_request_formatters(
 ) -> Dict[str, Callable[..., Any]]:
     request_formatter_maps = (
         METHOD_NORMALIZERS,
-        PYTHONIC_REQUEST_FORMATTERS,
         ABI_REQUEST_FORMATTERS,
+        PYTHONIC_REQUEST_FORMATTERS,
     )
     formatters = combine_formatters(request_formatter_maps, method_name)
     return compose(*formatters)

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -321,29 +321,14 @@ class Eth(ModuleV2, Module):
         """
         raise DeprecationWarning("This method has been deprecated as of EIP 1474.")
 
-    def getTransactionByBlock(
-        self, block_identifier: BlockIdentifier, transaction_index: int
-    ) -> TxData:
-        """
-        `eth_getTransactionByBlockHashAndIndex`
-        `eth_getTransactionByBlockNumberAndIndex`
-        """
-        method = select_method_for_block_identifier(
-            block_identifier,
+    getTransactionByBlock: Method[Callable[[BlockIdentifier, int], TxData]] = Method(
+        method_choice_depends_on_args=select_method_for_block_identifier(
             if_predefined=RPC.eth_getTransactionByBlockNumberAndIndex,
             if_hash=RPC.eth_getTransactionByBlockHashAndIndex,
             if_number=RPC.eth_getTransactionByBlockNumberAndIndex,
-        )
-        result = self.web3.manager.request_blocking(
-            method,
-            [block_identifier, transaction_index],
-        )
-        if result is None:
-            raise TransactionNotFound(
-                f"Transaction index: {transaction_index} "
-                f"on block id: {block_identifier} not found."
-            )
-        return result
+        ),
+        mungers=[default_root_munger]
+    )
 
     def waitForTransactionReceipt(
         self, transaction_hash: _Hash32, timeout: int=120, poll_latency: float=0.1

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -343,14 +343,10 @@ class Eth(ModuleV2, Module):
                 )
             )
 
-    def getTransactionReceipt(self, transaction_hash: _Hash32) -> TxReceipt:
-        result = self.web3.manager.request_blocking(
-            RPC.eth_getTransactionReceipt,
-            [transaction_hash],
-        )
-        if result is None:
-            raise TransactionNotFound(f"Transaction with hash: {transaction_hash} not found.")
-        return result
+    getTransactionReceipt: Method[Callable[[_Hash32], TxReceipt]] = Method(
+        RPC.eth_getTransactionReceipt,
+        mungers=[default_root_munger]
+    )
 
     getTransactionCount: Method[Callable[..., Nonce]] = Method(
         RPC.eth_getTransactionCount,

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -327,7 +327,7 @@ def default_transaction_fields_middleware(
                 fill_default_from,
                 fill_default_gas,
             )
-            return make_request(method, [filled_transaction] + params[1:])
+            return make_request(method, [filled_transaction] + list(params)[1:])
         elif method in (
             'eth_estimateGas',
             'eth_sendTransaction',
@@ -336,7 +336,7 @@ def default_transaction_fields_middleware(
                 params[0],
                 fill_default_from,
             )
-            return make_request(method, [filled_transaction] + params[1:])
+            return make_request(method, [filled_transaction] + list(params)[1:])
         else:
             return make_request(method, params)
     return middleware


### PR DESCRIPTION
### What was wrong?
The latest in moving eth methods to use `Method`. This installation includes:
- eth_getTransactionByBlock
- eth_getTransactionReceipt
- eth_sendTransaction

Related to Issue #1585 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Manually test sendTransaction

#### Cute Animal Picture
<img width="288" alt="image" src="https://user-images.githubusercontent.com/6540608/93641300-46c80100-f9b9-11ea-8fbc-d1fc17f71cce.png">

