### PR TITLE
Move filter method to use Method class

### DIFF
--- a/newsfragments/1778.misc.rst
+++ b/newsfragments/1778.misc.rst
@@ -1,0 +1,1 @@
+Move eth.filter method to use ``Method`` class

--- a/tests/core/filtering/test_contract_past_event_filtering.py
+++ b/tests/core/filtering/test_contract_past_event_filtering.py
@@ -4,9 +4,6 @@ from eth_utils import (
     is_same_address,
 )
 
-# Ignore warning in pyethereum 1.6 - will go away with the upgrade
-pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
-
 
 @pytest.mark.parametrize('call_as_instance', (True, False))
 @pytest.mark.parametrize('api_style', ('v4', 'build_filter'))

--- a/tests/core/filtering/test_existing_filter_instance.py
+++ b/tests/core/filtering/test_existing_filter_instance.py
@@ -17,7 +17,7 @@ def filter_id(web3):
     return block_filter.filter_id
 
 
-def test_instatiate_existing_filter(web3, sleep_interval, wait_for_block, filter_id):
+def test_instantiate_existing_filter(web3, sleep_interval, wait_for_block, filter_id):
     with pytest.raises(TypeError):
         web3.eth.filter('latest', filter_id)
     with pytest.raises(TypeError):

--- a/tests/core/filtering/test_filters_against_many_blocks.py
+++ b/tests/core/filtering/test_filters_against_many_blocks.py
@@ -79,8 +79,7 @@ def test_block_filter(web3):
     assert len(block_filter.get_new_entries()) == web3.eth.blockNumber
 
 
-def test_transaction_filter_with_mining(
-        web3):
+def test_transaction_filter_with_mining(web3):
 
     transaction_filter = web3.eth.filter("pending")
 

--- a/tests/core/filtering/test_utils_functions.py
+++ b/tests/core/filtering/test_utils_functions.py
@@ -131,7 +131,7 @@ from web3._utils.filters import (
 def test_match_fn_with_various_data_types(web3, data, expected, match_data_and_abi):
     abi_types, match_data = zip(*match_data_and_abi)
     encoded_data = web3.codec.encode_abi(abi_types, data)
-    assert match_fn(web3, match_data_and_abi, encoded_data) == expected
+    assert match_fn(web3.codec, match_data_and_abi, encoded_data) == expected
 
 
 @pytest.mark.parametrize(
@@ -206,7 +206,7 @@ def test_match_fn_with_various_data_types_strict(w3_strict_abi,
                                                  match_data_and_abi):
     abi_types, match_data = zip(*match_data_and_abi)
     encoded_data = w3_strict_abi.codec.encode_abi(abi_types, data)
-    assert match_fn(w3_strict_abi, match_data_and_abi, encoded_data) == expected
+    assert match_fn(w3_strict_abi.codec, match_data_and_abi, encoded_data) == expected
 
 
 @pytest.mark.parametrize(
@@ -233,4 +233,4 @@ def test_wrong_type_match_data(web3):
     abi_types, match_data = zip(*match_data_and_abi)
     encoded_data = web3.codec.encode_abi(abi_types, data)
     with pytest.raises(ValueError):
-        match_fn(web3, match_data_and_abi, encoded_data)
+        match_fn(web3.codec, match_data_and_abi, encoded_data)

--- a/tests/core/method-class/test_method.py
+++ b/tests/core/method-class/test_method.py
@@ -54,7 +54,7 @@ def test_get_formatters_default_formatter_for_falsy_config():
     )
 
     default_request_formatters = method.request_formatters(method.method_selector_fn())
-    default_result_formatters = method.result_formatters(method.method_selector_fn())
+    default_result_formatters = method.result_formatters(method.method_selector_fn(), 'some module')
     assert _apply_request_formatters(['a', 'b', 'c'], default_request_formatters) == ('a', 'b', 'c')
     assert apply_result_formatters(
         default_result_formatters, ['a', 'b', 'c']) == ['a', 'b', 'c']

--- a/tests/core/method-class/test_result_formatters.py
+++ b/tests/core/method-class/test_result_formatters.py
@@ -19,7 +19,7 @@ from web3.providers import (
 )
 
 
-def result_formatter(method):
+def result_formatter(method, module):
     def formatter(self):
         return 'OKAY'
     return compose(formatter)

--- a/tests/core/middleware/test_filter_middleware.py
+++ b/tests/core/middleware/test_filter_middleware.py
@@ -23,10 +23,7 @@ from web3.providers.base import (
 
 class DummyProvider(BaseProvider):
     def make_request(self, method, params):
-        raise NotImplementedError("Cannot make request for {0}:{1}".format(
-            method,
-            params,
-        ))
+        raise NotImplementedError(f"Cannot make request for {method}:{params}")
 
 
 BLOCK_HASH = '0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553'

--- a/tests/core/utilities/test_select_filter_method.py
+++ b/tests/core/utilities/test_select_filter_method.py
@@ -1,0 +1,38 @@
+import pytest
+
+from web3._utils.filters import (
+    _UseExistingFilter,
+    select_filter_method,
+)
+from web3.exceptions import (
+    ValidationError,
+)
+
+
+@pytest.mark.parametrize('value, expected', (
+    ('latest', 'new_block_filter'),
+    ('pending', 'new_pending_tx_filter'),
+    ({'to': '0x' + '00' * 20}, 'new_filter'),
+))
+def test_select_filter_method(value, expected):
+    filter_method = select_filter_method(
+        if_new_block_filter='new_block_filter',
+        if_new_pending_transaction_filter='new_pending_tx_filter',
+        if_new_filter='new_filter',
+    )
+    assert filter_method(value) == expected
+
+
+@pytest.mark.parametrize('value, error', (
+    ('0x0', _UseExistingFilter),
+    ('disallowed string', ValidationError),
+    (1, ValidationError),  # filter id needs to be a hexstr
+))
+def test_select_filter_method_raises_error(value, error):
+    filter_method = select_filter_method(
+        if_new_block_filter='new_block_filter',
+        if_new_pending_transaction_filter='new_pending_tx_filter',
+        if_new_filter='new_filter',
+    )
+    with pytest.raises(error):
+        filter_method(value)

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -23,7 +23,6 @@ from eth_typing import (
 )
 from eth_utils import (
     is_checksum_address,
-    is_hex,
     is_string,
 )
 from eth_utils.toolz import (
@@ -473,14 +472,14 @@ class Eth(ModuleV2, Module):
         if isinstance(filter_params, dict):
             return [filter_params]
         elif is_string(filter_params):
-            if filter_params in ['latest', 'pending'] or is_hex(filter_params):
+            if filter_params in ['latest', 'pending']:
                 return [filter_params]
             else:
                 raise ValueError(
-                    "The filter API only accepts the values of `pending`, "
-                    "`latest` or a hex-encoded `filter_id` for string based filters"
+                    "The filter API only accepts the values of `pending` or "
+                    "`latest` for string based filters"
                 )
-        elif is_hex(filter_id):
+        elif filter_id and not filter_params:
             return [filter_id]
         else:
             raise TypeError("Must provide either filter_params as a string or "

--- a/web3/main.py
+++ b/web3/main.py
@@ -166,13 +166,14 @@ class Web3:
         ens: ENS = cast(ENS, empty)
     ) -> None:
         self.manager = self.RequestManager(self, provider, middlewares)
+        # this codec gets used in the module initialization,
+        # so it needs to come before attach_modules
+        self.codec = ABICodec(build_default_registry())
 
         if modules is None:
             modules = get_default_modules()
 
         attach_modules(self, modules)
-
-        self.codec = ABICodec(build_default_registry())
 
         self.ens = ens
 


### PR DESCRIPTION
### What was wrong?
Filter is the last method in Eth that wasn't using Method. This PR fixes that. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Make sure tests are using the correct middleware
- [x] Better solution than passing around a string in place of a method
- [x] Lint
- [x] Get rid of TODOs
- [x] Manually test

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/99317791-d821eb00-2823-11eb-872e-f4eea1c116f3.png)

