### PR TITLE
fix return type of send_transaction in docs

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -732,7 +732,7 @@ The following methods are available on the ``web3.eth`` namespace.
     .. code-block:: python
 
         >>> web3.eth.send_transaction({'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'from': web3.eth.coinbase, 'value': 12345})
-        '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331'
+        HexBytes('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
 
 .. py:method:: Eth.sendTransaction(transaction)
 

--- a/newsfragments/686.doc.rst
+++ b/newsfragments/686.doc.rst
@@ -1,0 +1,1 @@
+Fix return type of ``send_transaction`` in docs.


### PR DESCRIPTION
### What was wrong?

The return type of `send_transaction` was off in the docs. Updated from str -> HexBytes. Closes #686.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.redd.it/ikaaz918pqi61.jpg)
