### PR TITLE
deprecate getFilterChanges in favor of get_filter_changes

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -64,7 +64,7 @@ Filter Class
     Retrieve new entries for this filter.
 
     Logs will be retrieved using the
-    :func:`web3.eth.Eth.getFilterChanges` which returns only new entries since the last
+    :func:`web3.eth.Eth.get_filter_changes` which returns only new entries since the last
     poll.
 
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -278,7 +278,7 @@ API
 ^^^
 
 - :meth:`web3.eth.filter() <web3.eth.Eth.filter>`
-- :meth:`web3.eth.getFilterChanges() <web3.eth.Eth.getFilterChanges>`
+- :meth:`web3.eth.get_filter_changes() <web3.eth.Eth.get_filter_changes>`
 - :meth:`web3.eth.get_filter_logs() <web3.eth.Eth.get_filter_logs>`
 - :meth:`web3.eth.uninstall_filter() <web3.eth.Eth.uninstall_filter>`
 - :meth:`web3.eth.get_logs() <web3.eth.Eth.get_logs>`

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1060,7 +1060,7 @@ with the filtering API.
         >>> web3.eth.filter({'fromBlock': 1000000, 'toBlock': 1000100, 'address': '0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B'})
         <LogFilter at 0x10b7803d8>
 
-.. py:method:: Eth.getFilterChanges(self, filter_id)
+.. py:method:: Eth.get_filter_changes(self, filter_id)
 
     * Delegates to ``eth_getFilterChanges`` RPC Method.
 
@@ -1070,7 +1070,7 @@ with the filtering API.
     .. code-block:: python
 
         >>> filt = web3.eth.filter()
-        >>> web3.eth.getFilterChanges(filt.filter_id)
+        >>> web3.eth.get_filter_changes(filt.filter_id)
         [
             {
                 'address': '0xDc3A9Db694BCdd55EBaE4A89B22aC6D12b3F0c24',
@@ -1086,6 +1086,12 @@ with the filtering API.
             },
             ...
         ]
+
+
+.. py:method:: Eth.getFilterChanges(self, filter_id)
+
+    .. warning:: Deprecated: This property is deprecated in favor of
+      :meth:`~web3.eth.Eth.get_filter_changes()`
 
 
 .. py:method:: Eth.get_filter_logs(self, filter_id)

--- a/newsfragments/1916.feature.rst
+++ b/newsfragments/1916.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.get_filter_changes`` deprecate ``w3.eth.getFilterChanges``

--- a/tests/core/middleware/test_filter_middleware.py
+++ b/tests/core/middleware/test_filter_middleware.py
@@ -149,10 +149,10 @@ def test_local_filter_middleware(w3, iter_block_number):
 
     log_filter = w3.eth.filter(filter_params={'fromBlock': 'latest'})
 
-    assert w3.eth.getFilterChanges(block_filter.filter_id) == [HexBytes(BLOCK_HASH)]
+    assert w3.eth.get_filter_changes(block_filter.filter_id) == [HexBytes(BLOCK_HASH)]
 
     iter_block_number.send(2)
-    results = w3.eth.getFilterChanges(log_filter.filter_id)
+    results = w3.eth.get_filter_changes(log_filter.filter_id)
     assert results == FILTER_LOG
 
     assert w3.eth.get_filter_logs(log_filter.filter_id) == FILTER_LOG

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -161,7 +161,7 @@ class Filter:
         return filter(self.is_valid_entry, entries)
 
     def get_new_entries(self) -> List[LogReceipt]:
-        log_entries = self._filter_valid_entries(self.eth_module.getFilterChanges(self.filter_id))
+        log_entries = self._filter_valid_entries(self.eth_module.get_filter_changes(self.filter_id))
         return self._format_log_entries(log_entries)
 
     def get_all_entries(self) -> List[LogReceipt]:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -161,10 +161,8 @@ class EthModuleTest:
     def test_eth_getBalance_deprecated(self, web3: "Web3") -> None:
         coinbase = web3.eth.coinbase
 
-        with pytest.warns(DeprecationWarning):
-            with pytest.raises(InvalidAddress):
-                web3.eth.getBalance(ChecksumAddress(HexAddress(HexStr(coinbase.lower()))))
-
+        with pytest.warns(DeprecationWarning,
+                          match='getBalance is deprecated in favor of get_balance'):
             balance = web3.eth.getBalance(coinbase)
 
         assert is_integer(balance)
@@ -1298,7 +1296,7 @@ class EthModuleTest:
     def test_eth_newFilter(self, web3: "Web3") -> None:
         filter = web3.eth.filter({})
 
-        changes = web3.eth.getFilterChanges(filter.filter_id)
+        changes = web3.eth.get_filter_changes(filter.filter_id)
         assert is_list_like(changes)
         assert not changes
 
@@ -1312,7 +1310,7 @@ class EthModuleTest:
     def test_eth_newFilter_deprecated(self, web3: "Web3") -> None:
         filter = web3.eth.filter({})
 
-        changes = web3.eth.getFilterChanges(filter.filter_id)
+        changes = web3.eth.get_filter_changes(filter.filter_id)
         assert is_list_like(changes)
         assert not changes
 
@@ -1329,7 +1327,7 @@ class EthModuleTest:
         filter = web3.eth.filter('latest')
         assert is_string(filter.filter_id)
 
-        changes = web3.eth.getFilterChanges(filter.filter_id)
+        changes = web3.eth.get_filter_changes(filter.filter_id)
         assert is_list_like(changes)
         assert not changes
 
@@ -1345,7 +1343,7 @@ class EthModuleTest:
         filter = web3.eth.filter('pending')
         assert is_string(filter.filter_id)
 
-        changes = web3.eth.getFilterChanges(filter.filter_id)
+        changes = web3.eth.get_filter_changes(filter.filter_id)
         assert is_list_like(changes)
         assert not changes
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -600,7 +600,7 @@ class Eth(ModuleV2, Module):
         mungers=[filter_munger],
     )
 
-    getFilterChanges: Method[Callable[[HexStr], List[LogReceipt]]] = Method(
+    get_filter_changes: Method[Callable[[HexStr], List[LogReceipt]]] = Method(
         RPC.eth_getFilterChanges,
         mungers=[default_root_munger]
     )
@@ -716,3 +716,6 @@ class Eth(ModuleV2, Module):
                                              'get_transaction_receipt')
     uninstallFilter = DeprecatedMethod(uninstall_filter, 'uninstallFilter', 'uninstall_filter')
     getFilterLogs = DeprecatedMethod(get_filter_logs, 'getFilterLogs', 'get_filter_logs')
+    getFilterChanges = DeprecatedMethod(get_filter_changes,
+                                        'getFilterChanges',
+                                        'get_filter_changes')


### PR DESCRIPTION
### What was wrong?
Added get_filter_changes, deprecated getFilterChanges

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()