### PR TITLE
Move eth.getCode to eth.get_code

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -143,7 +143,7 @@ API
 - :meth:`web3.eth.get_balance() <web3.eth.Eth.get_balance>`
 - :meth:`web3.eth.get_block() <web3.eth.Eth.get_block>`
 - :meth:`web3.eth.get_block_transaction_count() <web3.eth.Eth.get_block_transaction_count>`
-- :meth:`web3.eth.getCode() <web3.eth.Eth.getCode>`
+- :meth:`web3.eth.get_code() <web3.eth.Eth.get_code>`
 - :meth:`web3.eth.getProof() <web3.eth.Eth.getProof>`
 - :meth:`web3.eth.get_storage_at() <web3.eth.Eth.get_storage_at>`
 - :meth:`web3.eth.getTransaction() <web3.eth.Eth.getTransaction>`

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -351,7 +351,7 @@ The following methods are available on the ``web3.eth`` namespace.
         assert verify_eth_getProof(proof, block.stateRoot)
 
 
-.. py:method:: Eth.getCode(account, block_identifier=eth.default_block)
+.. py:method:: Eth.get_code(account, block_identifier=eth.default_block)
 
     * Delegates to ``eth_getCode`` RPC Method
 
@@ -363,12 +363,17 @@ The following methods are available on the ``web3.eth`` namespace.
     .. code-block:: python
 
         # For a contract address.
-        >>> web3.eth.getCode('0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B')
+        >>> web3.eth.get_code('0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B')
         '0x6060604052361561027c5760e060020a60003504630199.....'
         # For a private key address.
-        >>> web3.eth.getCode('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
+        >>> web3.eth.get_code('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
         '0x'
 
+
+.. py:method:: Eth.getCode(account, block_identifier=eth.default_block)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.get_code`
 
 .. py:method:: Eth.get_block(block_identifier=eth.default_block, full_transactions=False)
 

--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -371,7 +371,7 @@ class Package(object):
         linked_deployments = get_linked_deployments(deployments)
         if linked_deployments:
             for deployment_data in linked_deployments.values():
-                on_chain_bytecode = self.w3.eth.getCode(
+                on_chain_bytecode = self.w3.eth.get_code(
                     deployment_data["address"]
                 )
                 unresolved_linked_refs = normalize_linked_references(

--- a/newsfragments/1856.feature.rst
+++ b/newsfragments/1856.feature.rst
@@ -1,0 +1,1 @@
+Add ``eth.get_code``, deprecate ``eth.getCode``

--- a/tests/core/contracts/conftest.py
+++ b/tests/core/contracts/conftest.py
@@ -442,7 +442,7 @@ def strict_emitter(w3_strict_abi,
     deploy_receipt = wait_for_transaction(w3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
-    bytecode = w3.eth.getCode(contract_address)
+    bytecode = w3.eth.get_code(contract_address)
     assert bytecode == StrictEmitter.bytecode_runtime
     emitter_contract = StrictEmitter(address=contract_address)
     assert emitter_contract.address == contract_address
@@ -499,7 +499,7 @@ def event_contract(
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
-    bytecode = web3.eth.getCode(contract_address)
+    bytecode = web3.eth.get_code(contract_address)
     assert bytecode == EventContract.bytecode_runtime
     event_contract = EventContract(address=contract_address)
     assert event_contract.address == contract_address
@@ -557,7 +557,7 @@ def indexed_event(
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
-    bytecode = web3.eth.getCode(contract_address)
+    bytecode = web3.eth.get_code(contract_address)
     assert bytecode == IndexedEventContract.bytecode_runtime
     indexed_event_contract = IndexedEventContract(address=contract_address)
     assert indexed_event_contract.address == contract_address

--- a/tests/core/contracts/test_concise_contract.py
+++ b/tests/core/contracts/test_concise_contract.py
@@ -20,7 +20,7 @@ def deploy(web3, Contract, args=None):
     deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     assert deploy_receipt is not None
     contract = Contract(address=deploy_receipt['contractAddress'])
-    assert len(web3.eth.getCode(contract.address)) > 0
+    assert len(web3.eth.get_code(contract.address)) > 0
     return contract
 
 

--- a/tests/core/contracts/test_contract_ambiguous_functions.py
+++ b/tests/core/contracts/test_contract_ambiguous_functions.py
@@ -47,7 +47,7 @@ def string_contract(web3, StringContract, address_conversion_func):
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
     contract = StringContract(address=contract_address)
     assert contract.address == contract_address
-    assert len(web3.eth.getCode(contract.address)) > 0
+    assert len(web3.eth.get_code(contract.address)) > 0
     return contract
 
 

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -45,7 +45,7 @@ def deploy(web3, Contract, apply_func=identity, args=None):
     address = apply_func(deploy_receipt['contractAddress'])
     contract = Contract(address=address)
     assert contract.address == address
-    assert len(web3.eth.getCode(contract.address)) > 0
+    assert len(web3.eth.get_code(contract.address)) > 0
     return contract
 
 

--- a/tests/core/contracts/test_contract_caller_interface.py
+++ b/tests/core/contracts/test_contract_caller_interface.py
@@ -19,7 +19,7 @@ def deploy(web3, Contract, apply_func=identity, args=None):
     address = apply_func(deploy_receipt['contractAddress'])
     contract = Contract(address=address)
     assert contract.address == address
-    assert len(web3.eth.getCode(contract.address)) > 0
+    assert len(web3.eth.get_code(contract.address)) > 0
     return contract
 
 

--- a/tests/core/contracts/test_contract_constructor.py
+++ b/tests/core/contracts/test_contract_constructor.py
@@ -100,7 +100,7 @@ def test_contract_constructor_transact_no_constructor(
     assert txn_receipt['contractAddress']
     contract_address = address_conversion_func(txn_receipt['contractAddress'])
 
-    blockchain_code = web3.eth.getCode(contract_address)
+    blockchain_code = web3.eth.get_code(contract_address)
     assert blockchain_code == decode_hex(MATH_RUNTIME)
 
 
@@ -117,7 +117,7 @@ def test_contract_constructor_transact_with_constructor_without_arguments(
     assert txn_receipt['contractAddress']
     contract_address = address_conversion_func(txn_receipt['contractAddress'])
 
-    blockchain_code = web3.eth.getCode(contract_address)
+    blockchain_code = web3.eth.get_code(contract_address)
     assert blockchain_code == decode_hex(SIMPLE_CONSTRUCTOR_RUNTIME)
 
 
@@ -148,7 +148,7 @@ def test_contract_constructor_transact_with_constructor_with_arguments(
     assert txn_receipt['contractAddress']
     contract_address = address_conversion_func(txn_receipt['contractAddress'])
 
-    blockchain_code = web3.eth.getCode(contract_address)
+    blockchain_code = web3.eth.get_code(contract_address)
     assert blockchain_code == decode_hex(WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME)
     assert expected_a == WithConstructorArgumentsContract(
         address=contract_address).functions.data_a().call()
@@ -166,7 +166,7 @@ def test_contract_constructor_transact_with_constructor_with_address_arguments(
     assert txn_receipt is not None
     assert txn_receipt['contractAddress']
     contract_address = address_conversion_func(txn_receipt['contractAddress'])
-    blockchain_code = web3.eth.getCode(contract_address)
+    blockchain_code = web3.eth.get_code(contract_address)
     assert blockchain_code == decode_hex(WITH_CONSTRUCTOR_ADDRESS_RUNTIME)
     assert TEST_ADDRESS == WithConstructorAddressArgumentsContract(
         address=contract_address).functions.testAddr().call()

--- a/tests/core/contracts/test_contract_deployment.py
+++ b/tests/core/contracts/test_contract_deployment.py
@@ -16,7 +16,7 @@ def test_contract_deployment_no_constructor(web3, MathContract,
     assert txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']
 
-    blockchain_code = web3.eth.getCode(contract_address)
+    blockchain_code = web3.eth.get_code(contract_address)
     assert blockchain_code == decode_hex(MATH_RUNTIME)
 
 
@@ -31,7 +31,7 @@ def test_contract_deployment_with_constructor_without_args(web3,
     assert txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']
 
-    blockchain_code = web3.eth.getCode(contract_address)
+    blockchain_code = web3.eth.get_code(contract_address)
     assert blockchain_code == decode_hex(SIMPLE_CONSTRUCTOR_RUNTIME)
 
 
@@ -50,7 +50,7 @@ def test_contract_deployment_with_constructor_with_arguments(web3,
         assert txn_receipt['contractAddress']
         contract_address = txn_receipt['contractAddress']
 
-        blockchain_code = web3.eth.getCode(contract_address)
+        blockchain_code = web3.eth.get_code(contract_address)
         assert blockchain_code == decode_hex(WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME)
 
 
@@ -72,7 +72,7 @@ def test_contract_deployment_with_constructor_with_arguments_strict(w3_strict_ab
     assert txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']
 
-    blockchain_code = w3_strict_abi.eth.getCode(contract_address)
+    blockchain_code = w3_strict_abi.eth.get_code(contract_address)
     assert blockchain_code == decode_hex(WITH_CONSTRUCTOR_ARGUMENTS_RUNTIME)
 
 
@@ -99,5 +99,5 @@ def test_contract_deployment_with_constructor_with_address_argument(web3,
     assert txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']
 
-    blockchain_code = web3.eth.getCode(contract_address)
+    blockchain_code = web3.eth.get_code(contract_address)
     assert blockchain_code == decode_hex(WITH_CONSTRUCTOR_ADDRESS_RUNTIME)

--- a/tests/core/contracts/test_contract_transact_interface.py
+++ b/tests/core/contracts/test_contract_transact_interface.py
@@ -25,7 +25,7 @@ def deploy(web3, Contract, apply_func=identity, args=None):
     address = apply_func(deploy_receipt['contractAddress'])
     contract = Contract(address=address)
     assert contract.address == address
-    assert len(web3.eth.getCode(contract.address)) > 0
+    assert len(web3.eth.get_code(contract.address)) > 0
     return contract
 
 

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -35,7 +35,7 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_convers
     deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
-    bytecode = web3.eth.getCode(contract_address)
+    bytecode = web3.eth.get_code(contract_address)
     assert bytecode == Emitter.bytecode_runtime
     _emitter = Emitter(address=contract_address)
     assert _emitter.address == contract_address
@@ -62,7 +62,7 @@ def event_contract(
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
-    bytecode = web3.eth.getCode(contract_address)
+    bytecode = web3.eth.get_code(contract_address)
     assert bytecode == EventContract.bytecode_runtime
     event_contract = EventContract(address=contract_address)
     assert event_contract.address == contract_address
@@ -89,7 +89,7 @@ def indexed_event_contract(
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
-    bytecode = web3.eth.getCode(contract_address)
+    bytecode = web3.eth.get_code(contract_address)
     assert bytecode == IndexedEventContract.bytecode_runtime
     indexed_event_contract = IndexedEventContract(address=contract_address)
     assert indexed_event_contract.address == contract_address

--- a/tests/core/contracts/test_extracting_event_data_old.py
+++ b/tests/core/contracts/test_extracting_event_data_old.py
@@ -21,7 +21,7 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_convers
     deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
-    bytecode = web3.eth.getCode(contract_address)
+    bytecode = web3.eth.get_code(contract_address)
     assert bytecode == Emitter.bytecode_runtime
     _emitter = Emitter(address=contract_address)
     assert _emitter.address == contract_address

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -85,7 +85,7 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_convers
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
-    bytecode = web3.eth.getCode(contract_address)
+    bytecode = web3.eth.get_code(contract_address)
     assert bytecode == Emitter.bytecode_runtime
     _emitter = Emitter(address=contract_address)
     assert _emitter.address == contract_address

--- a/tests/core/filtering/test_contract_data_filters.py
+++ b/tests/core/filtering/test_contract_data_filters.py
@@ -74,7 +74,7 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_convers
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
-    bytecode = web3.eth.getCode(contract_address)
+    bytecode = web3.eth.get_code(contract_address)
     assert bytecode == Emitter.bytecode_runtime
     _emitter = Emitter(address=contract_address)
     assert _emitter.address == contract_address

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -308,29 +308,37 @@ class EthModuleTest:
         assert is_integer(uncle_count)
         assert uncle_count == 0
 
-    def test_eth_getCode(self, web3: "Web3", math_contract_address: ChecksumAddress) -> None:
-        code = web3.eth.getCode(math_contract_address)
+    def test_eth_get_code(self, web3: "Web3", math_contract_address: ChecksumAddress) -> None:
+        code = web3.eth.get_code(math_contract_address)
         assert isinstance(code, HexBytes)
         assert len(code) > 0
 
-    def test_eth_getCode_ens_address(
+    def test_eth_getCode_deprecated(self,
+                                    web3: "Web3",
+                                    math_contract_address: ChecksumAddress) -> None:
+        with pytest.warns(DeprecationWarning, match='getCode is deprecated in favor of get_code'):
+            code = web3.eth.getCode(math_contract_address)
+        assert isinstance(code, HexBytes)
+        assert len(code) > 0
+
+    def test_eth_get_code_ens_address(
         self, web3: "Web3", math_contract_address: ChecksumAddress
     ) -> None:
         with ens_addresses(
             web3, {'mathcontract.eth': math_contract_address}
         ):
-            code = web3.eth.getCode('mathcontract.eth')
+            code = web3.eth.get_code('mathcontract.eth')
             assert isinstance(code, HexBytes)
             assert len(code) > 0
 
-    def test_eth_getCode_invalid_address(self, web3: "Web3", math_contract: "Contract") -> None:
+    def test_eth_get_code_invalid_address(self, web3: "Web3", math_contract: "Contract") -> None:
         with pytest.raises(InvalidAddress):
-            web3.eth.getCode(ChecksumAddress(HexAddress(HexStr(math_contract.address.lower()))))
+            web3.eth.get_code(ChecksumAddress(HexAddress(HexStr(math_contract.address.lower()))))
 
-    def test_eth_getCode_with_block_identifier(
+    def test_eth_get_code_with_block_identifier(
         self, web3: "Web3", emitter_contract: "Contract"
     ) -> None:
-        code = web3.eth.getCode(emitter_contract.address, block_identifier=web3.eth.block_number)
+        code = web3.eth.get_code(emitter_contract.address, block_identifier=web3.eth.block_number)
         assert isinstance(code, HexBytes)
         assert len(code) > 0
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1510,7 +1510,7 @@ def call_contract_function(
         # eth-abi-utils
         is_missing_code_error = (
             return_data in ACCEPTABLE_EMPTY_STRINGS
-            and web3.eth.getCode(address) in ACCEPTABLE_EMPTY_STRINGS)
+            and web3.eth.get_code(address) in ACCEPTABLE_EMPTY_STRINGS)
         if is_missing_code_error:
             msg = (
                 "Could not transact with/call contract function, is contract "

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -329,7 +329,7 @@ class Eth(ModuleV2, Module):
         mungers=[get_proof_munger],
     )
 
-    getCode: Method[Callable[..., HexBytes]] = Method(
+    get_code: Method[Callable[..., HexBytes]] = Method(
         RPC.eth_getCode,
         mungers=[block_id_munger]
     )
@@ -653,3 +653,4 @@ class Eth(ModuleV2, Module):
     getBlockTransactionCount = DeprecatedMethod(get_block_transaction_count,
                                                 'getBlockTransactionCount',
                                                 'get_block_transaction_count')
+    getCode = DeprecatedMethod(get_code, 'getCode', 'get_code')


### PR DESCRIPTION
### What was wrong?
Added `eth.get_code`, deprecated `eth.getCode`

Related to Issue #1429 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/106058544-9ed0eb80-60ae-11eb-95fe-f8b94be2cf2a.png)

