### PR TITLE
Add eth.protocol_version, deprecate eth.protocolVersion

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -165,7 +165,7 @@ The following properties are available on the ``web3.eth`` namespace.
       :attr:`~web3.eth.Eth.block_number`
 
 
-.. py:attribute:: Eth.protocolVersion
+.. py:attribute:: Eth.protocol_version
 
     * Delegates to ``eth_protocolVersion`` RPC Method
 
@@ -173,8 +173,14 @@ The following properties are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-       >>> web3.eth.protocolVersion
+       >>> web3.eth.protocol_version
        '63'
+
+
+.. py:attribute:: Eth.protocolVersion
+
+    .. warning:: Deprecated: This property is deprecated in favor of
+      :attr:`~web3.eth.Eth.protocol_version`
 
 
 .. py:attribute:: Eth.chain_id

--- a/newsfragments/1853.feature.rst
+++ b/newsfragments/1853.feature.rst
@@ -1,0 +1,1 @@
+Add ``eth.protocol_version``, deprecate ``eth.protocolVersion``

--- a/tests/core/eth-module/test_eth_properties.py
+++ b/tests/core/eth-module/test_eth_properties.py
@@ -1,8 +1,13 @@
 import pytest
 
 
+def test_eth_protocol_version(web3):
+    assert web3.eth.protocol_version == '63'
+
+
 def test_eth_protocolVersion(web3):
-    assert web3.eth.protocolVersion == '63'
+    with pytest.warns(DeprecationWarning):
+        assert web3.eth.protocolVersion == '63'
 
 
 def test_eth_chain_id(web3):

--- a/tests/core/version-module/test_version_module.py
+++ b/tests/core/version-module/test_version_module.py
@@ -53,4 +53,4 @@ async def test_async_blocking_version(async_w3, blocking_w3):
     assert async_w3.async_version.api == blocking_w3.api
 
     assert await async_w3.async_version.node == blocking_w3.clientVersion
-    assert await async_w3.async_version.ethereum == blocking_w3.eth.protocolVersion
+    assert await async_w3.async_version.ethereum == blocking_w3.eth.protocol_version

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -59,8 +59,15 @@ if TYPE_CHECKING:
 
 
 class EthModuleTest:
+    def test_eth_protocol_version(self, web3: "Web3") -> None:
+        protocol_version = web3.eth.protocol_version
+
+        assert is_string(protocol_version)
+        assert protocol_version.isdigit()
+
     def test_eth_protocolVersion(self, web3: "Web3") -> None:
-        protocol_version = web3.eth.protocolVersion
+        with pytest.warns(DeprecationWarning):
+            protocol_version = web3.eth.protocolVersion
 
         assert is_string(protocol_version)
         assert protocol_version.isdigit()

--- a/web3/_utils/module_testing/version_module.py
+++ b/web3/_utils/module_testing/version_module.py
@@ -1,3 +1,4 @@
+import pytest
 from typing import (
     TYPE_CHECKING,
 )
@@ -11,8 +12,15 @@ if TYPE_CHECKING:
 
 
 class VersionModuleTest:
+    def test_eth_protocol_version(self, web3: "Web3") -> None:
+        protocol_version = web3.eth.protocol_version
+
+        assert is_string(protocol_version)
+        assert protocol_version.isdigit()
+
     def test_eth_protocolVersion(self, web3: "Web3") -> None:
-        protocol_version = web3.eth.protocolVersion
+        with pytest.warns(DeprecationWarning):
+            protocol_version = web3.eth.protocolVersion
 
         assert is_string(protocol_version)
         assert protocol_version.isdigit()

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -115,14 +115,22 @@ class Eth(ModuleV2, Module):
     def icapNamereg(self) -> NoReturn:
         raise NotImplementedError()
 
-    protocol_version: Method[Callable[[], str]] = Method(
+    _protocol_version: Method[Callable[[], str]] = Method(
         RPC.eth_protocolVersion,
         mungers=None,
     )
 
     @property
+    def protocol_version(self) -> str:
+        return self._protocol_version()
+
+    @property
     def protocolVersion(self) -> str:
-        return self.protocol_version()
+        warnings.warn(
+            'protocolVersion is deprecated in favor of protocol_version',
+            category=DeprecationWarning,
+        )
+        return self.protocol_version
 
     is_syncing: Method[Callable[[], Union[SyncStatus, bool]]] = Method(
         RPC.eth_syncing,

--- a/web3/version.py
+++ b/web3/version.py
@@ -66,5 +66,5 @@ class Version(Module):
     @property
     def ethereum(self) -> NoReturn:
         raise DeprecationWarning(
-            "This method has been deprecated ... Please use web3.eth.protocolVersion instead."
+            "This method has been deprecated ... Please use web3.eth.protocol_version instead."
         )


### PR DESCRIPTION
### What was wrong?
Added `eth.protocol_version`, deprecated `eth.protocolVersion`. This is the last of the eth properties!

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/6540608/105769784-972d0d80-5f1b-11eb-86ab-5de49ab3d7f5.png)

