### PR TITLE
Remove module

### DIFF
--- a/newsfragments/1805.misc.rst
+++ b/newsfragments/1805.misc.rst
@@ -1,0 +1,1 @@
+Remove Module class in favor of ModuleV2. ModuleV2 can handle both async and sync calls.

--- a/tests/core/utilities/test_attach_modules.py
+++ b/tests/core/utilities/test_attach_modules.py
@@ -1,0 +1,84 @@
+import pytest
+
+from web3 import Web3
+from web3._utils.module import (
+    attach_modules,
+)
+from web3.exceptions import (
+    ValidationError,
+)
+from web3.module import (
+    ModuleV2,
+)
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
+
+
+class MockEth(ModuleV2):
+    def block_number(self):
+        return 42
+
+
+class MockGeth(ModuleV2):
+    pass
+
+
+class MockGethAdmin(ModuleV2):
+    def start_ws(self):
+        return True
+
+
+class MockGethPersonal(ModuleV2):
+    def unlock_account(self):
+        return True
+
+
+def test_attach_modules():
+    mods = {
+        "geth": (MockGeth, {
+            "personal": (MockGethPersonal,),
+            "admin": (MockGethAdmin,),
+        }),
+        "eth": (MockEth,),
+    }
+    w3 = Web3(EthereumTesterProvider(), modules={})
+    attach_modules(w3, mods)
+    assert w3.eth.block_number() == 42
+    assert w3.geth.personal.unlock_account() is True
+    assert w3.geth.admin.start_ws() is True
+
+
+def test_attach_modules_multiple_levels_deep():
+    mods = {
+        "eth": (MockEth,),
+        "geth": (MockGeth, {
+            "personal": (MockGethPersonal, {
+                "admin": (MockGethAdmin,),
+            }),
+        }),
+    }
+    w3 = Web3(EthereumTesterProvider(), modules={})
+    attach_modules(w3, mods)
+    assert w3.eth.block_number() == 42
+    assert w3.geth.personal.unlock_account() is True
+    assert w3.geth.personal.admin.start_ws() is True
+
+
+def test_attach_modules_with_wrong_module_format():
+    mods = {
+        "eth": (MockEth, MockGeth, MockGethPersonal)
+    }
+    w3 = Web3(EthereumTesterProvider, modules={})
+    with pytest.raises(ValidationError, match="Module definitions can only have 1 or 2 elements"):
+        attach_modules(w3, mods)
+
+
+def test_attach_modules_with_existing_modules():
+    mods = {
+        "eth": (MockEth,),
+    }
+    w3 = Web3(EthereumTesterProvider, modules=mods)
+    with pytest.raises(AttributeError,
+                       match="The web3 object already has an attribute with that name"):
+        attach_modules(w3, mods)

--- a/web3/_utils/admin.py
+++ b/web3/_utils/admin.py
@@ -16,7 +16,7 @@ from web3.method import (
     default_root_munger,
 )
 from web3.module import (
-    Module,
+    ModuleV2,
 )
 from web3.types import (
     EnodeURI,
@@ -26,7 +26,7 @@ from web3.types import (
 
 
 def admin_start_params_munger(
-    module: Module, host: str = 'localhost', port: int = 8546, cors: str = '',
+    module: ModuleV2, host: str = 'localhost', port: int = 8546, cors: str = '',
     apis: str = 'eth,net,web3'
 ) -> Tuple[str, int, str, str]:
     return (host, port, cors, apis)

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -61,10 +61,6 @@ from web3.types import (
 
 if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
-    from web3.module import (  # noqa: F401
-        Module,
-        ModuleV2,
-    )
     from web3.eth import Eth  # noqa: F401
 
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -97,10 +97,7 @@ from web3.types import (
 
 if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
-    from web3.module import (  # noqa: F401
-        Module,
-        ModuleV2,
-    )
+    from web3.module import ModuleV2  # noqa: F401
     from web3.eth import Eth  # noqa: F401
 
 
@@ -659,7 +656,7 @@ FILTER_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
 @to_tuple
 def apply_module_to_formatters(
         formatters: Tuple[Callable[..., TReturn]],
-        module: Union["Module", "ModuleV2"],
+        module: "ModuleV2",
         method_name: Union[RPCEndpoint, Callable[..., RPCEndpoint]],
 ) -> Iterable[Callable[..., TReturn]]:
     for f in formatters:
@@ -668,7 +665,7 @@ def apply_module_to_formatters(
 
 def get_result_formatters(
     method_name: Union[RPCEndpoint, Callable[..., RPCEndpoint]],
-    module: Union["Module", "ModuleV2"],
+    module: "ModuleV2",
 ) -> Dict[str, Callable[..., Any]]:
     formatters = combine_formatters(
         (PYTHONIC_RESULT_FORMATTERS,),

--- a/web3/_utils/module.py
+++ b/web3/_utils/module.py
@@ -1,25 +1,44 @@
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
+    Optional,
     Sequence,
-    TypeVar,
+    Union,
 )
 
 from web3.exceptions import (
     ValidationError,
 )
 
-T = TypeVar("T")
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
+    from web3.module import ModuleV2  # noqa: F401
 
 
-def attach_modules(parent_module: T, module_definitions: Dict[str, Sequence[Any]]) -> None:
+def attach_modules(
+    parent_module: Union["Web3", "ModuleV2"],
+    module_definitions: Dict[str, Sequence[Any]],
+    w3: Optional[Union["Web3", "ModuleV2"]] = None
+) -> None:
     for module_name, module_info in module_definitions.items():
         module_class = module_info[0]
-        module_class.attach(parent_module, module_name)
+
+        if hasattr(parent_module, module_name):
+            raise AttributeError(
+                f"Cannot set {parent_module} module named '{module_name}'.  The web3 object "
+                "already has an attribute with that name"
+            )
+
+        if w3 is None:
+            setattr(parent_module, module_name, module_class(parent_module))
+            w3 = parent_module
+        else:
+            setattr(parent_module, module_name, module_class(w3))
 
         if len(module_info) == 2:
             submodule_definitions = module_info[1]
             module = getattr(parent_module, module_name)
-            attach_modules(module, submodule_definitions)
+            attach_modules(module, submodule_definitions, w3)
         elif len(module_info) != 1:
             raise ValidationError("Module definitions can only have 1 or 2 elements.")

--- a/web3/beacon/main.py
+++ b/web3/beacon/main.py
@@ -6,11 +6,11 @@ from typing import (
 import requests
 
 from web3.module import (
-    Module,
+    ModuleV2,
 )
 
 
-class Beacon(Module):
+class Beacon(ModuleV2):
     def __init__(
         self,
         base_url: str,

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -81,7 +81,6 @@ from web3.method import (
     default_root_munger,
 )
 from web3.module import (
-    Module,
     ModuleV2,
 )
 from web3.types import (
@@ -105,7 +104,7 @@ from web3.types import (
 )
 
 
-class Eth(ModuleV2, Module):
+class Eth(ModuleV2):
     account = Account()
     _default_account: Union[ChecksumAddress, Empty] = empty
     _default_block: BlockIdentifier = "latest"

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -56,7 +56,6 @@ from web3._utils.txpool import (
     status,
 )
 from web3.module import (
-    Module,
     ModuleV2,
 )
 
@@ -137,6 +136,6 @@ class GethMiner(ModuleV2):
     stopAutoDag = stopAutoDag
 
 
-class Geth(Module):
+class Geth(ModuleV2):
     personal: GethPersonal
     admin: GethAdmin

--- a/web3/main.py
+++ b/web3/main.py
@@ -285,7 +285,7 @@ class Web3:
     def enable_unstable_package_management_api(self) -> None:
         from web3.pm import PM  # noqa: F811
         if not hasattr(self, '_pm'):
-            PM.attach(self, '_pm')
+            attach_modules(self, {'_pm': (PM,)})
 
     def enable_strict_bytes_type_checking(self) -> None:
         self.codec = ABICodec(build_strict_registry())

--- a/web3/method.py
+++ b/web3/method.py
@@ -37,10 +37,7 @@ from web3.types import (
 
 if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
-    from web3.module import (  # noqa: F401
-        Module,
-        ModuleV2,
-    )
+    from web3.module import ModuleV2  # noqa: F401
 
 Munger = Callable[..., Any]
 
@@ -62,14 +59,14 @@ def _munger_star_apply(fn: Callable[..., TReturn]) -> Callable[..., TReturn]:
     return inner
 
 
-def default_munger(module: Union["Module", "ModuleV2"], *args: Any, **kwargs: Any) -> Tuple[()]:
+def default_munger(module: "ModuleV2", *args: Any, **kwargs: Any) -> Tuple[()]:
     if not args and not kwargs:
         return ()
     else:
         raise TypeError("Parameters passed to method without parameter mungers defined.")
 
 
-def default_root_munger(module: Union["Module", "ModuleV2"], *args: Any) -> List[Any]:
+def default_root_munger(module: "ModuleV2", *args: Any) -> List[Any]:
     return [*args]
 
 
@@ -152,7 +149,7 @@ class Method(Generic[TFunc]):
         raise ValueError("``json_rpc_method`` config invalid.  May be a string or function")
 
     def input_munger(
-        self, module: Union["Module", "ModuleV2"], args: Any, kwargs: Any
+        self, module: "ModuleV2", args: Any, kwargs: Any
     ) -> List[Any]:
         # This function takes the "root_munger" - the first munger in
         # the list of mungers) and then pipes the return value of the
@@ -171,7 +168,7 @@ class Method(Generic[TFunc]):
         return munged_inputs
 
     def process_params(
-        self, module: Union["Module", "ModuleV2"], *args: Any, **kwargs: Any
+        self, module: "ModuleV2", *args: Any, **kwargs: Any
     ) -> Tuple[Tuple[Union[RPCEndpoint, Callable[..., Any]], Any], Tuple[Any, Any]]:
         params = self.input_munger(module, args, kwargs)
 

--- a/web3/module.py
+++ b/web3/module.py
@@ -3,7 +3,6 @@ from typing import (
     Any,
     Callable,
     Coroutine,
-    Optional,
     TypeVar,
     Union,
 )
@@ -47,7 +46,7 @@ TReturn = TypeVar('TReturn')
 
 @curry
 def retrieve_blocking_method_call_fn(
-    w3: "Web3", module: Union["Module", "ModuleV2"], method: Method[Callable[..., TReturn]]
+    w3: "Web3", module: "ModuleV2", method: Method[Callable[..., TReturn]]
 ) -> Callable[..., Union[TReturn, LogFilter]]:
     def caller(*args: Any, **kwargs: Any) -> Union[TReturn, LogFilter]:
         try:
@@ -62,7 +61,7 @@ def retrieve_blocking_method_call_fn(
 
 @curry
 def retrieve_async_method_call_fn(
-    w3: "Web3", module: Union["Module", "ModuleV2"], method: Method[Callable[..., Any]]
+    w3: "Web3", module: "ModuleV2", method: Method[Callable[..., Any]]
 ) -> Callable[..., Coroutine[Any, Any, RPCResponse]]:
     async def caller(*args: Any, **kwargs: Any) -> RPCResponse:
         (method_str, params), response_formatters = method.process_params(module, *args, **kwargs)
@@ -72,40 +71,11 @@ def retrieve_async_method_call_fn(
     return caller
 
 
-#  TODO: Replace this with ModuleV2 when ready.
-class Module:
-    web3: "Web3" = None
-
-    def __init__(self, web3: "Web3") -> None:
-        self.web3 = web3
-
-    @classmethod
-    def attach(cls, target: "Web3", module_name: Optional[str] = None) -> None:
-        if not module_name:
-            module_name = cls.__name__.lower()
-
-        if hasattr(target, module_name):
-            raise AttributeError(
-                "Cannot set {0} module named '{1}'.  The web3 object "
-                "already has an attribute with that name".format(
-                    target,
-                    module_name,
-                )
-            )
-
-        if isinstance(target, Module):
-            web3 = target.web3
-        else:
-            web3 = target
-
-        setattr(target, module_name, cls(web3))
-
-
 #  Module should no longer have access to the full web3 api.
 #  Only the calling functions need access to the request methods.
 #  Any "re-entrant" shinanigans can go in the middlewares, which do
 #  have web3 access.
-class ModuleV2(Module):
+class ModuleV2:
     is_async = False
 
     def __init__(self, web3: "Web3") -> None:

--- a/web3/pm.py
+++ b/web3/pm.py
@@ -60,7 +60,7 @@ from web3.exceptions import (
     PMError,
 )
 from web3.module import (
-    Module,
+    ModuleV2,
 )
 from web3.types import (
     ENS,
@@ -312,7 +312,7 @@ class SimpleRegistry(ERC1319Registry):
         return cls(tx_receipt["contractAddress"], w3)
 
 
-class PM(Module):
+class PM(ModuleV2):
     """
     The PM module will work with any subclass of ``ERC1319Registry``, tailored to a particular
     implementation of `ERC1319  <https://github.com/ethereum/EIPs/issues/1319>`__, set as

--- a/web3/testing.py
+++ b/web3/testing.py
@@ -6,11 +6,11 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.module import (
-    Module,
+    ModuleV2,
 )
 
 
-class Testing(Module):
+class Testing(ModuleV2):
     def timeTravel(self, timestamp: int) -> None:
         return self.web3.manager.request_blocking(RPC.testing_timeTravel, [timestamp])
 

--- a/web3/version.py
+++ b/web3/version.py
@@ -10,7 +10,6 @@ from web3.method import (
     Method,
 )
 from web3.module import (
-    Module,
     ModuleV2,
 )
 
@@ -50,7 +49,7 @@ class BlockingVersion(BaseVersion):
         return self._get_protocol_version()
 
 
-class Version(Module):
+class Version(ModuleV2):
     @property
     def api(self) -> NoReturn:
         raise DeprecationWarning(


### PR DESCRIPTION
### What was wrong?
Out with the old, in with the new! Got rid of the last `Module` references, in favor of `ModuleV2` which supports async. The next PR, I'll change the ModuleV2 to Module, since it no longer makes sense to have it versioned any more. 

I debated putting the attach_modules function on the web3 class, and ultimately decided to keep it in _utils/module. If anyone has a strong opinion one way or the other, I will happily move it!


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![image](https://user-images.githubusercontent.com/6540608/114468810-4a1b1800-9ba9-11eb-9a08-40e8b288580f.png)
