### PR TITLE
deprecate uninstallFilter in favor of uninstall_filter

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -280,7 +280,7 @@ API
 - :meth:`web3.eth.filter() <web3.eth.Eth.filter>`
 - :meth:`web3.eth.getFilterChanges() <web3.eth.Eth.getFilterChanges>`
 - :meth:`web3.eth.getFilterLogs() <web3.eth.Eth.getFilterLogs>`
-- :meth:`web3.eth.uninstallFilter() <web3.eth.Eth.uninstallFilter>`
+- :meth:`web3.eth.uninstall_filter() <web3.eth.Eth.uninstall_filter>`
 - :meth:`web3.eth.getLogs() <web3.eth.Eth.getLogs>`
 - :meth:`Contract.events.your_event_name.createFilter() <web3.contract.Contract.events.your_event_name.createFilter>`
 - :meth:`Contract.events.your_event_name.build_filter() <web3.contract.Contract.events.your_event_name.build_filter>`

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1097,9 +1097,9 @@ with the filtering API.
         ]
 
 
-.. py:method:: Eth.uninstallFilter(self, filter_id)
+.. py:method:: Eth.uninstall_filter(self, filter_id)
 
-    * Delegates to ``eth_uninstallFilter`` RPC Method.
+    * Delegates to ``eth_uninstall_filter`` RPC Method.
 
     Uninstalls the filter specified by the given ``filter_id``.  Returns
     boolean as to whether the filter was successfully uninstalled.
@@ -1107,11 +1107,15 @@ with the filtering API.
     .. code-block:: python
 
         >>> filt = web3.eth.filter()
-        >>> web3.eth.uninstallFilter(filt.filter_id)
+        >>> web3.eth.uninstall_filter(filt.filter_id)
         True
-        >>> web3.eth.uninstallFilter(filt.filter_id)
+        >>> web3.eth.uninstall_filter(filt.filter_id)
         False  # already uninstalled.
 
+.. py:method:: Eth.uninstallFilter(self, filter_id)
+
+    .. warning:: Deprecated: This property is deprecated in favor of
+      :attr:`~web3.eth.Eth.uninstall_filter()`
 
 .. py:method:: Eth.getLogs(filter_params)
 

--- a/newsfragments/1924.feature.rst
+++ b/newsfragments/1924.feature.rst
@@ -1,0 +1,1 @@
+deprecate uninstallFilter in favor of uninstall_filter

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1245,7 +1245,7 @@ class EthModuleTest:
         assert is_list_like(logs)
         assert not logs
 
-        result = web3.eth.uninstallFilter(filter.filter_id)
+        result = web3.eth.uninstall_filter(filter.filter_id)
         assert result is True
 
     def test_eth_newBlockFilter(self, web3: "Web3") -> None:
@@ -1261,7 +1261,7 @@ class EthModuleTest:
         # assert is_list_like(logs)
         # assert not logs
 
-        result = web3.eth.uninstallFilter(filter.filter_id)
+        result = web3.eth.uninstall_filter(filter.filter_id)
         assert result is True
 
     def test_eth_newPendingTransactionFilter(self, web3: "Web3") -> None:
@@ -1277,7 +1277,7 @@ class EthModuleTest:
         # assert is_list_like(logs)
         # assert not logs
 
-        result = web3.eth.uninstallFilter(filter.filter_id)
+        result = web3.eth.uninstall_filter(filter.filter_id)
         assert result is True
 
     def test_eth_getLogs_without_logs(
@@ -1440,7 +1440,17 @@ class EthModuleTest:
         if pending_call_result != 1:
             raise AssertionError("pending call result was %d instead of 1" % pending_call_result)
 
-    def test_eth_uninstallFilter(self, web3: "Web3") -> None:
+    def test_eth_uninstall_filter_deprecated(self, web3: "Web3") -> None:
+        filter = web3.eth.filter({})
+        assert is_string(filter.filter_id)
+
+        success = web3.eth.uninstall_filter(filter.filter_id)
+        assert success is True
+
+        failure = web3.eth.uninstall_filter(filter.filter_id)
+        assert failure is False
+
+    def test_eth_uninstallFilter_deprecated(self, web3: "Web3") -> None:
         filter = web3.eth.filter({})
         assert is_string(filter.filter_id)
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -615,7 +615,7 @@ class Eth(ModuleV2, Module):
         mungers=[default_root_munger],
     )
 
-    uninstallFilter: Method[Callable[[HexStr], bool]] = Method(
+    uninstall_filter: Method[Callable[[HexStr], bool]] = Method(
         RPC.eth_uninstallFilter,
         mungers=[default_root_munger],
     )
@@ -685,6 +685,7 @@ class Eth(ModuleV2, Module):
     getUncleCount = DeprecatedMethod(get_uncle_count, 'getUncleCount', 'get_uncle_count')
     sendTransaction = DeprecatedMethod(send_transaction, 'sendTransaction', 'send_transaction')
     signTransaction = DeprecatedMethod(sign_transaction, 'signTransaction', 'sign_transaction')
+    uninstallFilter = DeprecatedMethod(uninstall_filter, 'uninstallFilter', 'uninstall_filter')
     sendRawTransaction = DeprecatedMethod(send_raw_transaction,
                                           'sendRawTransaction',
                                           'send_raw_transaction')


### PR DESCRIPTION
### What was wrong?
Added uninstall_filter, deprecated uninstallFilter

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()