### PR TITLE
Allow both 0.7.0 and 0.7.0a1 for ipfshttpclient

### DIFF
--- a/newsfragments/1993.misc.rst
+++ b/newsfragments/1993.misc.rst
@@ -1,0 +1,1 @@
+Update ipfshttpclient to use v0.7.0

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.9.5,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
-        "ipfshttpclient==0.7.0a1",
+        "ipfshttpclient==0.7.0",
         "jsonschema>=3.2.0,<4.0.0",
         "lru-dict>=1.1.6,<2.0.0",
         "protobuf>=3.10.0,<4",


### PR DESCRIPTION
### What was wrong?
The `ipfshttpclient` version was fixed to `0.7.0a1`. However, `0.7.0` was released already with "No changes compared to 0.7.0a1" (https://github.com/ipfs-shipyard/py-ipfs-http-client/blob/master/CHANGELOG.md).

> py-ipfs-http-client 0.7.0 (15.03.2021)
> * No changes compared to 0.7.0a1 – breaking changes delayed to the unknown future

Since the version is fixed, web3.py cannot be installed when `ipfshttpclient==0.7.0` is installed.

### How was it fixed?
Under `setup.py`, `install_requires` was updated so both versions are supported.
