### PR TITLE
eth.defaultBlock -> eth.default_block

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -43,16 +43,23 @@ The following properties are available on the ``web3.eth`` namespace.
     The ethereum address that will be used as the default ``from`` address for
     all transactions.
 
+
 .. py:attribute:: Eth.defaultAccount
 
     .. warning:: Deprecated: This property is deprecated in favor of
       :attr:`~web3.eth.Eth.default_account`
 
 
-.. py:attribute:: Eth.defaultBlock
+.. py:attribute:: Eth.default_block
 
     The default block number that will be used for any RPC methods that accept
     a block identifier.  Defaults to ``'latest'``.
+
+
+.. py:attribute:: Eth.defaultBlock
+
+    .. warning:: Deprecated: This property is deprecated in favor of
+      :attr:`~web3.eth.default_block`
 
 
 .. py:attribute:: Eth.syncing
@@ -176,7 +183,7 @@ Methods
 The following methods are available on the ``web3.eth`` namespace.
 
 
-.. py:method:: Eth.get_balance(account, block_identifier=eth.defaultBlock)
+.. py:method:: Eth.get_balance(account, block_identifier=eth.default_block)
 
     * Delegates to ``eth_getBalance`` RPC Method
 
@@ -191,13 +198,13 @@ The following methods are available on the ``web3.eth`` namespace.
         77320681768999138915
 
 
-.. py:method:: Eth.getBalance(account, block_identifier=eth.defaultBlock)
+.. py:method:: Eth.getBalance(account, block_identifier=eth.default_block)
 
     .. warning:: Deprecated: This method is deprecated in favor of
       :meth:`~web3.eth.get_balance()`
 
 
-.. py:method:: Eth.get_storage_at(account, position, block_identifier=eth.defaultBlock)
+.. py:method:: Eth.get_storage_at(account, position, block_identifier=eth.default_block)
 
     * Delegates to ``eth_getStorageAt`` RPC Method
 
@@ -212,13 +219,13 @@ The following methods are available on the ``web3.eth`` namespace.
         '0x00000000000000000000000000000000000000000000000000120a0b063499d4'
 
 
-.. py:method:: Eth.getStorageAt(account, position, block_identifier=eth.defaultBlock)
+.. py:method:: Eth.getStorageAt(account, position, block_identifier=eth.default_block)
 
     .. warning:: Deprecated: This method is deprecated in favor of
       :meth:`~web3.eth.Eth.get_storage_at`
 
 
-.. py:method:: Eth.getProof(account, positions, block_identifier=eth.defaultBlock)
+.. py:method:: Eth.getProof(account, positions, block_identifier=eth.default_block)
 
     * Delegates to ``eth_getProof`` RPC Method
 
@@ -319,7 +326,7 @@ The following methods are available on the ``web3.eth`` namespace.
         assert verify_eth_getProof(proof, block.stateRoot)
 
 
-.. py:method:: Eth.getCode(account, block_identifier=eth.defaultBlock)
+.. py:method:: Eth.getCode(account, block_identifier=eth.default_block)
 
     * Delegates to ``eth_getCode`` RPC Method
 
@@ -338,7 +345,7 @@ The following methods are available on the ``web3.eth`` namespace.
         '0x'
 
 
-.. py:method:: Eth.get_block(block_identifier=eth.defaultBlock, full_transactions=False)
+.. py:method:: Eth.get_block(block_identifier=eth.default_block, full_transactions=False)
 
     * Delegates to ``eth_getBlockByNumber`` or ``eth_getBlockByHash`` RPC Methods
 
@@ -612,7 +619,7 @@ The following methods are available on the ``web3.eth`` namespace.
         })
 
 
-.. py:method:: Eth.getTransactionCount(account, block_identifier=web3.eth.defaultBlock)
+.. py:method:: Eth.getTransactionCount(account, block_identifier=web3.eth.default_block)
 
     * Delegates to ``eth_getTransactionCount`` RPC Method
 
@@ -819,7 +826,7 @@ The following methods are available on the ``web3.eth`` namespace.
     ``account`` may be a checksum address or an ENS name
 
 
-.. py:method:: Eth.call(transaction, block_identifier=web3.eth.defaultBlock)
+.. py:method:: Eth.call(transaction, block_identifier=web3.eth.default_block)
 
     * Delegates to ``eth_call`` RPC Method
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -59,7 +59,7 @@ The following properties are available on the ``web3.eth`` namespace.
 .. py:attribute:: Eth.defaultBlock
 
     .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.eth.default_block`
+      :attr:`~web3.eth.Eth.default_block`
 
 
 .. py:attribute:: Eth.syncing
@@ -383,7 +383,7 @@ The following methods are available on the ``web3.eth`` namespace.
             'uncles': [],
         })
 
-.. py:method:: Eth.getBlock(block_identifier=eth.defaultBlock, full_transactions=False)
+.. py:method:: Eth.getBlock(block_identifier=eth.default_block, full_transactions=False)
 
     .. warning:: Deprecated: This method is deprecated in favor of
       :meth:`~web3.eth.Eth.get_block`

--- a/newsfragments/1849.feature.rst
+++ b/newsfragments/1849.feature.rst
@@ -1,0 +1,2 @@
+Add ``eth.default_block``, deprecate ``eth.defaultBlock``.
+Also adds ``parity.default_block``, and deprecates ``parity.defaultBlock``.

--- a/tests/core/eth-module/test_default_account_api.py
+++ b/tests/core/eth-module/test_default_account_api.py
@@ -26,6 +26,8 @@ def test_uses_defaultAccount_when_set_with_warning(web3, extra_accounts,
                                                    wait_for_transaction):
     with pytest.warns(DeprecationWarning):
         web3.eth.defaultAccount = extra_accounts[2]
+
+    with pytest.warns(DeprecationWarning):
         assert web3.eth.defaultAccount == extra_accounts[2]
 
     txn_hash = web3.eth.sendTransaction({
@@ -58,6 +60,10 @@ def test_uses_given_from_address_when_provided_with_warning(web3, extra_accounts
                                                             wait_for_transaction):
     with pytest.warns(DeprecationWarning):
         web3.eth.defaultAccount = extra_accounts[2]
+
+    with pytest.warns(DeprecationWarning):
+        assert web3.eth.defaultAccount == extra_accounts[2]
+
     txn_hash = web3.eth.sendTransaction({
         "from": extra_accounts[5],
         "to": extra_accounts[1],

--- a/tests/core/eth-module/test_default_block_api.py
+++ b/tests/core/eth-module/test_default_block_api.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def wait_for_first_block(web3, wait_for_block):
+    wait_for_block(web3)
+
+
+def test_uses_default_block(web3, extra_accounts,
+                            wait_for_transaction):
+    assert(web3.eth.default_block == 'latest')
+    web3.eth.default_block = web3.eth.blockNumber
+    assert(web3.eth.default_block == web3.eth.blockNumber)
+
+
+def test_uses_default_block_with_warning(web3, extra_accounts,
+                                         wait_for_transaction):
+    with pytest.warns(DeprecationWarning):
+        assert(web3.eth.defaultBlock == 'latest')
+
+    with pytest.warns(DeprecationWarning):
+        web3.eth.defaultBlock = web3.eth.blockNumber
+
+    with pytest.warns(DeprecationWarning):
+        assert(web3.eth.defaultBlock == web3.eth.blockNumber)

--- a/tests/core/eth-module/test_default_block_api.py
+++ b/tests/core/eth-module/test_default_block_api.py
@@ -16,10 +16,10 @@ def test_uses_default_block(web3, extra_accounts,
 def test_uses_default_block_with_warning(web3, extra_accounts,
                                          wait_for_transaction):
     with pytest.warns(DeprecationWarning):
-        assert(web3.eth.defaultBlock == 'latest')
+        assert web3.eth.defaultBlock == 'latest'
 
     with pytest.warns(DeprecationWarning):
         web3.eth.defaultBlock = web3.eth.blockNumber
 
     with pytest.warns(DeprecationWarning):
-        assert(web3.eth.defaultBlock == web3.eth.blockNumber)
+        assert web3.eth.defaultBlock == web3.eth.blockNumber

--- a/web3/_utils/empty.py
+++ b/web3/_utils/empty.py
@@ -3,7 +3,7 @@ from web3._utils.compat import (
 )
 
 
-class Empty():
+class Empty:
     def __bool__(self) -> Literal[False]:
         return False
 

--- a/web3/_utils/empty.py
+++ b/web3/_utils/empty.py
@@ -3,7 +3,7 @@ from web3._utils.compat import (
 )
 
 
-class Empty:
+class Empty():
     def __bool__(self) -> Literal[False]:
         return False
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -104,7 +104,7 @@ from web3.types import (
 class Eth(ModuleV2, Module):
     account = Account()
     _default_account: Union[ChecksumAddress, Empty] = empty
-    _default_block: BlockIdentifier = "latest"  # noqa: E704
+    _default_block: BlockIdentifier = "latest"
     defaultContractFactory: Type[Union[Contract, ConciseContract, ContractCaller]] = Contract  # noqa: E704,E501
     iban = Iban
     gasPriceStrategy = None
@@ -222,20 +222,6 @@ class Eth(ModuleV2, Module):
         )
         self._default_account = account
 
-    def block_id_munger(
-        self,
-        account: Union[Address, ChecksumAddress, ENS],
-        block_identifier: Optional[BlockIdentifier] = None
-    ) -> Tuple[Union[Address, ChecksumAddress, ENS], BlockIdentifier]:
-        if block_identifier is None:
-            block_identifier = self.default_block
-        return (account, block_identifier)
-
-    get_balance: Method[Callable[..., Wei]] = Method(
-        RPC.eth_getBalance,
-        mungers=[block_id_munger],
-    )
-
     """ property default_block """
 
     @property
@@ -261,6 +247,20 @@ class Eth(ModuleV2, Module):
             category=DeprecationWarning,
         )
         self._default_block = value
+
+    def block_id_munger(
+        self,
+        account: Union[Address, ChecksumAddress, ENS],
+        block_identifier: Optional[BlockIdentifier] = None
+    ) -> Tuple[Union[Address, ChecksumAddress, ENS], BlockIdentifier]:
+        if block_identifier is None:
+            block_identifier = self.default_block
+        return (account, block_identifier)
+
+    get_balance: Method[Callable[..., Wei]] = Method(
+        RPC.eth_getBalance,
+        mungers=[block_id_munger],
+    )
 
     def get_storage_at_munger(
         self,

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -37,9 +37,6 @@ from hexbytes import (
 from web3._utils.blocks import (
     select_method_for_block_identifier,
 )
-from web3._utils.compat import (
-    Literal,
-)
 from web3._utils.empty import (
     Empty,
     empty,
@@ -106,8 +103,8 @@ from web3.types import (
 
 class Eth(ModuleV2, Module):
     account = Account()
-    _default_account: Union[Empty, ChecksumAddress] = empty
-    defaultBlock: Literal["latest"] = "latest"  # noqa: E704
+    _default_account: Union[ChecksumAddress, Empty] = empty
+    _default_block: BlockIdentifier = "latest"  # noqa: E704
     defaultContractFactory: Type[Union[Contract, ConciseContract, ContractCaller]] = Contract  # noqa: E704,E501
     iban = Iban
     gasPriceStrategy = None
@@ -199,16 +196,18 @@ class Eth(ModuleV2, Module):
     def chainId(self) -> int:
         return self.web3.manager.request_blocking(RPC.eth_chainId, [])
 
+    """ property default_account """
+
     @property
-    def default_account(self) -> Union[Empty, ChecksumAddress]:
+    def default_account(self) -> Union[ChecksumAddress, Empty]:
         return self._default_account
 
     @default_account.setter
-    def default_account(self, account: Union[Empty, ChecksumAddress]) -> None:
+    def default_account(self, account: Union[ChecksumAddress, Empty]) -> None:
         self._default_account = account
 
     @property
-    def defaultAccount(self) -> Union[Empty, ChecksumAddress]:
+    def defaultAccount(self) -> Union[ChecksumAddress, Empty]:
         warnings.warn(
             'defaultAccount is deprecated in favor of default_account',
             category=DeprecationWarning,
@@ -216,7 +215,7 @@ class Eth(ModuleV2, Module):
         return self._default_account
 
     @defaultAccount.setter
-    def defaultAccount(self, account: Union[Empty, ChecksumAddress]) -> None:
+    def defaultAccount(self, account: Union[ChecksumAddress, Empty]) -> None:
         warnings.warn(
             'defaultAccount is deprecated in favor of default_account',
             category=DeprecationWarning,
@@ -229,13 +228,39 @@ class Eth(ModuleV2, Module):
         block_identifier: Optional[BlockIdentifier] = None
     ) -> Tuple[Union[Address, ChecksumAddress, ENS], BlockIdentifier]:
         if block_identifier is None:
-            block_identifier = self.defaultBlock
+            block_identifier = self.default_block
         return (account, block_identifier)
 
     get_balance: Method[Callable[..., Wei]] = Method(
         RPC.eth_getBalance,
         mungers=[block_id_munger],
     )
+
+    """ property default_block """
+
+    @property
+    def default_block(self) -> BlockIdentifier:
+        return self._default_block
+
+    @default_block.setter
+    def default_block(self, value: BlockIdentifier) -> None:
+        self._default_block = value
+
+    @property
+    def defaultBlock(self) -> BlockIdentifier:
+        warnings.warn(
+            'defaultBlock is deprecated in favor of default_block',
+            category=DeprecationWarning,
+        )
+        return self._default_block
+
+    @defaultBlock.setter
+    def defaultBlock(self, value: BlockIdentifier) -> None:
+        warnings.warn(
+            'defaultBlock is deprecated in favor of default_block',
+            category=DeprecationWarning,
+        )
+        self._default_block = value
 
     def get_storage_at_munger(
         self,
@@ -244,7 +269,7 @@ class Eth(ModuleV2, Module):
         block_identifier: Optional[BlockIdentifier] = None
     ) -> Tuple[Union[Address, ChecksumAddress, ENS], int, BlockIdentifier]:
         if block_identifier is None:
-            block_identifier = self.defaultBlock
+            block_identifier = self.default_block
         return (account, position, block_identifier)
 
     get_storage_at: Method[Callable[..., HexBytes]] = Method(
@@ -259,7 +284,7 @@ class Eth(ModuleV2, Module):
         block_identifier: Optional[BlockIdentifier] = None
     ) -> Tuple[Union[Address, ChecksumAddress, ENS], Sequence[int], Optional[BlockIdentifier]]:
         if block_identifier is None:
-            block_identifier = self.defaultBlock
+            block_identifier = self.default_block
         return (account, positions, block_identifier)
 
     getProof: Method[
@@ -455,7 +480,7 @@ class Eth(ModuleV2, Module):
 
         # TODO: move to middleware
         if block_identifier is None:
-            block_identifier = self.defaultBlock
+            block_identifier = self.default_block
 
         return (transaction, block_identifier)
 

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -5,6 +5,7 @@ from typing import (
     Tuple,
     Union,
 )
+import warnings
 
 from eth_typing import (
     Address,
@@ -19,9 +20,6 @@ from eth_utils.toolz import (
     assoc,
 )
 
-from web3._utils.compat import (
-    Literal,
-)
 from web3._utils.personal import (
     ec_recover,
     ecRecover,
@@ -90,13 +88,39 @@ class Parity(ModuleV2):
     """
     https://paritytech.github.io/wiki/JSONRPC-parity-module
     """
-    defaultBlock: Literal["latest"] = "latest"  # noqa: E704
+    _default_block: BlockIdentifier = "latest"  # noqa: E704
     personal: ParityPersonal
 
     enode: Method[Callable[[], str]] = Method(
         RPC.parity_enode,
         mungers=None,
     )
+
+    """ property default_block """
+
+    @property
+    def default_block(self) -> BlockIdentifier:
+        return self._default_block
+
+    @default_block.setter
+    def default_block(self, value: BlockIdentifier) -> None:
+        self._default_block = value
+
+    @property
+    def defaultBlock(self) -> BlockIdentifier:
+        warnings.warn(
+            'defaultBlock is deprecated in favor of default_block',
+            category=DeprecationWarning,
+        )
+        return self._default_block
+
+    @defaultBlock.setter
+    def defaultBlock(self, value: BlockIdentifier) -> None:
+        warnings.warn(
+            'defaultBlock is deprecated in favor of default_block',
+            category=DeprecationWarning,
+        )
+        self._default_block = value
 
     def list_storage_keys_munger(
         self,

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -88,7 +88,7 @@ class Parity(ModuleV2):
     """
     https://paritytech.github.io/wiki/JSONRPC-parity-module
     """
-    _default_block: BlockIdentifier = "latest"  # noqa: E704
+    _default_block: BlockIdentifier = "latest"
     personal: ParityPersonal
 
     enode: Method[Callable[[], str]] = Method(
@@ -130,7 +130,7 @@ class Parity(ModuleV2):
         block_identifier: Optional[BlockIdentifier] = None,
     ) -> Tuple[Union[Address, ChecksumAddress, ENS, Hash32], int, Hash32, BlockIdentifier]:
         if block_identifier is None:
-            block_identifier = self.defaultBlock
+            block_identifier = self.default_block
         return (address, quantity, hash_, block_identifier)
 
     listStorageKeys: Method[Callable[..., List[Hash32]]] = Method(
@@ -190,7 +190,7 @@ class Parity(ModuleV2):
 
         # TODO: move to middleware
         if block_identifier is None:
-            block_identifier = self.defaultBlock
+            block_identifier = self.default_block
 
         return (transaction, mode, block_identifier)
 


### PR DESCRIPTION
### What was wrong?
Moving default_block to snake case. 

This was branched off of #1848, so should be merged after. To see only the changes from this PR, use this URL: https://github.com/ethereum/web3.py/compare/27ecea7...kclowes:default-block-snake

Related to Issue #1429

### How was it fixed?
Deprecated `defaultBlock`, added `default_block`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="197" alt="image" src="https://user-images.githubusercontent.com/6540608/105554631-f9400580-5cc4-11eb-855d-6df75e2fd4d3.png">
