### PR TITLE
Update ipfshttpclient

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,8 @@ ethpm_steps: &ethpm_steps
     - run:
         name: install ipfs
         command:
-          wget https://dist.ipfs.io/go-ipfs/v0.4.22/go-ipfs_v0.4.22_linux-amd64.tar.gz &&
-          tar xvfz go-ipfs_v0.4.22_linux-amd64.tar.gz &&
+          wget https://dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz &&
+          tar xvfz go-ipfs_v0.7.0_linux-amd64.tar.gz &&
           sudo cp go-ipfs/ipfs /usr/local/bin &&
           ipfs init
     - run:

--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -605,7 +605,7 @@ To inline the source code directly in the manifest, use ``inline_source()`` or `
 
 To include the source as a content-addressed URI, ``Py-EthPM`` can pin your source via the Infura IPFS API. As well as the contract name and compiler output, this function requires that you provide the desired IPFS backend to pin the contract sources.
 
-.. code:: python
+.. doctest::
 
    >>> import json
    >>> from ethpm import ASSETS_DIR, get_ethpm_spec_dir

--- a/newsfragments/1775.misc.rst
+++ b/newsfragments/1775.misc.rst
@@ -1,0 +1,1 @@
+Update ipfshttpclient dependency so that ethpm Infura tests are passing again.

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.9.5,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
-        "ipfshttpclient>=0.4.13,<1",
+        "ipfshttpclient==0.7.0a1",
         "jsonschema>=3.2.0,<4.0.0",
         "lru-dict>=1.1.6,<2.0.0",
         "protobuf>=3.10.0,<4",

--- a/tests/core/pm-module/test_ens_integration.py
+++ b/tests/core/pm-module/test_ens_integration.py
@@ -127,7 +127,6 @@ def test_ens_must_be_set_before_ens_methods_can_be_used(ens):
         w3.pm.set_registry("tester.eth")
 
 
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_web3_ens(ens):
     w3 = ens.web3
     ns = ENS.fromWeb3(w3, ens.ens.address)

--- a/tests/core/pm-module/test_registry_integration.py
+++ b/tests/core/pm-module/test_registry_integration.py
@@ -58,7 +58,6 @@ def test_pm_set_custom_registry(empty_sol_registry, fresh_w3):
     assert is_address(fresh_w3.pm.registry.address)
 
 
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_pm_must_set_registry_before_all_registry_interaction_functions(fresh_w3):
     with pytest.raises(PMError):
         fresh_w3.pm.release_package(
@@ -82,7 +81,6 @@ def test_pm_must_set_registry_before_all_registry_interaction_functions(fresh_w3
         fresh_w3.pm.get_package_count()
 
 
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_pm_release_package(empty_sol_registry, w3):
     w3.pm.registry = empty_sol_registry
     w3.pm.release_package(

--- a/tests/ethpm/_utils/test_backend_utils.py
+++ b/tests/ethpm/_utils/test_backend_utils.py
@@ -31,8 +31,7 @@ from ethpm.uri import (
     ),
 )
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
-def test_get_resolvable_backends_for_supported_uris(uri, backends):
+def test_get_resolvable_backends_for_supported_uris(dummy_ipfs_backend, uri, backends):
     good_backends = get_resolvable_backends_for_uri(uri)
     assert good_backends == backends
 
@@ -45,8 +44,7 @@ def test_get_resolvable_backends_for_supported_uris(uri, backends):
     ),
 )
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
-def test_get_translatable_backends_for_supported_uris(uri, backends):
+def test_get_translatable_backends_for_supported_uris(dummy_ipfs_backend, uri, backends):
     good_backends = get_translatable_backends_for_uri(uri)
     assert good_backends == backends
 
@@ -69,7 +67,6 @@ def test_get_translatable_backends_for_supported_uris(uri, backends):
     ),
 )
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_resolve_uri_contents_raises_exception_for_unsupported_schemes(uri):
     with pytest.raises(CannotHandleURI):
         resolve_uri_contents(uri)

--- a/tests/ethpm/backends/test_http_backends.py
+++ b/tests/ethpm/backends/test_http_backends.py
@@ -23,7 +23,6 @@ from ethpm.constants import (
     ),
 )
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_github_over_https_backend_fetch_uri_contents(uri, owned_contract, w3):
     # these tests may occassionally fail CI as a result of their network requests
     backend = GithubOverHTTPSBackend()
@@ -34,7 +33,6 @@ def test_github_over_https_backend_fetch_uri_contents(uri, owned_contract, w3):
 
 
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_github_over_https_backend_raises_error_with_invalid_content_hash(w3):
     invalid_uri = "https://api.github.com/repos/ethpm/py-ethpm/git/blobs/a7232a93f1e9e75d606f6c1da18aa16037e03123"  # noqa: E501
     with pytest.raises(HTTPError):

--- a/tests/ethpm/backends/test_ipfs_backends.py
+++ b/tests/ethpm/backends/test_ipfs_backends.py
@@ -43,22 +43,15 @@ def fake_client(owned_manifest_path):
 
 
 @pytest.mark.parametrize(
-    # TODO: Change DummyIPFSBackend back to InfuraIPFSBackend once ipfshttpclient is updated
-    # "base_uri,backend", ((INFURA_GATEWAY_MULTIADDR, InfuraIPFSBackend()),)
-    "base_uri,backend", ((INFURA_GATEWAY_MULTIADDR, DummyIPFSBackend()),)
+    "base_uri,backend", ((INFURA_GATEWAY_MULTIADDR, InfuraIPFSBackend()),)
 )
 def test_ipfs_and_infura_gateway_backends_fetch_uri_contents(base_uri, backend):
-    pytest.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
     uri = "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV"
     assert backend.base_uri == base_uri
     contents = backend.fetch_uri_contents(uri)
     assert contents.startswith(b"pragma solidity")
 
 
-@pytest.mark.xfail(
-    reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0",
-    strict=False
-)
 def test_local_ipfs_backend(owned_manifest_path):
     uri = "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV"
     backend = LocalIPFSBackend()
@@ -67,7 +60,6 @@ def test_local_ipfs_backend(owned_manifest_path):
     assert contents.startswith(b"pragma solidity")
 
 
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 @pytest.mark.parametrize(
     "uri,expected",
     (
@@ -101,7 +93,6 @@ def test_get_ipfs_backend_class_with_default_backend():
     assert issubclass(backend, InfuraIPFSBackend)
 
 
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_get_ipfs_backend_with_default_backend():
     backend = get_ipfs_backend()
     assert isinstance(backend, InfuraIPFSBackend)

--- a/tests/ethpm/integration/test_ipfs_integration.py
+++ b/tests/ethpm/integration/test_ipfs_integration.py
@@ -45,7 +45,6 @@ def backend(request):
     return request.param()
 
 
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_builder_pins_manifest_to_provided_ipfs_backend(backend, request):
     if not request.config.getoption("--integration"):
         pytest.skip("Not asked to run integration tests")

--- a/tests/ethpm/test_package_init.py
+++ b/tests/ethpm/test_package_init.py
@@ -115,7 +115,6 @@ def test_from_file_raises_type_error_with_invalid_param_type():
 VALID_IPFS_PKG = "ipfs://QmdQfNxmcfGjeVwsXEBLCh5CDYsr2VyZtXoqdVm6F26JJE"
 
 
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_package_from_uri_with_valid_uri(w3):
     package = Package.from_uri(VALID_IPFS_PKG, w3)
     assert package.name == "standard-token"
@@ -136,7 +135,6 @@ def test_package_from_uri_with_valid_uri(w3):
     ),
 )
 @pytest.mark.skipif('WEB3_INFURA_PROJECT_ID' not in os.environ, reason='Infura API key unavailable')
-@pytest.mark.xfail(reason="py-ipfs-http-client library doesn't support go-ipfs v0.7.0")
 def test_package_from_uri_rejects_invalid_ipfs_uri(uri, w3):
     with pytest.raises(CannotHandleURI):
         Package.from_uri(uri, w3)


### PR DESCRIPTION
### What was wrong?
The `ipfshttpclient` package updated, and now our tests can pass again!


### How was it fixed?
Updated, but not sure if pinning to the alpha version is any better. If it's not better, I can close this PR until it's out of pre-release. I pinned instead of providing a range because it sounds like there will be breaking changes still. 

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/96050377-bb665200-0e36-11eb-9b79-771115b6eba9.png)

