### PR TITLE
Mark failing tests as such until ipfshttpclient is updated

### DIFF
--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -605,7 +605,7 @@ To inline the source code directly in the manifest, use ``inline_source()`` or `
 
 To include the source as a content-addressed URI, ``Py-EthPM`` can pin your source via the Infura IPFS API. As well as the contract name and compiler output, this function requires that you provide the desired IPFS backend to pin the contract sources.
 
-.. doctest::
+.. code:: python
 
    >>> import json
    >>> from ethpm import ASSETS_DIR, get_ethpm_spec_dir

--- a/newsfragments/1768.misc.rst
+++ b/newsfragments/1768.misc.rst
@@ -1,0 +1,1 @@
+Expect failures to tests that require the Infura IPFS http client. Infura updated their version of ``go-ipfs`` which is incompatible with the latest version of ``ipfshttpclient``.

--- a/tests/core/pm-module/test_ens_integration.py
+++ b/tests/core/pm-module/test_ens_integration.py
@@ -127,6 +127,7 @@ def test_ens_must_be_set_before_ens_methods_can_be_used(ens):
         w3.pm.set_registry("tester.eth")
 
 
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_web3_ens(ens):
     w3 = ens.web3
     ns = ENS.fromWeb3(w3, ens.ens.address)

--- a/tests/core/pm-module/test_registry_integration.py
+++ b/tests/core/pm-module/test_registry_integration.py
@@ -58,6 +58,7 @@ def test_pm_set_custom_registry(empty_sol_registry, fresh_w3):
     assert is_address(fresh_w3.pm.registry.address)
 
 
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_pm_must_set_registry_before_all_registry_interaction_functions(fresh_w3):
     with pytest.raises(PMError):
         fresh_w3.pm.release_package(
@@ -81,6 +82,7 @@ def test_pm_must_set_registry_before_all_registry_interaction_functions(fresh_w3
         fresh_w3.pm.get_package_count()
 
 
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_pm_release_package(empty_sol_registry, w3):
     w3.pm.registry = empty_sol_registry
     w3.pm.release_package(

--- a/tests/ethpm/_utils/test_backend_utils.py
+++ b/tests/ethpm/_utils/test_backend_utils.py
@@ -31,7 +31,8 @@ from ethpm.uri import (
     ),
 )
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
-def test_get_resolvable_backends_for_supported_uris(dummy_ipfs_backend, uri, backends):
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
+def test_get_resolvable_backends_for_supported_uris(uri, backends):
     good_backends = get_resolvable_backends_for_uri(uri)
     assert good_backends == backends
 
@@ -44,9 +45,8 @@ def test_get_resolvable_backends_for_supported_uris(dummy_ipfs_backend, uri, bac
     ),
 )
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
-def test_get_translatable_backends_for_supported_uris(
-    dummy_ipfs_backend, uri, backends
-):
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
+def test_get_translatable_backends_for_supported_uris(uri, backends):
     good_backends = get_translatable_backends_for_uri(uri)
     assert good_backends == backends
 
@@ -69,6 +69,7 @@ def test_get_translatable_backends_for_supported_uris(
     ),
 )
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_resolve_uri_contents_raises_exception_for_unsupported_schemes(uri):
     with pytest.raises(CannotHandleURI):
         resolve_uri_contents(uri)

--- a/tests/ethpm/backends/test_http_backends.py
+++ b/tests/ethpm/backends/test_http_backends.py
@@ -23,6 +23,7 @@ from ethpm.constants import (
     ),
 )
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_github_over_https_backend_fetch_uri_contents(uri, owned_contract, w3):
     # these tests may occassionally fail CI as a result of their network requests
     backend = GithubOverHTTPSBackend()
@@ -33,6 +34,7 @@ def test_github_over_https_backend_fetch_uri_contents(uri, owned_contract, w3):
 
 
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_github_over_https_backend_raises_error_with_invalid_content_hash(w3):
     invalid_uri = "https://api.github.com/repos/ethpm/py-ethpm/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03123"  # noqa: E501
     with pytest.raises(HTTPError):

--- a/tests/ethpm/backends/test_ipfs_backends.py
+++ b/tests/ethpm/backends/test_ipfs_backends.py
@@ -43,15 +43,22 @@ def fake_client(owned_manifest_path):
 
 
 @pytest.mark.parametrize(
-    "base_uri,backend", ((INFURA_GATEWAY_MULTIADDR, InfuraIPFSBackend()),)
+    # TODO: Change DummyIPFSBackend back to InfuraIPFSBackend once ipfshttpclient is updated
+    # "base_uri,backend", ((INFURA_GATEWAY_MULTIADDR, InfuraIPFSBackend()),)
+    "base_uri,backend", ((INFURA_GATEWAY_MULTIADDR, DummyIPFSBackend()),)
 )
 def test_ipfs_and_infura_gateway_backends_fetch_uri_contents(base_uri, backend):
+    pytest.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
     uri = "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV"
     assert backend.base_uri == base_uri
     contents = backend.fetch_uri_contents(uri)
     assert contents.startswith(b"pragma solidity")
 
 
+@pytest.mark.xfail(
+    reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0",
+    strict=False
+)
 def test_local_ipfs_backend(owned_manifest_path):
     uri = "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV"
     backend = LocalIPFSBackend()
@@ -60,6 +67,7 @@ def test_local_ipfs_backend(owned_manifest_path):
     assert contents.startswith(b"pragma solidity")
 
 
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 @pytest.mark.parametrize(
     "uri,expected",
     (
@@ -93,6 +101,7 @@ def test_get_ipfs_backend_class_with_default_backend():
     assert issubclass(backend, InfuraIPFSBackend)
 
 
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_get_ipfs_backend_with_default_backend():
     backend = get_ipfs_backend()
     assert isinstance(backend, InfuraIPFSBackend)

--- a/tests/ethpm/integration/test_ipfs_integration.py
+++ b/tests/ethpm/integration/test_ipfs_integration.py
@@ -45,6 +45,7 @@ def backend(request):
     return request.param()
 
 
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_builder_pins_manifest_to_provided_ipfs_backend(backend, request):
     if not request.config.getoption("--integration"):
         pytest.skip("Not asked to run integration tests")

--- a/tests/ethpm/test_package_init.py
+++ b/tests/ethpm/test_package_init.py
@@ -65,7 +65,7 @@ def test_package_init_for_all_manifest_use_cases(all_manifests, w3):
 
 
 def test_package_init_for_manifest_with_build_dependency(
-    dummy_ipfs_backend, piper_coin_manifest, w3
+    piper_coin_manifest, w3
 ):
     pkg = Package(piper_coin_manifest, w3)
     assert isinstance(pkg, Package)
@@ -115,7 +115,8 @@ def test_from_file_raises_type_error_with_invalid_param_type():
 VALID_IPFS_PKG = "ipfs://QmdQfNxmcfGjeVwsXEBLCh5CDYsr2VyZtXoqdVm6F26JJE"
 
 
-def test_package_from_uri_with_valid_uri(dummy_ipfs_backend, w3):
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
+def test_package_from_uri_with_valid_uri(w3):
     package = Package.from_uri(VALID_IPFS_PKG, w3)
     assert package.name == "standard-token"
     assert isinstance(package, Package)
@@ -135,6 +136,7 @@ def test_package_from_uri_with_valid_uri(dummy_ipfs_backend, w3):
     ),
 )
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
+@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_package_from_uri_rejects_invalid_ipfs_uri(uri, w3):
     with pytest.raises(CannotHandleURI):
         Package.from_uri(uri, w3)


### PR DESCRIPTION
### What was wrong?
Infura's IPFS gateway updated to go-ipfs v0.7.0 which `ipfshttpclient` doesn't support, so all of our IPFS tests that use the Infura backend are broken. 

Related to Issue #1757

### How was it fixed?
See comment [here](https://github.com/ethereum/web3.py/pull/1757#issuecomment-702628285) for a better description of the problem. If `ipfshttpclient` doesn't update soon (PR up [here](https://github.com/ipfs-shipyard/py-ipfs-http-client/pull/241)), it may be worth pursuing one of the more long-term solutions, but we can decide that in a few weeks. For now, this unblocks a bunch of PRs that need to be merged.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.boredpanda.com/blog/wp-content/uploads/2017/01/funny-animal-fails-14-586b670e9a3de__605.jpg)
