### PR TITLE
Add get_work, deprecate getWork

### DIFF
--- a/newsfragments/1934.feature.rst
+++ b/newsfragments/1934.feature.rst
@@ -1,0 +1,1 @@
+Add ``w3.eth.get_work``, deprecate ``w3.eth.getWork``

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -662,7 +662,7 @@ class Eth(ModuleV2, Module):
     def getCompilers(self) -> NoReturn:
         raise DeprecationWarning("This method has been deprecated as of EIP 1474.")
 
-    getWork: Method[Callable[[], List[HexBytes]]] = Method(
+    get_work: Method[Callable[[], List[HexBytes]]] = Method(
         RPC.eth_getWork,
         mungers=None,
     )
@@ -719,3 +719,4 @@ class Eth(ModuleV2, Module):
     getFilterChanges = DeprecatedMethod(get_filter_changes,
                                         'getFilterChanges',
                                         'get_filter_changes')
+    getWork = DeprecatedMethod(get_work, 'getWork', 'get_work')


### PR DESCRIPTION
### What was wrong?
Moved get_work to snake case, deprecated getWork.

There were no tests, nor usages outside of the definition to change. I did manually test and it looked like it was working as expected. 

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/113630596-5c370c80-9625-11eb-99e2-3eab20b02d67.png)

