### PR TITLE
Add requests-mock dependency to dev requirements

### DIFF
--- a/newsfragments/1827.misc.rst
+++ b/newsfragments/1827.misc.rst
@@ -1,0 +1,1 @@
+Remove ``request-mock`` dependency in beacon tests

--- a/tests/beacon/test_beacon.py
+++ b/tests/beacon/test_beacon.py
@@ -1,45 +1,15 @@
-import json
 import pytest
 
 import requests
 
-import requests_mock
 from web3.beacon import (
     Beacon,
 )
 
-GENESIS_RESPONSE = {
-    "data": {
-        "genesis_time": "1590832934",
-        "genesis_validators_root": (
-            "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-        ),
-        "genesis_fork_version": "0x00000000",
-    }
-}
-
 
 @pytest.fixture
-def session():
-    session = requests.Session()
-    adapter = requests_mock.Adapter()
-    session.mount("mock://", adapter)
-
-    adapter.register_uri(
-        "GET",
-        "mock://example.com/api/eth/v1/beacon/genesis",
-        text=json.dumps(GENESIS_RESPONSE),
-    )
-    return session
-
-
-@pytest.fixture
-def beacon(session):
-    #  return Beacon(
-    #  beacon_url="mock://example.com/api",
-    #  session=session,
-    #  )
-    return Beacon(base_url="http://localhost:5051", session=session)
+def beacon():
+    return Beacon(base_url="http://localhost:5051", session=requests.Session())
 
 
 # Beacon endpoint tests:


### PR DESCRIPTION
### What was wrong?
`requests-mock` is used in the beacon tests and I found I couldn't run my tests locally from the top-level `tests/` dir without it installed. 

### How was it fixed?
Added requests-mock dependency to setup.py. 

@marcgarreau let me know if this is the wrong solution!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="275" alt="image" src="https://user-images.githubusercontent.com/6540608/104064057-742ff900-51ba-11eb-81f6-394180a8bd47.png">

