### PR TITLE
Allow for ENS name resolution

### DIFF
--- a/ens/utils.py
+++ b/ens/utils.py
@@ -212,3 +212,13 @@ def assert_signer_in_modifier_kwargs(modifier_kwargs: Any) -> ChecksumAddress:
 
 def is_none_or_zero_address(addr: Union[Address, ChecksumAddress, HexAddress]) -> bool:
     return not addr or addr == EMPTY_ADDR_HEX
+
+
+def is_valid_ens_name(ens_name: str) -> bool:
+    split_domain = ens_name.split('.')
+    if len(split_domain) == 1:
+        return False
+    for name in split_domain:
+        if not is_valid_name(name):
+            return False
+    return True

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -215,8 +215,14 @@ def disable_auto_mine(func):
 
 class TestEthereumTesterEthModule(EthModuleTest):
     test_eth_sign = not_implemented(EthModuleTest.test_eth_sign, ValueError)
+    test_eth_sign_ens_names = not_implemented(
+        EthModuleTest.test_eth_sign_ens_names, ValueError
+    )
     test_eth_signTypedData = not_implemented(EthModuleTest.test_eth_signTypedData, ValueError)
     test_eth_signTransaction = not_implemented(EthModuleTest.test_eth_signTransaction, ValueError)
+    test_eth_signTransaction_ens_names = not_implemented(
+        EthModuleTest.test_eth_signTransaction_ens_names, ValueError
+    )
     test_eth_submitHashrate = not_implemented(EthModuleTest.test_eth_submitHashrate, ValueError)
     test_eth_submitWork = not_implemented(EthModuleTest.test_eth_submitWork, ValueError)
 
@@ -282,6 +288,10 @@ class TestEthereumTesterEthModule(EthModuleTest):
     @pytest.mark.xfail(reason='json-rpc method is not implemented on eth-tester')
     def test_eth_getStorageAt(self, web3, emitter_contract_address):
         super().test_eth_getStorageAt(web3, emitter_contract_address)
+
+    @pytest.mark.xfail(reason='json-rpc method is not implemented on eth-tester')
+    def test_eth_getStorageAt_ens_name(self, web3, emitter_contract_address):
+        super().test_eth_getStorageAt_ens_name(web3, emitter_contract_address)
 
     def test_eth_estimateGas_with_block(self,
                                         web3,

--- a/web3/_utils/validation.py
+++ b/web3/_utils/validation.py
@@ -34,6 +34,9 @@ from eth_utils.toolz import (
     valmap,
 )
 
+from ens.utils import (
+    is_valid_ens_name,
+)
 from web3._utils.abi import (
     abi_to_signature,
     filter_by_type,
@@ -152,10 +155,19 @@ def validate_abi_value(abi_type: TypeStr, value: Any) -> None:
     )
 
 
+def is_not_address_string(value: Any) -> bool:
+    return (is_string(value) and not is_bytes(value) and not
+            is_checksum_address(value) and not is_hex_address(value))
+
+
 def validate_address(value: Any) -> None:
     """
     Helper function for validating an address
     """
+    if is_not_address_string(value):
+        if not is_valid_ens_name(value):
+            raise InvalidAddress(f"ENS name: '{value}' is invalid.")
+        return
     if is_bytes(value):
         if not is_binary_address(value):
             raise InvalidAddress("Address must be 20 bytes when input type is bytes", value)


### PR DESCRIPTION
### What was wrong?
ENS names were throwing an `InvalidAddress` in methods that were using `Method`.

Related to Issue #1585 

### How was it fixed?
Added a new method that does a high-level validation of an ENS address, before it gets resolved in the middleware.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Manually test
- [x] Address PR feedback
- [x] Make sure all changed methods are programmatically tested
- [x] Squash/cleanup

#### Cute Animal Picture

![](https://mylovelypaw.com/wp-content/uploads/2020/02/Cute-Koala-Bears-Photo-Gallery-7-1200x977.jpg)
