### PR TITLE
specifies 'module' scope for relevant pytest fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -101,7 +101,7 @@ def web3():
     return Web3(provider)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def w3_strict_abi():
     w3 = Web3(EthereumTesterProvider())
     w3.enable_strict_bytes_type_checking()

--- a/newsfragments/1767.misc.rst
+++ b/newsfragments/1767.misc.rst
@@ -1,0 +1,1 @@
+Remove duplicate block_number_formatter method in favor of to_hex_if_integer method

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -113,7 +113,7 @@ class LogFunctions:
     LogAddressNotIndexed = 17
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def emitter_event_ids():
     return LogFunctions
 
@@ -156,6 +156,6 @@ def return_filter(
     return contract.events[event_name].createFilter(**kwargs)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def create_filter(request):
     return functools.partial(return_filter)


### PR DESCRIPTION
specifies 'module' scope for pytest fixtures 'emitter_event_ids', 'w3_strict_abi', and 'create_filter'.

### What was wrong?
At the end of our tests we have hypothesis deprecation warnings that look like - `HypothesisDeprecationWarning: tests/core/utilities/test_event_filter_builder.py::test_match_any_bytes_type_properties uses the 'web3' fixture, which is reset between function calls but not between test cases generated by @given(...). You can change it to a module- or session-scoped fixture if it is safe to reuse; if not we recommend using a context manager inside your test function. See https://docs.pytest.org/en/latest/fixture.html#sharing-test-data for details on fixture scope`.

Related to Issue #1729 and PR #1766 

### How was it fixed?
'module' scope was specified for pytest fixtures 'Emitter', 'emitter_event_ids', and 'w3_strict_abi' pytest fixtures.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/ll0qek0wdqm41.jpg)
