### PR TITLE
deprecate estimateGas in favor of estimate_gas

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -229,7 +229,7 @@ Each Contract Factory exposes the following methods.
     will accept ENS names.
 
     If a ``gas`` value is not provided, then the ``gas`` value for the
-    deployment transaction will be created using the ``web3.eth.estimateGas()``
+    deployment transaction will be created using the ``web3.eth.estimate_gas()``
     method.
 
     Returns the transaction hash for the deploy transaction.
@@ -343,7 +343,7 @@ Each Contract Factory exposes the following methods.
     will accept ENS names.
 
     If a ``gas`` value is not provided, then the ``gas`` value for the
-    deployment transaction will be created using the ``web3.eth.estimateGas()``
+    deployment transaction will be created using the ``web3.eth.estimate_gas()``
     method.
 
     Returns the transaction hash for the deploy transaction.
@@ -765,7 +765,7 @@ Methods
     will accept ENS names.
 
     If a ``gas`` value is not provided, then the ``gas`` value for the
-    method transaction will be created using the ``web3.eth.estimateGas()``
+    method transaction will be created using the ``web3.eth.estimate_gas()``
     method.
 
     Returns the transaction hash.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -179,7 +179,7 @@ API
 - :meth:`web3.eth.get_transaction_receipt() <web3.eth.Eth.get_transaction_receipt>`
 - :meth:`web3.eth.sign() <web3.eth.Eth.sign>`
 - :meth:`web3.eth.sign_typed_data() <web3.eth.Eth.sign_typed_data>`
-- :meth:`web3.eth.estimateGas() <web3.eth.Eth.estimateGas>`
+- :meth:`web3.eth.estimate_gas() <web3.eth.Eth.estimate_gas>`
 - :meth:`web3.eth.generate_gas_price() <web3.eth.Eth.generate_gas_price>`
 - :meth:`web3.eth.set_gas_price_strategy() <web3.eth.Eth.set_gas_price_strategy>`
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -732,9 +732,9 @@ The following methods are available on the ``web3.eth`` namespace.
 
     If the ``transaction`` specifies a ``data`` value but does not specify
     ``gas`` then the ``gas`` value will be populated using the
-    :meth:`~web3.eth.Eth.estimateGas()` function with an additional buffer of ``100000``
+    :meth:`~web3.eth.Eth.estimate_gas()` function with an additional buffer of ``100000``
     gas up to the ``gasLimit`` of the latest block.  In the event that the
-    value returned by :meth:`~web3.eth.Eth.estimateGas()` method is greater than the
+    value returned by :meth:`~web3.eth.Eth.estimate_gas()` method is greater than the
     ``gasLimit`` a ``ValueError`` will be raised.
 
 
@@ -947,7 +947,7 @@ The following methods are available on the ``web3.eth`` namespace.
     In most cases it is better to make contract function call through the :py:class:`web3.contract.Contract` interface.
 
 
-.. py:method:: Eth.estimateGas(transaction, block_identifier=None)
+.. py:method:: Eth.estimate_gas(transaction, block_identifier=None)
 
     * Delegates to ``eth_estimateGas`` RPC Method
 
@@ -956,18 +956,17 @@ The following methods are available on the ``web3.eth`` namespace.
     be used as a gas estimate.
 
     The ``transaction`` and ``block_identifier`` parameters are handled in the
-    same manner as the :meth:`~web3.eth.call()` method.
+    same manner as the :meth:`~web3.eth.Eth.send_transaction()` method.
 
     .. code-block:: python
 
-        >>> web3.eth.estimateGas({'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'from': web3.eth.coinbase, 'value': 12345})
+        >>> web3.eth.estimate_gas({'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'from':web3.eth.coinbase, 'value': 12345})
         21000
 
-    .. note::
-        The parameter ``block_identifier`` is not enabled in geth nodes,
-        hence passing a value of ``block_identifier`` when connected to a geth
-        nodes would result in an error like:  ``ValueError: {'code': -32602, 'message': 'too many arguments, want at most 1'}``
+.. py:method:: Eth.estimateGas(transaction, block_identifier=None)
 
+    .. warning:: Deprecated: This method is deprecated in favor of
+      :meth:`~web3.eth.Eth.estimate_gas()`
 
 .. py:method:: Eth.generate_gas_price(transaction_params=None)
 

--- a/newsfragments/1913.feature.rst
+++ b/newsfragments/1913.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.estimate_gas`` deprecate ``w3.eth.estimateGas``

--- a/tests/integration/parity/common.py
+++ b/tests/integration/parity/common.py
@@ -27,10 +27,10 @@ class ParityWeb3ModuleTest(Web3ModuleTest):
 
 class ParityEthModuleTest(EthModuleTest):
     @pytest.mark.xfail(reason='Parity returns a gas value even when a function will revert')
-    def test_eth_estimateGas_revert_with_msg(self, web3, revert_contract, unlocked_account):
-        super().test_eth_estimateGas_revert_with_msg(web3, revert_contract, unlocked_account)
+    def test_eth_estimate_gas_revert_with_msg(self, web3, revert_contract, unlocked_account):
+        super().test_eth_estimate_gas_revert_with_msg(web3, revert_contract, unlocked_account)
 
-    def test_eth_estimateGas_revert_without_msg(
+    def test_eth_estimate_gas_revert_without_msg(
         self,
         web3,
         revert_contract,
@@ -44,7 +44,7 @@ class ParityEthModuleTest(EthModuleTest):
                     "to": revert_contract.address,
                 },
             )
-            web3.eth.estimateGas(txn_params)
+            web3.eth.estimate_gas(txn_params)
 
     @pytest.mark.xfail(reason='Parity dropped "pending" option in 1.11.1')
     def test_eth_getBlockByNumber_pending(self, web3):

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -350,10 +350,10 @@ class TestEthereumTesterEthModule(EthModuleTest):
     def test_eth_get_storage_at_ens_name(self, web3, emitter_contract_address):
         super().test_eth_get_storage_at_ens_name(web3, emitter_contract_address)
 
-    def test_eth_estimateGas_with_block(self,
-                                        web3,
-                                        unlocked_account_dual_type):
-        super().test_eth_estimateGas_with_block(
+    def test_eth_estimate_gas_with_block(self,
+                                         web3,
+                                         unlocked_account_dual_type):
+        super().test_eth_estimate_gas_with_block(
             web3, unlocked_account_dual_type
         )
 
@@ -401,7 +401,7 @@ class TestEthereumTesterEthModule(EthModuleTest):
             )
             web3.eth.call(txn_params)
 
-    def test_eth_estimateGas_revert_with_msg(self, web3, revert_contract, unlocked_account):
+    def test_eth_estimate_gas_revert_with_msg(self, web3, revert_contract, unlocked_account):
         with pytest.raises(TransactionFailed,
                            match='execution reverted: Function has been reverted'):
             txn_params = revert_contract._prepare_transaction(
@@ -411,9 +411,9 @@ class TestEthereumTesterEthModule(EthModuleTest):
                     "to": revert_contract.address,
                 },
             )
-            web3.eth.estimateGas(txn_params)
+            web3.eth.estimate_gas(txn_params)
 
-    def test_eth_estimateGas_revert_without_msg(self, web3, revert_contract, unlocked_account):
+    def test_eth_estimate_gas_revert_without_msg(self, web3, revert_contract, unlocked_account):
         with pytest.raises(TransactionFailed, match="execution reverted"):
             txn_params = revert_contract._prepare_transaction(
                 fn_name="revertWithoutMessage",
@@ -422,7 +422,7 @@ class TestEthereumTesterEthModule(EthModuleTest):
                     "to": revert_contract.address,
                 },
             )
-            web3.eth.estimateGas(txn_params)
+            web3.eth.estimate_gas(txn_params)
 
 
 class TestEthereumTesterVersionModule(VersionModuleTest):

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1021,7 +1021,7 @@ class EthModuleTest:
             )
             web3.eth.call(txn_params)
 
-    def test_eth_estimateGas_revert_with_msg(
+    def test_eth_estimate_gas_revert_with_msg(
         self,
         web3: "Web3",
         revert_contract: "Contract",
@@ -1036,9 +1036,9 @@ class EthModuleTest:
                     "to": revert_contract.address,
                 },
             )
-            web3.eth.estimateGas(txn_params)
+            web3.eth.estimate_gas(txn_params)
 
-    def test_eth_estimateGas_revert_without_msg(
+    def test_eth_estimate_gas_revert_without_msg(
         self,
         web3: "Web3",
         revert_contract: "Contract",
@@ -1052,12 +1052,12 @@ class EthModuleTest:
                     "to": revert_contract.address,
                 },
             )
-            web3.eth.estimateGas(txn_params)
+            web3.eth.estimate_gas(txn_params)
 
-    def test_eth_estimateGas(
+    def test_eth_estimate_gas(
         self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
-        gas_estimate = web3.eth.estimateGas({
+        gas_estimate = web3.eth.estimate_gas({
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
@@ -1065,10 +1065,23 @@ class EthModuleTest:
         assert is_integer(gas_estimate)
         assert gas_estimate > 0
 
-    def test_eth_estimateGas_with_block(
+    def test_eth_estimateGas_deprecated(
         self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
-        gas_estimate = web3.eth.estimateGas({
+        with pytest.warns(DeprecationWarning,
+                          match="estimateGas is deprecated in favor of estimate_gas"):
+            gas_estimate = web3.eth.estimateGas({
+                'from': unlocked_account_dual_type,
+                'to': unlocked_account_dual_type,
+                'value': Wei(1),
+            })
+        assert is_integer(gas_estimate)
+        assert gas_estimate > 0
+
+    def test_eth_estimate_gas_with_block(
+        self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        gas_estimate = web3.eth.estimate_gas({
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -52,7 +52,7 @@ VALID_TRANSACTION_PARAMS: List[TX_PARAM_LITERALS] = [
 TRANSACTION_DEFAULTS = {
     'value': 0,
     'data': b'',
-    'gas': lambda web3, tx: web3.eth.estimateGas(tx),
+    'gas': lambda web3, tx: web3.eth.estimate_gas(tx),
     'gasPrice': lambda web3, tx: web3.eth.generate_gas_price(tx) or web3.eth.gas_price,
     'chainId': lambda web3, tx: web3.eth.chain_id,
 }
@@ -124,7 +124,7 @@ def get_buffered_gas_estimate(
 ) -> Wei:
     gas_estimate_transaction = cast(TxParams, dict(**transaction))
 
-    gas_estimate = web3.eth.estimateGas(gas_estimate_transaction)
+    gas_estimate = web3.eth.estimate_gas(gas_estimate_transaction)
 
     gas_limit = get_block_gas_limit(web3)
 

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -639,7 +639,7 @@ class ContractConstructor:
 
         estimate_gas_transaction['data'] = self.data_in_transaction
 
-        return self.web3.eth.estimateGas(
+        return self.web3.eth.estimate_gas(
             estimate_gas_transaction, block_identifier=block_identifier
         )
 
@@ -1615,7 +1615,7 @@ def estimate_gas_for_function(
         fn_kwargs=kwargs,
     )
 
-    return web3.eth.estimateGas(estimate_transaction, block_identifier)
+    return web3.eth.estimate_gas(estimate_transaction, block_identifier)
 
 
 def build_transaction_for_function(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -559,7 +559,7 @@ class Eth(ModuleV2, Module):
 
         return params
 
-    estimateGas: Method[Callable[..., Wei]] = Method(
+    estimate_gas: Method[Callable[..., Wei]] = Method(
         RPC.eth_estimateGas,
         mungers=[estimate_gas_munger]
     )
@@ -707,6 +707,7 @@ class Eth(ModuleV2, Module):
     submitHashrate = DeprecatedMethod(submit_hashrate, 'submitHashrate', 'submit_hashrate')
     submitWork = DeprecatedMethod(submit_work, 'submitWork', 'submit_work')
     getLogs = DeprecatedMethod(get_logs, 'getLogs', 'get_logs')
+    estimateGas = DeprecatedMethod(estimate_gas, 'estimateGas', 'estimate_gas')
     sendRawTransaction = DeprecatedMethod(send_raw_transaction,
                                           'sendRawTransaction',
                                           'send_raw_transaction')

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -298,7 +298,7 @@ def guess_from(web3: "Web3", transaction: TxParams) -> ChecksumAddress:
 
 
 def guess_gas(web3: "Web3", transaction: TxParams) -> Wei:
-    return Wei(web3.eth.estimateGas(transaction) * 2)
+    return Wei(web3.eth.estimate_gas(transaction) * 2)
 
 
 @curry


### PR DESCRIPTION
### What was wrong?
Added estimate_gas, deprecated estimateGas

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()