### PR TITLE
Remove an if statement

### DIFF
--- a/ethpm/validation/manifest.py
+++ b/ethpm/validation/manifest.py
@@ -91,9 +91,7 @@ def validate_manifest_against_schema(manifest: Dict[str, Any]) -> None:
 
 
 def check_for_deployments(manifest: Dict[str, Any]) -> bool:
-    if "deployments" not in manifest or not manifest["deployments"]:
-        return False
-    return True
+    return "deployments" in manifest and bool(manifest.get("deployments", None))
 
 
 def validate_build_dependencies_are_present(manifest: Dict[str, Any]) -> None:


### PR DESCRIPTION
Signed-off-by: Harmouch101 <mahmoudddharmouchhh@gmail.com>

### What was wrong?
unnecessary if statement in a manifest file.
Related to Issue #
no issues.
### How was it fixed?
by understanding the logic of the if statement.
```
                                if condition    return value of the func
manifest = {'deployments': None}  --->  True  ---> False
manifest = {'deployments': 'something'}  --->  False  ---> True
manifest = {'not_deployments': 'something'}  --->  True  ---> False

final statement

"deployments" in manifest and bool(manifest.get("deployments", None))
```
### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![cute little cat](https://i.ebayimg.com/images/g/3WUAAOSwfR5fvCMG/s-l500.jpg)
