### PR TITLE
fix event filter creation bug

### DIFF
--- a/newsfragments/1807.bugfix.rst
+++ b/newsfragments/1807.bugfix.rst
@@ -1,0 +1,1 @@
+Fix event filter creation if the event ABI contains a ``values`` key.

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -401,7 +401,7 @@ class EventFilterBuilder:
         if not isinstance(w3, web3.Web3):
             raise ValueError("Invalid web3 argument: got: {0}".format(repr(w3)))
 
-        for arg in self.args.values():
+        for arg in AttributeDict.values(self.args):
             arg._immutable = True
         self._immutable = True
 


### PR DESCRIPTION
### What was wrong?
- The Uniswap governance contract contains one event that blew up upon filter creation. Turned out to be an edge case triggered by the event containing a `values` key.
- Closes #1807 

### How was it fixed?
One-liner.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.pinimg.com/originals/6e/6b/84/6e6b843b4c9f4fa149f78ed7e8ac6d46.jpg)
