### PR TITLE
[WIP] Handle Empty Revert Message

### DIFF
--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -9,6 +9,9 @@ import json
 import pytest
 
 import eth_abi
+from eth_tester.exceptions import (
+    TransactionFailed,
+)
 from eth_utils import (
     is_text,
 )
@@ -30,7 +33,6 @@ from web3.exceptions import (
     MismatchedABI,
     NoABIFound,
     NoABIFunctionsFound,
-    SolidityError,
     ValidationError,
 )
 
@@ -872,7 +874,7 @@ def test_call_nested_tuple_contract(nested_tuple_contract, method_input, expecte
 
 
 def test_call_revert_contract(revert_contract):
-    with pytest.raises(SolidityError, match="Function has been reverted."):
+    with pytest.raises(TransactionFailed, match="Function has been reverted."):
         # eth-tester will do a gas estimation if we don't submit a gas value,
         # which does not contain the revert reason. Avoid that by giving a gas
         # value.

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -8,7 +8,7 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.exceptions import (
-    SolidityError,
+    TransactionError,
 )
 from web3.types import (
     RPCResponse,
@@ -94,7 +94,7 @@ GANACHE_RESPONSE = RPCResponse({
         'test_get-ganache-revert-reason',
     ])
 def test_get_revert_reason(response, expected) -> None:
-    with pytest.raises(SolidityError, match=expected):
+    with pytest.raises(TransactionError, match=expected):
         raise_solidity_error_on_revert(response)
 
 
@@ -104,8 +104,8 @@ def test_get_revert_reason_other_error() -> None:
 
 def test_get_error_formatters() -> None:
     formatters = get_error_formatters(RPC.eth_call)
-    with pytest.raises(SolidityError, match='not allowed to monitor'):
+    with pytest.raises(TransactionError, match='not allowed to monitor'):
         formatters(REVERT_WITH_MSG)
-    with pytest.raises(SolidityError):
+    with pytest.raises(TransactionError):
         formatters(REVERT_WITHOUT_MSG)
     assert formatters(OTHER_ERROR) == OTHER_ERROR

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -4,6 +4,10 @@ from flaky import (
     flaky,
 )
 
+from eth_typing import (
+    ChecksumAddress,
+)
+
 from web3._utils.module_testing import (  # noqa: F401
     EthModuleTest,
     ParityModuleTest,
@@ -174,6 +178,22 @@ class ParityEthModuleTest(EthModuleTest):
         super().test_invalid_eth_signTypedData(
             web3, unlocked_account_dual_type
         )
+
+    def test_eth_estimateGas_revert_without_msg(
+        self,
+        web3: "Web3",
+        revert_contract: "Contract",
+        unlocked_account: ChecksumAddress,
+    ) -> None:
+        with pytest.raises(ValueError, match="The execution failed due to an exception."):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithoutMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.estimateGas(txn_params)
 
 
 class ParityTraceModuleTest(ParityTraceModuleTest):

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -4,10 +4,6 @@ from flaky import (
     flaky,
 )
 
-from eth_typing import (
-    ChecksumAddress,
-)
-
 from web3._utils.module_testing import (  # noqa: F401
     EthModuleTest,
     ParityModuleTest,
@@ -181,9 +177,9 @@ class ParityEthModuleTest(EthModuleTest):
 
     def test_eth_estimateGas_revert_without_msg(
         self,
-        web3: "Web3",
-        revert_contract: "Contract",
-        unlocked_account: ChecksumAddress,
+        web3,
+        revert_contract,
+        unlocked_account,
     ) -> None:
         with pytest.raises(ValueError, match="The execution failed due to an exception."):
             txn_params = revert_contract._prepare_transaction(

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -21,9 +21,6 @@ from web3._utils.module_testing import (
 from web3._utils.module_testing.emitter_contract import (
     EMITTER_ENUM,
 )
-from web3.exceptions import (
-    SolidityError,
-)
 from web3.providers.eth_tester import (
     EthereumTesterProvider,
 )

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -21,6 +21,9 @@ from web3._utils.module_testing import (
 from web3._utils.module_testing.emitter_contract import (
     EMITTER_ENUM,
 )
+from web3.exceptions import (
+    SolidityError,
+)
 from web3.providers.eth_tester import (
     EthereumTesterProvider,
 )

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -4,6 +4,9 @@ import pytest
 from eth_tester import (
     EthereumTester,
 )
+from eth_tester.exceptions import (
+    TransactionFailed,
+)
 from eth_utils import (
     is_checksum_address,
     is_dict,
@@ -335,6 +338,52 @@ class TestEthereumTesterEthModule(EthModuleTest):
     @pytest.mark.xfail(raises=KeyError, reason="ethereum tester doesn't return 'to' key")
     def test_eth_getTransactionReceipt_mined(self, web3, block_with_txn, mined_txn_hash):
         super().test_eth_getTransactionReceipt_mined(web3, block_with_txn, mined_txn_hash)
+
+    def test_eth_call_revert_with_msg(self, web3, revert_contract, unlocked_account):
+        with pytest.raises(TransactionFailed,
+                           match='execution reverted: Function has been reverted'):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.call(txn_params)
+
+    def test_eth_call_revert_without_msg(self, web3, revert_contract, unlocked_account):
+        with pytest.raises(TransactionFailed, match="execution reverted"):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithoutMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.call(txn_params)
+
+    def test_eth_estimateGas_revert_with_msg(self, web3, revert_contract, unlocked_account):
+        with pytest.raises(TransactionFailed,
+                           match='execution reverted: Function has been reverted'):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.estimateGas(txn_params)
+
+    def test_eth_estimateGas_revert_without_msg(self, web3, revert_contract, unlocked_account):
+        with pytest.raises(TransactionFailed, match="execution reverted"):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithoutMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.estimateGas(txn_params)
 
 
 class TestEthereumTesterVersionModule(VersionModuleTest):

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -81,7 +81,6 @@ from web3.datastructures import (
 )
 from web3.exceptions import (
     BlockNotFound,
-    SolidityError,
     TransactionError,
     TransactionNotFound,
 )

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -82,6 +82,7 @@ from web3.datastructures import (
 from web3.exceptions import (
     BlockNotFound,
     SolidityError,
+    TransactionError,
     TransactionNotFound,
 )
 from web3.types import (
@@ -503,26 +504,26 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
 
     # Ganache case:
     if isinstance(data, dict) and response['error'].get('message'):
-        raise SolidityError(f'execution reverted: {response["error"]["message"]}')
+        raise TransactionError(f'execution reverted: {response["error"]["message"]}')
 
     # Parity/OpenEthereum case:
     if data.startswith('Reverted '):
         # "Reverted", function selector and offset are always the same for revert errors
         prefix = 'Reverted 0x08c379a00000000000000000000000000000000000000000000000000000000000000020'  # noqa: 501
         if not data.startswith(prefix):
-            raise SolidityError('execution reverted')
+            raise TransactionError('execution reverted')
 
         reason_length = int(data[len(prefix):len(prefix) + 64], 16)
         reason = data[len(prefix) + 64:len(prefix) + 64 + reason_length * 2]
-        raise SolidityError(f'execution reverted: {bytes.fromhex(reason).decode("utf8")}')
+        raise TransactionError(f'execution reverted: {bytes.fromhex(reason).decode("utf8")}')
 
     # Geth case:
     if 'message' in response['error'] and response['error'].get('code', '') == 3:
-        raise SolidityError(response['error']['message'])
+        raise TransactionError(response['error']['message'])
 
     # Revert without error message case:
     if 'execution reverted' in response['error'].get('message'):
-        raise SolidityError('execution reverted')
+        raise TransactionError('execution reverted')
 
     return response
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -520,6 +520,10 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
     if 'message' in response['error'] and response['error'].get('code', '') == 3:
         raise SolidityError(response['error']['message'])
 
+    # Revert without error message case:
+    if 'execution reverted' in response['error'].get('message'):
+        raise SolidityError('execution reverted')
+
     return response
 
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -758,6 +758,22 @@ class EthModuleTest:
             )
             web3.eth.call(txn_params)
 
+    def test_eth_call_revert_without_msg(
+        self,
+        web3: "Web3",
+        revert_contract: "Contract",
+        unlocked_account: ChecksumAddress,
+    ) -> None:
+        with pytest.raises(SolidityError, match="execution reverted"):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithoutMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.call(txn_params)
+
     def test_eth_estimateGas_revert_with_msg(
         self,
         web3: "Web3",
@@ -767,6 +783,22 @@ class EthModuleTest:
         with pytest.raises(SolidityError, match='execution reverted: Function has been reverted'):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.estimateGas(txn_params)
+
+    def test_eth_estimateGas_revert_without_msg(
+        self,
+        web3: "Web3",
+        revert_contract: "Contract",
+        unlocked_account: ChecksumAddress,
+    ) -> None:
+        with pytest.raises(SolidityError, match="execution reverted"):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithoutMessage",
                 transaction={
                     "from": unlocked_account,
                     "to": revert_contract.address,

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -37,7 +37,7 @@ from web3.exceptions import (
     BlockNotFound,
     InvalidAddress,
     NameNotFound,
-    SolidityError,
+    TransactionError,
     TransactionNotFound,
 )
 from web3.types import (  # noqa: F401
@@ -748,7 +748,8 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        with pytest.raises(SolidityError, match='execution reverted: Function has been reverted'):
+        with pytest.raises(TransactionError,
+                           match='execution reverted: Function has been reverted'):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithMessage",
                 transaction={
@@ -764,7 +765,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        with pytest.raises(SolidityError, match="execution reverted"):
+        with pytest.raises(TransactionError, match="execution reverted"):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithoutMessage",
                 transaction={
@@ -780,7 +781,8 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        with pytest.raises(SolidityError, match='execution reverted: Function has been reverted'):
+        with pytest.raises(TransactionError,
+                           match='execution reverted: Function has been reverted'):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithMessage",
                 transaction={
@@ -796,7 +798,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        with pytest.raises(SolidityError, match="execution reverted"):
+        with pytest.raises(TransactionError, match="execution reverted"):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithoutMessage",
                 transaction={

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -1,10 +1,6 @@
 import datetime
 import time
 
-from eth_tester.exceptions import (
-    TransactionFailed,
-)
-
 from web3.types import (
     BlockData,
 )
@@ -198,8 +194,7 @@ class InvalidEventABI(ValueError):
     pass
 
 
-class SolidityError(ValueError, TransactionFailed):
-    # TODO - remove TransactionFailed inheritance in v6
+class SolidityError(ValueError):
     # Inherits from ValueError for backwards compatibility
     """
     Raised on a solidity require/revert

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -1,6 +1,10 @@
 import datetime
 import time
 
+from eth_tester.exceptions import (
+    TransactionFailed,
+)
+
 from web3.types import (
     BlockData,
 )
@@ -194,7 +198,8 @@ class InvalidEventABI(ValueError):
     pass
 
 
-class SolidityError(ValueError):
+class SolidityError(ValueError, TransactionFailed):
+    # TODO - remove TransactionFailed inheritance in v6
     # Inherits from ValueError for backwards compatibility
     """
     Raised on a solidity require/revert

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -197,7 +197,7 @@ class InvalidEventABI(ValueError):
 class SolidityError(ValueError):
     # Inherits from ValueError for backwards compatibility
     """
-    Raised on a solidity require/revert
+    Raised on assert/require/revert statement in contracts
     """
     pass
 

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -200,3 +200,11 @@ class SolidityError(ValueError):
     Raised on a solidity require/revert
     """
     pass
+
+
+class TransactionError(SolidityError):
+    # Inherits from SolidityError for backwards compatibility
+    """
+    Raised on assert/require/revert statement in contracts
+    """
+    pass

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -16,9 +16,6 @@ from eth_abi.exceptions import (
 from web3._utils.compat import (
     Literal,
 )
-from web3.exceptions import (
-    TransactionError,
-)
 from web3.providers import (
     BaseProvider,
 )
@@ -108,12 +105,12 @@ class EthereumTesterProvider(BaseProvider):
             return RPCResponse({
                 "error": "RPC Endpoint has not been implemented: {0}".format(method),
             })
-        # except TransactionFailed as e:
-        #     try:
-        #         reason = decode_single('(string)', e.args[0].args[0][4:])[0]
-        #     except (InsufficientDataBytes, AttributeError):
-        #         reason = e.args[0]
-        #     raise TransactionError(f'execution reverted: {reason}')
+        except TransactionFailed as e:
+            try:
+                reason = decode_single('(string)', e.args[0].args[0][4:])[0]
+            except (InsufficientDataBytes, AttributeError):
+                reason = e.args[0]
+            raise TransactionFailed(f'execution reverted: {reason}')
         else:
             return {
                 'result': response,

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -17,7 +17,7 @@ from web3._utils.compat import (
     Literal,
 )
 from web3.exceptions import (
-    SolidityError,
+    TransactionError,
 )
 from web3.providers import (
     BaseProvider,
@@ -108,12 +108,12 @@ class EthereumTesterProvider(BaseProvider):
             return RPCResponse({
                 "error": "RPC Endpoint has not been implemented: {0}".format(method),
             })
-        except TransactionFailed as e:
-            try:
-                reason = decode_single('(string)', e.args[0].args[0][4:])[0]
-            except (InsufficientDataBytes, AttributeError):
-                reason = e.args[0]
-            raise SolidityError(f'execution reverted: {reason}')
+        # except TransactionFailed as e:
+        #     try:
+        #         reason = decode_single('(string)', e.args[0].args[0][4:])[0]
+        #     except (InsufficientDataBytes, AttributeError):
+        #         reason = e.args[0]
+        #     raise TransactionError(f'execution reverted: {reason}')
         else:
             return {
                 'result': response,

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -111,7 +111,7 @@ class EthereumTesterProvider(BaseProvider):
         except TransactionFailed as e:
             try:
                 reason = decode_single('(string)', e.args[0].args[0][4:])[0]
-            except InsufficientDataBytes:
+            except (InsufficientDataBytes, AttributeError):
                 reason = e.args[0]
             raise SolidityError(f'execution reverted: {reason}')
         else:

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -9,6 +9,9 @@ from typing import (
 from eth_abi import (
     decode_single,
 )
+from eth_abi.exceptions import (
+    InsufficientDataBytes,
+)
 
 from web3._utils.compat import (
     Literal,
@@ -106,10 +109,10 @@ class EthereumTesterProvider(BaseProvider):
                 "error": "RPC Endpoint has not been implemented: {0}".format(method),
             })
         except TransactionFailed as e:
-            if type(e.args[0]) == str:
-                reason = e.args[0]
-            else:
+            try:
                 reason = decode_single('(string)', e.args[0].args[0][4:])[0]
+            except InsufficientDataBytes:
+                reason = e.args[0]
             raise SolidityError(f'execution reverted: {reason}')
         else:
             return {


### PR DESCRIPTION
### What was wrong?
EDIT: I'm going to split this into 2 PRs - one for the bugfix, one for making the error more generic.

This is a backwards incompatible bugfix that returns eth-tester functionality to what it was before 5.13.0 

@fubuloubu pointed out that vyper tests were failing since web3 converts eth-tester's `TransactionFailed` error to a `SolidityError`, and we weren't handling the empty response message quite right. eth-tester couldn't decode the empty error message on a `revert`. I added logic to try and `decode_single` on the error message, and if that fails, just return the plain, undecoded error message. I also discovered that we didn't have any tests that check what happens if the revert error message is empty, so I added some. 

When estimateGas gets reverted and doesn't have an error message, Parity returns a generic error message, so I opted to leave it as a ValueError, instead of catching it and returning a SolidityError, since I'm not sure we can reliably determine if it comes from a `revert` or not.

### How was it fixed?
I did a couple things in this PR:
- Added integration tests for the case where there is no error message that comes back from a revert
- Added a new case for an empty error message in the raise_solidity_error_on_revert function
- Eth-tester returns a TransactionFailed error again
- Made a new `TransactionError` class that inherits from `SolidityError` to make it more generic, without breaking existing functionality.

~Something that I considered doing was changing `SolidityError` to inherit from eth-tester's `TransactionFailed`, but ultimately decided not to put that in so that we didn't have to add the eth-tester library to our dependency list. I could be persuaded that it really should be a `TransactionFailed` however, since it is a breaking change.~

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/102142323-6dae9b80-3e1f-11eb-90d6-9bc36a6f7274.png)

