### PR TITLE
Mark flaky ethpm test as flaky

### DIFF
--- a/newsfragments/1833.misc.rst
+++ b/newsfragments/1833.misc.rst
@@ -1,0 +1,1 @@
+Mark ethpm's local IPFS backend test as flaky

--- a/tests/ethpm/backends/test_ipfs_backends.py
+++ b/tests/ethpm/backends/test_ipfs_backends.py
@@ -7,6 +7,9 @@ import pytest
 from eth_utils import (
     to_text,
 )
+from ipfshttpclient.exceptions import (
+    TimeoutError,
+)
 
 from ethpm.backends.ipfs import (
     DummyIPFSBackend,
@@ -52,6 +55,7 @@ def test_ipfs_and_infura_gateway_backends_fetch_uri_contents(base_uri, backend):
     assert contents.startswith(b"pragma solidity")
 
 
+@pytest.mark.xfail(strict=False, raises=TimeoutError)
 def test_local_ipfs_backend(owned_manifest_path):
     uri = "ipfs://Qme4otpS88NV8yQi8TfTP89EsQC5bko3F5N1yhRoi6cwGV"
     backend = LocalIPFSBackend()


### PR DESCRIPTION
### What was wrong?
We have a test in the ethpm module that consistently runs into a timeout error during testing, especially when it gets run over and over again, like for small PR changes.

### How was it fixed?
The PR pretty much speaks for itself, but added an xfail that specifies what error it's all right to fail with. If it fails with a different error, it will show up in the test output and fail the build.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/104241315-b5264880-541a-11eb-8591-25f090c9b065.png)

