### PR TITLE
Add handler for Ganache revert message format

### DIFF
--- a/newsfragments/1794.bugfix.rst
+++ b/newsfragments/1794.bugfix.rst
@@ -1,0 +1,1 @@
+Handle revert reason parsing for Ganache

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -49,6 +49,20 @@ OTHER_ERROR = RPCResponse({
     "id": 1,
 })
 
+GANACHE_RESPONSE = RPCResponse({
+    'id': 24,
+    'jsonrpc': '2.0',
+    'error': {
+        'message': 'VM Exception while processing transaction: revert Custom revert message',
+        'code': -32000,
+        'data': {
+            'stack': 'o: VM Exception while processing transaction: revert Custom revert message\n', 
+            'name': 'o'
+        }
+    }
+})
+
+
 
 @pytest.mark.parametrize(
     "response,expected",
@@ -67,6 +81,11 @@ def test_get_revert_reason(response, expected) -> None:
 
 def test_get_revert_reason_other_error() -> None:
     assert raise_solidity_error_on_revert(OTHER_ERROR) is OTHER_ERROR
+
+
+def test_get_revert_reason_ganache() -> None:
+    with pytest.raises(SolidityError, match='VM Exception while processing transaction: revert Custom revert message'):
+        raise_solidity_error_on_revert(GANACHE_RESPONSE)
 
 
 def test_get_error_formatters() -> None:

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -85,7 +85,8 @@ def test_get_revert_reason_other_error() -> None:
 def test_get_revert_reason_ganache() -> None:
     with pytest.raises(
         SolidityError,
-        match='VM Exception while processing transaction: revert Custom revert message'
+        match='execution reverted: VM Exception while processing transaction: \
+revert Custom revert message'
     ):
         raise_solidity_error_on_revert(GANACHE_RESPONSE)
 

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -56,12 +56,11 @@ GANACHE_RESPONSE = RPCResponse({
         'message': 'VM Exception while processing transaction: revert Custom revert message',
         'code': -32000,
         'data': {
-            'stack': 'o: VM Exception while processing transaction: revert Custom revert message\n', 
+            'stack': 'o: VM Exception while processing transaction: revert Custom revert message\n',
             'name': 'o'
         }
     }
 })
-
 
 
 @pytest.mark.parametrize(
@@ -84,7 +83,10 @@ def test_get_revert_reason_other_error() -> None:
 
 
 def test_get_revert_reason_ganache() -> None:
-    with pytest.raises(SolidityError, match='VM Exception while processing transaction: revert Custom revert message'):
+    with pytest.raises(
+        SolidityError,
+        match='VM Exception while processing transaction: revert Custom revert message'
+    ):
         raise_solidity_error_on_revert(GANACHE_RESPONSE)
 
 

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -14,6 +14,7 @@ from web3.types import (
     RPCResponse,
 )
 
+# OpenEthereum/default case:
 REVERT_WITH_MSG = RPCResponse({
     'jsonrpc': '2.0',
     'error': {
@@ -49,6 +50,21 @@ OTHER_ERROR = RPCResponse({
     "id": 1,
 })
 
+GETH_RESPONSE = RPCResponse({
+    'jsonrpc': '2.0',
+    'id': 2,
+    'error': {
+        'code': 3,
+        'message': 'execution reverted: Function has been reverted.',
+        'data': (
+            '0x08c379a0000000000000000000000000000000000000000000000'
+            '0000000000000000020000000000000000000000000000000000000'
+            '000000000000000000000000001b46756e6374696f6e20686173206'
+            '265656e2072657665727465642e0000000000'
+        ),
+    },
+})
+
 GANACHE_RESPONSE = RPCResponse({
     'id': 24,
     'jsonrpc': '2.0',
@@ -68,10 +84,14 @@ GANACHE_RESPONSE = RPCResponse({
     (
         (REVERT_WITH_MSG, 'execution reverted: not allowed to monitor'),
         (REVERT_WITHOUT_MSG, 'execution reverted'),
+        (GETH_RESPONSE, 'execution reverted: Function has been reverted.'),
+        (GANACHE_RESPONSE, 'execution reverted: VM Exception while processing transaction: revert Custom revert message'),  # noqa: 501
     ),
     ids=[
         'test-get-revert-reason-with-msg',
         'test-get-revert-reason-without-msg',
+        'test-get-geth-revert-reason',
+        'test_get-ganache-revert-reason',
     ])
 def test_get_revert_reason(response, expected) -> None:
     with pytest.raises(SolidityError, match=expected):
@@ -80,15 +100,6 @@ def test_get_revert_reason(response, expected) -> None:
 
 def test_get_revert_reason_other_error() -> None:
     assert raise_solidity_error_on_revert(OTHER_ERROR) is OTHER_ERROR
-
-
-def test_get_revert_reason_ganache() -> None:
-    with pytest.raises(
-        SolidityError,
-        match='execution reverted: VM Exception while processing transaction: \
-revert Custom revert message'
-    ):
-        raise_solidity_error_on_revert(GANACHE_RESPONSE)
 
 
 def test_get_error_formatters() -> None:

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -485,8 +485,13 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
     if not isinstance(response['error'], dict):
         raise ValueError('Error expected to be a dict')
 
-    # Parity/OpenEthereum case:
     data = response['error'].get('data', '')
+
+    # Ganache case:
+    if isinstance(data, dict) and response['error'].get('message'):
+        raise SolidityError(response['error']['message'])
+
+    # Parity/OpenEthereum case:
     if data.startswith('Reverted '):
         # "Reverted", function selector and offset are always the same for revert errors
         prefix = 'Reverted 0x08c379a00000000000000000000000000000000000000000000000000000000000000020'  # noqa: 501

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -489,7 +489,7 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
 
     # Ganache case:
     if isinstance(data, dict) and response['error'].get('message'):
-        raise SolidityError(response['error']['message'])
+        raise SolidityError(f'execution reverted: {response["error"]["message"]}')
 
     # Parity/OpenEthereum case:
     if data.startswith('Reverted '):


### PR DESCRIPTION
### What was wrong?

Related to Issue #1793 

### How was it fixed?

The case when `data` field in the RPC response is `dict` was handled, so Ganache revert reasons could be parsed correctly. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Cute possum here](https://pbs.twimg.com/media/EnH9o2qW4AQHbb3?format=jpg&name=medium)
