### PR TITLE
Mark flaky geth test as such

### DIFF
--- a/newsfragments/1834.misc.rst
+++ b/newsfragments/1834.misc.rst
@@ -1,0 +1,1 @@
+Mark Geth's replaceTransaction_already_mined test as flaky

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -1,3 +1,6 @@
+from concurrent.futures._base import (
+    TimeoutError as FuturesTimeoutError,
+)
 import pytest
 
 from web3._utils.module_testing import (  # noqa: F401
@@ -21,6 +24,11 @@ class GoEthereumEthModuleTest(EthModuleTest):
         # https://github.com/ethereum/go-ethereum/commit/51db5975cc5fb88db6a0dba1826b534fd4df29d7
         super().test_eth_submitHashrate(web3)
 
+    @pytest.mark.xfail(
+        strict=False,
+        raises=FuturesTimeoutError,
+        reason='Sometimes a TimeoutError is hit when waiting for the txn to be mined',
+    )
     def test_eth_replaceTransaction_already_mined(self, web3, unlocked_account_dual_type):
         web3.geth.miner.start()
         super().test_eth_replaceTransaction_already_mined(web3, unlocked_account_dual_type)


### PR DESCRIPTION
### What was wrong?
Sometimes geth integration tests timeout when waiting for a transaction, so I added an `xfail` with an error to mark it as flaky.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/104623003-26e6d800-564f-11eb-9759-263b488c9f75.png)

