### PR TITLE
Add list_storage_keys, deprecate listStorageKeys

### DIFF
--- a/newsfragments/1944.feature.rst
+++ b/newsfragments/1944.feature.rst
@@ -1,0 +1,1 @@
+Add list_storage_keys deprecate listStorageKeys

--- a/web3/_utils/module_testing/parity_module.py
+++ b/web3/_utils/module_testing/parity_module.py
@@ -135,7 +135,21 @@ class ParityModuleTest:
     def test_list_storage_keys_no_support(
         self, web3: "Web3", emitter_contract_address: ChecksumAddress
     ) -> None:
-        keys = web3.parity.listStorageKeys(emitter_contract_address, 10, None)
+        keys = web3.parity.list_storage_keys(emitter_contract_address, 10, None)
+        assert keys == []
+
+    def test_list_storage_keys(
+        self, web3: "Web3", emitter_contract_address: ChecksumAddress
+    ) -> None:
+        keys = web3.parity.list_storage_keys(emitter_contract_address, 10, None)
+        assert keys == []
+
+    def test_listStorageKeys_deprecated(
+        self, web3: "Web3", emitter_contract_address: ChecksumAddress
+    ) -> None:
+        with pytest.warns(DeprecationWarning,
+                          match='listStorageKeys is deprecated in favor of list_storage_keys'):
+            keys = web3.parity.listStorageKeys(emitter_contract_address, 10, None)
         assert keys == []
 
     def test_mode(self, web3: "Web3") -> None:

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -41,6 +41,7 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.method import (
+    DeprecatedMethod,
     Method,
     default_root_munger,
 )
@@ -133,7 +134,7 @@ class Parity(ModuleV2):
             block_identifier = self.default_block
         return (address, quantity, hash_, block_identifier)
 
-    listStorageKeys: Method[Callable[..., List[Hash32]]] = Method(
+    list_storage_keys: Method[Callable[..., List[Hash32]]] = Method(
         RPC.parity_listStorageKeys,
         mungers=[list_storage_keys_munger],
     )
@@ -218,3 +219,6 @@ class Parity(ModuleV2):
         RPC.parity_mode,
         mungers=None
     )
+
+    # Deprecated Methods
+    listStorageKeys = DeprecatedMethod(list_storage_keys, 'listStorageKeys', 'list_storage_keys')


### PR DESCRIPTION
### What was wrong?
Add list_storage_keys, deprecate listStorageKeys

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/de/90/0b/de900ba82de7d422e0fe723f6e19c928.jpg)
