### PR TITLE
Add get_transaction_receipt, deprecate getTransactionReceipt

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -85,7 +85,7 @@ def wait_for_transaction():
         poll_delay_counter = PollDelayCounter()
         with Timeout(timeout) as timeout:
             while True:
-                txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
+                txn_receipt = web3.eth.get_transaction_receipt(txn_hash)
                 if txn_receipt is not None:
                     break
                 time.sleep(poll_delay_counter())

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -237,7 +237,7 @@ Each Contract Factory exposes the following methods.
     .. code-block:: python
 
         >>> deploy_txn = token_contract.constructor(web3.eth.coinbase, 12345).transact()
-        >>> txn_receipt = web3.eth.getTransactionReceipt(deploy_txn)
+        >>> txn_receipt = web3.eth.get_transaction_receipt(deploy_txn)
         >>> txn_receipt['contractAddress']
         '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
 
@@ -937,7 +937,7 @@ For example:
 
         myContract = web3.eth.contract(address=contract_address, abi=contract_abi)
         tx_hash = myContract.functions.myFunction().transact()
-        receipt = web3.eth.getTransactionReceipt(tx_hash)
+        receipt = web3.eth.get_transaction_receipt(tx_hash)
         myContract.events.myEvent().processReceipt(receipt)
 
 :py:class:`ContractEvent` provides methods to interact with contract events. Positional and keyword arguments supplied to the contract event subclass will be used to find the contract event by signature.
@@ -954,7 +954,7 @@ For example:
    .. code-block:: python
 
        >>> tx_hash = contract.functions.myFunction(12345).transact({'to':contract_address})
-       >>> tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+       >>> tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
        >>> rich_logs = contract.events.myEvent().processReceipt(tx_receipt)
        >>> rich_logs[0]['args']
        {'myArg': 12345}
@@ -971,7 +971,7 @@ For example:
    .. code-block:: python
 
        >>> tx_hash = contract.functions.myFunction(12345).transact({'to':contract_address})
-       >>> tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+       >>> tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
        >>> processed_logs = contract.events.myEvent().processReceipt(tx_receipt)
        >>> processed_logs
        (
@@ -1020,7 +1020,7 @@ For example:
    .. code-block:: python
 
        >>> tx_hash = contract.functions.myFunction(12345).transact({'to':contract_address})
-       >>> tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+       >>> tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
        >>> log_to_process = tx_receipt['logs'][0]
        >>> processed_log = contract.events.myEvent().processLog(log_to_process)
        >>> processed_log

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -241,12 +241,12 @@ instead return ``None``.
 Looking up receipts
 -------------------
 
-Transaction receipts can be retrieved using the ``web3.eth.getTransactionReceipt`` API.
+Transaction receipts can be retrieved using the ``web3.eth.get_transaction_receipt`` API.
 
 
 .. code-block:: python
 
-    >>> web3.eth.getTransactionReceipt('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')
+    >>> web3.eth.get_transaction_receipt('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')
     {
         'blockHash': '0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd',
         'blockNumber': 46147,
@@ -317,7 +317,7 @@ The following example demonstrates a few things:
             abi=contract_interface['abi'],
             bytecode=contract_interface['bin']).constructor().transact()
 
-        address = w3.eth.getTransactionReceipt(tx_hash)['contractAddress']
+        address = w3.eth.get_transaction_receipt(tx_hash)['contractAddress']
         return address
 
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -176,7 +176,7 @@ API
 - :meth:`web3.eth.replace_transaction() <web3.eth.Eth.replace_transaction>`
 - :meth:`web3.eth.modifyTransaction() <web3.eth.Eth.modifyTransaction>`
 - :meth:`web3.eth.waitForTransactionReceipt() <web3.eth.Eth.waitForTransactionReceipt>`
-- :meth:`web3.eth.getTransactionReceipt() <web3.eth.Eth.getTransactionReceipt>`
+- :meth:`web3.eth.get_transaction_receipt() <web3.eth.Eth.get_transaction_receipt>`
 - :meth:`web3.eth.sign() <web3.eth.Eth.sign>`
 - :meth:`web3.eth.signTypedData() <web3.eth.Eth.signTypedData>`
 - :meth:`web3.eth.estimateGas() <web3.eth.Eth.estimateGas>`

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -644,7 +644,7 @@ The following methods are available on the ``web3.eth`` namespace.
         })
 
 
-.. py:method:: Eth.getTransactionReceipt(transaction_hash)
+.. py:method:: Eth.get_transaction_receipt(transaction_hash)
 
     * Delegates to ``eth_getTransactionReceipt`` RPC Method
 
@@ -654,12 +654,12 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.getTransactionReceipt('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')  # not yet mined
+        >>> web3.eth.get_transaction_receipt('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')  # not yet mined
         Traceback # ... etc ...
         TransactionNotFound: Transaction with hash: 0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060 not found.
 
         # wait for it to be mined....
-        >>> web3.eth.getTransactionReceipt('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')
+        >>> web3.eth.get_transaction_receipt('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')
         AttributeDict({
             'blockHash': '0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd',
             'blockNumber': 46147,
@@ -675,6 +675,10 @@ The following methods are available on the ``web3.eth`` namespace.
             'transactionIndex': 0,
         })
 
+.. py:method:: Eth.getTransactionReceipt(transaction_hash)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.get_transaction_receipt()`
 
 .. py:method:: Eth.get_transaction_count(account, block_identifier=web3.eth.default_block)
 

--- a/ethpm/_utils/deployments.py
+++ b/ethpm/_utils/deployments.py
@@ -98,7 +98,7 @@ def validate_deployments_tx_receipt(
     for name, data in deployments.items():
         if "transaction" in data:
             tx_hash = data["transaction"]
-            tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+            tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
             # tx_address will be None if contract created via contract factory
             tx_address = tx_receipt["contractAddress"]
 

--- a/newsfragments/1893.feature.rst
+++ b/newsfragments/1893.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.get_transaction_receipt``, deprecate ``w3.eth.getTransactionReceipt``

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -101,7 +101,7 @@ def test_unmined_transaction_wait_for_receipt(web3):
         'value': 123457
     })
     with pytest.raises(TransactionNotFound):
-        web3.eth.getTransactionReceipt(txn_hash)
+        web3.eth.get_transaction_receipt(txn_hash)
 
     txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
     assert txn_receipt['transactionHash'] == txn_hash

--- a/tests/core/filtering/test_filters_against_many_blocks.py
+++ b/tests/core/filtering/test_filters_against_many_blocks.py
@@ -11,7 +11,7 @@ def deploy_contracts(web3, contract, wait_for_transaction):
     for i in range(25):
         tx_hash = contract.constructor().transact()
         wait_for_transaction(web3, tx_hash)
-        yield web3.eth.getTransactionReceipt(tx_hash)['contractAddress']
+        yield web3.eth.get_transaction_receipt(tx_hash)['contractAddress']
 
 
 def pad_with_transactions(w3):

--- a/tests/core/pm-module/test_pm_init.py
+++ b/tests/core/pm-module/test_pm_init.py
@@ -76,7 +76,7 @@ def test_deploy_a_standalone_package_integration(w3):
     ERC20 = token_package.get_contract_factory('StandardToken')
     # totalSupply = 100
     tx_hash = ERC20.constructor(100).transact()
-    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+    tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
     address = tx_receipt["contractAddress"]
     erc20 = w3.eth.contract(address=address, abi=ERC20.abi)
     total_supply = erc20.functions.totalSupply().call()

--- a/tests/ethpm/integration/test_escrow_manifest.py
+++ b/tests/ethpm/integration/test_escrow_manifest.py
@@ -25,7 +25,7 @@ def test_deployed_escrow_and_safe_send(escrow_manifest, w3):
         bytecode=safe_send_contract_type["deploymentBytecode"]["bytecode"],
     )
     tx_hash = SafeSend.constructor().transact()
-    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+    tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
     safe_send_address = to_canonical_address(tx_receipt["contractAddress"])
 
     EscrowPackage = Package(escrow_manifest, w3)

--- a/tests/integration/generate_fixtures/common.py
+++ b/tests/integration/generate_fixtures/common.py
@@ -215,7 +215,7 @@ def mine_transaction_hash(web3, txn_hash):
     web3.geth.miner.start(1)
     while time.time() < start_time + 120:
         try:
-            receipt = web3.eth.getTransactionReceipt(txn_hash)
+            receipt = web3.eth.get_transaction_receipt(txn_hash)
         except TransactionNotFound:
             continue
         if receipt is not None:

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -59,9 +59,9 @@ class ParityEthModuleTest(EthModuleTest):
         super().test_eth_replace_transaction_already_mined(web3, unlocked_account)
 
     @flaky(max_runs=MAX_FLAKY_RUNS)
-    def test_eth_getTransactionReceipt_unmined(self, web3, unlocked_account):
+    def test_eth_get_transaction_receipt_unmined(self, web3, unlocked_account):
         # Parity diverges from json-rpc spec and retrieves pending block
-        # transactions with getTransactionReceipt.
+        # transactions with get_transaction_receipt.
         txn_hash = web3.eth.send_transaction({
             'from': unlocked_account,
             'to': unlocked_account,
@@ -69,7 +69,7 @@ class ParityEthModuleTest(EthModuleTest):
             'gas': 21000,
             'gasPrice': web3.eth.gas_price,
         })
-        receipt = web3.eth.getTransactionReceipt(txn_hash)
+        receipt = web3.eth.get_transaction_receipt(txn_hash)
         assert receipt is not None
         assert receipt['blockHash'] is None
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -261,8 +261,8 @@ class TestEthereumTesterEthModule(EthModuleTest):
         assert block['hash'] is not None
 
     @disable_auto_mine
-    def test_eth_getTransactionReceipt_unmined(self, eth_tester, web3, unlocked_account):
-        super().test_eth_getTransactionReceipt_unmined(web3, unlocked_account)
+    def test_eth_get_transaction_receipt_unmined(self, eth_tester, web3, unlocked_account):
+        super().test_eth_get_transaction_receipt_unmined(web3, unlocked_account)
 
     @disable_auto_mine
     def test_eth_replaceTransaction_deprecated(self, eth_tester, web3, unlocked_account):
@@ -354,8 +354,14 @@ class TestEthereumTesterEthModule(EthModuleTest):
         assert chain_id == 61
 
     @pytest.mark.xfail(raises=KeyError, reason="ethereum tester doesn't return 'to' key")
-    def test_eth_getTransactionReceipt_mined(self, web3, block_with_txn, mined_txn_hash):
-        super().test_eth_getTransactionReceipt_mined(web3, block_with_txn, mined_txn_hash)
+    def test_eth_get_transaction_receipt_mined(self, web3, block_with_txn, mined_txn_hash):
+        super().test_eth_get_transaction_receipt_mined(web3, block_with_txn, mined_txn_hash)
+
+    @pytest.mark.xfail(raises=KeyError, reason="ethereum tester doesn't return 'to' key")
+    def test_eth_getTransactionReceipt_mined_deprecated(self, web3, block_with_txn, mined_txn_hash):
+        super().test_eth_getTransactionReceipt_mined_deprecated(web3,
+                                                                block_with_txn,
+                                                                mined_txn_hash)
 
     def test_eth_call_revert_with_msg(self, web3, revert_contract, unlocked_account):
         with pytest.raises(TransactionFailed,

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1136,10 +1136,10 @@ class EthModuleTest:
         assert is_dict(transaction)
         assert transaction['hash'] == HexBytes(mined_txn_hash)
 
-    def test_eth_getTransactionReceipt_mined(
+    def test_eth_get_transaction_receipt_mined(
         self, web3: "Web3", block_with_txn: BlockData, mined_txn_hash: HexStr
     ) -> None:
-        receipt = web3.eth.getTransactionReceipt(mined_txn_hash)
+        receipt = web3.eth.get_transaction_receipt(mined_txn_hash)
         assert is_dict(receipt)
         assert receipt['blockNumber'] == block_with_txn['number']
         assert receipt['blockHash'] == block_with_txn['hash']
@@ -1149,7 +1149,23 @@ class EthModuleTest:
         assert receipt['from'] is not None
         assert is_checksum_address(receipt['from'])
 
-    def test_eth_getTransactionReceipt_unmined(
+    def test_eth_getTransactionReceipt_mined_deprecated(
+        self, web3: "Web3", block_with_txn: BlockData, mined_txn_hash: HexStr
+    ) -> None:
+        with pytest.warns(
+                DeprecationWarning,
+                match="getTransactionReceipt is deprecated in favor of get_transaction_receipt"):
+            receipt = web3.eth.getTransactionReceipt(mined_txn_hash)
+        assert is_dict(receipt)
+        assert receipt['blockNumber'] == block_with_txn['number']
+        assert receipt['blockHash'] == block_with_txn['hash']
+        assert receipt['transactionIndex'] == 0
+        assert receipt['transactionHash'] == HexBytes(mined_txn_hash)
+        assert is_checksum_address(receipt['to'])
+        assert receipt['from'] is not None
+        assert is_checksum_address(receipt['from'])
+
+    def test_eth_get_transaction_receipt_unmined(
         self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
         txn_hash = web3.eth.send_transaction({
@@ -1160,16 +1176,16 @@ class EthModuleTest:
             'gasPrice': web3.eth.gas_price,
         })
         with pytest.raises(TransactionNotFound):
-            web3.eth.getTransactionReceipt(txn_hash)
+            web3.eth.get_transaction_receipt(txn_hash)
 
-    def test_eth_getTransactionReceipt_with_log_entry(
+    def test_eth_get_transaction_receipt_with_log_entry(
         self,
         web3: "Web3",
         block_with_txn_with_log: BlockData,
         emitter_contract: "Contract",
         txn_hash_with_log: HexStr,
     ) -> None:
-        receipt = web3.eth.getTransactionReceipt(txn_hash_with_log)
+        receipt = web3.eth.get_transaction_receipt(txn_hash_with_log)
         assert is_dict(receipt)
         assert receipt['blockNumber'] == block_with_txn_with_log['number']
         assert receipt['blockHash'] == block_with_txn_with_log['hash']

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -99,7 +99,7 @@ def wait_for_transaction_receipt(
     with Timeout(timeout) as _timeout:
         while True:
             try:
-                txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
+                txn_receipt = web3.eth.get_transaction_receipt(txn_hash)
             except TransactionNotFound:
                 txn_receipt = None
             # FIXME: The check for a null `blockHash` is due to parity's

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -430,14 +430,12 @@ class Eth(ModuleV2, Module):
                 )
             )
 
-    getTransactionReceipt: Method[Callable[[_Hash32], TxReceipt]] = Method(
+    get_transaction_receipt: Method[Callable[[_Hash32], TxReceipt]] = Method(
         RPC.eth_getTransactionReceipt,
         mungers=[default_root_munger]
     )
 
     get_transaction_count: Method[Callable[..., Nonce]] = Method(
-
-
         RPC.eth_getTransactionCount,
         mungers=[block_id_munger],
     )
@@ -678,3 +676,6 @@ class Eth(ModuleV2, Module):
     sendRawTransaction = DeprecatedMethod(send_raw_transaction,
                                           'sendRawTransaction',
                                           'send_raw_transaction')
+    getTransactionReceipt = DeprecatedMethod(get_transaction_receipt,
+                                             'getTransactionReceipt',
+                                             'get_transaction_receipt')


### PR DESCRIPTION
### What was wrong?
Add get_transaction_receipt, deprecate getTransactionReceipt

Related to Issue #1429


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Check if all deprecation warnings have been caught

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/110022336-07803900-7ce9-11eb-8bba-63e771fb4b71.png)

