### PR TITLE
eth.gasPrice to snake case

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -277,7 +277,7 @@ Each Contract Factory exposes the following methods.
     .. code-block:: python
 
         >>> transaction = {
-        'gasPrice': w3.eth.gasPrice,
+        'gasPrice': w3.eth.gas_price,
         'chainId': None
         }
         >>> contract_data = token_contract.constructor(web3.eth.coinbase, 12345).buildTransaction(transaction)

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -132,7 +132,7 @@ The following properties are available on the ``web3.eth`` namespace.
 .. py:attribute:: Eth.gasPrice
 
     .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.eth.gas_price`
+      :attr:`~web3.eth.Eth.gas_price`
 
 
 .. py:attribute:: Eth.accounts

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -117,7 +117,7 @@ The following properties are available on the ``web3.eth`` namespace.
         906
 
 
-.. py:attribute:: Eth.gasPrice
+.. py:attribute:: Eth.gas_price
 
     * Delegates to ``eth_gasPrice`` RPC Method
 
@@ -125,8 +125,14 @@ The following properties are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.gasPrice
+        >>> web3.eth.gas_price
         20000000000
+
+
+.. py:attribute:: Eth.gasPrice
+
+    .. warning:: Deprecated: This property is deprecated in favor of
+      :attr:`~web3.eth.gas_price`
 
 
 .. py:attribute:: Eth.accounts
@@ -683,7 +689,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
         >>> signed_txn = w3.eth.signTransaction(dict(
             nonce=w3.eth.getTransactionCount(w3.eth.coinbase),
-            gasPrice=w3.eth.gasPrice,
+            gasPrice=w3.eth.gas_price,
             gas=100000,
             to='0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
             value=1,
@@ -703,7 +709,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
         >>> signed_txn = w3.eth.account.signTransaction(dict(
             nonce=w3.eth.getTransactionCount(w3.eth.coinbase),
-            gasPrice=w3.eth.gasPrice,
+            gasPrice=w3.eth.gas_price,
             gas=100000,
             to='0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
             value=12345,

--- a/newsfragments/1850.feature.rst
+++ b/newsfragments/1850.feature.rst
@@ -1,0 +1,1 @@
+Add ``eth.gas_price``, deprecate ``eth.gasPrice``

--- a/tests/core/eth-module/test_gas_pricing.py
+++ b/tests/core/eth-module/test_gas_pricing.py
@@ -5,12 +5,10 @@ from unittest.mock import (
 
 
 def test_get_set_gas_price(web3):
-
     assert web3.eth.gas_price > 0
 
 
 def test_get_set_gasPrice(web3):
-
     with pytest.warns(DeprecationWarning):
         assert web3.eth.gasPrice > 0
 

--- a/tests/core/eth-module/test_gas_pricing.py
+++ b/tests/core/eth-module/test_gas_pricing.py
@@ -1,6 +1,18 @@
+import pytest
 from unittest.mock import (
     Mock,
 )
+
+
+def test_get_set_gas_price(web3):
+
+    assert web3.eth.gas_price > 0
+
+
+def test_get_set_gasPrice(web3):
+
+    with pytest.warns(DeprecationWarning):
+        assert web3.eth.gasPrice > 0
 
 
 def test_no_gas_price_strategy_returns_none(web3):

--- a/tests/core/mining-module/test_miner_setGasPrice.py
+++ b/tests/core/mining-module/test_miner_setGasPrice.py
@@ -14,18 +14,18 @@ from web3._utils.threads import (
 def test_miner_set_gas_price(web3_empty, wait_for_block):
     web3 = web3_empty
 
-    initial_gas_price = web3.eth.gasPrice
+    initial_gas_price = web3.eth.gas_price
 
     # sanity check
-    assert web3.eth.gasPrice > 1000
+    assert web3.eth.gas_price > 1000
 
     web3.geth.miner.set_gas_price(initial_gas_price // 2)
 
     with Timeout(60) as timeout:
-        while web3.eth.gasPrice == initial_gas_price:
+        while web3.eth.gas_price == initial_gas_price:
             timeout.sleep(random.random())
 
-    after_gas_price = web3.eth.gasPrice
+    after_gas_price = web3.eth.gas_price
     assert after_gas_price < initial_gas_price
 
 
@@ -33,8 +33,8 @@ def test_miner_set_gas_price(web3_empty, wait_for_block):
 def test_miner_setGasPrice(web3_empty, wait_for_block):
     web3 = web3_empty
 
-    initial_gas_price = web3.eth.gasPrice
-    assert web3.eth.gasPrice > 1000
+    initial_gas_price = web3.eth.gas_price
+    assert web3.eth.gas_price > 1000
 
     # sanity check
 
@@ -42,8 +42,8 @@ def test_miner_setGasPrice(web3_empty, wait_for_block):
         web3.geth.miner.setGasPrice(initial_gas_price // 2)
 
     with Timeout(60) as timeout:
-        while web3.eth.gasPrice == initial_gas_price:
+        while web3.eth.gas_price == initial_gas_price:
             timeout.sleep(random.random())
 
-    after_gas_price = web3.eth.gasPrice
+    after_gas_price = web3.eth.gas_price
     assert after_gas_price < initial_gas_price

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -281,7 +281,7 @@ def setup_chain_state(web3):
         'to': coinbase,
         'value': 1,
         'gas': 21000,
-        'gas_price': web3.eth.gasPrice,
+        'gas_price': web3.eth.gas_price,
     })
     mined_txn_receipt = mine_transaction_hash(web3, mined_txn_hash)
     print('MINED_TXN_HASH:', mined_txn_hash)

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -67,7 +67,7 @@ class ParityEthModuleTest(EthModuleTest):
             'to': unlocked_account,
             'value': 1,
             'gas': 21000,
-            'gasPrice': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gas_price,
         })
         receipt = web3.eth.getTransactionReceipt(txn_hash)
         assert receipt is not None

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -100,8 +100,14 @@ class EthModuleTest:
         # chain id value from geth fixture genesis file
         assert chain_id == 131277322940537
 
-    def test_eth_gasPrice(self, web3: "Web3") -> None:
-        gas_price = web3.eth.gasPrice
+    def test_eth_gas_price(self, web3: "Web3") -> None:
+        gas_price = web3.eth.gas_price
+        assert is_integer(gas_price)
+        assert gas_price > 0
+
+    def test_eth_gasPrice_deprecated(self, web3: "Web3") -> None:
+        with pytest.warns(DeprecationWarning):
+            gas_price = web3.eth.gasPrice
         assert is_integer(gas_price)
         assert gas_price > 0
 
@@ -461,7 +467,7 @@ class EthModuleTest:
             'to': unlocked_account,
             'value': Wei(1),
             'gas': Wei(21000),
-            'gasPrice': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gas_price,
             'nonce': Nonce(0),
         }
         result = web3.eth.signTransaction(txn_params)
@@ -482,7 +488,7 @@ class EthModuleTest:
                 'to': 'unlocked-account.eth',
                 'value': Wei(1),
                 'gas': Wei(21000),
-                'gasPrice': web3.eth.gasPrice,
+                'gasPrice': web3.eth.gas_price,
                 'nonce': Nonce(0),
             }
             result = web3.eth.signTransaction(txn_params)
@@ -503,7 +509,7 @@ class EthModuleTest:
             'to': unlocked_account,
             'value': Wei(1),
             'gas': Wei(21000),
-            'gasPrice': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gas_price,
         }
 
         with pytest.raises(InvalidAddress):
@@ -522,7 +528,7 @@ class EthModuleTest:
             'to': unlocked_account_dual_type,
             'value': Wei(1),
             'gas': Wei(21000),
-            'gasPrice': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gas_price,
         }
         txn_hash = web3.eth.sendTransaction(txn_params)
         txn = web3.eth.getTransaction(txn_hash)
@@ -542,7 +548,7 @@ class EthModuleTest:
             'value': Wei(1),
             'gas': Wei(21000),
             # Increased gas price to ensure transaction hash different from other tests
-            'gasPrice': Wei(web3.eth.gasPrice * 3),
+            'gasPrice': Wei(web3.eth.gas_price * 3),
             'nonce': web3.eth.getTransactionCount(unlocked_account),
         }
         txn_hash = web3.eth.sendTransaction(txn_params)
@@ -563,11 +569,11 @@ class EthModuleTest:
             'to': unlocked_account_dual_type,
             'value': Wei(1),
             'gas': Wei(21000),
-            'gasPrice': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gas_price,
         }
         txn_hash = web3.eth.sendTransaction(txn_params)
 
-        txn_params['gasPrice'] = Wei(web3.eth.gasPrice * 2)
+        txn_params['gasPrice'] = Wei(web3.eth.gas_price * 2)
         replace_txn_hash = web3.eth.replaceTransaction(txn_hash, txn_params)
         replace_txn = web3.eth.getTransaction(replace_txn_hash)
 
@@ -585,7 +591,7 @@ class EthModuleTest:
             'to': unlocked_account_dual_type,
             'value': Wei(1),
             'gas': Wei(21000),
-            'gasPrice': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gas_price,
         }
         with pytest.raises(TransactionNotFound):
             web3.eth.replaceTransaction(
@@ -601,12 +607,12 @@ class EthModuleTest:
             'to': unlocked_account_dual_type,
             'value': Wei(1),
             'gas': Wei(21000),
-            'gasPrice': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gas_price,
         }
         txn_hash = web3.eth.sendTransaction(txn_params)
         web3.eth.waitForTransactionReceipt(txn_hash)
 
-        txn_params['gasPrice'] = Wei(web3.eth.gasPrice * 2)
+        txn_params['gasPrice'] = Wei(web3.eth.gas_price * 2)
         with pytest.raises(ValueError, match="Supplied transaction with hash"):
             web3.eth.replaceTransaction(txn_hash, txn_params)
 
@@ -618,12 +624,12 @@ class EthModuleTest:
             'to': unlocked_account,
             'value': Wei(1),
             'gas': Wei(21000),
-            'gasPrice': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gas_price,
         }
         txn_hash = web3.eth.sendTransaction(txn_params)
         txn = web3.eth.getTransaction(txn_hash)
 
-        txn_params['gasPrice'] = Wei(web3.eth.gasPrice * 2)
+        txn_params['gasPrice'] = Wei(web3.eth.gas_price * 2)
         txn_params['nonce'] = Nonce(txn['nonce'] + 1)
         with pytest.raises(ValueError):
             web3.eth.replaceTransaction(txn_hash, txn_params)
@@ -715,7 +721,7 @@ class EthModuleTest:
             'to': unlocked_account,
             'value': Wei(1),
             'gas': Wei(21000),
-            'gasPrice': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gas_price,
         }
         txn_hash = web3.eth.sendTransaction(txn_params)
 
@@ -995,7 +1001,7 @@ class EthModuleTest:
             'to': unlocked_account_dual_type,
             'value': Wei(1),
             'gas': Wei(21000),
-            'gasPrice': web3.eth.gasPrice,
+            'gasPrice': web3.eth.gas_price,
         })
         with pytest.raises(TransactionNotFound):
             web3.eth.getTransactionReceipt(txn_hash)

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -53,7 +53,7 @@ TRANSACTION_DEFAULTS = {
     'value': 0,
     'data': b'',
     'gas': lambda web3, tx: web3.eth.estimateGas(tx),
-    'gasPrice': lambda web3, tx: web3.eth.generateGasPrice(tx) or web3.eth.gasPrice,
+    'gasPrice': lambda web3, tx: web3.eth.generateGasPrice(tx) or web3.eth.gas_price,
     'chainId': lambda web3, tx: web3.eth.chainId,
 }
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -160,14 +160,22 @@ class Eth(ModuleV2, Module):
     def hashrate(self) -> int:
         return self.get_hashrate()
 
-    gas_price: Method[Callable[[], Wei]] = Method(
+    _gas_price: Method[Callable[[], Wei]] = Method(
         RPC.eth_gasPrice,
         mungers=None,
     )
 
     @property
+    def gas_price(self) -> Wei:
+        return self._gas_price()
+
+    @property
     def gasPrice(self) -> Wei:
-        return self.gas_price()
+        warnings.warn(
+            'gasPrice is deprecated in favor of gas_price',
+            category=DeprecationWarning,
+        )
+        return self.gas_price
 
     get_accounts: Method[Callable[[], Tuple[ChecksumAddress]]] = Method(
         RPC.eth_accounts,


### PR DESCRIPTION
### What was wrong?
Moved `eth.gasPrice` -> `eth.gas_price`.

Related to Issue #1429 

### How was it fixed?
Added `gas_price` property, deprecated `gasPrice`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="158" alt="image" src="https://user-images.githubusercontent.com/6540608/105559544-b6832b00-5cce-11eb-81b9-f6595bdf74b0.png">

