### PR TITLE
Update eth-tester dependency

### DIFF
--- a/newsfragments/1782.bugfix.rst
+++ b/newsfragments/1782.bugfix.rst
@@ -1,0 +1,1 @@
+Update eth-tester dependency to fix tester environment install version conflict.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'tester': [
-        "eth-tester[py-evm]==v0.5.0-beta.2",
+        "eth-tester[py-evm]==v0.5.0-beta.3",
         "py-geth>=2.4.0,<3",
     ],
     'linter': [


### PR DESCRIPTION
### What was wrong?
It seems to me that using `web3[tester]` was broken recently - due to the recent version bump in [pyrlp](https://github.com/ethereum/pyrlp). 

Whenever installing a `web3[tester]` environment - I'd get ...
```
pkg_resources.DistributionNotFound: The 'rlp<=2.0.0-alpha.1,>=1.1.0' distribution was not found and is required by eth-tester
```

### How was it fixed?
A new version of `eth-tester` was just released that has the updated version of `py-evm` -> `pyrlp`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/97282182-59c9be80-180c-11eb-8086-3b0b810e5cb0.png)

