### PR TITLE
clarify docs for sendRawTransaction nonce lookup

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -755,7 +755,7 @@ The following methods are available on the ``web3.eth`` namespace.
     .. code-block:: python
 
         >>> signed_txn = w3.eth.account.signTransaction(dict(
-            nonce=w3.eth.getTransactionCount(w3.eth.coinbase),
+            nonce=w3.eth.getTransactionCount(public_address_of_senders_account),
             gasPrice=w3.eth.gas_price,
             gas=100000,
             to='0xd3CdA913deB6f67967B99D67aCDFa1712C293601',

--- a/newsfragments/1866.doc.rst
+++ b/newsfragments/1866.doc.rst
@@ -1,0 +1,1 @@
+Clarify nonce lookup in sendRawTransaction docs.


### PR DESCRIPTION
### What was wrong?
the sendRawTransaction docs refer to `w3.eth.coinbase`, but most users are probably sending raw txs because they aren't using a local node.

Closes #1866 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.pinimg.com/236x/24/01/4a/24014a8cd8fe52bf88e41d49a6610f40--giclee-print-art-prints.jpg)
