### PR TITLE
Add third arg state override set. Fix #1921

### DIFF
--- a/newsfragments/1921.feature.rst
+++ b/newsfragments/1921.feature.rst
@@ -1,0 +1,1 @@
+Handle optional ``eth_call`` state override param.

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -378,6 +378,10 @@ class TestEthereumTesterEthModule(EthModuleTest):
                                                                 block_with_txn,
                                                                 mined_txn_hash)
 
+    @pytest.mark.xfail(raises=TypeError, reason="call override param not implemented on eth-tester")
+    def test_eth_call_with_override(self, web3, revert_contract):
+        super().test_eth_call_with_override(web3, revert_contract)
+
     def test_eth_call_revert_with_msg(self, web3, revert_contract, unlocked_account):
         with pytest.raises(TransactionFailed,
                            match='execution reverted: Function has been reverted'):

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -974,6 +974,28 @@ class EthModuleTest:
         result = web3.codec.decode_single('uint256', call_result)
         assert result == 18
 
+    def test_eth_call_with_override(
+        self, web3: "Web3", revert_contract: "Contract"
+    ) -> None:
+        coinbase = web3.eth.coinbase
+        txn_params = revert_contract._prepare_transaction(
+            fn_name='normalFunction',
+            transaction={'from': coinbase, 'to': revert_contract.address},
+        )
+        call_result = web3.eth.call(txn_params)
+        result = web3.codec.decode_single('bool', call_result)
+        assert result is True
+
+        # override runtime bytecode: `normalFunction` returns `false`
+        override_code = '0x6080604052348015600f57600080fd5b5060043610603c5760003560e01c8063185c38a4146041578063c06a97cb146049578063d67e4b84146051575b600080fd5b60476071565b005b604f60df565b005b605760e4565b604051808215151515815260200191505060405180910390f35b6040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252601b8152602001807f46756e6374696f6e20686173206265656e2072657665727465642e000000000081525060200191505060405180910390fd5b600080fd5b60008090509056fea2646970667358221220bb71e9e9a2e271cd0fbe833524a3ea67df95f25ea13aef5b0a761fa52b538f1064736f6c63430006010033'  # noqa: E501
+        call_result = web3.eth.call(
+            txn_params,
+            'latest',
+            {revert_contract.address: {'code': override_code}}
+        )
+        result = web3.codec.decode_single('bool', call_result)
+        assert result is False
+
     def test_eth_call_with_0_result(
         self, web3: "Web3", math_contract: "Contract"
     ) -> None:

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -521,8 +521,9 @@ class Eth(ModuleV2, Module):
     def call_munger(
         self,
         transaction: TxParams,
-        block_identifier: Optional[BlockIdentifier] = None
-    ) -> Tuple[TxParams, BlockIdentifier]:
+        block_identifier: Optional[BlockIdentifier] = None,
+        state_override: Optional[TxParams] = None,
+    ) -> Tuple[TxParams, BlockIdentifier, TxParams]:
         # TODO: move to middleware
         if 'from' not in transaction and is_checksum_address(self.default_account):
             transaction = assoc(transaction, 'from', self.default_account)
@@ -531,7 +532,7 @@ class Eth(ModuleV2, Module):
         if block_identifier is None:
             block_identifier = self.default_block
 
-        return (transaction, block_identifier)
+        return (transaction, block_identifier, state_override)
 
     call: Method[Callable[..., Union[bytes, bytearray]]] = Method(
         RPC.eth_call,

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -88,6 +88,7 @@ from web3.types import (
     ENS,
     BlockData,
     BlockIdentifier,
+    CallOverrideParams,
     FilterParams,
     GasPriceStrategy,
     LogReceipt,
@@ -522,8 +523,8 @@ class Eth(ModuleV2, Module):
         self,
         transaction: TxParams,
         block_identifier: Optional[BlockIdentifier] = None,
-        state_override: Optional[TxParams] = None,
-    ) -> Tuple[TxParams, BlockIdentifier, TxParams]:
+        state_override: Optional[CallOverrideParams] = None,
+    ) -> Union[Tuple[TxParams, BlockIdentifier], Tuple[TxParams, BlockIdentifier, CallOverrideParams]]:  # noqa-E501
         # TODO: move to middleware
         if 'from' not in transaction and is_checksum_address(self.default_account):
             transaction = assoc(transaction, 'from', self.default_account)
@@ -532,7 +533,10 @@ class Eth(ModuleV2, Module):
         if block_identifier is None:
             block_identifier = self.default_block
 
-        return (transaction, block_identifier, state_override)
+        if state_override is None:
+            return (transaction, block_identifier)
+        else:
+            return (transaction, block_identifier, state_override)
 
     call: Method[Callable[..., Union[bytes, bytearray]]] = Method(
         RPC.eth_call,

--- a/web3/types.py
+++ b/web3/types.py
@@ -193,6 +193,15 @@ TxParams = TypedDict("TxParams", {
     "value": Wei,
 }, total=False)
 
+
+class CallOverrideParams(TypedDict):
+    balance: Optional[Wei]
+    nonce: Optional[int]
+    code: Optional[Union[bytes, HexStr]]
+    state: Optional[Dict[str, Any]]
+    stateDiff: Optional[Dict[Address, Dict[str, Any]]]
+
+
 GasPriceStrategy = Callable[["Web3", TxParams], Wei]
 
 


### PR DESCRIPTION
### What was wrong?
On optional parameter is missing https://geth.ethereum.org/docs/rpc/ns-eth#3-object---state-override-set

Related to Issue #1921

### How was it fixed?
Add optional arg

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/d6/fa/39/d6fa396519ee3b8c6b84ee75f5eb9300.jpg)

PS : it's my first, not sure if it's well fixed, please give me adice on how to improve or correct.
