### PR TITLE
Fixes emitter fixture scoping issues

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -64,7 +64,7 @@ def wait_for_miner_start():
     return _wait_for_miner_start
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def wait_for_block():
     def _wait_for_block(web3, block_number=1, timeout=None):
         if not timeout:
@@ -79,7 +79,7 @@ def wait_for_block():
     return _wait_for_block
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def wait_for_transaction():
     def _wait_for_transaction(web3, txn_hash, timeout=120):
         poll_delay_counter = PollDelayCounter()

--- a/newsfragments/1780.misc.rst
+++ b/newsfragments/1780.misc.rst
@@ -1,0 +1,3 @@
+Specify 'module' scope for 'wait_for_block' and 'wait_for_transaction' fixtures. Specify 'module'
+scope for emitter fixtures ('emitter', 'Emitter', 'EMITTER', 'EMITTER_ABI', 'EMITTER_RUNTIME',
+'EMITTER_CODE') and 'web3(request)'in test_contract_data_filters.py.

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -1,17 +1,41 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 
 from eth_utils.toolz import (
     dissoc,
 )
 
+from web3 import Web3
 from web3.exceptions import (
     ValidationError,
 )
+from web3.middleware import (
+    local_filter_middleware,
+)
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
+
+# -*- coding: utf-8 -*-
+
 
 # Ignore warning in pyethereum 1.6 - will go away with the upgrade
 pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
+
+
+# Ignore warning in pyethereum 1.6 - will go away with the upgrade
+pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
+
+
+@pytest.fixture(
+    params=[True, False],
+    ids=["local_filter_middleware", "node_based_filter"])
+def web3(request):
+    use_filter_middleware = request.param
+    provider = EthereumTesterProvider()
+    w3 = Web3(provider)
+    if use_filter_middleware:
+        w3.middleware_onion.add(local_filter_middleware)
+    return w3
 
 
 @pytest.fixture()

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -4,38 +4,11 @@ from eth_utils.toolz import (
     dissoc,
 )
 
-from web3 import Web3
 from web3.exceptions import (
     ValidationError,
 )
-from web3.middleware import (
-    local_filter_middleware,
-)
-from web3.providers.eth_tester import (
-    EthereumTesterProvider,
-)
 
 # -*- coding: utf-8 -*-
-
-
-# Ignore warning in pyethereum 1.6 - will go away with the upgrade
-pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
-
-
-# Ignore warning in pyethereum 1.6 - will go away with the upgrade
-pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
-
-
-@pytest.fixture(
-    params=[True, False],
-    ids=["local_filter_middleware", "node_based_filter"])
-def web3(request):
-    use_filter_middleware = request.param
-    provider = EthereumTesterProvider()
-    w3 = Web3(provider)
-    if use_filter_middleware:
-        w3.middleware_onion.add(local_filter_middleware)
-    return w3
 
 
 @pytest.fixture()

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -27,6 +27,7 @@ def tester_snapshot(web3):
 
 
 @pytest.fixture(
+    scope='function',
     params=[True, False],
     ids=["local_filter_middleware", "node_based_filter"])
 def web3(request):

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -27,7 +27,6 @@ def tester_snapshot(web3):
 
 
 @pytest.fixture(
-    scope='function',
     params=[True, False],
     ids=["local_filter_middleware", "node_based_filter"])
 def web3(request):

--- a/tests/core/filtering/test_contract_data_filters.py
+++ b/tests/core/filtering/test_contract_data_filters.py
@@ -19,9 +19,6 @@ from web3.providers.eth_tester import (
     EthereumTesterProvider,
 )
 
-# Ignore warning in pyethereum 1.6 - will go away with the upgrade
-pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
-
 
 @pytest.fixture(
     scope="module",

--- a/tests/core/filtering/test_contract_data_filters.py
+++ b/tests/core/filtering/test_contract_data_filters.py
@@ -6,6 +6,83 @@ from hypothesis import (
     strategies as st,
 )
 
+from web3 import Web3
+from web3._utils.module_testing.emitter_contract import (
+    CONTRACT_EMITTER_ABI,
+    CONTRACT_EMITTER_CODE,
+    CONTRACT_EMITTER_RUNTIME,
+)
+from web3.middleware import (
+    local_filter_middleware,
+)
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
+
+# Ignore warning in pyethereum 1.6 - will go away with the upgrade
+pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
+
+
+@pytest.fixture(
+    scope="module",
+    params=[True, False],
+    ids=["local_filter_middleware", "node_based_filter"])
+def web3(request):
+    use_filter_middleware = request.param
+    provider = EthereumTesterProvider()
+    w3 = Web3(provider)
+    if use_filter_middleware:
+        w3.middleware_onion.add(local_filter_middleware)
+    return w3
+
+
+@pytest.fixture(scope="module")
+def EMITTER_CODE():
+    return CONTRACT_EMITTER_CODE
+
+
+@pytest.fixture(scope="module")
+def EMITTER_RUNTIME():
+    return CONTRACT_EMITTER_RUNTIME
+
+
+@pytest.fixture(scope="module")
+def EMITTER_ABI():
+    return CONTRACT_EMITTER_ABI
+
+
+@pytest.fixture(scope="module")
+def EMITTER(EMITTER_CODE,
+            EMITTER_RUNTIME,
+            EMITTER_ABI):
+    return {
+        'bytecode': EMITTER_CODE,
+        'bytecode_runtime': EMITTER_RUNTIME,
+        'abi': EMITTER_ABI,
+    }
+
+
+@pytest.fixture(scope="module")
+def Emitter(web3, EMITTER):
+    return web3.eth.contract(**EMITTER)
+
+
+@pytest.fixture(scope="module")
+def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_conversion_func):
+    wait_for_block(web3)
+    deploy_txn_hash = Emitter.constructor().transact({
+        'from': web3.eth.coinbase,
+        'gas': 1000000,
+        'gasPrice': 1})
+    deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
+    contract_address = address_conversion_func(deploy_receipt['contractAddress'])
+
+    bytecode = web3.eth.getCode(contract_address)
+    assert bytecode == Emitter.bytecode_runtime
+    _emitter = Emitter(address=contract_address)
+    assert _emitter.address == contract_address
+    return _emitter
+
 
 def not_empty_string(x):
     return x != ''

--- a/tests/core/filtering/test_contract_on_event_filtering.py
+++ b/tests/core/filtering/test_contract_on_event_filtering.py
@@ -4,8 +4,28 @@ from eth_utils import (
     is_address,
 )
 
+from web3 import Web3
+from web3.middleware import (
+    local_filter_middleware,
+)
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
+
 # Ignore warning in pyethereum 1.6 - will go away with the upgrade
 pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
+
+
+@pytest.fixture(
+    params=[True, False],
+    ids=["local_filter_middleware", "node_based_filter"])
+def web3(request):
+    use_filter_middleware = request.param
+    provider = EthereumTesterProvider()
+    w3 = Web3(provider)
+    if use_filter_middleware:
+        w3.middleware_onion.add(local_filter_middleware)
+    return w3
 
 
 @pytest.mark.parametrize('call_as_instance', (True, False))

--- a/tests/core/filtering/test_contract_on_event_filtering.py
+++ b/tests/core/filtering/test_contract_on_event_filtering.py
@@ -4,29 +4,6 @@ from eth_utils import (
     is_address,
 )
 
-from web3 import Web3
-from web3.middleware import (
-    local_filter_middleware,
-)
-from web3.providers.eth_tester import (
-    EthereumTesterProvider,
-)
-
-# Ignore warning in pyethereum 1.6 - will go away with the upgrade
-pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
-
-
-@pytest.fixture(
-    params=[True, False],
-    ids=["local_filter_middleware", "node_based_filter"])
-def web3(request):
-    use_filter_middleware = request.param
-    provider = EthereumTesterProvider()
-    w3 = Web3(provider)
-    if use_filter_middleware:
-        w3.middleware_onion.add(local_filter_middleware)
-    return w3
-
 
 @pytest.mark.parametrize('call_as_instance', (True, False))
 def test_create_filter_address_parameter(web3, emitter, Emitter, call_as_instance):


### PR DESCRIPTION
## What was wrong?
At the end of our tests we have hypothesis deprecation warnings that look like - HypothesisDeprecationWarning: tests/core/utilities/test_event_filter_builder.py::test_match_any_bytes_type_properties uses the 'web3' fixture, which is reset between function calls but not between test cases generated by @given(...). You can change it to a module- or session-scoped fixture if it is safe to reuse; if not we recommend using a context manager inside your test function. See https://docs.pytest.org/en/latest/fixture.html#sharing-test-data for details on fixture scope.

Related to Issue #1729

### How was it fixed?
emitter fixtures ('emitter', 'Emitter', 'EMITTER', EMITTER_ABI, 'EMITTER_RUNTIME', 'EMITTER_CODE')  were changed to have  'module' scope for test_contract_data_filters and function scope otherwise.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcTBWhQObjrW9gUOFpSVFEAAFKCCD_MpmgBltg&usqp=CAU)
