### PR TITLE
deprecate waitForTransactionReceipt in favor of snakecased wait_for_transaction_receipt

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -84,7 +84,7 @@ To run this example, you will need to install a few extra features:
     >>> tx_hash = Greeter.constructor().transact()
 
     # Wait for the transaction to be mined, and get the transaction receipt
-    >>> tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    >>> tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
 
     >>> greeter = w3.eth.contract(
     ...     address=tx_receipt.contractAddress,
@@ -95,7 +95,7 @@ To run this example, you will need to install a few extra features:
     'Hello'
 
     >>> tx_hash = greeter.functions.setGreeting('Nihao').transact()
-    >>> tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    >>> tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     >>> greeter.functions.greet().call()
     'Nihao'
 
@@ -686,7 +686,7 @@ Taking the following contract code as an example:
     >>> ArraysContract = w3.eth.contract(abi=abi, bytecode=bytecode)
 
     >>> tx_hash = ArraysContract.constructor([b'b']).transact()
-    >>> tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    >>> tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
 
     >>> array_contract = w3.eth.contract(
     ...     address=tx_receipt.contractAddress,
@@ -1069,7 +1069,7 @@ Event Log Object
     assert bob == '0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF', bob
     tx_hash = my_token_contract.constructor(1000000).transact({'from': alice, 'gas': 899000, 'gasPrice': 320000})
     assert tx_hash == HexBytes('0x611aa2d5c3e51f08d0665c4529c5520ed32520d8a48ba2cf2aff3f2fce3f26e4'), tx_hash
-    txn_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    txn_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     assert txn_receipt['contractAddress'] == '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b', txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']
     contract = w3.eth.contract(contract_address, abi=ABI)
@@ -1077,7 +1077,7 @@ Event Log Object
     decimals = 10 ** 18
     assert total_supply == 1000000 * decimals, total_supply
     tx_hash = contract.functions.transfer(alice, 10).transact({'gas': 899000, 'gasPrice': 200000})
-    tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
 
 .. doctest:: createFilter
 
@@ -1096,7 +1096,7 @@ Event Log Object
      >>> transfer_filter.get_new_entries()
      []
      >>> tx_hash = contract.functions.transfer(alice, 10).transact({'gas': 899000, 'gasPrice': 200000})
-     >>> tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+     >>> tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
      >>> transfer_filter.get_new_entries()
      [AttributeDict({'args': AttributeDict({'from': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
       'to': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
@@ -1173,7 +1173,7 @@ For example:
    ABI = json.loads('[{"constant":false,"inputs":[],"name":"return13","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"constant":true,"inputs":[],"name":"counter","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"amt","type":"uint256"}],"name":"increment","outputs":[{"name":"result","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"a","type":"int256"},{"name":"b","type":"int256"}],"name":"add","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"constant":false,"inputs":[],"name":"increment","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"a","type":"int256"}],"name":"multiply7","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"value","type":"uint256"}],"name":"increased","type":"event"}]')
    contract = w3.eth.contract(abi=ABI, bytecode=bytecode)
    deploy_txn = contract.constructor().transact()
-   deploy_receipt = w3.eth.waitForTransactionReceipt(deploy_txn)
+   deploy_receipt = w3.eth.wait_for_transaction_receipt(deploy_txn)
    address = deploy_receipt.contractAddress
 
 .. doctest:: contractcaller

--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -109,13 +109,13 @@ LinkableContract
    >>> # Deploy SafeSendLib
    >>> SafeSendFactory = EscrowPackage.get_contract_factory("SafeSendLib")
    >>> safe_send_tx_hash = SafeSendFactory.constructor().transact()
-   >>> safe_send_tx_receipt = w3.eth.waitForTransactionReceipt(safe_send_tx_hash)
+   >>> safe_send_tx_receipt = w3.eth.wait_for_transaction_receipt(safe_send_tx_hash)
 
    >>> # Link Escrow factory to deployed SafeSendLib instance
    >>> LinkedEscrowFactory = EscrowFactory.link_bytecode({"SafeSendLib": safe_send_tx_receipt.contractAddress})
    >>> assert LinkedEscrowFactory.needs_bytecode_linking is False
    >>> escrow_tx_hash = LinkedEscrowFactory.constructor(w3.eth.accounts[0]).transact()
-   >>> escrow_tx_receipt = w3.eth.waitForTransactionReceipt(escrow_tx_hash)
+   >>> escrow_tx_receipt = w3.eth.wait_for_transaction_receipt(escrow_tx_hash)
    >>> assert is_address(escrow_tx_receipt.contractAddress)
 
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -339,7 +339,7 @@ The following example demonstrates a few things:
     if gas_estimate < 100000:
          print("Sending transaction to setVar(255)\n")
          tx_hash = store_var_contract.functions.setVar(255).transact()
-         receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+         receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
          print("Transaction receipt mined:")
          pprint.pprint(dict(receipt))
          print("\nWas transaction successful?")
@@ -466,7 +466,7 @@ contract which conforms to this standard.
     assert bob == '0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF', bob
     tx_hash = factory.constructor(1000000).transact({'from': alice, 'gas': 899000, 'gasPrice': 320000})
     assert tx_hash == HexBytes('0x611aa2d5c3e51f08d0665c4529c5520ed32520d8a48ba2cf2aff3f2fce3f26e4'), tx_hash
-    txn_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    txn_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     assert txn_receipt['contractAddress'] == '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b', txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']
     contract = w3.eth.contract(contract_address, abi=ABI)
@@ -549,7 +549,7 @@ Next we can transfer some tokens from ``alice`` to ``bob`` using the contract's
 .. doctest::
 
     >>> tx_hash = contract.functions.transfer(bob, 100).transact({'from': alice})
-    >>> tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    >>> tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     >>> contract.functions.balanceOf(alice).call()
     999999999999999999999900
     >>> contract.functions.balanceOf(bob).call()
@@ -568,7 +568,7 @@ spend using the ``allowance`` function.
     >>> contract.functions.allowance(alice, bob).call()
     0
     >>> tx_hash = contract.functions.approve(bob, 200).transact({'from': alice})
-    >>> tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    >>> tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     >>> contract.functions.allowance(alice, bob).call()
     200
 
@@ -586,7 +586,7 @@ When someone has an allowance they can transfer those tokens using the
     >>> contract.functions.balanceOf(bob).call()
     100
     >>> tx_hash = contract.functions.transferFrom(alice, bob, 75).transact({'from': bob})
-    >>> tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    >>> tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     >>> contract.functions.allowance(alice, bob).call()
     125
     >>> contract.functions.balanceOf(bob).call()
@@ -658,7 +658,7 @@ And finally, send the transaction
 .. code-block:: python
 
     txn_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
-    txn_receipt = w3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = w3.eth.wait_for_transaction_receipt(txn_hash)
 
 Tip : afterwards you can use the value stored in ``txn_hash``, in an explorer like `etherscan`_ to view the transaction's details
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -175,7 +175,7 @@ API
 - :meth:`web3.eth.send_raw_transaction() <web3.eth.Eth.send_raw_transaction>`
 - :meth:`web3.eth.replace_transaction() <web3.eth.Eth.replace_transaction>`
 - :meth:`web3.eth.modify_transaction() <web3.eth.Eth.modify_transaction>`
-- :meth:`web3.eth.waitForTransactionReceipt() <web3.eth.Eth.waitForTransactionReceipt>`
+- :meth:`web3.eth.wait_for_transaction_receipt() <web3.eth.Eth.wait_for_transaction_receipt>`
 - :meth:`web3.eth.get_transaction_receipt() <web3.eth.Eth.get_transaction_receipt>`
 - :meth:`web3.eth.sign() <web3.eth.Eth.sign>`
 - :meth:`web3.eth.signTypedData() <web3.eth.Eth.signTypedData>`
@@ -205,7 +205,7 @@ instance of the contract:
 
    >>> ExampleContract = w3.eth.contract(abi=abi, bytecode=bytecode)
    >>> tx_hash = ExampleContract.constructor().transact()
-   >>> tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+   >>> tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
    >>> tx_receipt.contractAddress
    '0x8a22225eD7eD460D7ee3842bce2402B9deaD23D3'
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -624,8 +624,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> web3.eth.wait_for_transaction_receipt
-        ('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')
+        >>> web3.eth.wait_for_transaction_receipt('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')
         # If transaction is not yet in a block, time passes, while the thread sleeps...
         # ...
         # Then when the transaction is added to a block, its receipt is returned:

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -613,18 +613,19 @@ The following methods are available on the ``web3.eth`` namespace.
     .. warning:: Deprecated: This method is deprecated in favor of
       :attr:`~web3.eth.Eth.get_transaction_by_block`
 
-.. py:method:: Eth.waitForTransactionReceipt(transaction_hash, timeout=120, poll_latency=0.1)
+.. py:method:: Eth.wait_for_transaction_receipt(transaction_hash, timeout=120, poll_latency=0.1)
 
     Waits for the transaction specified by ``transaction_hash`` to be included in a block, then
     returns its transaction receipt.
 
     Optionally, specify a ``timeout`` in seconds. If timeout elapses before the transaction
-    is added to a block, then :meth:`~Eth.waitForTransactionReceipt` raises a
+    is added to a block, then :meth:`~Eth.wait_for_transaction_receipt` raises a
     :class:`web3.exceptions.TimeExhausted` exception.
 
     .. code-block:: python
 
-        >>> web3.eth.waitForTransactionReceipt('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')
+        >>> web3.eth.wait_for_transaction_receipt
+        ('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')
         # If transaction is not yet in a block, time passes, while the thread sleeps...
         # ...
         # Then when the transaction is added to a block, its receipt is returned:
@@ -643,6 +644,11 @@ The following methods are available on the ``web3.eth`` namespace.
             'transactionIndex': 0,
         })
 
+
+.. py:method:: Eth.waitForTransactionReceipt(transaction_hash, timeout=120, poll_latency=0.1)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.wait_for_transaction_receipt()`
 
 .. py:method:: Eth.get_transaction_receipt(transaction_hash)
 

--- a/newsfragments/1896.feature.rst
+++ b/newsfragments/1896.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.wait_for_transaction_receipt`` deprecate ``w3.eth.waitForTransactionReceipt``

--- a/tests/core/contracts/test_concise_contract.py
+++ b/tests/core/contracts/test_concise_contract.py
@@ -17,7 +17,7 @@ from web3.contract import (
 def deploy(web3, Contract, args=None):
     args = args or []
     deploy_txn = Contract.constructor(*args).transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     contract = Contract(address=deploy_receipt['contractAddress'])
     assert len(web3.eth.get_code(contract.address)) > 0
@@ -35,7 +35,7 @@ def zero_address_contract(web3, WithConstructorAddressArgumentsContract, EMPTY_A
     deploy_txn = WithConstructorAddressArgumentsContract.constructor(
         EMPTY_ADDR,
     ).transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     _address_contract = WithConstructorAddressArgumentsContract(
         address=deploy_receipt['contractAddress'],

--- a/tests/core/contracts/test_contract_ambiguous_functions.py
+++ b/tests/core/contracts/test_contract_ambiguous_functions.py
@@ -42,7 +42,7 @@ AMBIGUOUS_CONTRACT_ABI = [
 @pytest.fixture()
 def string_contract(web3, StringContract, address_conversion_func):
     deploy_txn = StringContract.constructor("Caqalai").transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
     contract = StringContract(address=contract_address)

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -14,7 +14,7 @@ from web3.exceptions import (
 @pytest.fixture()
 def math_contract(web3, MathContract, address_conversion_func):
     deploy_txn = MathContract.constructor().transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     math_contract_address = address_conversion_func(deploy_receipt['contractAddress'])
     _math_contract = MathContract(address=math_contract_address)
@@ -25,7 +25,7 @@ def math_contract(web3, MathContract, address_conversion_func):
 @pytest.fixture()
 def fallback_function_contract(web3, FallbackFunctionContract, address_conversion_func):
     deploy_txn = FallbackFunctionContract.constructor().transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     fallback_contract_address = address_conversion_func(deploy_receipt['contractAddress'])
     _fallback_contract = FallbackFunctionContract(address=fallback_contract_address)
@@ -36,7 +36,7 @@ def fallback_function_contract(web3, FallbackFunctionContract, address_conversio
 @pytest.fixture()
 def payable_tester_contract(web3, PayableTesterContract, address_conversion_func):
     deploy_txn = PayableTesterContract.constructor().transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     payable_tester_address = address_conversion_func(deploy_receipt['contractAddress'])
     _payable_tester = PayableTesterContract(address=payable_tester_address)

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -40,7 +40,7 @@ from web3.exceptions import (
 def deploy(web3, Contract, apply_func=identity, args=None):
     args = args or []
     deploy_txn = Contract.constructor(*args).transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     address = apply_func(deploy_receipt['contractAddress'])
     contract = Contract(address=address)
@@ -159,7 +159,7 @@ def undeployed_math_contract(web3, MathContract, address_conversion_func):
 @pytest.fixture()
 def mismatched_math_contract(web3, StringContract, MathContract, address_conversion_func):
     deploy_txn = StringContract.constructor("Caqalai").transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     address = address_conversion_func(deploy_receipt['contractAddress'])
     _mismatched_math_contract = MathContract(address=address)

--- a/tests/core/contracts/test_contract_caller_interface.py
+++ b/tests/core/contracts/test_contract_caller_interface.py
@@ -14,7 +14,7 @@ from web3.exceptions import (
 def deploy(web3, Contract, apply_func=identity, args=None):
     args = args or []
     deploy_txn = Contract.constructor(*args).transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     address = apply_func(deploy_receipt['contractAddress'])
     contract = Contract(address=address)

--- a/tests/core/contracts/test_contract_constructor.py
+++ b/tests/core/contracts/test_contract_constructor.py
@@ -19,7 +19,7 @@ def test_contract_constructor_gas_estimate_no_constructor(web3, MathContract):
     gas_estimate = MathContract.constructor().estimateGas()
 
     deploy_txn = MathContract.constructor().transact()
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     gas_used = txn_receipt.get('gasUsed')
 
     assert abs(gas_estimate - gas_used) < 21000
@@ -29,7 +29,7 @@ def test_contract_constructor_gas_estimate_with_block_id(web3, MathContract):
     block_identifier = None
     gas_estimate = MathContract.constructor().estimateGas(block_identifier=block_identifier)
     deploy_txn = MathContract.constructor().transact()
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     gas_used = txn_receipt.get('gasUsed')
 
     assert abs(gas_estimate - gas_used) < 21000
@@ -41,7 +41,7 @@ def test_contract_constructor_gas_estimate_with_constructor_without_arguments(
     gas_estimate = SimpleConstructorContract.constructor().estimateGas()
 
     deploy_txn = SimpleConstructorContract.constructor().transact()
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     gas_used = txn_receipt.get('gasUsed')
 
     assert abs(gas_estimate - gas_used) < 21000
@@ -66,7 +66,7 @@ def test_contract_constructor_gas_estimate_with_constructor_with_arguments(
 
     deploy_txn = WithConstructorArgumentsContract.constructor(
         *constructor_args, **constructor_kwargs).transact()
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     gas_used = txn_receipt.get('gasUsed')
 
     assert abs(gas_estimate - gas_used) < 21000
@@ -81,7 +81,7 @@ def test_contract_constructor_gas_estimate_with_constructor_with_address_argumen
 
     deploy_txn = WithConstructorAddressArgumentsContract.constructor(
         address_conversion_func("0x16D9983245De15E7A9A73bC586E01FF6E08dE737")).transact()
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     gas_used = txn_receipt.get('gasUsed')
 
     assert abs(gas_estimate - gas_used) < 21000
@@ -94,7 +94,7 @@ def test_contract_constructor_transact_no_constructor(
         address_conversion_func):
     deploy_txn = MathContract.constructor().transact()
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -111,7 +111,7 @@ def test_contract_constructor_transact_with_constructor_without_arguments(
         address_conversion_func):
     deploy_txn = SimpleConstructorContract.constructor().transact()
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -142,7 +142,7 @@ def test_contract_constructor_transact_with_constructor_with_arguments(
     deploy_txn = WithConstructorArgumentsContract.constructor(
         *constructor_args, **constructor_kwargs).transact()
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -162,7 +162,7 @@ def test_contract_constructor_transact_with_constructor_with_address_arguments(
         WITH_CONSTRUCTOR_ADDRESS_RUNTIME,
         address_conversion_func):
     deploy_txn = WithConstructorAddressArgumentsContract.constructor(TEST_ADDRESS).transact()
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert txn_receipt is not None
     assert txn_receipt['contractAddress']
     contract_address = address_conversion_func(txn_receipt['contractAddress'])

--- a/tests/core/contracts/test_contract_deployment.py
+++ b/tests/core/contracts/test_contract_deployment.py
@@ -10,7 +10,7 @@ def test_contract_deployment_no_constructor(web3, MathContract,
                                             MATH_RUNTIME):
     deploy_txn = MathContract.constructor().transact()
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -25,7 +25,7 @@ def test_contract_deployment_with_constructor_without_args(web3,
                                                            SIMPLE_CONSTRUCTOR_RUNTIME):
     deploy_txn = SimpleConstructorContract.constructor().transact()
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -44,7 +44,7 @@ def test_contract_deployment_with_constructor_with_arguments(web3,
     ):
         deploy_txn = WithConstructorArgumentsContract.constructor(1234, 'abcd').transact()
 
-        txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+        txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
         assert txn_receipt is not None
 
         assert txn_receipt['contractAddress']
@@ -66,7 +66,7 @@ def test_contract_deployment_with_constructor_with_arguments_strict(w3_strict_ab
         1234, constructor_arg
     ).transact()
 
-    txn_receipt = w3_strict_abi.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = w3_strict_abi.eth.wait_for_transaction_receipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']
@@ -93,7 +93,7 @@ def test_contract_deployment_with_constructor_with_address_argument(web3,
         "0x16D9983245De15E7A9A73bC586E01FF6E08dE737",
     ).transact()
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert txn_receipt is not None
 
     assert txn_receipt['contractAddress']

--- a/tests/core/contracts/test_contract_estimateGas.py
+++ b/tests/core/contracts/test_contract_estimateGas.py
@@ -23,7 +23,7 @@ def math_contract(web3,
         bytecode_runtime=MATH_RUNTIME,
     )
     deploy_txn = MathContract.constructor().transact({'from': web3.eth.coinbase})
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
 
     assert deploy_receipt is not None
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
@@ -47,7 +47,7 @@ def fallback_function_contract(web3,
         bytecode_runtime=FALLBACK_FUNCTION_RUNTIME
     )
     deploy_txn = fallback_contract.constructor().transact({'from': web3.eth.coinbase})
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
 
     assert deploy_receipt is not None
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
@@ -61,7 +61,7 @@ def fallback_function_contract(web3,
 @pytest.fixture()
 def payable_tester_contract(web3, PayableTesterContract, address_conversion_func):
     deploy_txn = PayableTesterContract.constructor().transact({'from': web3.eth.coinbase})
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
 
     assert deploy_receipt is not None
     payable_tester_address = address_conversion_func(deploy_receipt['contractAddress'])
@@ -79,7 +79,7 @@ def test_contract_estimateGas(web3, math_contract, estimateGas, transact):
         contract=math_contract,
         contract_function='increment')
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     gas_used = txn_receipt.get('gasUsed')
 
     assert abs(gas_estimate - gas_used) < 21000
@@ -90,7 +90,7 @@ def test_contract_fallback_estimateGas(web3, fallback_function_contract):
 
     txn_hash = fallback_function_contract.fallback.transact()
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     gas_used = txn_receipt.get('gasUsed')
 
     assert abs(gas_estimate - gas_used) < 21000
@@ -105,7 +105,7 @@ def test_contract_estimateGas_with_arguments(web3, math_contract, estimateGas, t
         contract=math_contract,
         contract_function='add',
         func_args=[5, 6])
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     gas_used = txn_receipt.get('gasUsed')
 
     assert abs(gas_estimate - gas_used) < 21000
@@ -123,7 +123,7 @@ def test_estimateGas_not_sending_ether_to_nonpayable_function(
         contract=payable_tester_contract,
         contract_function='doNoValueCall')
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     gas_used = txn_receipt.get('gasUsed')
 
     assert abs(gas_estimate - gas_used) < 21000
@@ -146,7 +146,7 @@ def test_estimateGas_accepts_latest_block(web3, math_contract, transact):
         contract=math_contract,
         contract_function='increment')
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     gas_used = txn_receipt.get('gasUsed')
 
     assert abs(gas_estimate - gas_used) < 21000
@@ -154,7 +154,7 @@ def test_estimateGas_accepts_latest_block(web3, math_contract, transact):
 
 def test_estimateGas_block_identifier_unique_estimates(web3, math_contract, transact):
     txn_hash = transact(contract=math_contract, contract_function="increment")
-    web3.eth.waitForTransactionReceipt(txn_hash)
+    web3.eth.wait_for_transaction_receipt(txn_hash)
 
     latest_gas_estimate = math_contract.functions.counter().estimateGas(
         block_identifier="latest"

--- a/tests/core/contracts/test_contract_example.py
+++ b/tests/core/contracts/test_contract_example.py
@@ -60,7 +60,7 @@ def foo_contract(eth_tester, w3):
         'from': deploy_address,
     })
     # wait for the transaction to be mined
-    tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash, 180)
+    tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash, 180)
     # instantiate and return an instance of our contract.
     return FooContract(tx_receipt.contractAddress)
 
@@ -77,7 +77,7 @@ def test_can_update_greeting(w3, foo_contract):
     ).transact({
         'from': w3.eth.accounts[1],
     })
-    w3.eth.waitForTransactionReceipt(tx_hash, 180)
+    w3.eth.wait_for_transaction_receipt(tx_hash, 180)
 
     # verify that the contract is now using the updated greeting
     hw = foo_contract.caller.bar()
@@ -91,7 +91,7 @@ def test_updating_greeting_emits_event(w3, foo_contract):
     ).transact({
         'from': w3.eth.accounts[1],
     })
-    receipt = w3.eth.waitForTransactionReceipt(tx_hash, 180)
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash, 180)
 
     # get all of the `barred` logs for the contract
     logs = foo_contract.events.barred.getLogs()

--- a/tests/core/contracts/test_contract_init.py
+++ b/tests/core/contracts/test_contract_init.py
@@ -14,7 +14,7 @@ from web3.exceptions import (
 def math_addr(MathContract, address_conversion_func):
     web3 = MathContract.web3
     deploy_txn = MathContract.constructor().transact({'from': web3.eth.coinbase})
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     return address_conversion_func(deploy_receipt['contractAddress'])
 

--- a/tests/core/contracts/test_contract_transact_interface.py
+++ b/tests/core/contracts/test_contract_transact_interface.py
@@ -20,7 +20,7 @@ from web3.exceptions import (
 def deploy(web3, Contract, apply_func=identity, args=None):
     args = args or []
     deploy_txn = Contract.constructor(*args).transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     address = apply_func(deploy_receipt['contractAddress'])
     contract = Contract(address=address)
@@ -71,7 +71,7 @@ def test_transacting_with_contract_no_arguments(web3, math_contract, transact, c
 
     txn_hash = transact(contract=math_contract,
                         contract_function='increment')
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     assert txn_receipt is not None
 
     final_value = call(contract=math_contract,
@@ -91,7 +91,7 @@ def test_transact_not_sending_ether_to_nonpayable_function(
     assert initial_value is False
     txn_hash = transact(contract=payable_tester_contract,
                         contract_function='doNoValueCall')
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     assert txn_receipt is not None
 
     final_value = call(contract=payable_tester_contract,
@@ -113,7 +113,7 @@ def test_transact_sending_ether_to_nonpayable_function(
         txn_hash = transact(contract=payable_tester_contract,
                             contract_function='doNoValueCall',
                             tx_params={'value': 1})
-        txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+        txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
         assert txn_receipt is not None
 
     final_value = call(contract=payable_tester_contract,
@@ -143,7 +143,7 @@ def test_transacting_with_contract_with_arguments(web3,
                         func_args=transact_args,
                         func_kwargs=transact_kwargs)
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     assert txn_receipt is not None
 
     final_value = call(contract=math_contract,
@@ -161,7 +161,7 @@ def test_deploy_when_default_account_is_set(web3,
     StringContract = web3.eth.contract(**STRING_CONTRACT)
 
     deploy_txn = StringContract.constructor("Caqalai").transact()
-    web3.eth.waitForTransactionReceipt(deploy_txn)
+    web3.eth.wait_for_transaction_receipt(deploy_txn)
     txn_after = web3.eth.get_transaction(deploy_txn)
     assert txn_after['from'] == web3.eth.default_account
 
@@ -186,7 +186,7 @@ def test_transacting_with_contract_with_string_argument(web3, string_contract, t
     txn_hash = transact(contract=string_contract,
                         contract_function='setValue',
                         func_args=["ÄLÄMÖLÖ".encode('utf8')])
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     assert txn_receipt is not None
 
     final_value = call(contract=string_contract,
@@ -208,7 +208,7 @@ def test_transacting_with_contract_with_bytes32_array_argument(web3,
     txn_hash = transact(contract=arrays_contract,
                         contract_function="setBytes32Value",
                         func_args=[new_bytes32_array])
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     assert txn_receipt is not None
 
     final_value = call(contract=arrays_contract,
@@ -221,7 +221,7 @@ def test_transacting_with_contract_with_byte_array_argument(web3, arrays_contrac
     txn_hash = transact(contract=arrays_contract,
                         contract_function='setByteValue',
                         func_args=[new_byte_array])
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     assert txn_receipt is not None
 
     final_value = call(contract=arrays_contract,
@@ -242,7 +242,7 @@ def test_transacting_with_contract_respects_explicit_gas(web3,
     StringContract = web3.eth.contract(**STRING_CONTRACT)
 
     deploy_txn = StringContract.constructor("Caqalai").transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn, 30)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn, 30)
     assert deploy_receipt is not None
     string_contract = StringContract(address=deploy_receipt['contractAddress'])
 
@@ -252,7 +252,7 @@ def test_transacting_with_contract_respects_explicit_gas(web3,
                         contract_function='setValue',
                         func_args=[to_bytes(text="ÄLÄMÖLÖ")],
                         tx_kwargs={'gas': 200000})
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash, 30)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash, 30)
     assert txn_receipt is not None
 
     final_value = call(contract=string_contract,
@@ -276,7 +276,7 @@ def test_auto_gas_computation_when_transacting(web3,
     StringContract = web3.eth.contract(**STRING_CONTRACT)
 
     deploy_txn = StringContract.constructor("Caqalai").transact()
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn, 30)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn, 30)
     assert deploy_receipt is not None
     string_contract = StringContract(address=deploy_receipt['contractAddress'])
 
@@ -287,7 +287,7 @@ def test_auto_gas_computation_when_transacting(web3,
     txn_hash = transact(contract=string_contract,
                         contract_function="setValue",
                         func_args=[to_bytes(text="ÄLÄMÖLÖ")])
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash, 30)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash, 30)
     assert txn_receipt is not None
 
     final_value = call(contract=string_contract,
@@ -302,7 +302,7 @@ def test_fallback_transacting_with_contract(web3, fallback_function_contract, ca
     initial_value = call(contract=fallback_function_contract,
                          contract_function='getData')
     txn_hash = fallback_function_contract.fallback.transact()
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     assert txn_receipt is not None
 
     final_value = call(contract=fallback_function_contract,

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -32,7 +32,7 @@ def Emitter(web3, EMITTER):
 def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_conversion_func):
     wait_for_block(web3)
     deploy_txn_hash = Emitter.constructor().transact({'from': web3.eth.coinbase, 'gas': 1000000})
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn_hash)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
     bytecode = web3.eth.get_code(contract_address)

--- a/tests/core/contracts/test_extracting_event_data_old.py
+++ b/tests/core/contracts/test_extracting_event_data_old.py
@@ -18,7 +18,7 @@ def Emitter(web3, EMITTER):
 def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_conversion_func):
     wait_for_block(web3)
     deploy_txn_hash = Emitter.constructor().transact({'from': web3.eth.coinbase, 'gas': 1000000})
-    deploy_receipt = web3.eth.waitForTransactionReceipt(deploy_txn_hash)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
     bytecode = web3.eth.get_code(contract_address)

--- a/tests/core/contracts/test_implicit_contract.py
+++ b/tests/core/contracts/test_implicit_contract.py
@@ -19,7 +19,7 @@ def math_contract(web3, MATH_ABI, MATH_CODE, MATH_RUNTIME, address_conversion_fu
         bytecode_runtime=MATH_RUNTIME,
     )
     tx_hash = MathContract.constructor().transact()
-    tx_receipt = web3.eth.waitForTransactionReceipt(tx_hash)
+    tx_receipt = web3.eth.wait_for_transaction_receipt(tx_hash)
     math_address = address_conversion_func(tx_receipt['contractAddress'])
     # Return interactive contract instance at deployed address
     # TODO Does parent class not implement 'deploy()' for a reason?

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -36,7 +36,7 @@ def test_send_transaction_with_valid_chain_id(web3, make_chain_id, expect_succes
     }
     if expect_success:
         txn_hash = web3.eth.send_transaction(transaction)
-        receipt = web3.eth.waitForTransactionReceipt(txn_hash, timeout=RECEIPT_TIMEOUT)
+        receipt = web3.eth.wait_for_transaction_receipt(txn_hash, timeout=RECEIPT_TIMEOUT)
         assert receipt.get('blockNumber') is not None
     else:
         with pytest.raises(ValidationError) as exc_info:
@@ -84,13 +84,13 @@ def test_send_transaction_with_ens_names(web3):
         }
 
         txn_hash = web3.eth.send_transaction(transaction)
-        receipt = web3.eth.waitForTransactionReceipt(txn_hash, timeout=RECEIPT_TIMEOUT)
+        receipt = web3.eth.wait_for_transaction_receipt(txn_hash, timeout=RECEIPT_TIMEOUT)
         assert receipt.get('blockNumber') is not None
 
 
 def test_wait_for_missing_receipt(web3):
     with pytest.raises(TimeExhausted):
-        web3.eth.waitForTransactionReceipt(b'\0' * 32, timeout=RECEIPT_TIMEOUT)
+        web3.eth.wait_for_transaction_receipt(b'\0' * 32, timeout=RECEIPT_TIMEOUT)
 
 
 def test_unmined_transaction_wait_for_receipt(web3):
@@ -103,6 +103,6 @@ def test_unmined_transaction_wait_for_receipt(web3):
     with pytest.raises(TransactionNotFound):
         web3.eth.get_transaction_receipt(txn_hash)
 
-    txn_receipt = web3.eth.waitForTransactionReceipt(txn_hash)
+    txn_receipt = web3.eth.wait_for_transaction_receipt(txn_hash)
     assert txn_receipt['transactionHash'] == txn_hash
     assert txn_receipt['blockHash'] is not None

--- a/tests/core/pm-module/test_pm_init.py
+++ b/tests/core/pm-module/test_pm_init.py
@@ -34,7 +34,7 @@ def test_get_contract_factory_with_valid_owned_manifest(w3):
     owned_package = w3.pm.get_package_from_manifest(owned_manifest)
     owned_factory = owned_package.get_contract_factory('Owned')
     tx_hash = owned_factory.constructor().transact()
-    tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     owned_address = tx_receipt.contractAddress
     owned_instance = owned_package.get_contract_instance("Owned", owned_address)
     assert owned_instance.abi == owned_factory.abi
@@ -45,7 +45,7 @@ def test_get_contract_factory_with_valid_safe_math_lib_manifest(w3):
     safe_math_package = w3.pm.get_package_from_manifest(safe_math_lib_manifest)
     safe_math_factory = safe_math_package.get_contract_factory("SafeMathLib")
     tx_hash = safe_math_factory.constructor().transact()
-    tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     safe_math_address = tx_receipt.contractAddress
     safe_math_instance = safe_math_package.get_contract_instance("SafeMathLib", safe_math_address)
     assert safe_math_instance.functions.safeAdd(1, 2).call() == 3
@@ -58,12 +58,12 @@ def test_get_contract_factory_with_valid_escrow_manifest(w3):
     assert escrow_factory.needs_bytecode_linking
     safe_send_factory = escrow_package.get_contract_factory('SafeSendLib')
     safe_send_tx_hash = safe_send_factory.constructor().transact()
-    safe_send_tx_receipt = w3.eth.waitForTransactionReceipt(safe_send_tx_hash)
+    safe_send_tx_receipt = w3.eth.wait_for_transaction_receipt(safe_send_tx_hash)
     safe_send_address = safe_send_tx_receipt.contractAddress
     linked_escrow_factory = escrow_factory.link_bytecode({"SafeSendLib": safe_send_address})
     assert linked_escrow_factory.needs_bytecode_linking is False
     escrow_tx_hash = linked_escrow_factory.constructor(w3.eth.accounts[0]).transact()
-    escrow_tx_receipt = w3.eth.waitForTransactionReceipt(escrow_tx_hash)
+    escrow_tx_receipt = w3.eth.wait_for_transaction_receipt(escrow_tx_hash)
     escrow_address = escrow_tx_receipt.contractAddress
     escrow_instance = linked_escrow_factory(address=escrow_address)
     assert escrow_instance.functions.sender().call() == w3.eth.accounts[0]

--- a/tests/core/tools/pytest_ethereum/test_linker.py
+++ b/tests/core/tools/pytest_ethereum/test_linker.py
@@ -62,7 +62,7 @@ def test_linker_with_callback(escrow_deployer, w3):
     def callback_fn(package):
         escrow_instance = package.deployments.get_instance("Escrow")
         tx_hash = escrow_instance.functions.releaseFunds().transact({"from": sender})
-        w3.eth.waitForTransactionReceipt(tx_hash)
+        w3.eth.wait_for_transaction_receipt(tx_hash)
 
     escrow_strategy = linker(
         deploy("SafeSendLib", transaction={"from": sender}),

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -45,7 +45,7 @@ def deploy(w3, Factory, from_address, args=None):
     args = args or []
     factory = Factory(w3)
     deploy_txn = factory.constructor(*args).transact({'from': from_address})
-    deploy_receipt = w3.eth.waitForTransactionReceipt(deploy_txn)
+    deploy_receipt = w3.eth.wait_for_transaction_receipt(deploy_txn)
     assert deploy_receipt is not None
     return factory(address=deploy_receipt['contractAddress'])
 

--- a/tests/ethpm/integration/test_escrow_manifest.py
+++ b/tests/ethpm/integration/test_escrow_manifest.py
@@ -38,7 +38,7 @@ def test_deployed_escrow_and_safe_send(escrow_manifest, w3):
     escrow_tx_hash = LinkedEscrowFactory.constructor(
         "0x4F5B11c860b37b68DE6D14Fb7e7b5f18A9A1bdC0"
     ).transact()
-    escrow_tx_receipt = w3.eth.waitForTransactionReceipt(escrow_tx_hash)
+    escrow_tx_receipt = w3.eth.wait_for_transaction_receipt(escrow_tx_hash)
     escrow_address = escrow_tx_receipt.contractAddress
 
     # Cannot deploy with an unlinked factory

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -24,7 +24,7 @@ def safe_math_package(get_manifest, w3):
 def deployed_safe_math(safe_math_package, w3):
     SafeMath = safe_math_package.get_contract_factory("SafeMathLib")
     tx_hash = SafeMath.constructor().transact()
-    tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+    tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     return safe_math_package, tx_receipt.contractAddress
 
 

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -167,7 +167,7 @@ def generate_go_ethereum_fixture(destination_dir):
 
 
 def verify_chain_state(web3, chain_data):
-    receipt = web3.eth.waitForTransactionReceipt(chain_data['mined_txn_hash'])
+    receipt = web3.eth.wait_for_transaction_receipt(chain_data['mined_txn_hash'])
     latest = web3.eth.get_block('latest')
     assert receipt.blockNumber <= latest.number
 
@@ -175,7 +175,7 @@ def verify_chain_state(web3, chain_data):
 def mine_transaction_hash(web3, txn_hash):
     web3.geth.miner.start(1)
     try:
-        return web3.eth.waitForTransactionReceipt(txn_hash, timeout=120)
+        return web3.eth.wait_for_transaction_receipt(txn_hash, timeout=120)
     finally:
         web3.geth.miner.stop()
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -61,7 +61,7 @@ def math_contract_deploy_txn_hash(web3, math_contract_factory):
 
 @pytest.fixture(scope="module")
 def math_contract(web3, math_contract_factory, math_contract_deploy_txn_hash):
-    deploy_receipt = web3.eth.waitForTransactionReceipt(math_contract_deploy_txn_hash)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(math_contract_deploy_txn_hash)
     assert is_dict(deploy_receipt)
     contract_address = deploy_receipt['contractAddress']
     assert is_checksum_address(contract_address)
@@ -85,7 +85,7 @@ def emitter_contract_deploy_txn_hash(web3, emitter_contract_factory):
 
 @pytest.fixture(scope="module")
 def emitter_contract(web3, emitter_contract_factory, emitter_contract_deploy_txn_hash):
-    deploy_receipt = web3.eth.waitForTransactionReceipt(emitter_contract_deploy_txn_hash)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(emitter_contract_deploy_txn_hash)
     assert is_dict(deploy_receipt)
     contract_address = deploy_receipt['contractAddress']
     assert is_checksum_address(contract_address)
@@ -152,7 +152,7 @@ def revert_contract_deploy_txn_hash(web3, revert_contract_factory):
 
 @pytest.fixture(scope="module")
 def revert_contract(web3, revert_contract_factory, revert_contract_deploy_txn_hash):
-    deploy_receipt = web3.eth.waitForTransactionReceipt(revert_contract_deploy_txn_hash)
+    deploy_receipt = web3.eth.wait_for_transaction_receipt(revert_contract_deploy_txn_hash)
     assert is_dict(deploy_receipt)
     contract_address = deploy_receipt['contractAddress']
     assert is_checksum_address(contract_address)

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -735,7 +735,7 @@ class EthModuleTest:
             'gasPrice': web3.eth.gas_price,
         }
         txn_hash = web3.eth.send_transaction(txn_params)
-        web3.eth.waitForTransactionReceipt(txn_hash)
+        web3.eth.wait_for_transaction_receipt(txn_hash)
 
         txn_params['gasPrice'] = Wei(web3.eth.gas_price * 2)
         with pytest.raises(ValueError, match="Supplied transaction with hash"):

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -417,7 +417,13 @@ class Eth(ModuleV2, Module):
         mungers=[default_root_munger]
     )
 
+    @deprecated_for("wait_for_transaction_receipt")
     def waitForTransactionReceipt(
+        self, transaction_hash: _Hash32, timeout: int = 120, poll_latency: float = 0.1
+    ) -> TxReceipt:
+        return self.wait_for_transaction_receipt(transaction_hash, timeout, poll_latency)
+
+    def wait_for_transaction_receipt(
         self, transaction_hash: _Hash32, timeout: int = 120, poll_latency: float = 0.1
     ) -> TxReceipt:
         try:

--- a/web3/pm.py
+++ b/web3/pm.py
@@ -250,7 +250,7 @@ class SimpleRegistry(ERC1319Registry):
         tx_hash = self.registry.functions.release(
             package_name, version, manifest_uri
         ).transact()
-        self.w3.eth.waitForTransactionReceipt(tx_hash)
+        self.w3.eth.wait_for_transaction_receipt(tx_hash)
         return self._get_release_id(package_name, version)
 
     def _get_package_name(self, package_id: bytes) -> str:
@@ -308,7 +308,7 @@ class SimpleRegistry(ERC1319Registry):
         registry_package = Package(manifest, w3)
         registry_factory = registry_package.get_contract_factory(ContractName("PackageRegistry"))
         tx_hash = registry_factory.constructor().transact()
-        tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+        tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
         return cls(tx_receipt["contractAddress"], w3)
 
 

--- a/web3/tools/pytest_ethereum/linker.py
+++ b/web3/tools/pytest_ethereum/linker.py
@@ -70,7 +70,7 @@ def _deploy(
             "builder tool, use `contract_type(..., runtime_bytecode=True)`."
         )
     tx_hash = factory.constructor(*args).transact(transaction)
-    tx_receipt = package.w3.eth.waitForTransactionReceipt(tx_hash)
+    tx_receipt = package.w3.eth.wait_for_transaction_receipt(tx_hash)
     # Create manifest copy with new deployment instance
     latest_block_uri = create_latest_block_uri(package.w3, 0)
     deployment_data = create_deployment_data(


### PR DESCRIPTION
### What was wrong?
Added wait_for_transaction_receipt, deprecated waitForTransactionReceipt

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/86/83/5d/86835d9eb004b21f584b67ecc3ffb13d.jpg)
