### PR TITLE
Gracefully handle when the name key does not exist in the contract abi

### DIFF
--- a/newsfragments/1786.feature.rst
+++ b/newsfragments/1786.feature.rst
@@ -1,0 +1,1 @@
+When finding a contract function gracefully handle abis that do not have a name key.

--- a/tests/core/utilities/test_abi_filter_by_abi_name.py
+++ b/tests/core/utilities/test_abi_filter_by_abi_name.py
@@ -50,6 +50,13 @@ ABI_FUNC_3 = {
     "outputs": [],
     "type": "function",
 }
+ABI_FUNC_4_NO_NAME = {
+    "constant": False,
+    "inputs": [],
+    "outputs": [],
+    "type": "function",
+}
+
 
 ABI = [
     ABI_CONSTRUCTOR,
@@ -59,6 +66,7 @@ ABI = [
     ABI_FUNC_2_SIG_A,
     ABI_FUNC_2_SIG_B,
     ABI_FUNC_3,
+    ABI_FUNC_4_NO_NAME,
 ]
 
 

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -96,7 +96,7 @@ def filter_by_name(name: str, contract_abi: ABI) -> List[Union[ABIFunction, ABIE
         in contract_abi
         if (
             abi['type'] not in ('fallback', 'constructor', 'receive')
-            and abi['name'] == name
+            and abi.get('name') == name
         )
     ]
 


### PR DESCRIPTION
### What was wrong?
Some abi contracts do not have a name key. This will gracefully handle those cases by preventing an errors when that occurs.

Related to Issue [#1655](https://github.com/ethereum/web3.py/issues/1655)

### How was it fixed?
Use `get` method to return a default value of '' when there is no `name` key.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
🐱
