### PR TITLE
Update contributing.rst

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,7 +24,7 @@ Install all development dependencies:
 
 .. code:: sh
 
-    $ pip install -e .[dev]
+    $ pip install -e ".[dev]"
 
 
 Using Docker

--- a/newsfragments/1909.doc.rst
+++ b/newsfragments/1909.doc.rst
@@ -1,0 +1,1 @@
+Escape reserved characters in install script of Contributing docs.


### PR DESCRIPTION
Doc update: In some shells (zsh), `[]` are reserved characters, so we need to escape them. The old example only works in Bash.

#### Cute Animal Picture

```
\|/          (__)    
     `\------(oo)
       ||    (__)
       ||w--||     \|/
   \|/
```
