### PR TITLE
Only use Web3 module for typing in ethpm

### DIFF
--- a/ethpm/_utils/chains.py
+++ b/ethpm/_utils/chains.py
@@ -1,5 +1,6 @@
 import re
 from typing import (
+    TYPE_CHECKING,
     Any,
     Tuple,
 )
@@ -24,10 +25,12 @@ from hexbytes import (
 from ethpm.constants import (
     SUPPORTED_CHAIN_IDS,
 )
-from web3 import Web3
+
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
 
 
-def get_genesis_block_hash(web3: Web3) -> HexBytes:
+def get_genesis_block_hash(web3: "Web3") -> HexBytes:
     return web3.eth.getBlock(BlockNumber(0))["hash"]
 
 

--- a/ethpm/_utils/deployments.py
+++ b/ethpm/_utils/deployments.py
@@ -1,4 +1,5 @@
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Generator,
@@ -22,7 +23,9 @@ from ethpm.exceptions import (
     BytecodeLinkingError,
     EthPMValidationError,
 )
-from web3 import Web3
+
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
 
 
 def get_linked_deployments(deployments: Dict[str, Any]) -> Dict[str, Any]:
@@ -85,7 +88,7 @@ def normalize_linked_references(
 
 
 def validate_deployments_tx_receipt(
-    deployments: Dict[str, Any], w3: Web3, allow_missing_data: bool = False
+    deployments: Dict[str, Any], w3: "Web3", allow_missing_data: bool = False
 ) -> None:
     """
     Validate that address and block hash found in deployment data match what is found on-chain.

--- a/ethpm/contract.py
+++ b/ethpm/contract.py
@@ -1,4 +1,5 @@
 from typing import (  # noqa: F401
+    TYPE_CHECKING,
     Any,
     Dict,
     List,
@@ -26,7 +27,6 @@ from ethpm.exceptions import (
 from ethpm.validation.misc import (
     validate_empty_bytes,
 )
-from web3 import Web3
 from web3._utils.validation import (
     validate_address,
 )
@@ -34,6 +34,9 @@ from web3.contract import (
     Contract,
     ContractConstructor,
 )
+
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
 
 
 class LinkableContract(Contract):
@@ -57,7 +60,7 @@ class LinkableContract(Contract):
 
     @classmethod
     def factory(
-        cls, web3: Web3, class_name: str = None, **kwargs: Any
+        cls, web3: "Web3", class_name: str = None, **kwargs: Any
     ) -> Contract:
         dep_link_refs = kwargs.get("unlinked_references")
         bytecode = kwargs.get("bytecode")

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -3,6 +3,7 @@ from pathlib import (
     Path,
 )
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Generator,
@@ -78,7 +79,6 @@ from ethpm.validation.package import (
 from ethpm.validation.uri import (
     validate_single_matching_uri,
 )
-from web3 import Web3
 from web3._utils.validation import (
     validate_address,
 )
@@ -86,10 +86,13 @@ from web3.eth import (
     Contract,
 )
 
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
+
 
 class Package(object):
     def __init__(
-        self, manifest: Dict[str, Any], w3: Web3, uri: Optional[str] = None
+        self, manifest: Dict[str, Any], w3: "Web3", uri: Optional[str] = None
     ) -> None:
         """
         A package should be created using one of the available
@@ -116,7 +119,7 @@ class Package(object):
         self.manifest = manifest
         self._uri = uri
 
-    def update_w3(self, w3: Web3) -> "Package":
+    def update_w3(self, w3: "Web3") -> "Package":
         """
         Returns a new instance of `Package` containing the same manifest,
         but connected to a different web3 instance.
@@ -198,7 +201,7 @@ class Package(object):
             raise ValueError("No contract types found in manifest; {self.__repr__()}.")
 
     @classmethod
-    def from_file(cls, file_path: Path, w3: Web3) -> "Package":
+    def from_file(cls, file_path: Path, w3: "Web3") -> "Package":
         """
         Returns a ``Package`` instantiated by a manifest located at the provided Path.
         ``file_path`` arg must be a ``pathlib.Path`` instance.
@@ -216,7 +219,7 @@ class Package(object):
         return cls(manifest, w3, file_path.as_uri())
 
     @classmethod
-    def from_uri(cls, uri: URI, w3: Web3) -> "Package":
+    def from_uri(cls, uri: URI, w3: "Web3") -> "Package":
         """
         Returns a Package object instantiated by a manifest located at a content-addressed URI.
         A valid ``Web3`` instance is also required.

--- a/ethpm/tools/builder.py
+++ b/ethpm/tools/builder.py
@@ -5,6 +5,7 @@ from pathlib import (
 )
 import tempfile
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -62,10 +63,12 @@ from ethpm.validation.manifest import (
 from ethpm.validation.package import (
     validate_package_name,
 )
-from web3 import Web3
 from web3._utils.validation import (
     validate_address,
 )
+
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
 
 
 def build(obj: Dict[str, Any], *fns: Callable[..., Any]) -> Dict[str, Any]:
@@ -837,7 +840,7 @@ def validate(manifest: Manifest) -> Manifest:
 
 
 @curry
-def as_package(w3: Web3, manifest: Manifest) -> Package:
+def as_package(w3: "Web3", manifest: Manifest) -> Package:
     """
     Return a Package object instantiated with the provided manifest and web3 instance.
     """

--- a/ethpm/uri.py
+++ b/ethpm/uri.py
@@ -1,4 +1,7 @@
 import json
+from typing import (
+    TYPE_CHECKING,
+)
 
 from eth_typing import (
     URI,
@@ -35,10 +38,12 @@ from ethpm.backends.registry import (
 from ethpm.exceptions import (
     CannotHandleURI,
 )
-from web3 import Web3
 from web3.types import (
     BlockNumber,
 )
+
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa F401
 
 
 def resolve_uri_contents(uri: URI, fingerprint: bool = None) -> bytes:
@@ -96,7 +101,7 @@ def is_supported_content_addressed_uri(uri: URI) -> bool:
     return True
 
 
-def create_latest_block_uri(w3: Web3, from_blocks_ago: int = 3) -> URI:
+def create_latest_block_uri(w3: "Web3", from_blocks_ago: int = 3) -> URI:
     """
     Creates a block uri for the given w3 instance.
     Defaults to 3 blocks prior to the "latest" block to accommodate for block reorgs.
@@ -115,7 +120,7 @@ def create_latest_block_uri(w3: Web3, from_blocks_ago: int = 3) -> URI:
 
 
 @curry
-def check_if_chain_matches_chain_uri(web3: Web3, blockchain_uri: URI) -> bool:
+def check_if_chain_matches_chain_uri(web3: "Web3", blockchain_uri: URI) -> bool:
     chain_id, resource_type, resource_hash = parse_BIP122_uri(blockchain_uri)
     genesis_block = web3.eth.getBlock("earliest")
 

--- a/ethpm/validation/misc.py
+++ b/ethpm/validation/misc.py
@@ -8,7 +8,7 @@ from ethpm.exceptions import (
 from web3 import Web3
 
 
-def validate_w3_instance(w3: Web3) -> None:
+def validate_w3_instance(w3: "Web3") -> None:
     if w3 is None or not isinstance(w3, Web3):
         raise ValueError("Package does not have valid web3 instance.")
 

--- a/ethpm/validation/uri.py
+++ b/ethpm/validation/uri.py
@@ -1,5 +1,6 @@
 import hashlib
 from typing import (
+    TYPE_CHECKING,
     List,
 )
 from urllib import (
@@ -34,7 +35,9 @@ from ethpm.validation.misc import (
 from ethpm.validation.package import (
     validate_package_name,
 )
-from web3 import Web3
+
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
 
 
 def validate_ipfs_uri(uri: str) -> None:
@@ -116,7 +119,7 @@ def validate_registry_uri_scheme(scheme: str) -> None:
         )
 
 
-def validate_single_matching_uri(all_blockchain_uris: List[str], w3: Web3) -> str:
+def validate_single_matching_uri(all_blockchain_uris: List[str], w3: "Web3") -> str:
     """
     Return a single block URI after validating that it is the *only* URI in
     all_blockchain_uris that matches the w3 instance.

--- a/newsfragments/1816.misc.rst
+++ b/newsfragments/1816.misc.rst
@@ -1,0 +1,1 @@
+In ethpm module, only import Web3 if TYPE_CHECKING


### PR DESCRIPTION
### What was wrong?
When we release, we have to install web3 for ethpm, instead of relying on the local, editable web3. I think this PR fixes  that problem, but at the very least it doesn't require that web3 be installed just for type checking.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/102831289-a06d0c80-43a8-11eb-8117-3768006f7408.png)

