### PR TITLE
Remove setuptools-markdown requirement

### DIFF
--- a/newsfragments/1773.misc.rst
+++ b/newsfragments/1773.misc.rst
@@ -1,0 +1,1 @@
+Remove setuptools-markdown dependency and bump setuptools to v38.6.0

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
          "typing-extensions>=3.7.4.1,<4;python_version<'3.8'",
         "websockets>=8.1.0,<9.0.0",
     ],
-    setup_requires=['setuptools-markdown'],
     python_requires='>=3.6,<4',
     extras_require=extras_require,
     py_modules=['web3', 'ens', 'ethpm'],

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extras_require = {
         "pytest-pythonpath>=0.3",
         "pytest-watch>=4.2,<5",
         "pytest-xdist>=1.29,<2",
-        "setuptools>=36.2.0",
+        "setuptools>=38.6.0",
         "tox>=1.8.0",
         "tqdm>4.32,<5",
         "twine>=1.13,<2",
@@ -57,13 +57,16 @@ extras_require['dev'] = (
     + extras_require['dev']
 )
 
+with open('./README.md') as readme:
+    long_description = readme.read()
+
 setup(
     name='web3',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version='5.12.2',
     description="""Web3.py""",
     long_description_content_type='text/markdown',
-    long_description_markdown_filename='README.md',
+    long_description=long_description,
     author='Piper Merriam',
     author_email='pipermerriam@gmail.com',
     url='https://github.com/ethereum/web3.py',


### PR DESCRIPTION
... as this is now built-in

### What was wrong?

setuptools-markdown creates a huge dependency on pandoc and subsequently ghc, but is probably no longer necessary as this is now built in.

Related to Issue #306 

### How was it fixed?

Pursuant to https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/ it is now built-in and in fact this format is already used in web3.py

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/4/49/Koala_climbing_tree.jpg)
