### PR TITLE
Add trace_call, deprecate traceCall

### DIFF
--- a/newsfragments/1957.feature.rst
+++ b/newsfragments/1957.feature.rst
@@ -1,0 +1,1 @@
+Add ``parity.trace_call``, deprecate ``parity.traceCall``

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -195,7 +195,7 @@ class Parity(Module):
 
         return (transaction, mode, block_identifier)
 
-    traceCall: Method[Callable[..., ParityBlockTrace]] = Method(
+    trace_call: Method[Callable[..., ParityBlockTrace]] = Method(
         RPC.trace_call,
         mungers=[trace_call_munger],
     )
@@ -234,3 +234,4 @@ class Parity(Module):
     traceReplayBlockTransactions = DeprecatedMethod(trace_replay_block_transactions,
                                                     'traceReplayBlockTransactions',
                                                     'trace_replay_block_transactions')
+    traceCall = DeprecatedMethod(trace_call, 'traceCall', 'trace_call')


### PR DESCRIPTION
### What was wrong?
Added trace_call, deprecated traceCall from Parity Module

Related to Issue #1429

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/115935560-b0792380-a450-11eb-9498-c9a86f9826ff.png)

