### PR TITLE
Adding Python3.9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,6 +468,98 @@ jobs:
     environment:
       TOXENV: py38-wheel-cli
 
+  #
+  # Python 3.9
+  #
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+    environment:
+      TOXENV: py39-core
+
+  py39-ens:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+    environment:
+      TOXENV: py39-ens
+
+  py39-ethpm:
+    <<: *ethpm_steps
+    docker:
+      - image: circleci/python:3.9
+    environment:
+      TOXENV: py39-ethpm
+      # Please don't use this key for any shenanigans
+      WEB3_INFURA_PROJECT_ID: 7707850c2fb7465ebe6f150d67182e22
+
+  py39-integration-goethereum-ipc:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.9
+    environment:
+      TOXENV: py39-integration-goethereum-ipc
+      GETH_VERSION: v1.10.1
+
+  py39-integration-goethereum-http:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.9
+    environment:
+      TOXENV: py39-integration-goethereum-http
+      GETH_VERSION: v1.10.1
+
+  py39-integration-goethereum-ws:
+    <<: *geth_steps
+    docker:
+      - image: circleci/python:3.9
+    environment:
+      TOXENV: py39-integration-goethereum-ws
+      GETH_VERSION: v1.10.1
+
+  # py39-integration-parity-ipc:
+  #   <<: *parity_steps
+  #   docker:
+  #     - image: circleci/python:3.9
+  #   environment:
+  #     TOXENV: py39-integration-parity-ipc
+  #     PARITY_VERSION: v2.3.5
+  #     PARITY_OS: linux
+
+  # py39-integration-parity-http:
+  #   <<: *parity_steps
+  #   docker:
+  #     - image: circleci/python:3.9
+  #   environment:
+  #     TOXENV: py39-integration-parity-http
+  #     PARITY_VERSION: v2.3.5
+  #     PARITY_OS: linux
+
+  # py39-integration-parity-ws:
+  #   <<: *parity_steps
+  #   docker:
+  #     - image: circleci/python:3.9
+  #   environment:
+  #     TOXENV: py39-integration-parity-ws
+  #     PARITY_VERSION: v2.3.5
+  #     PARITY_OS: linux
+
+  py39-integration-ethtester-pyevm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+    environment:
+      TOXENV: py39-integration-ethtester
+      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
+
+  py39-wheel-cli:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-wheel-cli
+
 workflows:
   version: 2.1
   test:
@@ -476,6 +568,7 @@ workflows:
       - py36-core
       - py37-core
       - py38-core
+      - py39-core
       - lint
       - docs
       - py36-ens
@@ -509,3 +602,13 @@ workflows:
       # - py38-integration-parity-ws
       - py38-integration-ethtester-pyevm
       - py38-wheel-cli
+      - py39-ens
+      - py39-ethpm
+      - py39-integration-goethereum-ipc
+      - py39-integration-goethereum-http
+      - py39-integration-goethereum-ws
+      # - py39-integration-parity-ipc
+      # - py39-integration-parity-http
+      # - py39-integration-parity-ws
+      - py39-integration-ethtester-pyevm
+      - py39-wheel-cli

--- a/newsfragments/1774.misc.rst
+++ b/newsfragments/1774.misc.rst
@@ -1,0 +1,1 @@
+Add python3.9 support

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'tester': [
-        "eth-tester[py-evm]==v0.5.0-beta.3",
+        "eth-tester[py-evm]==v0.5.0-beta.4",
         "py-geth>=3.0.0,<4",
     ],
     'linter': [
@@ -85,7 +85,7 @@ setup(
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
         # remove typing_extensions after python_requires>=3.8, see web3._utils.compat
-         "typing-extensions>=3.7.4.1,<4;python_version<'3.8'",
+        "typing-extensions>=3.7.4.1,<4;python_version<'3.8'",
         "websockets>=8.1.0,<9.0.0",
     ],
     python_requires='>=3.6,<4',
@@ -106,5 +106,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 envlist=
-    py{36,37,38}-ens
-    py{36,37,38}-ethpm
-    py{36,37,38}-core
-    py{36,37,38}-integration-{goethereum,ethtester,parity}
+    py{36,37,38,39}-ens
+    py{36,37,38,39}-ethpm
+    py{36,37,38,39}-core
+    py{36,37,38,39}-integration-{goethereum,ethtester,parity}
     lint
     docs
-    py{36,37,38}-wheel-cli
+    py{36,37,38,39}-wheel-cli
 
 [isort]
 combine_as_imports=True
@@ -57,6 +57,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 
 [testenv:lint]
 basepython=python
@@ -90,6 +91,12 @@ commands={[common-wheel-cli]commands}
 skip_install=true
 
 [testenv:py38-wheel-cli]
+deps={[common-wheel-cli]deps}
+whitelist_externals={[common-wheel-cli]whitelist_externals}
+commands={[common-wheel-cli]commands}
+skip_install=true
+
+[testenv:py39-wheel-cli]
 deps={[common-wheel-cli]deps}
 whitelist_externals={[common-wheel-cli]whitelist_externals}
 commands={[common-wheel-cli]commands}


### PR DESCRIPTION
### What was wrong?

web3.py doesn't support python3.9

Related to Issue #1769 

### How was it fixed?

Followed PR #1471 template that added support to python3.8

### Todo:
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/26482095/96046192-7a2b6d80-0e49-11eb-8da1-dff4446071b2.png)
