### PR TITLE
change pypiwin32 to pywin32

### DIFF
--- a/newsfragments/1930.misc.rst
+++ b/newsfragments/1930.misc.rst
@@ -1,0 +1,1 @@
+Removed the unsupported pypiwin32 in favor of the supported pywin32.

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         "jsonschema>=3.2.0,<4.0.0",
         "lru-dict>=1.1.6,<2.0.0",
         "protobuf>=3.10.0,<4",
-        "pypiwin32>=223;platform_system=='Windows'",
+        "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
         # remove typing_extensions after python_requires>=3.8, see web3._utils.compat
          "typing-extensions>=3.7.4.1,<4;python_version<'3.8'",


### PR DESCRIPTION
### What was wrong?
pypiwin32 is outdated. pywin32 is newer and can be found on conda-forge. We'll probably want to update pywin32, as 223 is not the most recent, but can save that for a different PR. 

Closes #1742, #1721, #1892

### How was it fixed?
I finally got around to adding a CI smoke test for windows, which was a blocker for merging the initial PR. 

The initial commit was really outdated, so I just cherry-picked the commit and put it on top of the most recent master. Retained initial commit authorship - thanks @step21!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/112878148-d21b0100-9084-11eb-9570-64bbaa0eb35e.png)

