### PR TITLE
Swap getBlock for get_block

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -11,13 +11,13 @@ Looking up blocks
 -----------------
 
 Blocks can be looked up by either their number or hash using the
-``web3.eth.getBlock`` API.  Block hashes should be in their hexadecimal
+``web3.eth.get_block`` API.  Block hashes should be in their hexadecimal
 representation.  Block numbers
 
 .. code-block:: python
 
     # get a block by number
-    >>> web3.eth.getBlock(12345)
+    >>> web3.eth.get_block(12345)
     {
         'author': '0xad5C1768e5974C231b2148169da064e61910f31a',
         'difficulty': 735512610763,
@@ -45,7 +45,7 @@ representation.  Block numbers
     }
 
     # get a block by it's hash
-    >>> web3.eth.getBlock('0x767c2bfb3bdee3f78676c1285cd757bcd5d8c272cef2eb30d9733800a78c0b6d')
+    >>> web3.eth.get_block('0x767c2bfb3bdee3f78676c1285cd757bcd5d8c272cef2eb30d9733800a78c0b6d')
     {...}
 
 
@@ -53,11 +53,11 @@ Getting the latest block
 ------------------------
 
 You can also retrieve the latest block using the string ``'latest'`` in the
-``web3.eth.getBlock`` API.
+``web3.eth.get_block`` API.
 
 .. code-block:: python
 
-    >>> web3.eth.getBlock('latest')
+    >>> web3.eth.get_block('latest')
     {...}
 
 

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -30,8 +30,8 @@ AttributeDict
 .. py:method:: web3.middleware.attrdict_middleware
 
     This middleware converts the output of a function from a dictionary to an ``AttributeDict``
-    which enables dot-syntax access, like ``eth.getBlock('latest').number``
-    in addition to ``eth.getBlock('latest')['number']``.
+    which enables dot-syntax access, like ``eth.get_block('latest').number``
+    in addition to ``eth.get_block('latest')['number']``.
 
 .eth Name Resolution
 ~~~~~~~~~~~~~~~~~~~~~
@@ -272,7 +272,7 @@ Stalecheck
 
     If the latest block in the blockchain is older than 2 days in this example, then the
     middleware will raise a ``StaleBlockchain`` exception on every call except
-    ``web3.eth.getBlock()``.
+    ``web3.eth.get_block()``.
 
 
 Cache

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -133,7 +133,7 @@ Fetching Data
 
 Viewing account balances (:meth:`get_balance <web3.eth.Eth.get_balance>`), transactions
 (:meth:`getTransaction <web3.eth.Eth.getTransaction>`), and block data
-(:meth:`getBlock <web3.eth.Eth.getBlock>`) are some of the most common starting
+(:meth:`get_block <web3.eth.Eth.get_block>`) are some of the most common starting
 points in Web3.py.
 
 
@@ -141,7 +141,7 @@ API
 ^^^
 
 - :meth:`web3.eth.get_balance() <web3.eth.Eth.get_balance>`
-- :meth:`web3.eth.getBlock() <web3.eth.Eth.getBlock>`
+- :meth:`web3.eth.get_block() <web3.eth.Eth.get_block>`
 - :meth:`web3.eth.getBlockTransactionCount() <web3.eth.Eth.getBlockTransactionCount>`
 - :meth:`web3.eth.getCode() <web3.eth.Eth.getCode>`
 - :meth:`web3.eth.getProof() <web3.eth.Eth.getProof>`

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -107,7 +107,7 @@ to interact with the Ethereum blockchain. Try getting all the information about 
 
 .. code-block:: python
 
-    >>> w3.eth.getBlock('latest')
+    >>> w3.eth.get_block('latest')
     {'difficulty': 1,
      'gasLimit': 6283185,
      'gasUsed': 0,

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -15,7 +15,7 @@ you can find the latest block number in these two ways:
 
     .. code-block:: python
 
-        >>> block = web3.eth.getBlock('latest')
+        >>> block = web3.eth.get_block('latest')
         AttributeDict({
           'hash': '0xe8ad537a261e6fff80d551d8d087ee0f2202da9b09b64d172a5f45e818eb472a',
           'number': 4022281,
@@ -309,7 +309,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
             return True
 
-        block = w3.eth.getBlock(3391)
+        block = w3.eth.get_block(3391)
         proof = w3.eth.getProof('0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B', [0, 1], 3391)
         assert verify_eth_getProof(proof, block.stateRoot)
 
@@ -333,7 +333,7 @@ The following methods are available on the ``web3.eth`` namespace.
         '0x'
 
 
-.. py:method:: Eth.getBlock(block_identifier=eth.defaultBlock, full_transactions=False)
+.. py:method:: Eth.get_block(block_identifier=eth.defaultBlock, full_transactions=False)
 
     * Delegates to ``eth_getBlockByNumber`` or ``eth_getBlockByHash`` RPC Methods
 
@@ -348,7 +348,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.getBlock(2000000)
+        >>> web3.eth.get_block(2000000)
         AttributeDict({
             'difficulty': 49824742724615,
             'extraData': '0xe4b883e5bda9e7a59ee4bb99e9b1bc',
@@ -371,6 +371,10 @@ The following methods are available on the ``web3.eth`` namespace.
             'uncles': [],
         })
 
+.. py:method:: Eth.getBlock(block_identifier=eth.defaultBlock, full_transactions=False)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.get_block`
 
 .. py:method:: Eth.getBlockTransactionCount(block_identifier)
 

--- a/ethpm/_utils/chains.py
+++ b/ethpm/_utils/chains.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 def get_genesis_block_hash(web3: "Web3") -> HexBytes:
-    return web3.eth.getBlock(BlockNumber(0))["hash"]
+    return web3.eth.get_block(BlockNumber(0))["hash"]
 
 
 BLOCK = "block"

--- a/ethpm/uri.py
+++ b/ethpm/uri.py
@@ -108,27 +108,27 @@ def create_latest_block_uri(w3: "Web3", from_blocks_ago: int = 3) -> URI:
     If using a testnet with less than 3 mined blocks, adjust :from_blocks_ago:.
     """
     chain_id = to_hex(get_genesis_block_hash(w3))
-    latest_block_tx_receipt = w3.eth.getBlock("latest")
+    latest_block_tx_receipt = w3.eth.get_block("latest")
     target_block_number = BlockNumber(latest_block_tx_receipt["number"] - from_blocks_ago)
     if target_block_number < 0:
         raise Exception(
             f"Only {latest_block_tx_receipt['number']} blocks avaible on provided w3, "
             f"cannot create latest block uri for {from_blocks_ago} blocks ago."
         )
-    recent_block = to_hex(w3.eth.getBlock(target_block_number)["hash"])
+    recent_block = to_hex(w3.eth.get_block(target_block_number)["hash"])
     return create_block_uri(chain_id, recent_block)
 
 
 @curry
 def check_if_chain_matches_chain_uri(web3: "Web3", blockchain_uri: URI) -> bool:
     chain_id, resource_type, resource_hash = parse_BIP122_uri(blockchain_uri)
-    genesis_block = web3.eth.getBlock("earliest")
+    genesis_block = web3.eth.get_block("earliest")
 
     if encode_hex(genesis_block["hash"]) != chain_id:
         return False
 
     if resource_type == BLOCK:
-        resource = web3.eth.getBlock(resource_hash)
+        resource = web3.eth.get_block(resource_hash)
     else:
         raise ValueError(f"Unsupported resource type: {resource_type}")
 

--- a/newsfragments/1829.feature.rst
+++ b/newsfragments/1829.feature.rst
@@ -1,0 +1,1 @@
+Add ``eth.get_block`` method and deprecate ``eth.getBlock``.

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -588,7 +588,7 @@ def test_neg_block_indexes_from_the_end(web3, math_contract):
 
 
 def test_returns_data_from_specified_block(web3, math_contract):
-    start_num = web3.eth.getBlock('latest').number
+    start_num = web3.eth.get_block('latest').number
     web3.provider.make_request(method='evm_mine', params=[5])
     math_contract.functions.increment().transact()
     math_contract.functions.increment().transact()

--- a/tests/core/contracts/test_contract_caller_interface.py
+++ b/tests/core/contracts/test_contract_caller_interface.py
@@ -99,7 +99,7 @@ def test_caller_with_a_nonexistent_function(math_contract):
 
 
 def test_caller_with_block_identifier(web3, math_contract):
-    start_num = web3.eth.getBlock('latest').number
+    start_num = web3.eth.get_block('latest').number
     assert math_contract.caller.counter() == 0
 
     web3.provider.make_request(method='evm_mine', params=[5])
@@ -117,7 +117,7 @@ def test_caller_with_block_identifier_and_transaction_dict(web3,
                                                            caller_tester_contract,
                                                            transaction_dict,
                                                            address):
-    start_num = web3.eth.getBlock('latest').number
+    start_num = web3.eth.get_block('latest').number
     assert caller_tester_contract.caller.counter() == 0
 
     web3.provider.make_request(method='evm_mine', params=[5])

--- a/tests/core/contracts/test_contract_util_functions.py
+++ b/tests/core/contracts/test_contract_util_functions.py
@@ -6,8 +6,8 @@ from web3.contract import (
 #  This tests negative block number identifiers, which behave like python
 #  list slices, with -1 being the latest block and -2 being the block before that.
 #  This test is necessary because transaction calls allow negative block indexes, although
-#  getBlock() does not allow negative block identifiers. Support for negative block identifier
+#  get_block() does not allow negative block identifiers. Support for negative block identifier
 #  will likely be removed in v5.
 def test_parse_block_identifier_int(web3):
-    last_num = web3.eth.getBlock('latest').number
+    last_num = web3.eth.get_block('latest').number
     assert 0 == parse_block_identifier_int(web3, -1 - last_num)

--- a/tests/core/contracts/test_implicit_contract.py
+++ b/tests/core/contracts/test_implicit_contract.py
@@ -38,7 +38,7 @@ def math_contract(web3, MATH_ABI, MATH_CODE, MATH_RUNTIME, address_conversion_fu
 @pytest.fixture()
 def get_transaction_count(web3):
     def get_transaction_count(blocknum_or_label):
-        block = web3.eth.getBlock(blocknum_or_label)
+        block = web3.eth.get_block(blocknum_or_label)
         # Return the blocknum if we requested this via labels
         # so we can directly query the block next time (using the same API call)
         # Either way, return the number of transactions in the given block

--- a/tests/core/eth-module/test_poa.py
+++ b/tests/core/eth-module/test_poa.py
@@ -16,7 +16,7 @@ def test_long_extra_data(web3):
     })
     web3.middleware_onion.inject(return_block_with_long_extra_data, layer=0)
     with pytest.raises(ExtraDataLengthError):
-        web3.eth.getBlock('latest')
+        web3.eth.get_block('latest')
 
 
 def test_full_extra_data(web3):
@@ -24,7 +24,7 @@ def test_full_extra_data(web3):
         'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 32},
     })
     web3.middleware_onion.inject(return_block_with_long_extra_data, layer=0)
-    block = web3.eth.getBlock('latest')
+    block = web3.eth.get_block('latest')
     assert block.extraData == b'\xff' * 32
 
 
@@ -34,6 +34,6 @@ def test_geth_proof_of_authority(web3):
     })
     web3.middleware_onion.inject(geth_poa_middleware, layer=0)
     web3.middleware_onion.inject(return_block_with_long_extra_data, layer=0)
-    block = web3.eth.getBlock('latest')
+    block = web3.eth.get_block('latest')
     assert 'extraData' not in block
     assert block.proofOfAuthorityData == b'\xff' * 33

--- a/tests/core/filtering/test_existing_filter_instance.py
+++ b/tests/core/filtering/test_existing_filter_instance.py
@@ -40,6 +40,6 @@ def test_instantiate_existing_filter(web3, sleep_interval, wait_for_block, filte
     assert len(found_block_hashes) == 3
 
     expected_block_hashes = [
-        web3.eth.getBlock(n + 1).hash for n in range(current_block, current_block + 3)
+        web3.eth.get_block(n + 1).hash for n in range(current_block, current_block + 3)
     ]
     assert found_block_hashes == expected_block_hashes

--- a/tests/core/filtering/test_filter_against_latest_blocks.py
+++ b/tests/core/filtering/test_filter_against_latest_blocks.py
@@ -25,6 +25,6 @@ def test_sync_filter_against_latest_blocks(web3, sleep_interval, wait_for_block)
     assert len(found_block_hashes) == 3
 
     expected_block_hashes = [
-        web3.eth.getBlock(n + 1).hash for n in range(current_block, current_block + 3)
+        web3.eth.get_block(n + 1).hash for n in range(current_block, current_block + 3)
     ]
     assert found_block_hashes == expected_block_hashes

--- a/tests/core/middleware/test_latest_block_based_cache_middleware.py
+++ b/tests/core/middleware/test_latest_block_based_cache_middleware.py
@@ -164,7 +164,7 @@ def test_latest_block_based_cache_middleware_pulls_from_cache(
     w3.middleware_onion.add(block_data_middleware)
     w3.middleware_onion.add(result_generator_middleware)
 
-    current_block_hash = w3.eth.getBlock('latest')['hash']
+    current_block_hash = w3.eth.get_block('latest')['hash']
 
     def cache_class():
         return {

--- a/tests/core/middleware/test_stalecheck.py
+++ b/tests/core/middleware/test_stalecheck.py
@@ -72,7 +72,7 @@ def test_stalecheck_pass(request_middleware):
 
 def test_stalecheck_fail(request_middleware, now):
     with patch('web3.middleware.stalecheck._isfresh', return_value=False):
-        request_middleware.web3.eth.getBlock.return_value = stub_block(now)
+        request_middleware.web3.eth.get_block.return_value = stub_block(now)
         with pytest.raises(StaleBlockchain):
             request_middleware('', [])
 
@@ -84,16 +84,16 @@ def test_stalecheck_fail(request_middleware, now):
     ]
 )
 def test_stalecheck_ignores_get_by_block_methods(request_middleware, rpc_method):
-    # This is especially critical for getBlock('latest') which would cause infinite recursion
+    # This is especially critical for get_block('latest') which would cause infinite recursion
     with patch('web3.middleware.stalecheck._isfresh', side_effect=[False, True]):
         request_middleware(rpc_method, [])
-        assert not request_middleware.web3.eth.getBlock.called
+        assert not request_middleware.web3.eth.get_block.called
 
 
 def test_stalecheck_calls_isfresh_with_empty_cache(request_middleware, allowable_delay):
     with patch('web3.middleware.stalecheck._isfresh', side_effect=[False, True]) as freshspy:
         block = object()
-        request_middleware.web3.eth.getBlock.return_value = block
+        request_middleware.web3.eth.get_block.return_value = block
         request_middleware('', [])
         cache_call, live_call = freshspy.call_args_list
         assert cache_call[0] == (None, allowable_delay)
@@ -103,7 +103,7 @@ def test_stalecheck_calls_isfresh_with_empty_cache(request_middleware, allowable
 def test_stalecheck_adds_block_to_cache(request_middleware, allowable_delay):
     with patch('web3.middleware.stalecheck._isfresh', side_effect=[False, True, True]) as freshspy:
         block = object()
-        request_middleware.web3.eth.getBlock.return_value = block
+        request_middleware.web3.eth.get_block.return_value = block
 
         # cache miss
         request_middleware('', [])

--- a/tests/core/mining-module/test_miner_setExtra.py
+++ b/tests/core/mining-module/test_miner_setExtra.py
@@ -17,7 +17,7 @@ from web3._utils.threads import (
 def test_miner_set_extra(web3_empty, wait_for_block):
     web3 = web3_empty
 
-    initial_extra = decode_hex(web3.eth.getBlock(web3.eth.blockNumber)['extraData'])
+    initial_extra = decode_hex(web3.eth.get_block(web3.eth.blockNumber)['extraData'])
 
     new_extra_data = b'-this-is-32-bytes-of-extra-data-'
 
@@ -28,12 +28,12 @@ def test_miner_set_extra(web3_empty, wait_for_block):
 
     with Timeout(60) as timeout:
         while True:
-            extra_data = decode_hex(web3.eth.getBlock(web3.eth.blockNumber)['extraData'])
+            extra_data = decode_hex(web3.eth.get_block(web3.eth.blockNumber)['extraData'])
             if extra_data == new_extra_data:
                 break
             timeout.sleep(random.random())
 
-    after_extra = decode_hex(web3.eth.getBlock(web3.eth.blockNumber)['extraData'])
+    after_extra = decode_hex(web3.eth.get_block(web3.eth.blockNumber)['extraData'])
 
     assert after_extra == new_extra_data
 
@@ -42,7 +42,7 @@ def test_miner_set_extra(web3_empty, wait_for_block):
 def test_miner_setExtra(web3_empty, wait_for_block):
     web3 = web3_empty
 
-    initial_extra = decode_hex(web3.eth.getBlock(web3.eth.blockNumber)['extraData'])
+    initial_extra = decode_hex(web3.eth.get_block(web3.eth.blockNumber)['extraData'])
 
     new_extra_data = b'-this-is-32-bytes-of-extra-data-'
 
@@ -53,10 +53,10 @@ def test_miner_setExtra(web3_empty, wait_for_block):
         web3.geth.miner.setExtra(new_extra_data)
     with Timeout(60) as timeout:
         while True:
-            extra_data = decode_hex(web3.eth.getBlock(web3.eth.blockNumber)['extraData'])
+            extra_data = decode_hex(web3.eth.get_block(web3.eth.blockNumber)['extraData'])
             if extra_data == new_extra_data:
                 break
             timeout.sleep(random.random())
 
-    after_extra = decode_hex(web3.eth.getBlock(web3.eth.blockNumber)['extraData'])
+    after_extra = decode_hex(web3.eth.get_block(web3.eth.blockNumber)['extraData'])
     assert after_extra == new_extra_data

--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -92,6 +92,6 @@ def test_web3_auto_gethdev():
         'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 33},
     })
     w3.middleware_onion.inject(return_block_with_long_extra_data, layer=0)
-    block = w3.eth.getBlock('latest')
+    block = w3.eth.get_block('latest')
     assert 'extraData' not in block
     assert block.proofOfAuthorityData == b'\xff' * 33

--- a/tests/core/testing-module/test_testing_mine.py
+++ b/tests/core/testing-module/test_testing_mine.py
@@ -1,11 +1,11 @@
 def test_testing_mine_single_block(web3):
     web3.testing.mine()
 
-    before_mining_block = web3.eth.getBlock("latest")
+    before_mining_block = web3.eth.get_block("latest")
 
     web3.testing.mine()
 
-    after_mining_block = web3.eth.getBlock("latest")
+    after_mining_block = web3.eth.get_block("latest")
 
     assert after_mining_block['number'] - before_mining_block['number'] == 1
 
@@ -13,10 +13,10 @@ def test_testing_mine_single_block(web3):
 def test_testing_mine_multiple_blocks(web3):
     web3.testing.mine()
 
-    before_mining_block = web3.eth.getBlock("latest")
+    before_mining_block = web3.eth.get_block("latest")
 
     web3.testing.mine(5)
 
-    after_mining_block = web3.eth.getBlock("latest")
+    after_mining_block = web3.eth.get_block("latest")
 
     assert after_mining_block['number'] - before_mining_block['number'] == 5

--- a/tests/core/testing-module/test_testing_snapshot_and_revert.py
+++ b/tests/core/testing-module/test_testing_snapshot_and_revert.py
@@ -1,19 +1,19 @@
 def test_snapshot_revert_to_latest_snapshot(web3):
     web3.testing.mine(5)
 
-    block_before_snapshot = web3.eth.getBlock("latest")
+    block_before_snapshot = web3.eth.get_block("latest")
 
     web3.testing.snapshot()
 
-    block_after_snapshot = web3.eth.getBlock("latest")
+    block_after_snapshot = web3.eth.get_block("latest")
 
     web3.testing.mine(3)
 
-    block_after_mining = web3.eth.getBlock("latest")
+    block_after_mining = web3.eth.get_block("latest")
 
     web3.testing.revert()
 
-    block_after_revert = web3.eth.getBlock("latest")
+    block_after_revert = web3.eth.get_block("latest")
 
     assert block_after_mining['number'] > block_before_snapshot['number']
     assert block_before_snapshot['hash'] == block_after_snapshot['hash']
@@ -23,11 +23,11 @@ def test_snapshot_revert_to_latest_snapshot(web3):
 def test_snapshot_revert_to_specific(web3):
     web3.testing.mine(5)
 
-    block_before_snapshot = web3.eth.getBlock("latest")
+    block_before_snapshot = web3.eth.get_block("latest")
 
     snapshot_idx = web3.testing.snapshot()
 
-    block_after_snapshot = web3.eth.getBlock("latest")
+    block_after_snapshot = web3.eth.get_block("latest")
 
     web3.testing.mine()
     web3.testing.snapshot()
@@ -36,11 +36,11 @@ def test_snapshot_revert_to_specific(web3):
     web3.testing.mine()
     web3.testing.snapshot()
 
-    block_after_mining = web3.eth.getBlock("latest")
+    block_after_mining = web3.eth.get_block("latest")
 
     web3.testing.revert(snapshot_idx)
 
-    block_after_revert = web3.eth.getBlock("latest")
+    block_after_revert = web3.eth.get_block("latest")
 
     assert block_after_mining['number'] > block_before_snapshot['number']
     assert block_before_snapshot['hash'] == block_after_snapshot['hash']

--- a/tests/core/testing-module/test_testing_timeTravel.py
+++ b/tests/core/testing-module/test_testing_timeTravel.py
@@ -1,9 +1,9 @@
 def test_time_traveling(web3):
-    current_block_time = web3.eth.getBlock("pending")['timestamp']
+    current_block_time = web3.eth.get_block("pending")['timestamp']
 
     time_travel_to = current_block_time + 12345
 
     web3.testing.timeTravel(time_travel_to)
 
-    latest_block_time = web3.eth.getBlock("pending")['timestamp']
+    latest_block_time = web3.eth.get_block("pending")['timestamp']
     assert latest_block_time >= time_travel_to

--- a/tests/core/tools/pytest_ethereum/test_linker_utils.py
+++ b/tests/core/tools/pytest_ethereum/test_linker_utils.py
@@ -23,8 +23,8 @@ from web3.tools.pytest_ethereum.exceptions import (
 
 @pytest.fixture
 def chain_setup(w3):
-    old_chain_id = remove_0x_prefix(to_hex(w3.eth.getBlock(0)["hash"]))
-    block_hash = remove_0x_prefix(to_hex(w3.eth.getBlock("earliest").hash))
+    old_chain_id = remove_0x_prefix(to_hex(w3.eth.get_block(0)["hash"]))
+    block_hash = remove_0x_prefix(to_hex(w3.eth.get_block("earliest").hash))
     old_chain_uri = f"blockchain://{old_chain_id}/block/{block_hash}"
     match_data = {
         old_chain_uri: {"x": "x"},

--- a/tests/ethpm/conftest.py
+++ b/tests/ethpm/conftest.py
@@ -207,7 +207,7 @@ def safe_math_lib_package_with_alias(deployer, w3):
 def manifest_with_no_matching_deployments(w3, tmpdir, safe_math_manifest):
     w3.testing.mine(5)
     incorrect_genesis_hash = b"\x00" * 31 + b"\x01"
-    block = w3.eth.getBlock("earliest")
+    block = w3.eth.get_block("earliest")
     block_uri = create_block_uri(w3.toHex(incorrect_genesis_hash), w3.toHex(block.hash))
     manifest = copy.deepcopy(safe_math_manifest)
     manifest["deployments"][block_uri] = {

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -28,12 +28,12 @@ A Web3 instance configured to connect to the backend for the integration test.
 
 #### `empty_block`
 
-A block as returned by `web3.eth.getBlock` that has no transactions.
+A block as returned by `web3.eth.get_block` that has no transactions.
 
 
 #### `block_with_txn`
 
-A block as returned by `web3.eth.getBlock` that has a single transaction.
+A block as returned by `web3.eth.get_block` that has a single transaction.
 
 
 #### `math_contract`

--- a/tests/integration/common.py
+++ b/tests/integration/common.py
@@ -14,4 +14,4 @@ class MiscWebsocketTest:
             endpoint_uri=endpoint_uri, websocket_kwargs={'max_size': 1})
         )
         with pytest.raises((OSError, ConnectionClosed)):
-            w3.eth.getBlock(0)
+            w3.eth.get_block(0)

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -168,7 +168,7 @@ def generate_go_ethereum_fixture(destination_dir):
 
 def verify_chain_state(web3, chain_data):
     receipt = web3.eth.waitForTransactionReceipt(chain_data['mined_txn_hash'])
-    latest = web3.eth.getBlock('latest')
+    latest = web3.eth.get_block('latest')
     assert receipt.blockNumber <= latest.number
 
 
@@ -228,7 +228,7 @@ def setup_chain_state(web3):
     })
     print('TXN_HASH_WITH_LOG:', txn_hash_with_log)
     txn_receipt_with_log = mine_transaction_hash(web3, txn_hash_with_log)
-    block_with_log = web3.eth.getBlock(txn_receipt_with_log['blockHash'])
+    block_with_log = web3.eth.get_block(txn_receipt_with_log['blockHash'])
     print('BLOCK_HASH_WITH_LOG:', block_with_log['hash'])
 
     #
@@ -250,7 +250,7 @@ def setup_chain_state(web3):
     )
     print('TXN_HASH_REVERT_WITH_MSG:', txn_hash_revert_with_msg)
     txn_receipt_revert_with_msg = common.mine_transaction_hash(web3, txn_hash_revert_with_msg)
-    block_hash_revert_with_msg = web3.eth.getBlock(txn_receipt_revert_with_msg['blockHash'])
+    block_hash_revert_with_msg = web3.eth.get_block(txn_receipt_revert_with_msg['blockHash'])
     print('BLOCK_HASH_REVERT_WITH_MSG:', block_hash_revert_with_msg['hash'])
 
     txn_hash_revert_with_no_msg = revert_contract.functions.revertWithoutMessage().transact(
@@ -258,7 +258,7 @@ def setup_chain_state(web3):
     )
     print('TXN_HASH_REVERT_WITH_NO_MSG:', txn_hash_revert_with_no_msg)
     txn_receipt_revert_with_no_msg = common.mine_transaction_hash(web3, txn_hash_revert_with_no_msg)
-    block_hash_revert_no_msg = web3.eth.getBlock(txn_receipt_revert_with_no_msg['blockHash'])
+    block_hash_revert_no_msg = web3.eth.get_block(txn_receipt_revert_with_no_msg['blockHash'])
     print('BLOCK_HASH_REVERT_NO_MSG:', block_hash_revert_no_msg['hash'])
 
     #
@@ -266,7 +266,7 @@ def setup_chain_state(web3):
     #
     empty_block_number = mine_block(web3)
     print('MINED_EMPTY_BLOCK')
-    empty_block = web3.eth.getBlock(empty_block_number)
+    empty_block = web3.eth.get_block(empty_block_number)
     assert is_dict(empty_block)
     assert not empty_block['transactions']
     print('EMPTY_BLOCK_HASH:', empty_block['hash'])
@@ -285,7 +285,7 @@ def setup_chain_state(web3):
     })
     mined_txn_receipt = mine_transaction_hash(web3, mined_txn_hash)
     print('MINED_TXN_HASH:', mined_txn_hash)
-    block_with_txn = web3.eth.getBlock(mined_txn_receipt['blockHash'])
+    block_with_txn = web3.eth.get_block(mined_txn_receipt['blockHash'])
     print('BLOCK_WITH_TXN_HASH:', block_with_txn['hash'])
 
     geth_fixture = {

--- a/tests/integration/go_ethereum/conftest.py
+++ b/tests/integration/go_ethereum/conftest.py
@@ -197,14 +197,14 @@ def funded_account_for_raw_txn(geth_fixture_data):
 
 @pytest.fixture(scope="module")
 def empty_block(web3, geth_fixture_data):
-    block = web3.eth.getBlock(geth_fixture_data['empty_block_hash'])
+    block = web3.eth.get_block(geth_fixture_data['empty_block_hash'])
     assert is_dict(block)
     return block
 
 
 @pytest.fixture(scope="module")
 def block_with_txn(web3, geth_fixture_data):
-    block = web3.eth.getBlock(geth_fixture_data['block_with_txn_hash'])
+    block = web3.eth.get_block(geth_fixture_data['block_with_txn_hash'])
     assert is_dict(block)
     return block
 
@@ -216,7 +216,7 @@ def mined_txn_hash(geth_fixture_data):
 
 @pytest.fixture(scope="module")
 def block_with_txn_with_log(web3, geth_fixture_data):
-    block = web3.eth.getBlock(geth_fixture_data['block_hash_with_log'])
+    block = web3.eth.get_block(geth_fixture_data['block_hash_with_log'])
     assert is_dict(block)
     return block
 

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -108,7 +108,7 @@ class ParityEthModuleTest(EthModuleTest):
 
     @flaky(max_runs=MAX_FLAKY_RUNS)
     def test_eth_call_old_contract_state(self, web3, math_contract, unlocked_account):
-        start_block = web3.eth.getBlock('latest')
+        start_block = web3.eth.get_block('latest')
         block_num = start_block.number
         block_hash = start_block.hash
 

--- a/tests/integration/parity/conftest.py
+++ b/tests/integration/parity/conftest.py
@@ -170,14 +170,14 @@ def funded_account_for_raw_txn(parity_fixture_data):
 
 @pytest.fixture(scope="module")
 def empty_block(web3, parity_fixture_data):
-    block = web3.eth.getBlock(parity_fixture_data['empty_block_hash'])
+    block = web3.eth.get_block(parity_fixture_data['empty_block_hash'])
     assert is_dict(block)
     return block
 
 
 @pytest.fixture(scope="module")
 def block_with_txn(web3, parity_fixture_data):
-    block = web3.eth.getBlock(parity_fixture_data['block_with_txn_hash'])
+    block = web3.eth.get_block(parity_fixture_data['block_with_txn_hash'])
     assert is_dict(block)
     return block
 
@@ -189,7 +189,7 @@ def mined_txn_hash(parity_fixture_data):
 
 @pytest.fixture(scope="module")
 def block_with_txn_with_log(web3, parity_fixture_data):
-    block = web3.eth.getBlock(parity_fixture_data['block_hash_with_log'])
+    block = web3.eth.get_block(parity_fixture_data['block_hash_with_log'])
     assert is_dict(block)
     return block
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -100,7 +100,7 @@ def emitter_contract_address(emitter_contract, address_conversion_func):
 @pytest.fixture(scope="module")
 def empty_block(web3):
     web3.testing.mine()
-    block = web3.eth.getBlock("latest")
+    block = web3.eth.get_block("latest")
     assert not block['transactions']
     return block
 
@@ -115,7 +115,7 @@ def block_with_txn(web3):
         'gas_price': 1,
     })
     txn = web3.eth.getTransaction(txn_hash)
-    block = web3.eth.getBlock(txn['blockNumber'])
+    block = web3.eth.get_block(txn['blockNumber'])
     return block
 
 
@@ -132,7 +132,7 @@ def block_with_txn_with_log(web3, emitter_contract):
         'from': web3.eth.coinbase,
     })
     txn = web3.eth.getTransaction(txn_hash)
-    block = web3.eth.getBlock(txn['blockNumber'])
+    block = web3.eth.get_block(txn['blockNumber'])
     return block
 
 
@@ -253,7 +253,7 @@ class TestEthereumTesterEthModule(EthModuleTest):
     def test_eth_getBlockByHash_pending(
         self, web3: "Web3"
     ) -> None:
-        block = web3.eth.getBlock('pending')
+        block = web3.eth.get_block('pending')
         assert block['hash'] is not None
 
     @disable_auto_mine

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -145,7 +145,7 @@ class EthModuleTest:
         assert balance >= 0
 
     def test_eth_get_balance_with_block_identifier(self, web3: "Web3") -> None:
-        miner_address = web3.eth.getBlock(1)['miner']
+        miner_address = web3.eth.get_block(1)['miner']
         genesis_balance = web3.eth.get_balance(miner_address, 0)
         later_balance = web3.eth.get_balance(miner_address, 1)
 
@@ -847,62 +847,76 @@ class EthModuleTest:
         assert is_integer(gas_estimate)
         assert gas_estimate > 0
 
+    def test_eth_getBlock_deprecated(
+        self, web3: "Web3", empty_block: BlockData
+    ) -> None:
+        with pytest.warns(DeprecationWarning, match="getBlock is deprecated in favor of get_block"):
+            block = web3.eth.getBlock(empty_block['hash'])
+        assert block['hash'] == empty_block['hash']
+
     def test_eth_getBlockByHash(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
-        block = web3.eth.getBlock(empty_block['hash'])
+        block = web3.eth.get_block(empty_block['hash'])
         assert block['hash'] == empty_block['hash']
 
     def test_eth_getBlockByHash_not_found(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
         with pytest.raises(BlockNotFound):
-            web3.eth.getBlock(UNKNOWN_HASH)
+            web3.eth.get_block(UNKNOWN_HASH)
 
     def test_eth_getBlockByHash_pending(
         self, web3: "Web3"
     ) -> None:
-        block = web3.eth.getBlock('pending')
+        block = web3.eth.get_block('pending')
         assert block['hash'] is None
 
     def test_eth_getBlockByNumber_with_integer(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
-        block = web3.eth.getBlock(empty_block['number'])
+        block = web3.eth.get_block(empty_block['number'])
+        assert block['number'] == empty_block['number']
+
+    def test_eth_getBlockByNumber_with_integer_deprecated(
+        self, web3: "Web3", empty_block: BlockData
+    ) -> None:
+        with pytest.warns(DeprecationWarning, match="getBlock is deprecated in favor of get_block"):
+            block = web3.eth.getBlock(empty_block['number'])
         assert block['number'] == empty_block['number']
 
     def test_eth_getBlockByNumber_latest(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
         current_block_number = web3.eth.blockNumber
-        block = web3.eth.getBlock('latest')
+        block = web3.eth.get_block('latest')
         assert block['number'] == current_block_number
 
     def test_eth_getBlockByNumber_not_found(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
         with pytest.raises(BlockNotFound):
-            web3.eth.getBlock(BlockNumber(12345))
+            web3.eth.get_block(BlockNumber(12345))
 
     def test_eth_getBlockByNumber_pending(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
         current_block_number = web3.eth.blockNumber
-        block = web3.eth.getBlock('pending')
+        block = web3.eth.get_block('pending')
         assert block['number'] == current_block_number + 1
 
     def test_eth_getBlockByNumber_earliest(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
-        genesis_block = web3.eth.getBlock(BlockNumber(0))
-        block = web3.eth.getBlock('earliest')
+        genesis_block = web3.eth.get_block(BlockNumber(0))
+        block = web3.eth.get_block('earliest')
         assert block['number'] == 0
         assert block['hash'] == genesis_block['hash']
 
     def test_eth_getBlockByNumber_full_transactions(
         self, web3: "Web3", block_with_txn: BlockData
     ) -> None:
-        block = web3.eth.getBlock(block_with_txn['number'], True)
+        block = web3.eth.get_block(block_with_txn['number'], True)
         transaction = block['transactions'][0]
         assert transaction['hash'] == block_with_txn['transactions'][0]  # type: ignore
 
@@ -1172,7 +1186,7 @@ class EthModuleTest:
     def test_eth_call_old_contract_state(
         self, web3: "Web3", math_contract: "Contract", unlocked_account: ChecksumAddress
     ) -> None:
-        start_block = web3.eth.getBlock('latest')
+        start_block = web3.eth.get_block('latest')
         block_num = start_block["number"]
         block_hash = start_block["hash"]
 

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -115,7 +115,7 @@ def wait_for_transaction_receipt(
 def get_block_gas_limit(web3: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
     if block_identifier is None:
         block_identifier = web3.eth.blockNumber
-    block = web3.eth.getBlock(block_identifier)
+    block = web3.eth.get_block(block_identifier)
     return block['gasLimit']
 
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1545,7 +1545,7 @@ def parse_block_identifier(web3: 'Web3', block_identifier: BlockIdentifier) -> B
     elif block_identifier in ['latest', 'earliest', 'pending']:
         return block_identifier
     elif isinstance(block_identifier, bytes) or is_hex_encoded_block_hash(block_identifier):
-        return web3.eth.getBlock(block_identifier)['number']
+        return web3.eth.get_block(block_identifier)['number']
     else:
         raise BlockNumberOutofRange
 
@@ -1554,7 +1554,7 @@ def parse_block_identifier_int(web3: 'Web3', block_identifier_int: int) -> Block
     if block_identifier_int >= 0:
         block_num = block_identifier_int
     else:
-        last_block = web3.eth.getBlock('latest')['number']
+        last_block = web3.eth.get_block('latest')['number']
         block_num = last_block + block_identifier_int + 1
         if block_num < 0:
             raise BlockNumberOutofRange

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -260,7 +260,7 @@ class Eth(ModuleV2, Module):
     `eth_getBlockByHash`
     `eth_getBlockByNumber`
     """
-    getBlock: Method[Callable[..., BlockData]] = Method(
+    get_block: Method[Callable[..., BlockData]] = Method(
         method_choice_depends_on_args=select_method_for_block_identifier(
             if_predefined=RPC.eth_getBlockByNumber,
             if_hash=RPC.eth_getBlockByHash,
@@ -566,3 +566,4 @@ class Eth(ModuleV2, Module):
     # Deprecated Methods
     getBalance = DeprecatedMethod(get_balance, 'getBalance', 'get_balance')
     getStorageAt = DeprecatedMethod(get_storage_at, 'getStorageAt', 'get_storage_at')
+    getBlock = DeprecatedMethod(get_block, 'getBlock', 'get_block')

--- a/web3/gas_strategies/time_based.py
+++ b/web3/gas_strategies/time_based.py
@@ -44,29 +44,29 @@ Probability = collections.namedtuple('Probability', ['gas_price', 'prob'])
 
 
 def _get_avg_block_time(w3: Web3, sample_size: int) -> float:
-    latest = w3.eth.getBlock('latest')
+    latest = w3.eth.get_block('latest')
 
     constrained_sample_size = min(sample_size, latest['number'])
     if constrained_sample_size == 0:
         raise ValidationError('Constrained sample size is 0')
 
-    oldest = w3.eth.getBlock(BlockNumber(latest['number'] - constrained_sample_size))
+    oldest = w3.eth.get_block(BlockNumber(latest['number'] - constrained_sample_size))
     return (latest['timestamp'] - oldest['timestamp']) / constrained_sample_size
 
 
 def _get_weighted_avg_block_time(w3: Web3, sample_size: int) -> float:
-    latest_block_number = w3.eth.getBlock('latest')['number']
+    latest_block_number = w3.eth.get_block('latest')['number']
     constrained_sample_size = min(sample_size, latest_block_number)
     if constrained_sample_size == 0:
         raise ValidationError('Constrained sample size is 0')
 
-    oldest_block = w3.eth.getBlock(BlockNumber(latest_block_number - constrained_sample_size))
+    oldest_block = w3.eth.get_block(BlockNumber(latest_block_number - constrained_sample_size))
     oldest_block_number = oldest_block['number']
     prev_timestamp = oldest_block['timestamp']
     weighted_sum = 0.0
     sum_of_weights = 0.0
     for i in range(oldest_block_number + 1, latest_block_number + 1):
-        curr_timestamp = w3.eth.getBlock(BlockNumber(i))['timestamp']
+        curr_timestamp = w3.eth.get_block(BlockNumber(i))['timestamp']
         time = curr_timestamp - prev_timestamp
         weight = (i - oldest_block_number) / constrained_sample_size
         weighted_sum += (time * weight)
@@ -78,7 +78,7 @@ def _get_weighted_avg_block_time(w3: Web3, sample_size: int) -> float:
 def _get_raw_miner_data(
     w3: Web3, sample_size: int
 ) -> Iterable[Tuple[ChecksumAddress, HexBytes, Wei]]:
-    latest = w3.eth.getBlock('latest', full_transactions=True)
+    latest = w3.eth.get_block('latest', full_transactions=True)
 
     for transaction in latest['transactions']:
         # type ignored b/c actual transaction is TxData not HexBytes
@@ -92,7 +92,7 @@ def _get_raw_miner_data(
 
         # we intentionally trace backwards using parent hashes rather than
         # block numbers to make caching the data easier to implement.
-        block = w3.eth.getBlock(block['parentHash'], full_transactions=True)
+        block = w3.eth.get_block(block['parentHash'], full_transactions=True)
         for transaction in block['transactions']:
             # type ignored b/c actual transaction is TxData not HexBytes
             yield (block['miner'], block['hash'], transaction['gasPrice'])  # type: ignore

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -378,12 +378,12 @@ def construct_latest_block_based_cache_middleware(
                 # measured by blocks is greater than or equal to the number of
                 # blocks sampled then we need to recompute the average block
                 # time.
-                latest_block = web3.eth.getBlock('latest')
+                latest_block = web3.eth.get_block('latest')
                 ancestor_block_number = BlockNumber(max(
                     0,
                     latest_block['number'] - average_block_time_sample_size,
                 ))
-                ancestor_block = web3.eth.getBlock(ancestor_block_number)
+                ancestor_block = web3.eth.get_block(ancestor_block_number)
                 sample_size = latest_block['number'] - ancestor_block_number
 
                 block_info[AVG_BLOCK_SAMPLE_SIZE_KEY] = sample_size
@@ -401,10 +401,10 @@ def construct_latest_block_based_cache_middleware(
 
                 # latest block is too old so update cache
                 if time_since_latest_block > avg_block_time:
-                    block_info['latest_block'] = web3.eth.getBlock('latest')
+                    block_info['latest_block'] = web3.eth.get_block('latest')
             else:
                 # latest block has not been fetched so we fetch it.
-                block_info['latest_block'] = web3.eth.getBlock('latest')
+                block_info['latest_block'] = web3.eth.get_block('latest')
 
         lock = threading.Lock()
 

--- a/web3/middleware/filter.py
+++ b/web3/middleware/filter.py
@@ -331,7 +331,7 @@ def block_hashes_in_range(
     if from_block is None or to_block is None:
         return
     for block_number in range(from_block, to_block + 1):
-        yield getattr(w3.eth.getBlock(BlockNumber(block_number)), "hash", None)
+        yield getattr(w3.eth.get_block(BlockNumber(block_number)), "hash", None)
 
 
 def local_filter_middleware(

--- a/web3/middleware/stalecheck.py
+++ b/web3/middleware/stalecheck.py
@@ -56,7 +56,7 @@ def make_stalecheck_middleware(
                 if _isfresh(cache['latest'], allowable_delay):
                     pass
                 else:
-                    latest = web3.eth.getBlock('latest')
+                    latest = web3.eth.get_block('latest')
                     if _isfresh(latest, allowable_delay):
                         cache['latest'] = latest
                     else:


### PR DESCRIPTION
### What was wrong?
Yet another PR for moving the eth methods to snake case.

Related to Issue #1429

### How was it fixed?
Moved `getBlock` method to `get_block`, deprecated `getBlock`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.pinimg.com/originals/6e/9d/4e/6e9d4e344d4c9819f63ac2d817215989.jpg)
