### PR TITLE
readme: replace gitter link with discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web3.py
 
 [![Documentation Status](https://readthedocs.org/projects/web3py/badge/?version=latest)](https://web3py.readthedocs.io/en/latest/?badge=latest)
-[![Join the chat at https://gitter.im/ethereum/web3.py](https://badges.gitter.im/ethereum/web3.py.svg)](https://gitter.im/ethereum/web3.py?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Discord](https://img.shields.io/discord/809793915578089484?color=blue&label=chat&logo=discord&logoColor=white)](https://discord.gg/GHryRvPB84)
 [![Build Status](https://circleci.com/gh/ethereum/web3.py.svg?style=shield)](https://circleci.com/gh/ethereum/web3.py)
 
 A Python library for interacting with Ethereum, inspired by [web3.js](https://github.com/ethereum/web3.js).

--- a/newsfragments/1898.doc.rst
+++ b/newsfragments/1898.doc.rst
@@ -1,0 +1,1 @@
+Promote the new Ethereum Python Discord server on the README.


### PR DESCRIPTION
### What was wrong?
The new Ethereum Python Discord server is where the cool kids hang out now.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.pinimg.com/originals/5a/55/cd/5a55cdaa898df8a8b89dc8b1f7bf5b78.jpg)
