### PR TITLE
Swap SolidityError for ContractLogicError

### DIFF
--- a/newsfragments/1814.bugfix.rst
+++ b/newsfragments/1814.bugfix.rst
@@ -1,0 +1,2 @@
+Added a new ``ContractLogicError`` for when a contract reverts a transaction.
+``ContractLogicError`` will replace ``SolidityError``, in v6.

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -8,7 +8,7 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.exceptions import (
-    SolidityError,
+    ContractLogicError,
 )
 from web3.types import (
     RPCResponse,
@@ -94,7 +94,7 @@ GANACHE_RESPONSE = RPCResponse({
         'test_get-ganache-revert-reason',
     ])
 def test_get_revert_reason(response, expected) -> None:
-    with pytest.raises(SolidityError, match=expected):
+    with pytest.raises(ContractLogicError, match=expected):
         raise_solidity_error_on_revert(response)
 
 
@@ -104,8 +104,8 @@ def test_get_revert_reason_other_error() -> None:
 
 def test_get_error_formatters() -> None:
     formatters = get_error_formatters(RPC.eth_call)
-    with pytest.raises(SolidityError, match='not allowed to monitor'):
+    with pytest.raises(ContractLogicError, match='not allowed to monitor'):
         formatters(REVERT_WITH_MSG)
-    with pytest.raises(SolidityError):
+    with pytest.raises(ContractLogicError):
         formatters(REVERT_WITHOUT_MSG)
     assert formatters(OTHER_ERROR) == OTHER_ERROR

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -81,7 +81,7 @@ from web3.datastructures import (
 )
 from web3.exceptions import (
     BlockNotFound,
-    SolidityError,
+    ContractLogicError,
     TransactionNotFound,
 )
 from web3.types import (
@@ -503,26 +503,26 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
 
     # Ganache case:
     if isinstance(data, dict) and response['error'].get('message'):
-        raise SolidityError(f'execution reverted: {response["error"]["message"]}')
+        raise ContractLogicError(f'execution reverted: {response["error"]["message"]}')
 
     # Parity/OpenEthereum case:
     if data.startswith('Reverted '):
         # "Reverted", function selector and offset are always the same for revert errors
         prefix = 'Reverted 0x08c379a00000000000000000000000000000000000000000000000000000000000000020'  # noqa: 501
         if not data.startswith(prefix):
-            raise SolidityError('execution reverted')
+            raise ContractLogicError('execution reverted')
 
         reason_length = int(data[len(prefix):len(prefix) + 64], 16)
         reason = data[len(prefix) + 64:len(prefix) + 64 + reason_length * 2]
-        raise SolidityError(f'execution reverted: {bytes.fromhex(reason).decode("utf8")}')
+        raise ContractLogicError(f'execution reverted: {bytes.fromhex(reason).decode("utf8")}')
 
     # Geth case:
     if 'message' in response['error'] and response['error'].get('code', '') == 3:
-        raise SolidityError(response['error']['message'])
+        raise ContractLogicError(response['error']['message'])
 
     # Geth Revert without error message case:
     if 'execution reverted' in response['error'].get('message'):
-        raise SolidityError('execution reverted')
+        raise ContractLogicError('execution reverted')
 
     return response
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -35,9 +35,9 @@ from web3._utils.ens import (
 )
 from web3.exceptions import (
     BlockNotFound,
+    ContractLogicError,
     InvalidAddress,
     NameNotFound,
-    SolidityError,
     TransactionNotFound,
 )
 from web3.types import (  # noqa: F401
@@ -767,7 +767,8 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        with pytest.raises(SolidityError, match='execution reverted: Function has been reverted'):
+        with pytest.raises(ContractLogicError,
+                           match='execution reverted: Function has been reverted'):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithMessage",
                 transaction={
@@ -783,7 +784,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        with pytest.raises(SolidityError, match="execution reverted"):
+        with pytest.raises(ContractLogicError, match="execution reverted"):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithoutMessage",
                 transaction={
@@ -799,7 +800,8 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        with pytest.raises(SolidityError, match='execution reverted: Function has been reverted'):
+        with pytest.raises(ContractLogicError,
+                           match='execution reverted: Function has been reverted'):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithMessage",
                 transaction={
@@ -815,7 +817,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        with pytest.raises(SolidityError, match="execution reverted"):
+        with pytest.raises(ContractLogicError, match="execution reverted"):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithoutMessage",
                 transaction={

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -197,6 +197,15 @@ class InvalidEventABI(ValueError):
 class SolidityError(ValueError):
     # Inherits from ValueError for backwards compatibility
     """
-    Raised on a solidity require/revert
+    Raised on a contract revert error
+    """
+    pass
+
+
+class ContractLogicError(SolidityError, ValueError):
+    # Inherits from ValueError for backwards compatibility
+    # TODO: Remove SolidityError inheritance in v6
+    """
+    Raised on a contract revert error
     """
     pass


### PR DESCRIPTION
This is branched off of #1813, so should be merged after.

### What was wrong?
The SolidityError introduced in #1585 should be more generic to account for other languages.

Related to Issue #1813, #1585

### How was it fixed?
Swapped out `SolidityError` for a `ContractLogicError`. `ContractLogicError` inherits from the SolidityError for backwards compatibility, and we'll remove `SolidityError` in v6. Although the history doesn't reflect this any more, I made the change in the code without making any changes to the tests to make sure we had backwards compatibility, then made the change in the tests. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Cleanup commit history

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/6540608/102646510-62aa8280-4121-11eb-8c11-2139ef349a7a.png)

