### PR TITLE
Add get_uncle_by_block, deprecate getUncleByBlock

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -149,7 +149,7 @@ API
 - :meth:`web3.eth.get_transaction() <web3.eth.Eth.get_transaction>`
 - :meth:`web3.eth.get_transaction_by_block() <web3.eth.Eth.get_transaction_by_block>`
 - :meth:`web3.eth.getTransactionCount() <web3.eth.Eth.getTransactionCount>`
-- :meth:`web3.eth.getUncleByBlock() <web3.eth.Eth.getUncleByBlock>`
+- :meth:`web3.eth.get_uncle_by_block() <web3.eth.Eth.get_uncle_by_block>`
 - :meth:`web3.eth.getUncleCount() <web3.eth.Eth.getUncleCount>`
 
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -452,10 +452,10 @@ The following methods are available on the ``web3.eth`` namespace.
 .. py:method:: Eth.getUncle(block_identifier)
 
     .. note:: Method to get an Uncle from its hash is not available through
-      RPC, a possible substitute is the method ``Eth.getUncleByBlock``
+      RPC, a possible substitute is the method ``Eth.get_uncle_by_block``
 
 
-.. py:method:: Eth.getUncleByBlock(block_identifier, uncle_index)
+.. py:method:: Eth.get_uncle_by_block(block_identifier, uncle_index)
 
     * Delegates to ``eth_getUncleByBlockHashAndIndex`` or
       ``eth_getUncleByBlockNumberAndIndex`` RPC methods
@@ -469,7 +469,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.getUncleByBlock(56160, 0)
+        >>> web3.eth.get_uncle_by_block(56160, 0)
         AttributeDict({
           'author': '0xbe4532e1b1db5c913cf553be76180c1777055403',
           'difficulty': '0x17dd9ca0afe',
@@ -495,11 +495,15 @@ The following methods are available on the ``web3.eth`` namespace.
         })
 
         # You can also refer to the block by hash:
-        >>> web3.eth.getUncleByBlock('0x685b2226cbf6e1f890211010aa192bf16f0a0cba9534264a033b023d7367b845', 0)
+        >>> web3.eth.get_uncle_by_block('0x685b2226cbf6e1f890211010aa192bf16f0a0cba9534264a033b023d7367b845', 0)
         AttributeDict({
             ...
         })
 
+.. py:method:: Eth.getUncleByBlock(block_identifier, uncle_index)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.get_uncle_by_block()`
 
 .. py:method:: Eth.getUncleCount(block_identifier)
 

--- a/newsfragments/1862.feature.rst
+++ b/newsfragments/1862.feature.rst
@@ -1,0 +1,1 @@
+Add get_uncle_by_block, deprecate getUncleByBlock

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -371,7 +371,7 @@ PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
         apply_formatter_at_index(to_hex_if_integer, 0),
         apply_formatter_at_index(to_hex_if_integer, 1),
     ),
-    RPC.eth_getUncleByBlockHashAndIndex: apply_formatter_at_index(integer_to_hex, 1),
+    RPC.eth_getUncleByBlockHashAndIndex: apply_formatter_at_index(to_hex_if_integer, 1),
     RPC.eth_newFilter: apply_formatter_at_index(filter_params_formatter, 0),
     RPC.eth_getLogs: apply_formatter_at_index(filter_params_formatter, 0),
     RPC.eth_call: apply_formatters_to_sequence([

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -382,7 +382,7 @@ class Eth(ModuleV2, Module):
     `eth_getUncleByBlockHashAndIndex`
     `eth_getUncleByBlockNumberAndIndex`
     """
-    getUncleByBlock: Method[Callable[[BlockIdentifier, int], Uncle]] = Method(
+    get_uncle_by_block: Method[Callable[[BlockIdentifier, int], Uncle]] = Method(
         method_choice_depends_on_args=select_method_for_block_identifier(
             if_predefined=RPC.eth_getUncleByBlockNumberAndIndex,
             if_hash=RPC.eth_getUncleByBlockHashAndIndex,
@@ -659,3 +659,4 @@ class Eth(ModuleV2, Module):
     getTransactionByBlock = DeprecatedMethod(get_transaction_by_block,
                                              'getTransactionByBlock',
                                              'get_transaction_by_block')
+    getUncleByBlock = DeprecatedMethod(get_uncle_by_block, 'getUncleByBlock', 'get_uncle_by_block')


### PR DESCRIPTION
### What was wrong?
Added `eth.get_uncle_by_block`, deprecated `eth.getUncleByBlock`

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="133" alt="image" src="https://user-images.githubusercontent.com/6540608/106333973-f904b480-6246-11eb-927f-b920504b3fdf.png">

