### PR TITLE
Remove unneeded pytestmark warnings

### DIFF
--- a/newsfragments/1796.misc.rst
+++ b/newsfragments/1796.misc.rst
@@ -1,0 +1,1 @@
+Remove un-needed pytest.mark.filterwarnings("ignore:implicit cast from 'char *'") that we had in the tests.

--- a/tests/core/contracts/test_extracting_event_data_old.py
+++ b/tests/core/contracts/test_extracting_event_data_old.py
@@ -8,9 +8,6 @@ from web3._utils.events import (
     get_event_data,
 )
 
-# Ignore warning in pyethereum 1.6 - will go away with the upgrade
-pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
-
 
 @pytest.fixture()
 def Emitter(web3, EMITTER):

--- a/tests/core/filtering/test_contract_past_event_filtering.py
+++ b/tests/core/filtering/test_contract_past_event_filtering.py
@@ -4,9 +4,6 @@ from eth_utils import (
     is_same_address,
 )
 
-# Ignore warning in pyethereum 1.6 - will go away with the upgrade
-pytestmark = pytest.mark.filterwarnings("ignore:implicit cast from 'char *'")
-
 
 @pytest.mark.parametrize('call_as_instance', (True, False))
 @pytest.mark.parametrize('api_style', ('v4', 'build_filter'))


### PR DESCRIPTION
### What was wrong?
We had a few spare pytestmark filter warnings floating around that we weren't using. 


### How was it fixed?
Removed them!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/99733722-d56f0200-2a7e-11eb-91f1-9cb6e9ebeb1b.png)

