### PR TITLE
deprecate setContractFactory in favor of snakecased set_contract_factory

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1210,10 +1210,14 @@ Contracts
 
     See :doc:`./contracts` for more information about how to use contracts.
 
-.. py:method:: Eth.setContractFactory(contractFactoryClass)
+.. py:method:: Eth.set_contract_factory(contractFactoryClass)
 
     Modify the default contract factory from ``Contract`` to ``contractFactoryClass``.
     Future calls to ``Eth.contract()`` will then default to ``contractFactoryClass``.
 
     An example of an alternative Contract Factory is ``ConciseContract``.
 
+.. py:method:: Eth.setContractFactory(contractFactoryClass)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.set_contract_factory()`

--- a/newsfragments/1900.feature.rst
+++ b/newsfragments/1900.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.set_contract_factory`` deprecate ``w3.eth.setContractFactory``

--- a/tests/core/eth-module/test_eth_contract.py
+++ b/tests/core/eth-module/test_eth_contract.py
@@ -38,6 +38,6 @@ def test_contract_address_validation(web3, args, kwargs, expected):
 
 def test_set_contract_factory(web3):
     factoryClass = Mock()
-    web3.eth.setContractFactory(factoryClass)
+    web3.eth.set_contract_factory(factoryClass)
     web3.eth.contract(contract_name='myname')
     factoryClass.factory.assert_called_once_with(web3, contract_name='myname')

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -638,7 +638,13 @@ class Eth(ModuleV2, Module):
         else:
             return ContractFactory
 
+    @deprecated_for("set_contract_factory")
     def setContractFactory(
+        self, contractFactory: Type[Union[Contract, ConciseContract, ContractCaller]]
+    ) -> None:
+        return self.set_contract_factory(contractFactory)
+
+    def set_contract_factory(
         self, contractFactory: Type[Union[Contract, ConciseContract, ContractCaller]]
     ) -> None:
         self.defaultContractFactory = contractFactory


### PR DESCRIPTION
### What was wrong?
Added set_contract_factory, deprecated setContractFactory

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.burgesspetcare.com/wp-content/uploads/2020/02/april-blog-1.jpg)
