### PR TITLE
converting staticmethod calls to the proper decorator usage.

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -1,3 +1,6 @@
+from functools import (
+    wraps,
+)
 from typing import (
     TYPE_CHECKING,
     Optional,
@@ -70,22 +73,27 @@ class ENS:
     """
 
     @staticmethod
+    @wraps(label_to_hash)
     def labelhash(label: str) -> HexBytes:
         return label_to_hash(label)
 
     @staticmethod
+    @wraps(raw_name_to_hash)
     def namehash(name: str) -> HexBytes:
         return raw_name_to_hash(name)
 
     @staticmethod
+    @wraps(normalize_name)
     def nameprep(name: str) -> str:
         return normalize_name(name)
 
     @staticmethod
+    @wraps(is_valid_name)
     def is_valid_name(name: str) -> bool:
         return is_valid_name(name)
 
     @staticmethod
+    @wraps(address_to_reverse_domain)
     def reverse_domain(address: ChecksumAddress) -> str:
         return address_to_reverse_domain(address)
 

--- a/ens/main.py
+++ b/ens/main.py
@@ -69,11 +69,25 @@ class ENS:
     like: ``"0x314159265dD8dbb310642f98f50C066173C1259b"``
     """
 
-    labelhash = staticmethod(label_to_hash)
-    namehash = staticmethod(raw_name_to_hash)
-    nameprep = staticmethod(normalize_name)
-    is_valid_name = staticmethod(is_valid_name)
-    reverse_domain = staticmethod(address_to_reverse_domain)
+    @staticmethod
+    def labelhash(label: str) -> HexBytes:
+        return label_to_hash(label)
+
+    @staticmethod
+    def namehash(name: str) -> HexBytes:
+        return raw_name_to_hash(name)
+
+    @staticmethod
+    def nameprep(name: str) -> str:
+        return normalize_name(name)
+
+    @staticmethod
+    def is_valid_name(name: str) -> bool:
+        return is_valid_name(name)
+
+    @staticmethod
+    def reverse_domain(address: ChecksumAddress) -> str:
+        return address_to_reverse_domain(address)
 
     def __init__(
         self, provider: 'BaseProvider' = cast('BaseProvider', default), addr: ChecksumAddress = None

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -68,12 +68,6 @@ def dict_copy(func: TFunc) -> TFunc:
     return cast(TFunc, wrapper)
 
 
-def ensure_hex(data: HexBytes) -> HexBytes:
-    if not isinstance(data, str):
-        return Web3().toHex(data)
-    return data
-
-
 def init_web3(provider: 'BaseProvider' = cast('BaseProvider', default)) -> '_Web3':
     from web3 import Web3 as Web3Main
 

--- a/newsfragments/1979.misc.rst
+++ b/newsfragments/1979.misc.rst
@@ -1,0 +1,3 @@
+Convert staticmethod calls to use decorator.
+
+This was preventing the correct call signature to be displayed in pylance/pyright.

--- a/web3/main.py
+++ b/web3/main.py
@@ -1,3 +1,4 @@
+import decimal
 from eth_abi.codec import (
     ABICodec,
 )
@@ -18,9 +19,23 @@ from eth_utils import (
 from hexbytes import (
     HexBytes,
 )
-from typing import Any, cast, Dict, List, Optional, Sequence, TYPE_CHECKING
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    TYPE_CHECKING,
+    Union,
+    cast,
+)
 
-from eth_typing import HexStr, Primitives
+from eth_typing import (
+    AnyAddress,
+    ChecksumAddress,
+    HexStr,
+    Primitives,
+)
 from eth_typing.abi import TypeStr
 from eth_utils import (
     combomethod,
@@ -97,6 +112,7 @@ from web3.testing import (
 from web3.types import (  # noqa: F401
     Middleware,
     MiddlewareOnion,
+    Wei,
 )
 from web3.version import (
     Version,
@@ -138,20 +154,55 @@ class Web3:
     Iban = Iban
 
     # Encoding and Decoding
-    toBytes = staticmethod(to_bytes)
-    toInt = staticmethod(to_int)
-    toHex = staticmethod(to_hex)
-    toText = staticmethod(to_text)
-    toJSON = staticmethod(to_json)
+    @staticmethod
+    def toBytes(
+        primitive: Primitives = None, hexstr: HexStr = None, text: str = None
+    ) -> bytes:
+        return to_bytes(primitive, hexstr, text)
+
+    @staticmethod
+    def toInt(
+        primitive: Primitives = None, hexstr: HexStr = None, text: str = None
+    ) -> int:
+        return to_int(primitive, hexstr, text)
+
+    @staticmethod
+    def toHex(
+        primitive: Primitives = None, hexstr: HexStr = None, text: str = None
+    ) -> HexStr:
+        return to_hex(primitive, hexstr, text)
+
+    @staticmethod
+    def toText(
+        primitive: Primitives = None, hexstr: HexStr = None, text: str = None
+    ) -> str:
+        return to_text(primitive, hexstr, text)
+
+    @staticmethod
+    def toJSON(obj: Dict[Any, Any]) -> str:
+        return to_json(obj)
 
     # Currency Utility
-    toWei = staticmethod(to_wei)
-    fromWei = staticmethod(from_wei)
+    @staticmethod
+    def toWei(number: Union[int, float, str, decimal.Decimal], unit: str) -> Wei:
+        return cast(Wei, to_wei(number, unit))
+
+    @staticmethod
+    def fromWei(number: int, unit: str) -> Union[int, decimal.Decimal]:
+        return from_wei(number, unit)
 
     # Address Utility
-    isAddress = staticmethod(is_address)
-    isChecksumAddress = staticmethod(is_checksum_address)
-    toChecksumAddress = staticmethod(to_checksum_address)
+    @staticmethod
+    def isAddress(value: Any) -> bool:
+        return is_address(value)
+
+    @staticmethod
+    def isChecksumAddress(value: Any) -> bool:
+        return is_checksum_address(value)
+
+    @staticmethod
+    def toChecksumAddress(value: Union[AnyAddress, str, bytes]) -> ChecksumAddress:
+        return to_checksum_address(value)
 
     # mypy Types
     eth: Eth

--- a/web3/main.py
+++ b/web3/main.py
@@ -16,6 +16,9 @@ from eth_utils import (
     to_text,
     to_wei,
 )
+from functools import (
+    wraps,
+)
 from hexbytes import (
     HexBytes,
 )
@@ -155,52 +158,62 @@ class Web3:
 
     # Encoding and Decoding
     @staticmethod
+    @wraps(to_bytes)
     def toBytes(
         primitive: Primitives = None, hexstr: HexStr = None, text: str = None
     ) -> bytes:
         return to_bytes(primitive, hexstr, text)
 
     @staticmethod
+    @wraps(to_int)
     def toInt(
         primitive: Primitives = None, hexstr: HexStr = None, text: str = None
     ) -> int:
         return to_int(primitive, hexstr, text)
 
     @staticmethod
+    @wraps(to_hex)
     def toHex(
         primitive: Primitives = None, hexstr: HexStr = None, text: str = None
     ) -> HexStr:
         return to_hex(primitive, hexstr, text)
 
     @staticmethod
+    @wraps(to_text)
     def toText(
         primitive: Primitives = None, hexstr: HexStr = None, text: str = None
     ) -> str:
         return to_text(primitive, hexstr, text)
 
     @staticmethod
+    @wraps(to_json)
     def toJSON(obj: Dict[Any, Any]) -> str:
         return to_json(obj)
 
     # Currency Utility
     @staticmethod
+    @wraps(to_wei)
     def toWei(number: Union[int, float, str, decimal.Decimal], unit: str) -> Wei:
         return cast(Wei, to_wei(number, unit))
 
     @staticmethod
+    @wraps(from_wei)
     def fromWei(number: int, unit: str) -> Union[int, decimal.Decimal]:
         return from_wei(number, unit)
 
     # Address Utility
     @staticmethod
+    @wraps(is_address)
     def isAddress(value: Any) -> bool:
         return is_address(value)
 
     @staticmethod
+    @wraps(is_checksum_address)
     def isChecksumAddress(value: Any) -> bool:
         return is_checksum_address(value)
 
     @staticmethod
+    @wraps(to_checksum_address)
     def toChecksumAddress(value: Union[AnyAddress, str, bytes]) -> ChecksumAddress:
         return to_checksum_address(value)
 


### PR DESCRIPTION
this was preventing the correct call signature to be displayed in pylance/pyright

### What was wrong?

Related to Issue #
![image](https://user-images.githubusercontent.com/1946977/117216245-4e0b1600-adb4-11eb-84ed-6e57f87c8db1.png)
https://github.com/microsoft/pylance-release/issues/1210

### How was it fixed?

![image](https://user-images.githubusercontent.com/1946977/117256267-4fadfb80-adff-11eb-9d35-f3998b850ec3.png)


looking at the description in builtins.pyi
```python
class staticmethod(object):  # Special, only valid as a decorator.
```

changed the usage from assigning a function to a class member variable to the proper form of defining a new functions and using `@staticmethod` as a decorator.


One downside is missing docstrings.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pbs.twimg.com/media/E0lB6wZVoAIr8Dq?format=jpg&name=4096x4096)
