### PR TITLE
Add existing contract interaction to docs example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -267,6 +267,32 @@ If the transaction has not yet been mined then this method will return ``None``.
 Working with Contracts
 ----------------------
 
+
+Interacting with existing contracts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to use an existing contract, you'll need its deployed address and its ABI.
+Both can be found using block explorers, like Etherscan. Once you instantiate a contract
+instance, you can read data and execute transactions.
+
+.. code-block:: python
+
+    # Configure w3, e.g., w3 = Web3(...)
+    address = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F988'
+    abi = '[{"inputs":[{"internalType":"address","name":"account","type":"address"},{"internalType":"address","name":"minter_","type":"address"},...'
+    contract_instance = w3.eth.contract(address=address, abi=abi)
+
+    # read state:
+    contract_instance.functions.storedValue().call()
+    # 42
+
+    # update state:
+    tx_hash = contract.functions.updateValue(43).transact()
+
+
+Deploying new contracts
+~~~~~~~~~~~~~~~~~~~~~~~
+
 Given the following solidity source file stored at ``contract.sol``.
 
 .. code-block:: javascript

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -287,7 +287,7 @@ instance, you can read data and execute transactions.
     # 42
 
     # update state:
-    tx_hash = contract.functions.updateValue(43).transact()
+    tx_hash = contract_instance.functions.updateValue(43).transact()
 
 
 Deploying new contracts

--- a/newsfragments/1933.doc.rst
+++ b/newsfragments/1933.doc.rst
@@ -1,0 +1,1 @@
+Add existing contract interaction to docs examples.


### PR DESCRIPTION
### What was wrong?

Most folks are looking to interact with an existing contract, so the example with a full deployment is overkill.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.ebayimg.com/images/g/wdEAAOxyOlhSyzLa/s-l300.jpg)
