### PR TITLE
Remove beacon docs

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -6,17 +6,6 @@ v5 Breaking Changes Summary
 
 .. towncrier release notes start
 
-v5.14.0 (2021-01-04)
---------------------
-
-Misc
-~~~~
-
-- `#1816 <https://github.com/ethereum/web3.py/issues/1816>`__
-
-
-v5.14.0 (2020-12-21)
---------------------
 
 Features
 ~~~~~~~~
@@ -28,7 +17,7 @@ Features
 Misc
 ~~~~
 
-- `#1815 <https://github.com/ethereum/web3.py/issues/1815>`__
+- `#1815 <https://github.com/ethereum/web3.py/issues/1815>`__, `#1816 <https://github.com/ethereum/web3.py/issues/1816>`__
 
 
 v5.13.1 (2020-12-03)

--- a/docs/web3.beacon.rst
+++ b/docs/web3.beacon.rst
@@ -4,7 +4,6 @@ Web3 Eth 2.0 Beacon API
 Module contents
 ---------------
 
-.. automodule:: web3.beacon.main
-   :members:
-   :undoc-members:
-   :show-inheritance:
+Docs coming soon!
+
+See ``web3/beacon/main.py`` for available methods.

--- a/newsfragments/1825.bugfix.rst
+++ b/newsfragments/1825.bugfix.rst
@@ -1,0 +1,1 @@
+Remove auto-documenting from the Beacon API

--- a/web3/main.py
+++ b/web3/main.py
@@ -52,9 +52,6 @@ from web3._utils.module import (
 from web3._utils.normalizers import (
     abi_ens_resolver,
 )
-from web3.beacon import (
-    Beacon,
-)
 from web3.eth import (
     Eth,
 )
@@ -123,7 +120,6 @@ def get_default_modules() -> Dict[str, Sequence[Any]]:
             "txpool": (GethTxPool,),
         }),
         "testing": (Testing,),
-        "beacon": (Beacon,),
     }
 
 


### PR DESCRIPTION
### What was wrong?
Sphinx can't find beacon.main from the auto documentation which is blocking a release. 

### How was it fixed?
Removed web3.beacon.main from the beacon docs.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="205" alt="image" src="https://user-images.githubusercontent.com/6540608/103703707-44d47e80-4f65-11eb-974c-e723193058c0.png">

