### PR TITLE
Document call state overrides

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -938,7 +938,7 @@ The following methods are available on the ``web3.eth`` namespace.
     .. warning:: Deprecated: This property is deprecated in favor of
       :meth:`~web3.eth.Eth.sign_typed_data()`
 
-.. py:method:: Eth.call(transaction, block_identifier=web3.eth.default_block)
+.. py:method:: Eth.call(transaction, block_identifier=web3.eth.default_block, state_override=None)
 
     * Delegates to ``eth_call`` RPC Method
 
@@ -959,6 +959,10 @@ The following methods are available on the ``web3.eth`` namespace.
         HexBytes('0x0000000000000000000000000000000000000000000000000000000000000001')
 
     In most cases it is better to make contract function call through the :py:class:`web3.contract.Contract` interface.
+
+    Overriding state is a debugging feature available in Geth clients.
+    View their `usage documentation <https://geth.ethereum.org/docs/rpc/ns-eth#3-object---state-override-set>`_
+    for a list of possible parameters.
 
 
 .. py:method:: Eth.estimate_gas(transaction, block_identifier=None)

--- a/newsfragments/1965.doc.rst
+++ b/newsfragments/1965.doc.rst
@@ -1,0 +1,1 @@
+Document ``eth_call`` state overrides.


### PR DESCRIPTION
### What was wrong?

State overrides were undocumented within `eth_call`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTO1SoatPbyyHbzgYd5D_qRL8zYlKVEwSfUTg&usqp=CAU)
