### PR TITLE
Remove unused bufsize argument from integration test setup

### DIFF
--- a/newsfragments/1815.misc.rst
+++ b/newsfragments/1815.misc.rst
@@ -1,0 +1,1 @@
+Remove unused bufsize argument in integration testing setup to fix subprocess's RuntimeWarning

--- a/tests/integration/generate_fixtures/common.py
+++ b/tests/integration/generate_fixtures/common.py
@@ -190,7 +190,6 @@ def get_process(run_command):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        bufsize=1,
     )
     return proc
 

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -82,7 +82,6 @@ def get_geth_process(geth_binary,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        bufsize=1,
     )
     with popen_proc as proc:
         with graceful_kill_on_exit(proc) as graceful_proc:

--- a/tests/integration/go_ethereum/conftest.py
+++ b/tests/integration/go_ethereum/conftest.py
@@ -113,7 +113,6 @@ def geth_process(geth_binary, datadir, genesis_file, geth_command_arguments):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        bufsize=1,
     )
     try:
         yield proc

--- a/tests/integration/parity/utils.py
+++ b/tests/integration/parity/utils.py
@@ -40,7 +40,6 @@ def get_process(command_list, terminates=False):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        bufsize=1,
     )
     if terminates:
         wait_for_popen(proc, 30)


### PR DESCRIPTION
### What was wrong?
On our integration test setup, there was a runtime warning: `RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
    self.stdin = io.open(p2cwrite, 'wb', bufsize)`


### How was it fixed?
Removed the bufsize argument since it wasn't being used anyway. You can verify this fix by looking at the integration tests on master and noting that they have the RuntimeWarnings at the end, and then looking at the integration tests on this PR and noting that there are no warnings.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="221" alt="image" src="https://user-images.githubusercontent.com/6540608/102659149-26355180-4136-11eb-96e5-9f18fc1f77cc.png">

