### PR TITLE
Add get_transaction_from_block, deprecate getTransactionFromBlock

### DIFF
--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1410,10 +1410,13 @@ class EthModuleTest:
         failure = web3.eth.uninstallFilter(filter.filter_id)
         assert failure is False
 
-    def test_eth_getTransactionFromBlock_deprecation(
+    def test_eth_getTransactionFromBlock_deprecated(
         self, web3: "Web3", block_with_txn: BlockData
     ) -> None:
-        with pytest.raises(DeprecationWarning):
+        with pytest.warns(
+                DeprecationWarning,
+                match="getTransactionFromBlock is deprecated in favor of "
+                      "get_transaction_from_block"):
             web3.eth.getTransactionFromBlock(block_with_txn['hash'], 0)
 
     def test_eth_getCompilers_deprecation(self, web3: "Web3") -> None:

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -399,7 +399,13 @@ class Eth(ModuleV2, Module):
         mungers=[default_root_munger]
     )
 
+    @deprecated_for("get_transaction_from_block")
     def getTransactionFromBlock(
+        self, block_identifier: BlockIdentifier, transaction_index: int
+    ) -> NoReturn:
+        return self.get_transaction_from_block(block_identifier, transaction_index)
+
+    def get_transaction_from_block(
         self, block_identifier: BlockIdentifier, transaction_index: int
     ) -> NoReturn:
         """


### PR DESCRIPTION
### What was wrong?
Added modify_transaction, deprecated modifyTransaction

Related to Issue #1429

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/736x/e8/9a/ae/e89aae77cead87e332063ce9a9140d0e.jpg)
