### PR TITLE
Add send_raw_transaction, deprecate sendRawTransaction

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -183,7 +183,7 @@ There are a few options for making transactions:
   Use this method if:
     - you want to send ether from one account to another.
 
-- :meth:`~web3.eth.Eth.sendRawTransaction`
+- :meth:`~web3.eth.Eth.send_raw_transaction`
 
   Use this method if:
     - you want to sign the transaction elsewhere, e.g., a hardware wallet.
@@ -657,7 +657,7 @@ And finally, send the transaction
 
 .. code-block:: python
 
-    txn_hash = w3.eth.sendRawTransaction(signed_tx.rawTransaction)
+    txn_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
     txn_receipt = w3.eth.waitForTransactionReceipt(txn_hash)
 
 Tip : afterwards you can use the value stored in ``txn_hash``, in an explorer like `etherscan`_ to view the transaction's details

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -159,7 +159,7 @@ Making Transactions
 The most common use cases will be satisfied with
 :meth:`send_transaction <web3.eth.Eth.send_transaction>` or the combination of
 :meth:`sign_transaction <web3.eth.Eth.sign_transaction>` and
-:meth:`sendRawTransaction <web3.eth.Eth.sendRawTransaction>`.
+:meth:`send_raw_transaction <web3.eth.Eth.send_raw_transaction>`.
 
 .. note::
 
@@ -172,7 +172,7 @@ API
 
 - :meth:`web3.eth.send_transaction() <web3.eth.Eth.send_transaction>`
 - :meth:`web3.eth.sign_transaction() <web3.eth.Eth.sign_transaction>`
-- :meth:`web3.eth.sendRawTransaction() <web3.eth.Eth.sendRawTransaction>`
+- :meth:`web3.eth.send_raw_transaction() <web3.eth.Eth.send_raw_transaction>`
 - :meth:`web3.eth.replaceTransaction() <web3.eth.Eth.replaceTransaction>`
 - :meth:`web3.eth.modifyTransaction() <web3.eth.Eth.modifyTransaction>`
 - :meth:`web3.eth.waitForTransactionReceipt() <web3.eth.Eth.waitForTransactionReceipt>`

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -22,7 +22,7 @@ Local vs Hosted Keys
 Local Private Key
   A key is 32 :class:`bytes` of data that you can use to sign transactions and messages,
   before sending them to your node.
-  You must use :meth:`~web3.eth.Eth.sendRawTransaction`
+  You must use :meth:`~web3.eth.Eth.send_raw_transaction`
   when working with local keys, instead of
   :meth:`~web3.eth.Eth.send_transaction` .
 
@@ -224,7 +224,7 @@ Sign a Transaction
 ------------------------
 
 Create a transaction, sign it locally, and then send it to your node for broadcasting,
-with :meth:`~web3.eth.Eth.sendRawTransaction`.
+with :meth:`~web3.eth.Eth.send_raw_transaction`.
 
 .. doctest::
 
@@ -249,8 +249,8 @@ with :meth:`~web3.eth.Eth.sendRawTransaction`.
     >>> signed.v
     37
 
-    # When you run sendRawTransaction, you get back the hash of the transaction:
-    >>> w3.eth.sendRawTransaction(signed.rawTransaction)  # doctest: +SKIP
+    # When you run send_raw_transaction, you get back the hash of the transaction:
+    >>> w3.eth.send_raw_transaction(signed.rawTransaction)  # doctest: +SKIP
     '0xd8f64a42b57be0d565f385378db2f6bf324ce14a594afc05de90436e9ce01f60'
 
 Sign a Contract Transaction
@@ -262,7 +262,7 @@ To sign a transaction locally that will invoke a smart contract:
 #. Build the transaction
 #. Sign the transaction, with :meth:`w3.eth.account.sign_transaction()
    <eth_account.account.Account.sign_transaction>`
-#. Broadcast the transaction with :meth:`~web3.eth.Eth.sendRawTransaction`
+#. Broadcast the transaction with :meth:`~web3.eth.Eth.send_raw_transaction`
 
 .. testsetup::
 
@@ -317,8 +317,8 @@ To sign a transaction locally that will invoke a smart contract:
     >>> signed_txn.v
     37
 
-    >>> w3.eth.sendRawTransaction(signed_txn.rawTransaction)  # doctest: +SKIP
+    >>> w3.eth.send_raw_transaction(signed_txn.rawTransaction)  # doctest: +SKIP
 
-    # When you run sendRawTransaction, you get the same result as the hash of the transaction:
+    # When you run send_raw_transaction, you get the same result as the hash of the transaction:
     >>> w3.toHex(w3.keccak(signed_txn.rawTransaction))
     '0x4795adc6a719fa64fa21822630c0218c04996e2689ded114b6553cef1ae36618'

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -744,7 +744,7 @@ The following methods are available on the ``web3.eth`` namespace.
     * Delegates to ``eth_signTransaction`` RPC Method.
 
     Returns a transaction that's been signed by the node's private key, but not yet submitted.
-    The signed tx can be submitted with ``Eth.sendRawTransaction``
+    The signed tx can be submitted with ``Eth.send_raw_transaction``
 
     .. code-block:: python
 
@@ -765,7 +765,7 @@ The following methods are available on the ``web3.eth`` namespace.
     .. warning:: Deprecated: This property is deprecated in favor of
       :attr:`~web3.eth.Eth.sign_transaction()`
 
-.. py:method:: Eth.sendRawTransaction(raw_transaction)
+.. py:method:: Eth.send_raw_transaction(raw_transaction)
 
     * Delegates to ``eth_sendRawTransaction`` RPC Method
 
@@ -773,8 +773,8 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> signed_txn = w3.eth.account.signTransaction(dict(
-            nonce=w3.eth.getTransactionCount(public_address_of_senders_account),
+        >>> signed_txn = w3.eth.account.sign_transaction(dict(
+            nonce=w3.eth.get_transaction_count(public_address_of_senders_account),
             gasPrice=w3.eth.gas_price,
             gas=100000,
             to='0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
@@ -783,9 +783,13 @@ The following methods are available on the ``web3.eth`` namespace.
           ),
           private_key_for_senders_account,
         )
-        >>> w3.eth.sendRawTransaction(signed_txn.rawTransaction)
+        >>> w3.eth.send_raw_transaction(signed_txn.rawTransaction)
         HexBytes('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
 
+.. py:method:: Eth.sendRawTransaction(raw_transaction)
+
+    .. warning:: Deprecated: This property is deprecated in favor of
+      :meth:`~web3.eth.Eth.send_raw_transaction()`
 
 .. py:method:: Eth.replaceTransaction(transaction_hash, new_transaction)
 

--- a/newsfragments/1880.feature.rst
+++ b/newsfragments/1880.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.send_raw_transaction``, deprecate ``w3.eth.sendRawTransaction``

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -405,7 +405,7 @@ def test_eth_account_sign_and_send_EIP155_transaction_to_eth_tester(
         raw_tx,
         expected_tx_hash,
         r, s, v):
-    actual_tx_hash = w3.eth.sendRawTransaction(raw_tx)
+    actual_tx_hash = w3.eth.send_raw_transaction(raw_tx)
     assert actual_tx_hash == expected_tx_hash
     actual_txn = w3.eth.get_transaction(actual_tx_hash)
     for key in ('to', 'nonce', 'gas', 'gasPrice', 'value', ):

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -852,14 +852,14 @@ class EthModuleTest:
             ),
         ]
     )
-    def test_eth_sendRawTransaction(
+    def test_eth_send_raw_transaction(
         self,
         web3: "Web3",
         raw_transaction: Union[HexStr, bytes],
         funded_account_for_raw_txn: ChecksumAddress,
         expected_hash: HexStr,
     ) -> None:
-        txn_hash = web3.eth.sendRawTransaction(raw_transaction)
+        txn_hash = web3.eth.send_raw_transaction(raw_transaction)
         assert txn_hash == web3.toBytes(hexstr=expected_hash)
 
     def test_eth_call(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -473,7 +473,7 @@ class Eth(ModuleV2, Module):
         mungers=[send_transaction_munger]
     )
 
-    sendRawTransaction: Method[Callable[[Union[HexStr, bytes]], HexBytes]] = Method(
+    send_raw_transaction: Method[Callable[[Union[HexStr, bytes]], HexBytes]] = Method(
         RPC.eth_sendRawTransaction,
         mungers=[default_root_munger],
     )
@@ -668,3 +668,6 @@ class Eth(ModuleV2, Module):
     getUncleCount = DeprecatedMethod(get_uncle_count, 'getUncleCount', 'get_uncle_count')
     sendTransaction = DeprecatedMethod(send_transaction, 'sendTransaction', 'send_transaction')
     signTransaction = DeprecatedMethod(sign_transaction, 'signTransaction', 'sign_transaction')
+    sendRawTransaction = DeprecatedMethod(send_raw_transaction,
+                                          'sendRawTransaction',
+                                          'send_raw_transaction')


### PR DESCRIPTION
### What was wrong?
Added `send_raw_transaction`, deprecated `sendRawTransaction`.

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/108555684-08f63e00-72b3-11eb-81ab-19b6ffc76fae.png)

