### PR TITLE
fixed import eth_account

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -417,7 +417,7 @@ This middleware automatically captures transactions, signs them, and sends them 
    >>> from web3 import Web3, EthereumTesterProvider
    >>> w3 = Web3(EthereumTesterProvider)
    >>> from web3.middleware import construct_sign_and_send_raw_middleware
-   >>> from eth_account import Account
+   >>> from eth_account.account import Account
    >>> acct = Account.create('KEYSMASH FJAFJKLDSKF7JKFDJ 1530')
    >>> w3.middleware_onion.add(construct_sign_and_send_raw_middleware(acct))
    >>> w3.eth.default_account = acct.address

--- a/tests/core/middleware/test_transaction_signing.py
+++ b/tests/core/middleware/test_transaction_signing.py
@@ -1,8 +1,10 @@
 import pytest
 
-from eth_account import (
+
+from eth_account.account import (
     Account,
 )
+
 from eth_account.signers.local import (
     LocalAccount,
 )

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -3,7 +3,7 @@ import warnings
 
 import pkg_resources
 
-from eth_account import (
+from eth_account.account import (
     Account  # noqa: E402,
 )
 from web3.main import (

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -13,8 +13,8 @@ from typing import (
 )
 import warnings
 
-from eth_account import (
-    Account,
+from eth_account.account import (
+    Account
 )
 from eth_typing import (
     Address,

--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -14,9 +14,10 @@ from typing import (
     Union,
 )
 
-from eth_account import (
+from eth_account.account import (
     Account,
 )
+
 from eth_account.signers.local import (
     LocalAccount,
 )


### PR DESCRIPTION
### What was wrong?
```bash
    from eth_account import Account
ImportError: cannot import name 'Account' from 'eth_account' 
```
Related to Issue #

### How was it fixed?
Account should be import like this:
from eth_account.account import Account

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
