### PR TITLE
eth_call and eth_estimateGas use Method

### DIFF
--- a/newsfragments/1748.misc.rst
+++ b/newsfragments/1748.misc.rst
@@ -1,0 +1,1 @@
+eth_call and eth_estimateGas use ``Method`` class

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -406,6 +406,7 @@ PYTHONIC_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_blockNumber: to_integer_if_hex,
     RPC.eth_chainId: to_integer_if_hex,
     RPC.eth_coinbase: to_checksum_address,
+    RPC.eth_call: HexBytes,
     RPC.eth_estimateGas: to_integer_if_hex,
     RPC.eth_gasPrice: to_integer_if_hex,
     RPC.eth_getBalance: to_integer_if_hex,


### PR DESCRIPTION
### What was wrong/how was it fixed?
`eth_call` and `eth_estimateGas` now use the `Method` class. 

Related to Issue #1585 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Manually test


#### Cute Animal Picture
![](https://i.pinimg.com/originals/84/b4/4f/84b44f37ab978c0cc871f35c9750f718.jpg)