### PR TITLE
deprecate modifyTransaction in favor of snakecased modify_transaction

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -174,7 +174,7 @@ API
 - :meth:`web3.eth.sign_transaction() <web3.eth.Eth.sign_transaction>`
 - :meth:`web3.eth.send_raw_transaction() <web3.eth.Eth.send_raw_transaction>`
 - :meth:`web3.eth.replace_transaction() <web3.eth.Eth.replace_transaction>`
-- :meth:`web3.eth.modifyTransaction() <web3.eth.Eth.modifyTransaction>`
+- :meth:`web3.eth.modify_transaction() <web3.eth.Eth.modify_transaction>`
 - :meth:`web3.eth.waitForTransactionReceipt() <web3.eth.Eth.waitForTransactionReceipt>`
 - :meth:`web3.eth.getTransactionReceipt() <web3.eth.Eth.getTransactionReceipt>`
 - :meth:`web3.eth.sign() <web3.eth.Eth.sign>`

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -838,7 +838,7 @@ The following methods are available on the ``web3.eth`` namespace.
     .. warning:: Deprecated: This method is deprecated in favor of
       :meth:`~web3.eth.Eth.replace_transaction()`
 
-.. py:method:: Eth.modifyTransaction(transaction_hash, **transaction_params)
+.. py:method:: Eth.modify_transaction(transaction_hash, **transaction_params)
 
     * Delegates to ``eth_sendTransaction`` RPC Method
 
@@ -861,8 +861,13 @@ The following methods are available on the ``web3.eth`` namespace.
                 'value': 1000
             })
         '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331'
-        >>> web3.eth.modifyTransaction('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331', value=2000)
+        >>> web3.eth.modify_transaction
+        ('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331', value=2000)
 
+.. py:method:: Eth.modifyTransaction(transaction_hash, **transaction_params)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.modify_transaction()`
 
 .. py:method:: Eth.sign(account, data=None, hexstr=None, text=None)
 

--- a/newsfragments/1886.feature.rst
+++ b/newsfragments/1886.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.modify_transaction`` deprecate ``w3.eth.modifyTransaction``

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -306,8 +306,12 @@ class TestEthereumTesterEthModule(EthModuleTest):
         )
 
     @disable_auto_mine
-    def test_eth_modifyTransaction(self, eth_tester, web3, unlocked_account):
-        super().test_eth_modifyTransaction(web3, unlocked_account)
+    def test_eth_modifyTransaction_deprecated(self, eth_tester, web3, unlocked_account):
+        super().test_eth_modifyTransaction_deprecated(web3, unlocked_account)
+
+    @disable_auto_mine
+    def test_eth_modify_transaction(self, eth_tester, web3, unlocked_account):
+        super().test_eth_modify_transaction(web3, unlocked_account)
 
     @disable_auto_mine
     def test_eth_call_old_contract_state(self, eth_tester, web3, math_contract, unlocked_account):

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -872,12 +872,13 @@ class EthModuleTest:
             'gasPrice': web3.eth.gas_price,
         }
         txn_hash = web3.eth.send_transaction(txn_params)
-
-        modified_txn_hash = web3.eth.modifyTransaction(
-            txn_hash, gasPrice=(cast(int, txn_params['gasPrice']) * 2), value=2
-        )
+        with pytest.warns(
+                DeprecationWarning,
+                match="modifyTransaction is deprecated in favor of modify_transaction"):
+            modified_txn_hash = web3.eth.modifyTransaction(
+                txn_hash, gasPrice=(cast(int, txn_params['gasPrice']) * 2), value=2
+            )
         modified_txn = web3.eth.get_transaction(modified_txn_hash)
-
         assert is_same_address(modified_txn['from'], cast(ChecksumAddress, txn_params['from']))
         assert is_same_address(modified_txn['to'], cast(ChecksumAddress, txn_params['to']))
         assert modified_txn['value'] == 2

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -838,7 +838,30 @@ class EthModuleTest:
         # Strategy provides lower gas price - minimum preferred
         assert replace_txn['gasPrice'] == 12
 
-    def test_eth_modifyTransaction(
+    def test_eth_modify_transaction(
+        self, web3: "Web3", unlocked_account: ChecksumAddress
+    ) -> None:
+        txn_params: TxParams = {
+            'from': unlocked_account,
+            'to': unlocked_account,
+            'value': Wei(1),
+            'gas': Wei(21000),
+            'gasPrice': web3.eth.gas_price,
+        }
+        txn_hash = web3.eth.send_transaction(txn_params)
+
+        modified_txn_hash = web3.eth.modify_transaction(
+            txn_hash, gasPrice=(cast(int, txn_params['gasPrice']) * 2), value=2
+        )
+        modified_txn = web3.eth.get_transaction(modified_txn_hash)
+
+        assert is_same_address(modified_txn['from'], cast(ChecksumAddress, txn_params['from']))
+        assert is_same_address(modified_txn['to'], cast(ChecksumAddress, txn_params['to']))
+        assert modified_txn['value'] == 2
+        assert modified_txn['gas'] == 21000
+        assert modified_txn['gasPrice'] == cast(int, txn_params['gasPrice']) * 2
+
+    def test_eth_modifyTransaction_deprecated(
         self, web3: "Web3", unlocked_account: ChecksumAddress
     ) -> None:
         txn_params: TxParams = {

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -456,11 +456,7 @@ class Eth(ModuleV2, Module):
     def modifyTransaction(
         self, transaction_hash: _Hash32, **transaction_params: Any
     ) -> HexBytes:
-        assert_valid_transaction_params(cast(TxParams, transaction_params))
-        current_transaction = get_required_transaction(self.web3, transaction_hash)
-        current_transaction_params = extract_valid_transaction_params(current_transaction)
-        new_transaction = merge(current_transaction_params, transaction_params)
-        return replace_transaction(self.web3, current_transaction, new_transaction)
+        return self.modify_transaction(transaction_hash, **transaction_params)
 
     def modify_transaction(
         self, transaction_hash: _Hash32, **transaction_params: Any

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -452,7 +452,17 @@ class Eth(ModuleV2, Module):
 
     # todo: Update Any to stricter kwarg checking with TxParams
     # https://github.com/python/mypy/issues/4441
+    @deprecated_for("modify_transaction")
     def modifyTransaction(
+        self, transaction_hash: _Hash32, **transaction_params: Any
+    ) -> HexBytes:
+        assert_valid_transaction_params(cast(TxParams, transaction_params))
+        current_transaction = get_required_transaction(self.web3, transaction_hash)
+        current_transaction_params = extract_valid_transaction_params(current_transaction)
+        new_transaction = merge(current_transaction_params, transaction_params)
+        return replace_transaction(self.web3, current_transaction, new_transaction)
+
+    def modify_transaction(
         self, transaction_hash: _Hash32, **transaction_params: Any
     ) -> HexBytes:
         assert_valid_transaction_params(cast(TxParams, transaction_params))


### PR DESCRIPTION
### What was wrong?
Added modify_transaction, deprecated modifyTransaction

Related to Issue #1429 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/8/86/Eurasian_blue_tit_Lancashire.jpg)
