### PR TITLE
Remove v5 breaking changes link from the top of release notes

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,9 +1,6 @@
 Release Notes
 =============
 
-v5 Breaking Changes Summary
-   See the :ref:`v5 Migration Guide<migrating_v4_to_v5>`
-
 .. towncrier release notes start
 
 v5.15.0 (2021-01-15)

--- a/newsfragments/1837.doc.rst
+++ b/newsfragments/1837.doc.rst
@@ -1,0 +1,1 @@
+Remove v5 breaking changes link from the top of the release notes.


### PR DESCRIPTION
### What was wrong?
I noticed that we had a link to the v5 migration docs at the top of the release notes. Since v5 has been out for a long time now, I don't think we need it any more. A user can also find the docs in the sidebar.

### How was it fixed?
Removed it!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.pinimg.com/564x/31/64/08/316408d5f2ad866dc4d86b6942227249.jpg)
