### PR TITLE
Pin hypothesis to less than 6 until we fix our deprecation warnings

### DIFF
--- a/newsfragments/1831.misc.rst
+++ b/newsfragments/1831.misc.rst
@@ -1,0 +1,1 @@
+Pin Hypothesis dependency to <6.0 until we fix scoping deprecation warnings

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ extras_require = {
     'dev': [
         "bumpversion",
         "flaky>=3.3.0",
-        "hypothesis>=3.31.2",
+        "hypothesis>=3.31.2,<6",
         "pytest>=4.4.0,<5.0.0",
         "pytest-asyncio>=0.10.0,<0.11",
         "pytest-mock>=1.10,<2",


### PR DESCRIPTION
### What was wrong?
Hypothesis v6.0 breaks our tests since we haven't addressed the deprecation warnings yet. 

Related to Issue #1832

### How was it fixed?
Pinned hypothesis for now, but we'll need to fix the warnings before we upgrade.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![](https://i.pinimg.com/originals/56/de/a6/56dea69f9e497d1ddc525b237450b1e9.jpg)

