### PR TITLE
Read-only eth2 beacon API

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,7 @@ Table of Contents
 
     web3.main
     web3.eth
+    web3.beacon
     web3.pm
     web3.net
     web3.miner

--- a/newsfragments/1758.feature.rst
+++ b/newsfragments/1758.feature.rst
@@ -1,0 +1,1 @@
+Introduce experimental Ethereum 2.0 beacon node API

--- a/tests/beacon/test_beacon.py
+++ b/tests/beacon/test_beacon.py
@@ -1,0 +1,195 @@
+import json
+import pytest
+
+import requests
+
+import requests_mock
+from web3.beacon import (
+    Beacon,
+)
+
+GENESIS_RESPONSE = {
+    "data": {
+        "genesis_time": "1590832934",
+        "genesis_validators_root": (
+            "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+        ),
+        "genesis_fork_version": "0x00000000",
+    }
+}
+
+
+@pytest.fixture
+def session():
+    session = requests.Session()
+    adapter = requests_mock.Adapter()
+    session.mount("mock://", adapter)
+
+    adapter.register_uri(
+        "GET",
+        "mock://example.com/api/eth/v1/beacon/genesis",
+        text=json.dumps(GENESIS_RESPONSE),
+    )
+    return session
+
+
+@pytest.fixture
+def beacon(session):
+    #  return Beacon(
+    #  beacon_url="mock://example.com/api",
+    #  session=session,
+    #  )
+    return Beacon(base_url="http://localhost:5051", session=session)
+
+
+# Beacon endpoint tests:
+
+
+def test_eth2_beacon_get_genesis(beacon):
+    response = beacon.get_genesis()
+    assert response is not None
+
+
+def test_eth2_beacon_get_hash_root(beacon):
+    response = beacon.get_hash_root()
+    assert response is not None
+
+
+def test_eth2_beacon_get_fork_data(beacon):
+    response = beacon.get_fork_data()
+    assert response is not None
+
+
+def test_eth2_beacon_get_finality_checkpoint(beacon):
+    response = beacon.get_finality_checkpoint()
+    assert response is not None
+
+
+def test_eth2_beacon_get_validators(beacon):
+    response = beacon.get_validators()
+    assert response is not None
+
+
+def test_eth2_beacon_get_validator(beacon):
+    pyrmont_validator_pub_key = "0xa09c261fc2b44badc0059b6eeb8e6935f2b795f15dad32449afeec3bc635ef0ae92fe0bab5edba31aebfde1947e2acf5"  # noqa: E501
+    response = beacon.get_validator(pyrmont_validator_pub_key)
+    assert response is not None
+
+
+def test_eth2_beacon_get_validator_balances(beacon):
+    response = beacon.get_validator_balances()
+    assert response is not None
+
+
+def test_eth2_beacon_get_epoch_committees(beacon):
+    response = beacon.get_epoch_committees()
+    assert response is not None
+
+
+def test_eth2_beacon_get_block_headers(beacon):
+    response = beacon.get_block_headers()
+    assert response is not None
+
+
+def test_eth2_beacon_get_block_header(beacon):
+    response = beacon.get_block_header("123")
+    assert response is not None
+
+
+def test_eth2_beacon_get_block(beacon):
+    response = beacon.get_block("123")
+    assert response is not None
+
+
+def test_eth2_beacon_get_block_root(beacon):
+    response = beacon.get_block_root("123")
+    assert response is not None
+
+
+def test_eth2_beacon_get_block_attestations(beacon):
+    response = beacon.get_block_attestations("123")
+    assert response is not None
+
+
+def test_eth2_beacon_get_attestations(beacon):
+    response = beacon.get_attestations()
+    assert response is not None
+
+
+def test_eth2_beacon_get_attester_slashings(beacon):
+    response = beacon.get_attester_slashings()
+    assert response is not None
+
+
+def test_eth2_beacon_get_proposer_slashings(beacon):
+    response = beacon.get_proposer_slashings()
+    assert response is not None
+
+
+def test_eth2_beacon_get_voluntary_exits(beacon):
+    response = beacon.get_voluntary_exits()
+    assert response is not None
+
+
+# Config endpoint tests:
+
+
+def test_eth2_config_get_fork_schedule(beacon):
+    response = beacon.get_fork_schedule()
+    assert response is not None
+
+
+def test_eth2_config_get_spec(beacon):
+    response = beacon.get_spec()
+    assert response is not None
+
+
+def test_eth2_config_get_deposit_contract(beacon):
+    response = beacon.get_deposit_contract()
+    assert response is not None
+
+
+# Debug endpoint tests:
+
+
+def test_eth2_debug_get_beacon_state(beacon):
+    response = beacon.get_beacon_state()
+    assert response is not None
+
+
+def test_eth2_debug_get_beacon_heads(beacon):
+    response = beacon.get_beacon_heads()
+    assert response is not None
+
+
+# Node endpoint tests:
+
+
+def test_eth2_node_get_node_identity(beacon):
+    response = beacon.get_node_identity()
+    assert response is not None
+
+
+def test_eth2_node_get_peers(beacon):
+    response = beacon.get_peers()
+    assert response is not None
+
+
+def test_eth2_node_get_peer(beacon):
+    response = beacon.get_peer("")
+    assert response is not None
+
+
+def test_eth2_node_get_health(beacon):
+    response = beacon.get_health()
+    assert response <= 206
+
+
+def test_eth2_node_get_version(beacon):
+    response = beacon.get_version()
+    assert response is not None
+
+
+def test_eth2_node_get_syncing(beacon):
+    response = beacon.get_syncing()
+    assert response is not None

--- a/web3/beacon/__init__.py
+++ b/web3/beacon/__init__.py
@@ -1,0 +1,6 @@
+import warnings
+from .main import Beacon  # noqa: F401
+
+warnings.warn(
+    "Beacon node APIs are experimental and may not be implemented consistently by all clients.",
+)

--- a/web3/beacon/main.py
+++ b/web3/beacon/main.py
@@ -1,0 +1,150 @@
+from typing import (
+    Any,
+    Dict,
+)
+
+import requests
+
+from web3.module import (
+    Module,
+)
+
+
+class Beacon(Module):
+    def __init__(
+        self,
+        base_url: str,
+        session: requests.Session = requests.Session(),
+    ) -> None:
+        self.base_url = base_url
+        self.session = session
+
+    def _make_get_request(self, endpoint: str) -> Dict[str, Any]:
+        url = self.base_url + endpoint
+        response = self.session.get(url)
+        response.raise_for_status()
+        return response.json()
+
+    # [ BEACON endpoints ]
+
+    def get_genesis(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/beacon/genesis"
+        return self._make_get_request(endpoint)
+
+    def get_hash_root(self, state_id: str = "head") -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/states/{state_id}/root"
+        return self._make_get_request(endpoint)
+
+    def get_fork_data(self, state_id: str = "head") -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/states/{state_id}/fork"
+        return self._make_get_request(endpoint)
+
+    def get_finality_checkpoint(self, state_id: str = "head") -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/states/{state_id}/finality_checkpoints"
+        return self._make_get_request(endpoint)
+
+    def get_validators(self, state_id: str = "head") -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/states/{state_id}/validators"
+        return self._make_get_request(endpoint)
+
+    def get_validator(
+        self, validator_id: str, state_id: str = "head"
+    ) -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/states/{state_id}/validators/{validator_id}"
+        return self._make_get_request(endpoint)
+
+    def get_validator_balances(self, state_id: str = "head") -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/states/{state_id}/validator_balances"
+        return self._make_get_request(endpoint)
+
+    def get_epoch_committees(self, state_id: str = "head") -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/states/{state_id}/committees"
+        return self._make_get_request(endpoint)
+
+    def get_block_headers(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/beacon/headers"
+        return self._make_get_request(endpoint)
+
+    def get_block_header(self, block_id: str) -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/headers/{block_id}"
+        return self._make_get_request(endpoint)
+
+    def get_block(self, block_id: str) -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/blocks/{block_id}"
+        return self._make_get_request(endpoint)
+
+    def get_block_root(self, block_id: str) -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/blocks/{block_id}/root"
+        return self._make_get_request(endpoint)
+
+    def get_block_attestations(self, block_id: str) -> Dict[str, Any]:
+        endpoint = f"/eth/v1/beacon/blocks/{block_id}/attestations"
+        return self._make_get_request(endpoint)
+
+    def get_attestations(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/beacon/pool/attestations"
+        return self._make_get_request(endpoint)
+
+    def get_attester_slashings(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/beacon/pool/attester_slashings"
+        return self._make_get_request(endpoint)
+
+    def get_proposer_slashings(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/beacon/pool/proposer_slashings"
+        return self._make_get_request(endpoint)
+
+    def get_voluntary_exits(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/beacon/pool/voluntary_exits"
+        return self._make_get_request(endpoint)
+
+    # [ CONFIG endpoints ]
+
+    def get_fork_schedule(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/config/fork_schedule"
+        return self._make_get_request(endpoint)
+
+    def get_spec(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/config/spec"
+        return self._make_get_request(endpoint)
+
+    def get_deposit_contract(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/config/deposit_contract"
+        return self._make_get_request(endpoint)
+
+    # [ DEBUG endpoints ]
+
+    def get_beacon_state(self, state_id: str = "head") -> Dict[str, Any]:
+        endpoint = f"/eth/v1/debug/beacon/states/{state_id}"
+        return self._make_get_request(endpoint)
+
+    def get_beacon_heads(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/debug/beacon/heads"
+        return self._make_get_request(endpoint)
+
+    # [ NODE endpoints ]
+
+    def get_node_identity(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/node/identity"
+        return self._make_get_request(endpoint)
+
+    def get_peers(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/node/peers"
+        return self._make_get_request(endpoint)
+
+    def get_peer(self, peer_id: str) -> Dict[str, Any]:
+        endpoint = f"/eth/v1/node/peers/{peer_id}"
+        return self._make_get_request(endpoint)
+
+    def get_health(self) -> int:
+        endpoint = "/eth/v1/node/health"
+        url = self.base_url + endpoint
+        response = self.session.get(url)
+        return response.status_code
+
+    def get_version(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/node/version"
+        return self._make_get_request(endpoint)
+
+    def get_syncing(self) -> Dict[str, Any]:
+        endpoint = "/eth/v1/node/syncing"
+        return self._make_get_request(endpoint)


### PR DESCRIPTION
### What does it do?

- Introduces a naive eth2 beacon API interface
- Adds smoke tests (outside of the CI pipeline) for testing clients locally
- Related to #1758

### Background

- Looks like there's still some churn with these APIs and they're in various phases of development within each client.
- Most clients seem to have a few additional endpoints unique to their client.
- I used Teku for most of my local testing; a Teku beacon node produces passing tests in these smoke tests.
- The web3.js team has a TypeScript [schema](https://github.com/ethereum/web3.js/blob/1.x/packages/web3-eth2-beacon/src/schema.ts) up for some of the endpoints, so I used that to standardize on some of the method names.
- Interface:
``` python
from web3.beacon import Beacon
beacon = Beacon("http://localhost:5051")
beacon.get_genesis()
```
- ~I'm still unclear if there's agreement on where all the APIs will be served from. I made an assumption in this PR that the validator endpoints would need to be served by the validator client process, but I'm not seeing this spelled out clearly anywhere. The validator endpoints are not implemented by every client yet.~ Edit: Eth R&D Discord convo revealed that for security reasons, validator clients typically don't expose any http api, so amending for a single beacon url.
- TODO: some input and output validation/optimization, error handling. Some or all could be handled in follow-up PRs if we want to get v1 out quicker.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.redd.it/r7ni2u48wya11.jpg)
