### PR TITLE
Beacon docs fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,17 @@ output/*/index.html
 # Sphinx
 docs/_build
 docs/modules.rst
-docs/web3.*
+docs/web3.auto.infura.rst
+docs/web3.auto.rst
+docs/web3.gas_strategies.rst
+docs/web3.middleware.rst
+docs/web3.providers.eth_tester.rst
+docs/web3.providers.rst
+docs/web3.rst
+docs/web3.scripts.release.rst
+docs/web3.scripts.rst
+docs/web3.tools.pytest_ethereum.rst
+docs/web3.tools.rst
 
 # Blockchain
 chains

--- a/docs/web3.beacon.rst
+++ b/docs/web3.beacon.rst
@@ -1,0 +1,10 @@
+Web3 Eth 2.0 Beacon API
+=======================
+
+Module contents
+---------------
+
+.. automodule:: web3.beacon.main
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/newsfragments/1824.bugfix.rst
+++ b/newsfragments/1824.bugfix.rst
@@ -1,0 +1,2 @@
+Remove docs/web3.* from the gitignore to allow for the beacon docs to be added to git,
+and add ``beacon`` to the default web3 modules that get loaded.

--- a/web3/main.py
+++ b/web3/main.py
@@ -52,6 +52,9 @@ from web3._utils.module import (
 from web3._utils.normalizers import (
     abi_ens_resolver,
 )
+from web3.beacon import (
+    Beacon,
+)
 from web3.eth import (
     Eth,
 )
@@ -120,6 +123,7 @@ def get_default_modules() -> Dict[str, Sequence[Any]]:
             "txpool": (GethTxPool,),
         }),
         "testing": (Testing,),
+        "beacon": (Beacon,),
     }
 
 


### PR DESCRIPTION
### What was wrong?
We can't release because sphinx can't find the web3.beacon.main module to autobuild docs.


### How was it fixed?
Updated the .gitignore to allow the beacon docs and added the beacon module to web3 default modules to hopefully allow sphinx to find the beacon docs. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/103588209-ea281d80-4ea5-11eb-9047-60e2ccbffbd1.png)

