### PR TITLE
Remove snake dep warnings

### DIFF
--- a/newsfragments/1935.misc.rst
+++ b/newsfragments/1935.misc.rst
@@ -1,0 +1,1 @@
+Removes some stray depreaction warnings for getBalance, uninstallFilter, and protocolVersion

--- a/tests/core/middleware/test_transaction_signing.py
+++ b/tests/core/middleware/test_transaction_signing.py
@@ -282,7 +282,7 @@ def test_signed_transaction(
     else:
         start_balance = w3.eth.get_balance(_transaction.get('from', w3.eth.accounts[0]))
         w3.eth.send_transaction(_transaction)
-        assert w3.eth.getBalance(_transaction.get('from')) <= start_balance + expected
+        assert w3.eth.get_balance(_transaction.get('from')) <= start_balance + expected
 
 
 @pytest.mark.parametrize(

--- a/tests/core/version-module/test_version_module.py
+++ b/tests/core/version-module/test_version_module.py
@@ -53,4 +53,5 @@ async def test_async_blocking_version(async_w3, blocking_w3):
     assert async_w3.async_version.api == blocking_w3.api
 
     assert await async_w3.async_version.node == blocking_w3.clientVersion
-    assert await async_w3.async_version.ethereum == blocking_w3.eth.protocol_version
+    with pytest.warns(DeprecationWarning):
+        assert await async_w3.async_version.ethereum == blocking_w3.eth.protocol_version

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1306,7 +1306,7 @@ class EthModuleTest:
         assert is_list_like(logs)
         assert not logs
 
-        result = web3.eth.uninstallFilter(filter.filter_id)
+        result = web3.eth.uninstall_filter(filter.filter_id)
         assert result is True
 
     def test_eth_newFilter_deprecated(self, web3: "Web3") -> None:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -60,7 +60,9 @@ if TYPE_CHECKING:
 
 class EthModuleTest:
     def test_eth_protocol_version(self, web3: "Web3") -> None:
-        protocol_version = web3.eth.protocol_version
+        with pytest.warns(DeprecationWarning,
+                          match="This method has been deprecated in some clients"):
+            protocol_version = web3.eth.protocol_version
 
         assert is_string(protocol_version)
         assert protocol_version.isdigit()
@@ -1558,7 +1560,9 @@ class EthModuleTest:
     def test_eth_submitHashrate_deprecated(self, web3: "Web3") -> None:
         # node_id from EIP 1474: https://github.com/ethereum/EIPs/pull/1474/files
         node_id = HexStr('59daa26581d0acd1fce254fb7e85952f4c09d0915afd33d3886cd914bc7d283c')
-        result = web3.eth.submitHashrate(5000, node_id)
+        with pytest.warns(DeprecationWarning,
+                          match='submitHashrate is deprecated in favor of submit_hashrate'):
+            result = web3.eth.submitHashrate(5000, node_id)
         assert result is True
 
     def test_eth_submit_work(self, web3: "Web3") -> None:

--- a/web3/_utils/module_testing/version_module.py
+++ b/web3/_utils/module_testing/version_module.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
 
 class VersionModuleTest:
     def test_eth_protocol_version(self, web3: "Web3") -> None:
-        protocol_version = web3.eth.protocol_version
+        with pytest.warns(DeprecationWarning):
+            protocol_version = web3.eth.protocol_version
 
         assert is_string(protocol_version)
         assert protocol_version.isdigit()


### PR DESCRIPTION
### What was wrong?
There were a couple DeprecationWarnings that ended up uncaught, probably because of merge conflict resolution, etc. 

Related to Issue #1429

### How was it fixed?
used a pytest.warns to catch the DeprecationWarnings, or changed to use the correct method name.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/113632515-863dfe00-9628-11eb-87f9-67df27bf2446.png)

