### PR TITLE
Fix missing argument in Eth.signTransaction documentation

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -643,7 +643,7 @@ The following methods are available on the ``web3.eth`` namespace.
         '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331'
 
 
-.. py:method:: Eth.signTransaction()
+.. py:method:: Eth.signTransaction(transaction)
 
     * Delegates to ``eth_signTransaction`` RPC Method.
 


### PR DESCRIPTION
### What was wrong?
The documentation for the `Eth.signTransaction` method had a typo: an argument was missing

### How was it fixed?
Update the documentation to correctly show how to call `signTransaction` method

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![](https://i.redd.it/96lceq436b531.jpg)
