### PR TITLE
tests return values against different geth versions

### DIFF
--- a/newsfragments/1790.misc.rst
+++ b/newsfragments/1790.misc.rst
@@ -1,0 +1,1 @@
+Add getBlockByHash test for pending blocks

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -248,7 +248,7 @@ class TestEthereumTesterEthModule(EthModuleTest):
     test_eth_submitWork = not_implemented(EthModuleTest.test_eth_submitWork, ValueError)
 
     def test_eth_getBlockByHash_pending(
-        self, web3: "Web3", empty_block: BlockData
+        self, web3: "Web3"
     ) -> None:
         block = web3.eth.getBlock('pending')
         assert block['hash'] is not None

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -24,6 +24,9 @@ from web3._utils.module_testing.emitter_contract import (
 from web3.providers.eth_tester import (
     EthereumTesterProvider,
 )
+from web3.types import (  # noqa: F401
+    BlockData,
+)
 
 
 @pytest.fixture(scope="module")
@@ -243,6 +246,12 @@ class TestEthereumTesterEthModule(EthModuleTest):
     )
     test_eth_submitHashrate = not_implemented(EthModuleTest.test_eth_submitHashrate, ValueError)
     test_eth_submitWork = not_implemented(EthModuleTest.test_eth_submitWork, ValueError)
+
+    def test_eth_getBlockByHash_pending(
+        self, web3: "Web3", empty_block: BlockData
+    ) -> None:
+        block = web3.eth.getBlock('pending')
+        assert block['hash'] is not None
 
     @disable_auto_mine
     def test_eth_getTransactionReceipt_unmined(self, eth_tester, web3, unlocked_account):

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -809,7 +809,7 @@ class EthModuleTest:
             web3.eth.getBlock(UNKNOWN_HASH)
 
     def test_eth_getBlockByHash_pending(
-        self, web3: "Web3", empty_block: BlockData
+        self, web3: "Web3"
     ) -> None:
         block = web3.eth.getBlock('pending')
         assert block['hash'] is None

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -808,6 +808,12 @@ class EthModuleTest:
         with pytest.raises(BlockNotFound):
             web3.eth.getBlock(UNKNOWN_HASH)
 
+    def test_eth_getBlockByHash_pending(
+        self, web3: "Web3", empty_block: BlockData
+    ) -> None:
+        block = web3.eth.getBlock('pending')
+        assert block['hash'] is None
+
     def test_eth_getBlockByNumber_with_integer(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:


### PR DESCRIPTION
### What was wrong?

Related to Issue #1572

### How was it fixed?
In order to be compatible with the most recent geth versions v 1.9.19+, test_eth_getBlockByNumber was modified to ensure that a block number is being returned, rather than null. Also, a test for getBlockByHash for pending blocks was added. 


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://townsquare.media/site/832/files/2018/10/ThinkstockPhotos-475488041-e1539191570199.jpg?w=980&q=75)
