### PR TITLE
Move sendTransaction -> send_transaction

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -219,7 +219,7 @@ Each Contract Factory exposes the following methods.
     Construct and deploy a contract by sending a new public transaction.
 
     If provided ``transaction`` should be a dictionary conforming to the
-    ``web3.eth.sendTransaction(transaction)`` method.  This value may not
+    ``web3.eth.send_transaction(transaction)`` method.  This value may not
     contain the keys ``data`` or ``to``.
 
     If the contract takes constructor parameters they should be provided as
@@ -273,7 +273,7 @@ Each Contract Factory exposes the following methods.
     If any of the ``args`` specified in the ABI are an ``address`` type, they
     will accept ENS names.
 
-    Returns the transaction dictionary that you can pass to sendTransaction method.
+    Returns the transaction dictionary that you can pass to send_transaction method.
 
     .. code-block:: python
 
@@ -282,7 +282,7 @@ Each Contract Factory exposes the following methods.
         'chainId': None
         }
         >>> contract_data = token_contract.constructor(web3.eth.coinbase, 12345).buildTransaction(transaction)
-        >>> web3.eth.sendTransaction(contract_data)
+        >>> web3.eth.send_transaction(contract_data)
 
 .. _contract_createFilter:
 
@@ -333,7 +333,7 @@ Each Contract Factory exposes the following methods.
     Construct and send a transaction to deploy the contract.
 
     If provided ``transaction`` should be a dictionary conforming to the
-    ``web3.eth.sendTransaction(transaction)`` method.  This value may not
+    ``web3.eth.send_transaction(transaction)`` method.  This value may not
     contain the keys ``data`` or ``to``.
 
     If the contract takes constructor arguments they should be provided as a
@@ -758,7 +758,7 @@ Methods
 
     The end portion of this function call ``transact(transaction)`` takes a
     single parameter which should be a python dictionary conforming to
-    the same format as the ``web3.eth.sendTransaction(transaction)`` method.
+    the same format as the ``web3.eth.send_transaction(transaction)`` method.
     This dictionary may not contain the keys ``data``.
 
     If any of the ``args`` or ``kwargs`` specified in the ABI are an ``address`` type, they
@@ -882,7 +882,7 @@ Methods
             >>> math_contract.functions.increment(5).buildTransaction({'nonce': web3.eth.get_transaction_count('0xF5...')})
 
     Returns a transaction dictionary. This transaction dictionary can then be sent using
-    :meth:`~web3.eth.Eth.sendTransaction`.
+    :meth:`~web3.eth.Eth.send_transaction`.
 
     Additionally, the dictionary may be used for offline transaction signing using
     :meth:`~web3.eth.account.Account.signTransaction`.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -178,7 +178,7 @@ Making transactions
 
 There are a few options for making transactions:
 
-- :meth:`~web3.eth.Eth.sendTransaction`
+- :meth:`~web3.eth.Eth.send_transaction`
 
   Use this method if:
     - you want to send ether from one account to another.
@@ -198,7 +198,7 @@ There are a few options for making transactions:
 - :meth:`~web3.middleware.construct_sign_and_send_raw_middleware`
 
   Use this middleware if:
-    - you want to automate signing when using ``w3.eth.sendTransaction`` or ``ContractFunctions``.
+    - you want to automate signing when using ``w3.eth.send_transaction`` or ``ContractFunctions``.
 
 .. NOTE:: The location of your keys (e.g., local or hosted) will have implications on these methods. Read about the differences :ref:`here <eth-account>`.
 

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -39,7 +39,7 @@ AttributeDict
 .. py:method:: web3.middleware.name_to_address_middleware
 
     This middleware converts Ethereum Name Service (ENS) names into the
-    address that the name points to. For example :meth:`~web3.Eth.sendTransaction` will
+    address that the name points to. For example :meth:`w3.eth.send_transaction <web3.eth.Eth.send_transaction>` will
     accept .eth names in the 'from' and 'to' fields.
 
 .. note::

--- a/docs/node.rst
+++ b/docs/node.rst
@@ -62,8 +62,8 @@ work around this issue is to use a hosted node.
 The most popular hosted node option is `Infura <infura.io>`_.
 You can connect to it as if it were a local node,
 with a few caveats. It cannot (and *should not*) host private keys for
-you, meaning that some common methods like :meth:`w3.eth.sendTransaction()
-<web3.eth.Eth.sendTransaction>` are not directly available. To send transactions
+you, meaning that some common methods like :meth:`w3.eth.send_transaction()
+<web3.eth.Eth.send_transaction>` are not directly available. To send transactions
 to a hosted node, read about :ref:`eth-account`.
 
 Once you decide what node option you want, you need to choose which network to connect to.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -157,7 +157,7 @@ Making Transactions
 -------------------
 
 The most common use cases will be satisfied with
-:meth:`sendTransaction <web3.eth.Eth.sendTransaction>` or the combination of
+:meth:`send_transaction <web3.eth.Eth.send_transaction>` or the combination of
 :meth:`signTransaction <web3.eth.Eth.signTransaction>` and
 :meth:`sendRawTransaction <web3.eth.Eth.sendRawTransaction>`.
 
@@ -170,7 +170,7 @@ The most common use cases will be satisfied with
 API
 ^^^
 
-- :meth:`web3.eth.sendTransaction() <web3.eth.Eth.sendTransaction>`
+- :meth:`web3.eth.send_transaction() <web3.eth.Eth.send_transaction>`
 - :meth:`web3.eth.signTransaction() <web3.eth.Eth.signTransaction>`
 - :meth:`web3.eth.sendRawTransaction() <web3.eth.Eth.sendRawTransaction>`
 - :meth:`web3.eth.replaceTransaction() <web3.eth.Eth.replaceTransaction>`

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -24,13 +24,13 @@ Local Private Key
   before sending them to your node.
   You must use :meth:`~web3.eth.Eth.sendRawTransaction`
   when working with local keys, instead of
-  :meth:`~web3.eth.Eth.sendTransaction` .
+  :meth:`~web3.eth.Eth.send_transaction` .
 
 Hosted Private Key
   This is a common way to use accounts with local nodes.
   Each account returned by :attr:`w3.eth.accounts <web3.eth.Eth.accounts>`
   has a hosted private key stored in your node.
-  This allows you to use :meth:`~web3.eth.Eth.sendTransaction`.
+  This allows you to use :meth:`~web3.eth.Eth.send_transaction`.
 
 
 .. WARNING::

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -697,7 +697,7 @@ The following methods are available on the ``web3.eth`` namespace.
       :meth:`~web3.eth.Eth.get_transaction_count()`
 
 
-.. py:method:: Eth.sendTransaction(transaction)
+.. py:method:: Eth.send_transaction(transaction)
 
     * Delegates to ``eth_sendTransaction`` RPC Method
 
@@ -731,9 +731,13 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.sendTransaction({'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'from': web3.eth.coinbase, 'value': 12345})
+        >>> web3.eth.send_transaction({'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'from': web3.eth.coinbase, 'value': 12345})
         '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331'
 
+.. py:method:: Eth.sendTransaction(transaction)
+
+    .. warning:: Deprecated: This property is deprecated in favor of
+      :attr:`~web3.eth.Eth.send_transaction`
 
 .. py:method:: Eth.signTransaction(transaction)
 
@@ -787,7 +791,7 @@ The following methods are available on the ``web3.eth`` namespace.
     The ``transaction_hash`` must be the hash of a pending transaction.
 
     The ``new_transaction`` parameter should be a dictionary with transaction fields
-    as required by :meth:`~web3.eth.Eth.sendTransaction`. It will be used to entirely
+    as required by :meth:`~web3.eth.Eth.send_transaction`. It will be used to entirely
     replace the transaction of ``transaction_hash`` without using any of the pending
     transaction's values.
 
@@ -808,7 +812,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> tx = web3.eth.sendTransaction({
+        >>> tx = web3.eth.send_transaction({
                 'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
                 'from': web3.eth.coinbase,
                 'value': 1000
@@ -828,7 +832,7 @@ The following methods are available on the ``web3.eth`` namespace.
     Sends a transaction that modifies the transaction with ``transaction_hash``.
 
     ``transaction_params`` are keyword arguments that correspond to valid transaction
-    parameters as required by :meth:`~web3.eth.Eth.sendTransaction`. The parameter values
+    parameters as required by :meth:`~web3.eth.Eth.send_transaction`. The parameter values
     will override the pending transaction's values to create the replacement transaction
     to send.
 
@@ -838,7 +842,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> tx = web3.eth.sendTransaction({
+        >>> tx = web3.eth.send_transaction({
                 'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
                 'from': web3.eth.coinbase,
                 'value': 1000
@@ -897,7 +901,7 @@ The following methods are available on the ``web3.eth`` namespace.
     on the blockchain.  Returns the return value of the executed contract.
 
     The ``transaction`` parameter is handled in the same manner as the
-    :meth:`~web3.eth.Eth.sendTransaction()` method.
+    :meth:`~web3.eth.Eth.send_transaction()` method.
 
     .. code-block:: python
 
@@ -1190,3 +1194,4 @@ Contracts
     Future calls to ``Eth.contract()`` will then default to ``contractFactoryClass``.
 
     An example of an alternative Contract Factory is ``ConciseContract``.
+

--- a/ens/main.py
+++ b/ens/main.py
@@ -141,7 +141,7 @@ class ENS:
         :param str address: name will point to this address, in checksum format. If ``None``,
             erase the record. If not specified, name will point to the owner's address.
         :param dict transact: the transaction configuration, like in
-            :meth:`~web3.eth.Eth.sendTransaction`
+            :meth:`~web3.eth.Eth.send_transaction`
         :raises InvalidName: if ``name`` has invalid syntax
         :raises UnauthorizedError: if ``'from'`` in `transact` does not own `name`
         """
@@ -175,7 +175,7 @@ class ENS:
         :param str name: ENS name that address will point to
         :param str address: to set up, in checksum format
         :param dict transact: the transaction configuration, like in
-            :meth:`~web3.eth.sendTransaction`
+            :meth:`~web3.eth.send_transaction`
         :raises AddressMismatch: if the name does not already point to the address
         :raises InvalidName: if `name` has invalid syntax
         :raises UnauthorizedError: if ``'from'`` in `transact` does not own `name`
@@ -270,7 +270,7 @@ class ENS:
         :param new_owner: account that will own `name`. If ``None``, set owner to empty addr.
             If not specified, name will point to the parent domain owner's address.
         :param dict transact: the transaction configuration, like in
-            :meth:`~web3.eth.Eth.sendTransaction`
+            :meth:`~web3.eth.Eth.send_transaction`
         :raises InvalidName: if `name` has invalid syntax
         :raises UnauthorizedError: if ``'from'`` in `transact` does not own `name`
         :returns: the new owner's address

--- a/newsfragments/1878.feature.rst
+++ b/newsfragments/1878.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.send_transaction``, deprecate ``w3.eth.sendTransaction``

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -535,7 +535,7 @@ def test_call_receive_fallback_function(web3,
     assert initial_value == ''
     to = {'to': contract.address}
     merged = {**to, **tx_params}
-    web3.eth.sendTransaction(merged)
+    web3.eth.send_transaction(merged)
     final_value = call(contract=contract, contract_function='getText')
     assert final_value == expected
 

--- a/tests/core/contracts/test_contract_constructor.py
+++ b/tests/core/contracts/test_contract_constructor.py
@@ -189,7 +189,7 @@ def test_contract_constructor_build_transaction_no_constructor(
     unsent_txn = MathContract.constructor().buildTransaction({'nonce': nonce})
     assert txn['data'] == unsent_txn['data']
 
-    new_txn_hash = web3.eth.sendTransaction(unsent_txn)
+    new_txn_hash = web3.eth.send_transaction(unsent_txn)
     new_txn = web3.eth.get_transaction(new_txn_hash)
     assert new_txn['data'] == unsent_txn['data']
     assert new_txn['nonce'] == nonce
@@ -207,7 +207,7 @@ def test_contract_constructor_build_transaction_with_constructor_without_argumen
     unsent_txn = MathContract.constructor().buildTransaction({'nonce': nonce})
     assert txn['data'] == unsent_txn['data']
 
-    new_txn_hash = web3.eth.sendTransaction(unsent_txn)
+    new_txn_hash = web3.eth.send_transaction(unsent_txn)
     new_txn = web3.eth.get_transaction(new_txn_hash)
     assert new_txn['data'] == unsent_txn['data']
     assert new_txn['nonce'] == nonce
@@ -238,7 +238,7 @@ def test_contract_constructor_build_transaction_with_constructor_with_argument(
         *constructor_args, **constructor_kwargs).buildTransaction({'nonce': nonce})
     assert txn['data'] == unsent_txn['data']
 
-    new_txn_hash = web3.eth.sendTransaction(unsent_txn)
+    new_txn_hash = web3.eth.send_transaction(unsent_txn)
     new_txn = web3.eth.get_transaction(new_txn_hash)
     assert new_txn['data'] == unsent_txn['data']
     assert new_txn['nonce'] == nonce

--- a/tests/core/eth-module/test_default_account_api.py
+++ b/tests/core/eth-module/test_default_account_api.py
@@ -11,7 +11,7 @@ def test_uses_default_account_when_set(web3, extra_accounts,
     web3.eth.default_account = extra_accounts[2]
     assert web3.eth.default_account == extra_accounts[2]
 
-    txn_hash = web3.eth.sendTransaction({
+    txn_hash = web3.eth.send_transaction({
         "to": extra_accounts[1],
         "value": 1234,
     })
@@ -30,7 +30,7 @@ def test_uses_defaultAccount_when_set_with_warning(web3, extra_accounts,
     with pytest.warns(DeprecationWarning):
         assert web3.eth.defaultAccount == extra_accounts[2]
 
-    txn_hash = web3.eth.sendTransaction({
+    txn_hash = web3.eth.send_transaction({
         "to": extra_accounts[1],
         "value": 1234,
     })
@@ -44,7 +44,7 @@ def test_uses_defaultAccount_when_set_with_warning(web3, extra_accounts,
 def test_uses_given_from_address_when_provided(web3, extra_accounts,
                                                wait_for_transaction):
     web3.eth.default_account = extra_accounts[2]
-    txn_hash = web3.eth.sendTransaction({
+    txn_hash = web3.eth.send_transaction({
         "from": extra_accounts[5],
         "to": extra_accounts[1],
         "value": 1234,
@@ -64,7 +64,7 @@ def test_uses_given_from_address_when_provided_with_warning(web3, extra_accounts
     with pytest.warns(DeprecationWarning):
         assert web3.eth.defaultAccount == extra_accounts[2]
 
-    txn_hash = web3.eth.sendTransaction({
+    txn_hash = web3.eth.send_transaction({
         "from": extra_accounts[5],
         "to": extra_accounts[1],
         "value": 1234,

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -35,12 +35,12 @@ def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_succes
         'chainId': make_chain_id(web3),
     }
     if expect_success:
-        txn_hash = web3.eth.sendTransaction(transaction)
+        txn_hash = web3.eth.send_transaction(transaction)
         receipt = web3.eth.waitForTransactionReceipt(txn_hash, timeout=RECEIPT_TIMEOUT)
         assert receipt.get('blockNumber') is not None
     else:
         with pytest.raises(ValidationError) as exc_info:
-            web3.eth.sendTransaction(transaction)
+            web3.eth.send_transaction(transaction)
 
         assert 'chain ID' in str(exc_info.value)
 
@@ -69,7 +69,7 @@ def test_send_transaction_with_invalid_ens_names(web3, to, _from):
         }
 
         with pytest.raises(NameNotFound):
-            web3.eth.sendTransaction(transaction)
+            web3.eth.send_transaction(transaction)
 
 
 def test_send_transaction_with_ens_names(web3):
@@ -83,7 +83,7 @@ def test_send_transaction_with_ens_names(web3):
             'from': 'registered-name-2.eth',
         }
 
-        txn_hash = web3.eth.sendTransaction(transaction)
+        txn_hash = web3.eth.send_transaction(transaction)
         receipt = web3.eth.waitForTransactionReceipt(txn_hash, timeout=RECEIPT_TIMEOUT)
         assert receipt.get('blockNumber') is not None
 
@@ -95,7 +95,7 @@ def test_wait_for_missing_receipt(web3):
 
 def test_unmined_transaction_wait_for_receipt(web3):
     web3.middleware_onion.add(unmined_receipt_simulator_middleware)
-    txn_hash = web3.eth.sendTransaction({
+    txn_hash = web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 123457

--- a/tests/core/filtering/test_filter_against_pending_transactions.py
+++ b/tests/core/filtering/test_filter_against_pending_transactions.py
@@ -21,12 +21,12 @@ def test_sync_filter_against_pending_transactions(web3_empty,
 
     txn_filter = web3.eth.filter("pending")
 
-    txn_1_hash = web3.eth.sendTransaction({
+    txn_1_hash = web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 12345,
     })
-    txn_2_hash = web3.eth.sendTransaction({
+    txn_2_hash = web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 54321,
@@ -58,12 +58,12 @@ def test_async_filter_against_pending_transactions(web3_empty,
     txn_filter = web3.eth.filter("pending")
     txn_filter.watch(seen_txns.append)
 
-    txn_1_hash = web3.eth.sendTransaction({
+    txn_1_hash = web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 12345,
     })
-    txn_2_hash = web3.eth.sendTransaction({
+    txn_2_hash = web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 54321,

--- a/tests/core/filtering/test_filters_against_many_blocks.py
+++ b/tests/core/filtering/test_filters_against_many_blocks.py
@@ -20,7 +20,7 @@ def pad_with_transactions(w3):
         _from = accounts[random.randint(0, len(accounts) - 1)]
         _to = accounts[random.randint(0, len(accounts) - 1)]
         value = 50 + tx_count
-        w3.eth.sendTransaction({'from': _from, 'to': _to, 'value': value})
+        w3.eth.send_transaction({'from': _from, 'to': _to, 'value': value})
 
 
 def single_transaction(w3):
@@ -28,7 +28,7 @@ def single_transaction(w3):
     _from = accounts[random.randint(0, len(accounts) - 1)]
     _to = accounts[random.randint(0, len(accounts) - 1)]
     value = 50
-    tx_hash = w3.eth.sendTransaction({'from': _from, 'to': _to, 'value': value})
+    tx_hash = w3.eth.send_transaction({'from': _from, 'to': _to, 'value': value})
     return tx_hash
 
 

--- a/tests/core/middleware/test_transaction_signing.py
+++ b/tests/core/middleware/test_transaction_signing.py
@@ -207,7 +207,7 @@ def fund_account(w3):
     # fund local account
     tx_value = w3.toWei(10, 'ether')
     for address in (ADDRESS_1, ADDRESS_2):
-        w3.eth.sendTransaction({
+        w3.eth.send_transaction({
             'to': address,
             'from': w3.eth.accounts[0],
             'gas': 21000,
@@ -240,7 +240,7 @@ def fund_account(w3):
         ),
         (
             # Transaction with mismatched sender
-            # expect a validation error with sendTransaction + unmanaged account
+            # expect a validation error with send_transaction + unmanaged account
             {
                 'gas': 21000,
                 'value': 10
@@ -278,10 +278,10 @@ def test_signed_transaction(
     if isinstance(expected, type) and issubclass(expected, Exception):
         with pytest.raises(expected):
             start_balance = w3.eth.get_balance(_transaction.get('from', w3.eth.accounts[0]))
-            w3.eth.sendTransaction(_transaction)
+            w3.eth.send_transaction(_transaction)
     else:
         start_balance = w3.eth.get_balance(_transaction.get('from', w3.eth.accounts[0]))
-        w3.eth.sendTransaction(_transaction)
+        w3.eth.send_transaction(_transaction)
         assert w3.eth.getBalance(_transaction.get('from')) <= start_balance + expected
 
 

--- a/tests/core/txpool-module/test_txpool_content.py
+++ b/tests/core/txpool-module/test_txpool_content.py
@@ -14,13 +14,13 @@ def test_txpool_content(web3_empty):
         while web3.eth.hashrate or web3.eth.mining:
             timeout.sleep(random.random())
 
-    txn_1_hash = web3.eth.sendTransaction({
+    txn_1_hash = web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 12345,
     })
     txn_1 = web3.eth.get_transaction(txn_1_hash)
-    txn_2_hash = web3.eth.sendTransaction({
+    txn_2_hash = web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 54321,

--- a/tests/core/txpool-module/test_txpool_inspect.py
+++ b/tests/core/txpool-module/test_txpool_inspect.py
@@ -14,13 +14,13 @@ def test_txpool_inspect(web3_empty):
         while web3.eth.hashrate or web3.eth.mining:
             timeout.sleep(random.random())
 
-    txn_1_hash = web3.eth.sendTransaction({
+    txn_1_hash = web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 12345,
     })
     txn_1 = web3.eth.get_transaction(txn_1_hash)
-    txn_2_hash = web3.eth.sendTransaction({
+    txn_2_hash = web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
         'value': 54321,

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -276,7 +276,7 @@ def setup_chain_state(web3):
     #
     web3.geth.personal.unlock_account(coinbase, common.KEYFILE_PW)
     web3.geth.miner.start(1)
-    mined_txn_hash = web3.eth.sendTransaction({
+    mined_txn_hash = web3.eth.send_transaction({
         'from': coinbase,
         'to': coinbase,
         'value': 1,

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -62,7 +62,7 @@ class ParityEthModuleTest(EthModuleTest):
     def test_eth_getTransactionReceipt_unmined(self, web3, unlocked_account):
         # Parity diverges from json-rpc spec and retrieves pending block
         # transactions with getTransactionReceipt.
-        txn_hash = web3.eth.sendTransaction({
+        txn_hash = web3.eth.send_transaction({
             'from': unlocked_account,
             'to': unlocked_account,
             'value': 1,

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -107,7 +107,7 @@ def empty_block(web3):
 
 @pytest.fixture(scope="module")
 def block_with_txn(web3):
-    txn_hash = web3.eth.sendTransaction({
+    txn_hash = web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': web3.eth.coinbase,
         'value': 1,
@@ -170,7 +170,7 @@ def unlockable_account_pw(web3):
 @pytest.fixture(scope='module')
 def unlockable_account(web3, unlockable_account_pw):
     account = web3.geth.personal.import_raw_key(UNLOCKABLE_PRIVATE_KEY, unlockable_account_pw)
-    web3.eth.sendTransaction({
+    web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': account,
         'value': web3.toWei(10, 'ether'),
@@ -200,7 +200,7 @@ def unlocked_account_dual_type(web3, unlockable_account_dual_type, unlockable_ac
 @pytest.fixture(scope="module")
 def funded_account_for_raw_txn(web3):
     account = '0x39EEed73fb1D3855E90Cbd42f348b3D7b340aAA6'
-    web3.eth.sendTransaction({
+    web3.eth.send_transaction({
         'from': web3.eth.coinbase,
         'to': account,
         'value': web3.toWei(10, 'ether'),

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -556,7 +556,7 @@ class EthModuleTest:
             assert result['tx']['gasPrice'] == txn_params['gasPrice']
             assert result['tx']['nonce'] == txn_params['nonce']
 
-    def test_eth_sendTransaction_addr_checksum_required(
+    def test_eth_send_transaction_addr_checksum_required(
         self, web3: "Web3", unlocked_account: ChecksumAddress
     ) -> None:
         non_checksum_addr = unlocked_account.lower()
@@ -570,13 +570,13 @@ class EthModuleTest:
 
         with pytest.raises(InvalidAddress):
             invalid_params = cast(TxParams, dict(txn_params, **{'from': non_checksum_addr}))
-            web3.eth.sendTransaction(invalid_params)
+            web3.eth.send_transaction(invalid_params)
 
         with pytest.raises(InvalidAddress):
             invalid_params = cast(TxParams, dict(txn_params, **{'to': non_checksum_addr}))
-            web3.eth.sendTransaction(invalid_params)
+            web3.eth.send_transaction(invalid_params)
 
-    def test_eth_sendTransaction(
+    def test_eth_send_transaction(
         self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
         txn_params: TxParams = {
@@ -586,7 +586,7 @@ class EthModuleTest:
             'gas': Wei(21000),
             'gasPrice': web3.eth.gas_price,
         }
-        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn_hash = web3.eth.send_transaction(txn_params)
         txn = web3.eth.get_transaction(txn_hash)
 
         assert is_same_address(txn['from'], cast(ChecksumAddress, txn_params['from']))
@@ -595,7 +595,28 @@ class EthModuleTest:
         assert txn['gas'] == 21000
         assert txn['gasPrice'] == txn_params['gasPrice']
 
-    def test_eth_sendTransaction_with_nonce(
+    def test_eth_sendTransaction_deprecated(
+        self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        txn_params: TxParams = {
+            'from': unlocked_account_dual_type,
+            'to': unlocked_account_dual_type,
+            'value': Wei(1),
+            'gas': Wei(21000),
+            'gasPrice': web3.eth.gas_price,
+        }
+        with pytest.warns(DeprecationWarning,
+                          match="sendTransaction is deprecated in favor of send_transaction"):
+            txn_hash = web3.eth.sendTransaction(txn_params)
+        txn = web3.eth.get_transaction(txn_hash)
+
+        assert is_same_address(txn['from'], cast(ChecksumAddress, txn_params['from']))
+        assert is_same_address(txn['to'], cast(ChecksumAddress, txn_params['to']))
+        assert txn['value'] == 1
+        assert txn['gas'] == 21000
+        assert txn['gasPrice'] == txn_params['gasPrice']
+
+    def test_eth_send_transaction_with_nonce(
         self, web3: "Web3", unlocked_account: ChecksumAddress
     ) -> None:
         txn_params: TxParams = {
@@ -607,7 +628,7 @@ class EthModuleTest:
             'gasPrice': Wei(web3.eth.gas_price * 3),
             'nonce': web3.eth.get_transaction_count(unlocked_account),
         }
-        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn_hash = web3.eth.send_transaction(txn_params)
         txn = web3.eth.get_transaction(txn_hash)
 
         assert is_same_address(txn['from'], cast(ChecksumAddress, txn_params['from']))
@@ -627,7 +648,7 @@ class EthModuleTest:
             'gas': Wei(21000),
             'gasPrice': web3.eth.gas_price,
         }
-        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn_hash = web3.eth.send_transaction(txn_params)
 
         txn_params['gasPrice'] = Wei(web3.eth.gas_price * 2)
         replace_txn_hash = web3.eth.replaceTransaction(txn_hash, txn_params)
@@ -665,7 +686,7 @@ class EthModuleTest:
             'gas': Wei(21000),
             'gasPrice': web3.eth.gas_price,
         }
-        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn_hash = web3.eth.send_transaction(txn_params)
         web3.eth.waitForTransactionReceipt(txn_hash)
 
         txn_params['gasPrice'] = Wei(web3.eth.gas_price * 2)
@@ -682,7 +703,7 @@ class EthModuleTest:
             'gas': Wei(21000),
             'gasPrice': web3.eth.gas_price,
         }
-        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn_hash = web3.eth.send_transaction(txn_params)
         txn = web3.eth.get_transaction(txn_hash)
 
         txn_params['gasPrice'] = Wei(web3.eth.gas_price * 2)
@@ -700,7 +721,7 @@ class EthModuleTest:
             'gas': Wei(21000),
             'gasPrice': Wei(10),
         }
-        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn_hash = web3.eth.send_transaction(txn_params)
 
         txn_params['gasPrice'] = Wei(9)
         with pytest.raises(ValueError):
@@ -716,7 +737,7 @@ class EthModuleTest:
             'gas': Wei(21000),
             'gasPrice': Wei(10),
         }
-        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn_hash = web3.eth.send_transaction(txn_params)
 
         txn_params.pop('gasPrice')
         replace_txn_hash = web3.eth.replaceTransaction(txn_hash, txn_params)
@@ -734,7 +755,7 @@ class EthModuleTest:
             'gas': Wei(21000),
             'gasPrice': Wei(10),
         }
-        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn_hash = web3.eth.send_transaction(txn_params)
 
         def higher_gas_price_strategy(web3: "Web3", txn: TxParams) -> Wei:
             return Wei(20)
@@ -756,7 +777,7 @@ class EthModuleTest:
             'gas': Wei(21000),
             'gasPrice': Wei(10),
         }
-        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn_hash = web3.eth.send_transaction(txn_params)
 
         def lower_gas_price_strategy(web3: "Web3", txn: TxParams) -> Wei:
             return Wei(5)
@@ -779,7 +800,7 @@ class EthModuleTest:
             'gas': Wei(21000),
             'gasPrice': web3.eth.gas_price,
         }
-        txn_hash = web3.eth.sendTransaction(txn_params)
+        txn_hash = web3.eth.send_transaction(txn_params)
 
         modified_txn_hash = web3.eth.modifyTransaction(
             txn_hash, gasPrice=(cast(int, txn_params['gasPrice']) * 2), value=2
@@ -1083,7 +1104,7 @@ class EthModuleTest:
     def test_eth_getTransactionReceipt_unmined(
         self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
-        txn_hash = web3.eth.sendTransaction({
+        txn_hash = web3.eth.send_transaction({
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),

--- a/web3/_utils/module_testing/personal_module.py
+++ b/web3/_utils/module_testing/personal_module.py
@@ -167,24 +167,25 @@ class GoEthereumPersonalModuleTest:
         unlockable_account_dual_type: ChecksumAddress,
         unlockable_account_pw: str,
     ) -> None:
+        assert web3.eth.get_balance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
+        txn_params: TxParams = {
+            'from': unlockable_account_dual_type,
+            'to': unlockable_account_dual_type,
+            'gas': Wei(21000),
+            'value': Wei(1),
+            'gasPrice': web3.toWei(1, 'gwei'),
+        }
         with pytest.warns(DeprecationWarning):
-            assert web3.eth.get_balance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
-            txn_params: TxParams = {
-                'from': unlockable_account_dual_type,
-                'to': unlockable_account_dual_type,
-                'gas': Wei(21000),
-                'value': Wei(1),
-                'gasPrice': web3.toWei(1, 'gwei'),
-            }
             txn_hash = web3.geth.personal.sendTransaction(txn_params, unlockable_account_pw)
-            assert txn_hash
-            transaction = web3.eth.get_transaction(txn_hash)
+        assert txn_hash
 
-            assert is_same_address(transaction['from'], cast(ChecksumAddress, txn_params['from']))
-            assert is_same_address(transaction['to'], cast(ChecksumAddress, txn_params['to']))
-            assert transaction['gas'] == txn_params['gas']
-            assert transaction['value'] == txn_params['value']
-            assert transaction['gasPrice'] == txn_params['gasPrice']
+        transaction = web3.eth.get_transaction(txn_hash)
+
+        assert is_same_address(transaction['from'], cast(ChecksumAddress, txn_params['from']))
+        assert is_same_address(transaction['to'], cast(ChecksumAddress, txn_params['to']))
+        assert transaction['gas'] == txn_params['gas']
+        assert transaction['value'] == txn_params['value']
+        assert transaction['gasPrice'] == txn_params['gasPrice']
 
     def test_personal_sign_and_ecrecover(
         self,
@@ -483,24 +484,24 @@ class ParityPersonalModuleTest():
         unlockable_account_dual_type: ChecksumAddress,
         unlockable_account_pw: str,
     ) -> None:
+        assert web3.eth.get_balance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
+        txn_params: TxParams = {
+            'from': unlockable_account_dual_type,
+            'to': unlockable_account_dual_type,
+            'gas': Wei(21000),
+            'value': Wei(1),
+            'gasPrice': web3.toWei(1, 'gwei'),
+        }
         with pytest.warns(DeprecationWarning):
-            assert web3.eth.get_balance(unlockable_account_dual_type) > web3.toWei(1, 'ether')
-            txn_params: TxParams = {
-                'from': unlockable_account_dual_type,
-                'to': unlockable_account_dual_type,
-                'gas': Wei(21000),
-                'value': Wei(1),
-                'gasPrice': web3.toWei(1, 'gwei'),
-            }
             txn_hash = web3.parity.personal.sendTransaction(txn_params, unlockable_account_pw)
-            assert txn_hash
-            transaction = web3.eth.get_transaction(txn_hash)
+        assert txn_hash
+        transaction = web3.eth.get_transaction(txn_hash)
 
-            assert is_same_address(transaction['from'], cast(ChecksumAddress, txn_params['from']))
-            assert is_same_address(transaction['to'], cast(ChecksumAddress, txn_params['to']))
-            assert transaction['gas'] == txn_params['gas']
-            assert transaction['value'] == txn_params['value']
-            assert transaction['gasPrice'] == txn_params['gasPrice']
+        assert is_same_address(transaction['from'], cast(ChecksumAddress, txn_params['from']))
+        assert is_same_address(transaction['to'], cast(ChecksumAddress, txn_params['to']))
+        assert transaction['gas'] == txn_params['gas']
+        assert transaction['value'] == txn_params['value']
+        assert transaction['gasPrice'] == txn_params['gasPrice']
 
     def test_personal_sign_and_ecrecover(
         self,

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -214,4 +214,4 @@ def replace_transaction(
     new_transaction = prepare_replacement_transaction(
         web3, current_transaction, new_transaction
     )
-    return web3.eth.sendTransaction(new_transaction)
+    return web3.eth.send_transaction(new_transaction)

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -659,7 +659,7 @@ class ContractConstructor:
         transact_transaction['data'] = self.data_in_transaction
 
         # TODO: handle asynchronous contract creation
-        return self.web3.eth.sendTransaction(transact_transaction)
+        return self.web3.eth.send_transaction(transact_transaction)
 
     @combomethod
     def buildTransaction(self, transaction: Optional[TxParams] = None) -> TxParams:
@@ -1585,7 +1585,7 @@ def transact_with_contract_function(
         fn_kwargs=kwargs,
     )
 
-    txn_hash = web3.eth.sendTransaction(transact_transaction)
+    txn_hash = web3.eth.send_transaction(transact_transaction)
     return txn_hash
 
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -468,7 +468,7 @@ class Eth(ModuleV2, Module):
             )
         return (transaction,)
 
-    sendTransaction: Method[Callable[[TxParams], HexBytes]] = Method(
+    send_transaction: Method[Callable[[TxParams], HexBytes]] = Method(
         RPC.eth_sendTransaction,
         mungers=[send_transaction_munger]
     )
@@ -666,3 +666,4 @@ class Eth(ModuleV2, Module):
                                            'get_transaction_count')
     getUncleByBlock = DeprecatedMethod(get_uncle_by_block, 'getUncleByBlock', 'get_uncle_by_block')
     getUncleCount = DeprecatedMethod(get_uncle_count, 'getUncleCount', 'get_uncle_count')
+    sendTransaction = DeprecatedMethod(send_transaction, 'sendTransaction', 'send_transaction')


### PR DESCRIPTION
### What was wrong?
Added `send_transaction` method, deprecated `sendTransaction`

Related to Issue #1429 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/108266105-eb946900-7126-11eb-9502-0fb109228d9c.png)

