### PR TITLE
Remove SolidityError from eth-tester

### DIFF
--- a/newsfragments/1813.bugfix.rst
+++ b/newsfragments/1813.bugfix.rst
@@ -1,0 +1,2 @@
+PR #1585 changed the error that was coming back from eth-tester when the Revert opcode was called,
+ which broke some tests in downstream libraries. This PR reverts back to raising the original error.

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -9,6 +9,9 @@ import json
 import pytest
 
 import eth_abi
+from eth_tester.exceptions import (
+    TransactionFailed,
+)
 from eth_utils import (
     is_text,
 )
@@ -30,7 +33,6 @@ from web3.exceptions import (
     MismatchedABI,
     NoABIFound,
     NoABIFunctionsFound,
-    SolidityError,
     ValidationError,
 )
 
@@ -872,7 +874,7 @@ def test_call_nested_tuple_contract(nested_tuple_contract, method_input, expecte
 
 
 def test_call_revert_contract(revert_contract):
-    with pytest.raises(SolidityError, match="Function has been reverted."):
+    with pytest.raises(TransactionFailed, match="Function has been reverted."):
         # eth-tester will do a gas estimation if we don't submit a gas value,
         # which does not contain the revert reason. Avoid that by giving a gas
         # value.

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -30,6 +30,22 @@ class ParityEthModuleTest(EthModuleTest):
     def test_eth_estimateGas_revert_with_msg(self, web3, revert_contract, unlocked_account):
         super().test_eth_estimateGas_revert_with_msg(web3, revert_contract, unlocked_account)
 
+    def test_eth_estimateGas_revert_without_msg(
+        self,
+        web3,
+        revert_contract,
+        unlocked_account,
+    ) -> None:
+        with pytest.raises(ValueError, match="The execution failed due to an exception."):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithoutMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.estimateGas(txn_params)
+
     @pytest.mark.xfail(reason='Parity dropped "pending" option in 1.11.1')
     def test_eth_getBlockByNumber_pending(self, web3):
         super().test_eth_getBlockByNumber_pending(web3)

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -385,6 +385,7 @@ class TestEthereumTesterEthModule(EthModuleTest):
             )
             web3.eth.estimateGas(txn_params)
 
+
 class TestEthereumTesterVersionModule(VersionModuleTest):
     pass
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -4,6 +4,9 @@ import pytest
 from eth_tester import (
     EthereumTester,
 )
+from eth_tester.exceptions import (
+    TransactionFailed,
+)
 from eth_utils import (
     is_checksum_address,
     is_dict,
@@ -336,6 +339,51 @@ class TestEthereumTesterEthModule(EthModuleTest):
     def test_eth_getTransactionReceipt_mined(self, web3, block_with_txn, mined_txn_hash):
         super().test_eth_getTransactionReceipt_mined(web3, block_with_txn, mined_txn_hash)
 
+    def test_eth_call_revert_with_msg(self, web3, revert_contract, unlocked_account):
+        with pytest.raises(TransactionFailed,
+                           match='execution reverted: Function has been reverted'):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.call(txn_params)
+
+    def test_eth_call_revert_without_msg(self, web3, revert_contract, unlocked_account):
+        with pytest.raises(TransactionFailed, match="execution reverted"):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithoutMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.call(txn_params)
+
+    def test_eth_estimateGas_revert_with_msg(self, web3, revert_contract, unlocked_account):
+        with pytest.raises(TransactionFailed,
+                           match='execution reverted: Function has been reverted'):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.estimateGas(txn_params)
+
+    def test_eth_estimateGas_revert_without_msg(self, web3, revert_contract, unlocked_account):
+        with pytest.raises(TransactionFailed, match="execution reverted"):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithoutMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.estimateGas(txn_params)
 
 class TestEthereumTesterVersionModule(VersionModuleTest):
     pass

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -520,6 +520,10 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
     if 'message' in response['error'] and response['error'].get('code', '') == 3:
         raise SolidityError(response['error']['message'])
 
+    # Geth Revert without error message case:
+    if 'execution reverted' in response['error'].get('message'):
+        raise SolidityError('execution reverted')
+
     return response
 
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -770,6 +770,22 @@ class EthModuleTest:
             )
             web3.eth.call(txn_params)
 
+    def test_eth_call_revert_without_msg(
+        self,
+        web3: "Web3",
+        revert_contract: "Contract",
+        unlocked_account: ChecksumAddress,
+    ) -> None:
+        with pytest.raises(SolidityError, match="execution reverted"):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithoutMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.call(txn_params)
+
     def test_eth_estimateGas_revert_with_msg(
         self,
         web3: "Web3",
@@ -779,6 +795,22 @@ class EthModuleTest:
         with pytest.raises(SolidityError, match='execution reverted: Function has been reverted'):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithMessage",
+                transaction={
+                    "from": unlocked_account,
+                    "to": revert_contract.address,
+                },
+            )
+            web3.eth.estimateGas(txn_params)
+
+    def test_eth_estimateGas_revert_without_msg(
+        self,
+        web3: "Web3",
+        revert_contract: "Contract",
+        unlocked_account: ChecksumAddress,
+    ) -> None:
+        with pytest.raises(SolidityError, match="execution reverted"):
+            txn_params = revert_contract._prepare_transaction(
+                fn_name="revertWithoutMessage",
                 transaction={
                     "from": unlocked_account,
                     "to": revert_contract.address,


### PR DESCRIPTION
### What was wrong?

This is a backwards incompatible bugfix that returns eth-tester functionality to what it was before 5.13.0 

@fubuloubu pointed out that vyper tests were failing since web3 converts eth-tester's `TransactionFailed` error to a `SolidityError`, and we weren't handling the empty response message quite right. eth-tester couldn't decode the empty error message on a `revert`. I added logic to try and `decode_single` on the error message, and if that fails, just return the plain, undecoded error message. I also discovered that we didn't have any tests that check what happens if the revert error message is empty, so I added some. 

When estimateGas gets reverted and doesn't have an error message, Parity returns a generic error message, so I opted to leave it as a ValueError, instead of catching it and returning a SolidityError, since I'm not sure we can reliably determine if it comes from a `revert` or not.

### How was it fixed?
I did a couple things in this PR:
- Added integration tests for the case where there is no error message that comes back from a revert
- Added a new case for an empty error message in the raise_solidity_error_on_revert function
- Eth-tester returns a TransactionFailed error again



### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="235" alt="image" src="https://user-images.githubusercontent.com/6540608/102648813-68a26280-4125-11eb-851c-82874d314905.png">

