### PR TITLE
Move getBlockTransactionCount to get_block_transaction_count

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -142,7 +142,7 @@ API
 
 - :meth:`web3.eth.get_balance() <web3.eth.Eth.get_balance>`
 - :meth:`web3.eth.get_block() <web3.eth.Eth.get_block>`
-- :meth:`web3.eth.getBlockTransactionCount() <web3.eth.Eth.getBlockTransactionCount>`
+- :meth:`web3.eth.get_block_transaction_count() <web3.eth.Eth.get_block_transaction_count>`
 - :meth:`web3.eth.getCode() <web3.eth.Eth.getCode>`
 - :meth:`web3.eth.getProof() <web3.eth.Eth.getProof>`
 - :meth:`web3.eth.get_storage_at() <web3.eth.Eth.get_storage_at>`

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -376,7 +376,7 @@ The following methods are available on the ``web3.eth`` namespace.
     .. warning:: Deprecated: This method is deprecated in favor of
       :meth:`~web3.eth.Eth.get_block`
 
-.. py:method:: Eth.getBlockTransactionCount(block_identifier)
+.. py:method:: Eth.get_block_transaction_count(block_identifier)
 
     * Delegates to ``eth_getBlockTransactionCountByNumber`` or
       ``eth_getBlockTransactionCountByHash`` RPC Methods
@@ -389,10 +389,17 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.getBlockTransactionCount(46147)
+        >>> web3.eth.get_block_transaction_count(46147)
         1
-        >>> web3.eth.getBlockTransactionCount('0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd')  # block 46147
+        >>> web3.eth.get_block_transaction_count('0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd')  # block 46147
         1
+
+
+.. py:method:: Eth.getBlockTransactionCount(block_identifier)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.get_block_transaction_count`
+
 
 
 .. py:method:: Eth.getUncle(block_identifier)

--- a/newsfragments/1841.feature.rst
+++ b/newsfragments/1841.feature.rst
@@ -1,0 +1,1 @@
+Added ``get_block_transaction_count``, and deprecated ``getBlockTransactionCount``

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -180,7 +180,7 @@ class EthModuleTest:
     ) -> None:
         with pytest.warns(DeprecationWarning):
             storage = web3.eth.getStorageAt(emitter_contract_address, 0)
-            assert isinstance(storage, HexBytes)
+        assert isinstance(storage, HexBytes)
 
     def test_eth_get_storage_at_ens_name(
         self, web3: "Web3", emitter_contract_address: ChecksumAddress
@@ -217,7 +217,7 @@ class EthModuleTest:
     def test_eth_getBlockTransactionCountByHash_empty_block(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
-        transaction_count = web3.eth.getBlockTransactionCount(empty_block['hash'])
+        transaction_count = web3.eth.get_block_transaction_count(empty_block['hash'])
 
         assert is_integer(transaction_count)
         assert transaction_count == 0
@@ -225,7 +225,7 @@ class EthModuleTest:
     def test_eth_getBlockTransactionCountByNumber_empty_block(
         self, web3: "Web3", empty_block: BlockData
     ) -> None:
-        transaction_count = web3.eth.getBlockTransactionCount(empty_block['number'])
+        transaction_count = web3.eth.get_block_transaction_count(empty_block['number'])
 
         assert is_integer(transaction_count)
         assert transaction_count == 0
@@ -233,7 +233,7 @@ class EthModuleTest:
     def test_eth_getBlockTransactionCountByHash_block_with_txn(
         self, web3: "Web3", block_with_txn: BlockData
     ) -> None:
-        transaction_count = web3.eth.getBlockTransactionCount(block_with_txn['hash'])
+        transaction_count = web3.eth.get_block_transaction_count(block_with_txn['hash'])
 
         assert is_integer(transaction_count)
         assert transaction_count >= 1
@@ -241,7 +241,31 @@ class EthModuleTest:
     def test_eth_getBlockTransactionCountByNumber_block_with_txn(
         self, web3: "Web3", block_with_txn: BlockData
     ) -> None:
-        transaction_count = web3.eth.getBlockTransactionCount(block_with_txn['number'])
+        transaction_count = web3.eth.get_block_transaction_count(block_with_txn['number'])
+
+        assert is_integer(transaction_count)
+        assert transaction_count >= 1
+
+    def test_eth_getBlockTransactionCountByHash_block_with_txn_deprecated(
+        self, web3: "Web3", block_with_txn: BlockData
+    ) -> None:
+        with pytest.warns(
+            DeprecationWarning,
+            match="getBlockTransactionCount is deprecated in favor of get_block_transaction_count"
+        ):
+            transaction_count = web3.eth.getBlockTransactionCount(block_with_txn['hash'])
+
+        assert is_integer(transaction_count)
+        assert transaction_count >= 1
+
+    def test_eth_getBlockTransactionCountByNumber_block_with_txn_deprecated(
+        self, web3: "Web3", block_with_txn: BlockData
+    ) -> None:
+        with pytest.warns(
+            DeprecationWarning,
+            match="getBlockTransactionCount is deprecated in favor of get_block_transaction_count"
+        ):
+            transaction_count = web3.eth.getBlockTransactionCount(block_with_txn['number'])
 
         assert is_integer(transaction_count)
         assert transaction_count >= 1

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -273,7 +273,7 @@ class Eth(ModuleV2, Module):
     `eth_getBlockTransactionCountByHash`
     `eth_getBlockTransactionCountByNumber`
     """
-    getBlockTransactionCount: Method[Callable[[BlockIdentifier], int]] = Method(
+    get_block_transaction_count: Method[Callable[[BlockIdentifier], int]] = Method(
         method_choice_depends_on_args=select_method_for_block_identifier(
             if_predefined=RPC.eth_getBlockTransactionCountByNumber,
             if_hash=RPC.eth_getBlockTransactionCountByHash,
@@ -567,3 +567,6 @@ class Eth(ModuleV2, Module):
     getBalance = DeprecatedMethod(get_balance, 'getBalance', 'get_balance')
     getStorageAt = DeprecatedMethod(get_storage_at, 'getStorageAt', 'get_storage_at')
     getBlock = DeprecatedMethod(get_block, 'getBlock', 'get_block')
+    getBlockTransactionCount = DeprecatedMethod(get_block_transaction_count,
+                                                'getBlockTransactionCount',
+                                                'get_block_transaction_count')


### PR DESCRIPTION
### What was wrong?
`getBlockTransactionCount` needed to be moved to snake case. 

Related to Issue #1429 

### How was it fixed?
`getBlockTransactionCount` -> `get_block_transaction_count`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Manually test

#### Cute Animal Picture


![image](https://user-images.githubusercontent.com/6540608/105213478-fc43c600-5b0b-11eb-9e63-eb2bdb1c216b.png)
