### PR TITLE
deprecate generateGasPrice in favor of snakecased generate_gas_price

### DIFF
--- a/docs/gas_price.rst
+++ b/docs/gas_price.rst
@@ -16,11 +16,11 @@ Retrieving gas price
 --------------------
 
 To retreive the gas price using the selected strategy simply call
-:meth:`~web3.eth.Eth.generateGasPrice`
+:meth:`~web3.eth.Eth.generate_gas_price`
 
 .. code-block:: python
 
-    >>> Web3.eth.generateGasPrice()
+    >>> Web3.eth.generate_gas_price()
     20000000000
 
 Creating a gas price strategy

--- a/docs/gas_price.rst
+++ b/docs/gas_price.rst
@@ -20,7 +20,7 @@ To retreive the gas price using the selected strategy simply call
 
 .. code-block:: python
 
-    >>> Web3.eth.generate_gas_price()
+    >>> web3.eth.generate_gas_price()
     20000000000
 
 Creating a gas price strategy

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -180,7 +180,7 @@ API
 - :meth:`web3.eth.sign() <web3.eth.Eth.sign>`
 - :meth:`web3.eth.signTypedData() <web3.eth.Eth.signTypedData>`
 - :meth:`web3.eth.estimateGas() <web3.eth.Eth.estimateGas>`
-- :meth:`web3.eth.generateGasPrice() <web3.eth.Eth.generateGasPrice>`
+- :meth:`web3.eth.generate_gas_price() <web3.eth.Eth.generate_gas_price>`
 - :meth:`web3.eth.setGasPriceStrategy() <web3.eth.Eth.setGasPriceStrategy>`
 
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -980,7 +980,7 @@ The following methods are available on the ``web3.eth`` namespace.
 .. py:method:: Eth.generateGasPrice(transaction_params=None)
 
     .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.generate_gas_price_strategy()`
+      :meth:`~web3.eth.Eth.generate_gas_price()`
 
 .. py:method:: Eth.setGasPriceStrategy(gas_price_strategy)
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -970,7 +970,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> Web3.eth.generate_gas_price()
+        >>> web3.eth.generate_gas_price()
         20000000000
 
     .. note::

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -960,7 +960,7 @@ The following methods are available on the ``web3.eth`` namespace.
         nodes would result in an error like:  ``ValueError: {'code': -32602, 'message': 'too many arguments, want at most 1'}``
 
 
-.. py:method:: Eth.generateGasPrice(transaction_params=None)
+.. py:method:: Eth.generate_gas_price(transaction_params=None)
 
     Uses the selected gas price strategy to calculate a gas price. This method
     returns the gas price denominated in wei.
@@ -970,12 +970,17 @@ The following methods are available on the ``web3.eth`` namespace.
 
     .. code-block:: python
 
-        >>> Web3.eth.generateGasPrice()
+        >>> Web3.eth.generate_gas_price()
         20000000000
 
     .. note::
         For information about how gas price can be customized in web3 see
         :ref:`Gas_Price`.
+
+.. py:method:: Eth.generateGasPrice(transaction_params=None)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.generate_gas_price_strategy()`
 
 .. py:method:: Eth.setGasPriceStrategy(gas_price_strategy)
 

--- a/newsfragments/1905.feature.rst
+++ b/newsfragments/1905.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.generate_gas_price`` deprecate ``w3.eth.generateGasPrice``

--- a/tests/core/eth-module/test_gas_pricing.py
+++ b/tests/core/eth-module/test_gas_pricing.py
@@ -16,11 +16,13 @@ def test_get_set_gasPrice(web3):
 def test_no_gas_price_strategy_returns_none(web3):
     assert web3.eth.generate_gas_price() is None
 
+
 def test_generateGasPrice_deprecated(web3):
     with pytest.warns(DeprecationWarning,
                       match='generateGasPrice is deprecated in favor of generate_gas_price'):
         gas_price = web3.eth.generateGasPrice()
     assert gas_price is None
+
 
 def test_set_gas_price_strategy(web3):
     def my_gas_price_strategy(web3, transaction_params):

--- a/tests/core/eth-module/test_gas_pricing.py
+++ b/tests/core/eth-module/test_gas_pricing.py
@@ -14,14 +14,14 @@ def test_get_set_gasPrice(web3):
 
 
 def test_no_gas_price_strategy_returns_none(web3):
-    assert web3.eth.generateGasPrice() is None
+    assert web3.eth.generate_gas_price() is None
 
 
 def test_set_gas_price_strategy(web3):
     def my_gas_price_strategy(web3, transaction_params):
         return 5
     web3.eth.setGasPriceStrategy(my_gas_price_strategy)
-    assert web3.eth.generateGasPrice() == 5
+    assert web3.eth.generate_gas_price() == 5
 
 
 def test_gas_price_strategy_calls(web3):
@@ -31,5 +31,5 @@ def test_gas_price_strategy_calls(web3):
     }
     my_gas_price_strategy = Mock(return_value=5)
     web3.eth.setGasPriceStrategy(my_gas_price_strategy)
-    assert web3.eth.generateGasPrice(transaction) == 5
+    assert web3.eth.generate_gas_price(transaction) == 5
     my_gas_price_strategy.assert_called_once_with(web3, transaction)

--- a/tests/core/eth-module/test_gas_pricing.py
+++ b/tests/core/eth-module/test_gas_pricing.py
@@ -16,6 +16,11 @@ def test_get_set_gasPrice(web3):
 def test_no_gas_price_strategy_returns_none(web3):
     assert web3.eth.generate_gas_price() is None
 
+def test_generateGasPrice_deprecated(web3):
+    with pytest.warns(DeprecationWarning,
+                      match='generateGasPrice is deprecated in favor of generate_gas_price'):
+        gas_price = web3.eth.generateGasPrice()
+    assert gas_price is None
 
 def test_set_gas_price_strategy(web3):
     def my_gas_price_strategy(web3, transaction_params):

--- a/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
+++ b/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
@@ -164,7 +164,7 @@ def test_time_based_gas_price_strategy(strategy_params, expected):
         **strategy_params,
     )
     w3.eth.setGasPriceStrategy(time_based_gas_price_strategy)
-    actual = w3.eth.generateGasPrice()
+    actual = w3.eth.generate_gas_price()
     assert actual == expected
 
 
@@ -217,5 +217,5 @@ def test_time_based_gas_price_strategy_zero_sample(strategy_params_zero,
             **strategy_params_zero,
         )
         w3.eth.setGasPriceStrategy(time_based_gas_price_strategy_zero)
-        w3.eth.generateGasPrice()
+        w3.eth.generate_gas_price()
     assert str(excinfo.value) == expected_exception_message

--- a/tests/core/middleware/test_gas_price_strategy.py
+++ b/tests/core/middleware/test_gas_price_strategy.py
@@ -18,14 +18,14 @@ def the_gas_price_strategy_middleware(web3):
 
 
 def test_gas_price_generated(the_gas_price_strategy_middleware):
-    the_gas_price_strategy_middleware.web3.eth.generateGasPrice.return_value = 5
+    the_gas_price_strategy_middleware.web3.eth.generate_gas_price.return_value = 5
     method = 'eth_sendTransaction'
     params = [{
         'to': '0x0',
         'value': 1,
     }]
     the_gas_price_strategy_middleware(method, params)
-    the_gas_price_strategy_middleware.web3.eth.generateGasPrice.assert_called_once_with({
+    the_gas_price_strategy_middleware.web3.eth.generate_gas_price.assert_called_once_with({
         'to': '0x0',
         'value': 1,
     })
@@ -37,7 +37,7 @@ def test_gas_price_generated(the_gas_price_strategy_middleware):
 
 
 def test_gas_price_not_overridden(the_gas_price_strategy_middleware):
-    the_gas_price_strategy_middleware.web3.eth.generateGasPrice.return_value = 5
+    the_gas_price_strategy_middleware.web3.eth.generate_gas_price.return_value = 5
     method = 'eth_sendTransaction'
     params = [{
         'to': '0x0',
@@ -53,7 +53,7 @@ def test_gas_price_not_overridden(the_gas_price_strategy_middleware):
 
 
 def test_gas_price_not_set_without_gas_price_strategy(the_gas_price_strategy_middleware):
-    the_gas_price_strategy_middleware.web3.eth.generateGasPrice.return_value = None
+    the_gas_price_strategy_middleware.web3.eth.generate_gas_price.return_value = None
     method = 'eth_sendTransaction'
     params = [{
         'to': '0x0',

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -53,7 +53,7 @@ TRANSACTION_DEFAULTS = {
     'value': 0,
     'data': b'',
     'gas': lambda web3, tx: web3.eth.estimateGas(tx),
-    'gasPrice': lambda web3, tx: web3.eth.generateGasPrice(tx) or web3.eth.gas_price,
+    'gasPrice': lambda web3, tx: web3.eth.generate_gas_price(tx) or web3.eth.gas_price,
     'chainId': lambda web3, tx: web3.eth.chain_id,
 }
 
@@ -198,7 +198,7 @@ def prepare_replacement_transaction(
         if new_transaction['gasPrice'] <= current_transaction['gasPrice']:
             raise ValueError('Supplied gas price must exceed existing transaction gas price')
     else:
-        generated_gas_price = web3.eth.generateGasPrice(new_transaction)
+        generated_gas_price = web3.eth.generate_gas_price(new_transaction)
         minimum_gas_price = int(math.ceil(current_transaction['gasPrice'] * gas_multiplier))
         if generated_gas_price and generated_gas_price > minimum_gas_price:
             new_transaction = assoc(new_transaction, 'gasPrice', generated_gas_price)

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -657,7 +657,11 @@ class Eth(ModuleV2, Module):
         mungers=None,
     )
 
+    @deprecated_for("generate_gas_price")
     def generateGasPrice(self, transaction_params: Optional[TxParams] = None) -> Optional[Wei]:
+        return self.generate_gas_price(transaction_params)
+
+    def generate_gas_price(self, transaction_params: Optional[TxParams] = None) -> Optional[Wei]:
         if self.gasPriceStrategy:
             return self.gasPriceStrategy(self.web3, transaction_params)
         return None

--- a/web3/middleware/gas_price_strategy.py
+++ b/web3/middleware/gas_price_strategy.py
@@ -27,7 +27,7 @@ def gas_price_strategy_middleware(
         if method == 'eth_sendTransaction':
             transaction = params[0]
             if 'gasPrice' not in transaction:
-                generated_gas_price = web3.eth.generateGasPrice(transaction)
+                generated_gas_price = web3.eth.generate_gas_price(transaction)
                 if generated_gas_price is not None:
                     transaction = assoc(transaction, 'gasPrice', generated_gas_price)
                     return make_request(method, [transaction])


### PR DESCRIPTION
### What was wrong?
Added generate_gas_price, deprecated generateGasPrice

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.wkms.org/sites/wkms/files/202001/groundhog-4688628_1920.jpg)
