### PR TITLE
deprecate setGasPriceStrategy in favor of snakecased set_gas_price_strategy

### DIFF
--- a/docs/gas_price.rst
+++ b/docs/gas_price.rst
@@ -53,7 +53,7 @@ returns a higher gas price when the value of the transaction is higher than
 Selecting the gas price strategy
 --------------------------------
 
-The gas price strategy can be set by calling :meth:`~web3.eth.Eth.setGasPriceStrategy`.
+The gas price strategy can be set by calling :meth:`~web3.eth.Eth.set_gas_price_strategy`.
 
 .. code-block:: python
 
@@ -63,7 +63,7 @@ The gas price strategy can be set by calling :meth:`~web3.eth.Eth.setGasPriceStr
         ...
 
     w3 = Web3(...)
-    w3.eth.setGasPriceStrategy(value_based_gas_price_strategy)
+    w3.eth.set_gas_price_strategy(value_based_gas_price_strategy)
 
 Available gas price strategies
 ------------------------------
@@ -111,7 +111,7 @@ Available gas price strategies
         from web3.gas_strategies.time_based import medium_gas_price_strategy
 
         w3 = Web3()
-        w3.eth.setGasPriceStrategy(medium_gas_price_strategy)
+        w3.eth.set_gas_price_strategy(medium_gas_price_strategy)
 
         w3.middleware_onion.add(middleware.time_based_cache_middleware)
         w3.middleware_onion.add(middleware.latest_block_based_cache_middleware)

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -181,7 +181,7 @@ API
 - :meth:`web3.eth.sign_typed_data() <web3.eth.Eth.sign_typed_data>`
 - :meth:`web3.eth.estimateGas() <web3.eth.Eth.estimateGas>`
 - :meth:`web3.eth.generate_gas_price() <web3.eth.Eth.generate_gas_price>`
-- :meth:`web3.eth.setGasPriceStrategy() <web3.eth.Eth.setGasPriceStrategy>`
+- :meth:`web3.eth.set_gas_price_strategy() <web3.eth.Eth.set_gas_price_strategy>`
 
 
 .. _overview_contracts:

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -991,10 +991,15 @@ The following methods are available on the ``web3.eth`` namespace.
     .. warning:: Deprecated: This method is deprecated in favor of
       :meth:`~web3.eth.Eth.generate_gas_price()`
 
-.. py:method:: Eth.setGasPriceStrategy(gas_price_strategy)
+.. py:method:: Eth.set_gas_price_strategy(gas_price_strategy)
 
     Set the selected gas price strategy. It must be a method of the signature
     ``(web3, transaction_params)`` and return a gas price denominated in wei.
+
+.. py:method:: Eth.setGasPriceStrategy(gas_price_strategy)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.set_gas_price_strategy()`
 
 Filters
 -------

--- a/newsfragments/1906.feature.rst
+++ b/newsfragments/1906.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.set_gas_price_strategy`` deprecate ``w3.eth.setGasPriceStrategy``

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -127,7 +127,7 @@ def test_build_transaction_with_contract_default_account_is_set(
 def test_build_transaction_with_gas_price_strategy_set(web3, math_contract, buildTransaction):
     def my_gas_price_strategy(web3, transaction_params):
         return 5
-    web3.eth.setGasPriceStrategy(my_gas_price_strategy)
+    web3.eth.set_gas_price_strategy(my_gas_price_strategy)
     txn = buildTransaction(contract=math_contract, contract_function='increment')
     assert dissoc(txn, 'gas') == {
         'to': math_contract.address,

--- a/tests/core/eth-module/test_gas_pricing.py
+++ b/tests/core/eth-module/test_gas_pricing.py
@@ -27,7 +27,16 @@ def test_generateGasPrice_deprecated(web3):
 def test_set_gas_price_strategy(web3):
     def my_gas_price_strategy(web3, transaction_params):
         return 5
-    web3.eth.setGasPriceStrategy(my_gas_price_strategy)
+    web3.eth.set_gas_price_strategy(my_gas_price_strategy)
+    assert web3.eth.generate_gas_price() == 5
+
+
+def test_setGasPriceStrategy_deprecated(web3):
+    my_gas_price_strategy = Mock(return_value=5)
+    with pytest.warns(DeprecationWarning,
+                      match="setGasPriceStrategy is deprecated in favor of "
+                            "set_gas_price_strategy"):
+        web3.eth.setGasPriceStrategy(my_gas_price_strategy)
     assert web3.eth.generate_gas_price() == 5
 
 
@@ -37,6 +46,6 @@ def test_gas_price_strategy_calls(web3):
         'value': 1000000000
     }
     my_gas_price_strategy = Mock(return_value=5)
-    web3.eth.setGasPriceStrategy(my_gas_price_strategy)
+    web3.eth.set_gas_price_strategy(my_gas_price_strategy)
     assert web3.eth.generate_gas_price(transaction) == 5
     my_gas_price_strategy.assert_called_once_with(web3, transaction)

--- a/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
+++ b/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
@@ -163,7 +163,7 @@ def test_time_based_gas_price_strategy(strategy_params, expected):
     time_based_gas_price_strategy = construct_time_based_gas_price_strategy(
         **strategy_params,
     )
-    w3.eth.setGasPriceStrategy(time_based_gas_price_strategy)
+    w3.eth.set_gas_price_strategy(time_based_gas_price_strategy)
     actual = w3.eth.generate_gas_price()
     assert actual == expected
 
@@ -216,6 +216,6 @@ def test_time_based_gas_price_strategy_zero_sample(strategy_params_zero,
         time_based_gas_price_strategy_zero = construct_time_based_gas_price_strategy(
             **strategy_params_zero,
         )
-        w3.eth.setGasPriceStrategy(time_based_gas_price_strategy_zero)
+        w3.eth.set_gas_price_strategy(time_based_gas_price_strategy_zero)
         w3.eth.generate_gas_price()
     assert str(excinfo.value) == expected_exception_message

--- a/tests/core/utilities/test_prepare_transaction_replacement.py
+++ b/tests/core/utilities/test_prepare_transaction_replacement.py
@@ -91,7 +91,7 @@ def test_prepare_transaction_replacement_gas_price_defaulting_when_strategy_hige
     def higher_gas_price_strategy(web3, txn):
         return 20
 
-    web3.eth.setGasPriceStrategy(higher_gas_price_strategy)
+    web3.eth.set_gas_price_strategy(higher_gas_price_strategy)
 
     current_transaction = SIMPLE_CURRENT_TRANSACTION
     new_transaction = {
@@ -109,7 +109,7 @@ def test_prepare_transaction_replacement_gas_price_defaulting_when_strategy_lowe
     def lower_gas_price_strategy(web3, txn):
         return 5
 
-    web3.eth.setGasPriceStrategy(lower_gas_price_strategy)
+    web3.eth.set_gas_price_strategy(lower_gas_price_strategy)
 
     current_transaction = SIMPLE_CURRENT_TRANSACTION
     new_transaction = {

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -860,7 +860,7 @@ class EthModuleTest:
         def higher_gas_price_strategy(web3: "Web3", txn: TxParams) -> Wei:
             return Wei(20)
 
-        web3.eth.setGasPriceStrategy(higher_gas_price_strategy)
+        web3.eth.set_gas_price_strategy(higher_gas_price_strategy)
 
         txn_params.pop('gasPrice')
         replace_txn_hash = web3.eth.replace_transaction(txn_hash, txn_params)
@@ -882,7 +882,7 @@ class EthModuleTest:
         def lower_gas_price_strategy(web3: "Web3", txn: TxParams) -> Wei:
             return Wei(5)
 
-        web3.eth.setGasPriceStrategy(lower_gas_price_strategy)
+        web3.eth.set_gas_price_strategy(lower_gas_price_strategy)
 
         txn_params.pop('gasPrice')
         replace_txn_hash = web3.eth.replace_transaction(txn_hash, txn_params)

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -676,7 +676,11 @@ class Eth(ModuleV2, Module):
             return self.gasPriceStrategy(self.web3, transaction_params)
         return None
 
+    @deprecated_for("set_gas_price_strategy")
     def setGasPriceStrategy(self, gas_price_strategy: GasPriceStrategy) -> None:
+        return self.set_gas_price_strategy(gas_price_strategy)
+
+    def set_gas_price_strategy(self, gas_price_strategy: GasPriceStrategy) -> None:
         self.gasPriceStrategy = gas_price_strategy
 
     # Deprecated Methods


### PR DESCRIPTION
### What was wrong?
Added set_gas_price_strategy, deprecated set_gas_price_strategy

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.theconversation.com/files/38079/original/f69dt6kv-1387326807.jpg?ixlib=rb-1.1.0&q=45&auto=format&w=1200&h=675.0&fit=crop)
