### PR TITLE
deprecate getFilterLogs in favor of get_filter_logs

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -73,7 +73,7 @@ Filter Class
     Retrieve all entries for this filter.
 
     Logs will be retrieved using the
-    :func:`web3.eth.Eth.getFilterLogs` which returns all entries that match the given
+    :func:`web3.eth.Eth.get_filter_logs` which returns all entries that match the given
     filter.
 
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -279,7 +279,7 @@ API
 
 - :meth:`web3.eth.filter() <web3.eth.Eth.filter>`
 - :meth:`web3.eth.getFilterChanges() <web3.eth.Eth.getFilterChanges>`
-- :meth:`web3.eth.getFilterLogs() <web3.eth.Eth.getFilterLogs>`
+- :meth:`web3.eth.get_filter_logs() <web3.eth.Eth.get_filter_logs>`
 - :meth:`web3.eth.uninstallFilter() <web3.eth.Eth.uninstallFilter>`
 - :meth:`web3.eth.getLogs() <web3.eth.Eth.getLogs>`
 - :meth:`Contract.events.your_event_name.createFilter() <web3.contract.Contract.events.your_event_name.createFilter>`

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1070,16 +1070,16 @@ with the filtering API.
         ]
 
 
-.. py:method:: Eth.getFilterLogs(self, filter_id)
+.. py:method:: Eth.get_filter_logs(self, filter_id)
 
-    * Delegates to ``eth_getFilterLogs`` RPC Method.
+    * Delegates to ``eth_get_filter_logs`` RPC Method.
 
     Returns all entries for the given ``filter_id``
 
     .. code-block:: python
 
         >>> filt = web3.eth.filter()
-        >>> web3.eth.getFilterLogs(filt.filter_id)
+        >>> web3.eth.get_filter_logs(filt.filter_id)
         [
             {
                 'address': '0xDc3A9Db694BCdd55EBaE4A89B22aC6D12b3F0c24',
@@ -1096,6 +1096,11 @@ with the filtering API.
             ...
         ]
 
+
+.. py:method:: Eth.getFilterLogs(self, filter_id)
+
+    .. warning:: Deprecated: This property is deprecated in favor of
+      :attr:`~web3.eth.Eth.get_filter_logs()`
 
 .. py:method:: Eth.uninstallFilter(self, filter_id)
 
@@ -1116,7 +1121,7 @@ with the filtering API.
 .. py:method:: Eth.getLogs(filter_params)
 
     This is the equivalent of: creating a new
-    filter, running :meth:`~Eth.getFilterLogs`, and then uninstalling the filter. See
+    filter, running :meth:`~Eth.get_filter_logs`, and then uninstalling the filter. See
     :meth:`~Eth.filter` for details on allowed filter parameters.
 
 

--- a/newsfragments/1923.feature.rst
+++ b/newsfragments/1923.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.get_filter_logs`` deprecate ``w3.eth.getFilterLogs``

--- a/tests/core/middleware/test_filter_middleware.py
+++ b/tests/core/middleware/test_filter_middleware.py
@@ -155,7 +155,7 @@ def test_local_filter_middleware(w3, iter_block_number):
     results = w3.eth.getFilterChanges(log_filter.filter_id)
     assert results == FILTER_LOG
 
-    assert w3.eth.getFilterLogs(log_filter.filter_id) == FILTER_LOG
+    assert w3.eth.get_filter_logs(log_filter.filter_id) == FILTER_LOG
 
     filter_ids = (
         block_filter.filter_id,

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -165,7 +165,7 @@ class Filter:
         return self._format_log_entries(log_entries)
 
     def get_all_entries(self) -> List[LogReceipt]:
-        log_entries = self._filter_valid_entries(self.eth_module.getFilterLogs(self.filter_id))
+        log_entries = self._filter_valid_entries(self.eth_module.get_filter_logs(self.filter_id))
         return self._format_log_entries(log_entries)
 
     def _format_log_entries(self,

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1241,7 +1241,7 @@ class EthModuleTest:
         assert is_list_like(changes)
         assert not changes
 
-        logs = web3.eth.getFilterLogs(filter.filter_id)
+        logs = web3.eth.get_filter_logs(filter.filter_id)
         assert is_list_like(logs)
         assert not logs
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -595,7 +595,7 @@ class Eth(ModuleV2, Module):
         mungers=[default_root_munger]
     )
 
-    getFilterLogs: Method[Callable[[HexStr], List[LogReceipt]]] = Method(
+    get_filter_logs: Method[Callable[[HexStr], List[LogReceipt]]] = Method(
         RPC.eth_getFilterLogs,
         mungers=[default_root_munger]
     )
@@ -685,6 +685,7 @@ class Eth(ModuleV2, Module):
     getUncleCount = DeprecatedMethod(get_uncle_count, 'getUncleCount', 'get_uncle_count')
     sendTransaction = DeprecatedMethod(send_transaction, 'sendTransaction', 'send_transaction')
     signTransaction = DeprecatedMethod(sign_transaction, 'signTransaction', 'sign_transaction')
+    getFilterLogs = DeprecatedMethod(get_filter_logs, 'getFilterLogs', 'get_filter_logs')
     sendRawTransaction = DeprecatedMethod(send_raw_transaction,
                                           'sendRawTransaction',
                                           'send_raw_transaction')


### PR DESCRIPTION
### What was wrong?
Added get_filter_logs, deprecated getFilterLogs

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()