### PR TITLE
AsyncHTTPProvider accepts middleware

### DIFF
--- a/newsfragments/1999.feature.rst
+++ b/newsfragments/1999.feature.rst
@@ -1,0 +1,4 @@
+Add ability for AsyncHTTPProvider to accept middleware
+
+Also adds async gas_price_strategy middleware, and the AsyncEthereumTesterProvider now inherits from
+AsyncBase

--- a/newsfragments/1999.feature.rst
+++ b/newsfragments/1999.feature.rst
@@ -1,4 +1,5 @@
 Add ability for AsyncHTTPProvider to accept middleware
 
-Also adds async gas_price_strategy middleware, and the AsyncEthereumTesterProvider now inherits from
-AsyncBase
+Also adds async gas_price_strategy middleware, and moves gas estimate to middleware.
+
+AsyncEthereumTesterProvider now inherits from AsyncBase

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -75,19 +75,7 @@ def web3(geth_process, endpoint_uri):
 
 
 @pytest.fixture(scope="module")
-async def async_w3_http(geth_process, endpoint_uri):
-    await wait_for_aiohttp(endpoint_uri)
-    _web3 = Web3(
-        AsyncHTTPProvider(endpoint_uri),
-        middlewares=[],
-        modules={
-            'async_eth': (AsyncEth,),
-        })
-    return _web3
-
-
-@pytest.fixture(scope="module")
-async def aw3_gp(geth_process, endpoint_uri):
+async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
     _web3 = Web3(
         AsyncHTTPProvider(endpoint_uri),

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -8,6 +8,7 @@ from web3.eth import (
     AsyncEth,
 )
 from web3.middleware import (
+    async_buffered_gas_estimate_middleware,
     async_gas_price_strategy_middleware,
 )
 from web3.providers.async_rpc import (
@@ -79,9 +80,12 @@ async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
     _web3 = Web3(
         AsyncHTTPProvider(endpoint_uri),
-        middlewares=[async_gas_price_strategy_middleware],
+        middlewares=[
+            async_gas_price_strategy_middleware,
+            async_buffered_gas_estimate_middleware
+        ],
         modules={
-            'async_eth': (AsyncEth,),
+            'eth': (AsyncEth,),
         })
     return _web3
 

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -7,6 +7,9 @@ from web3 import Web3
 from web3.eth import (
     AsyncEth,
 )
+from web3.middleware import (
+    async_gas_price_strategy_middleware,
+)
 from web3.providers.async_rpc import (
     AsyncHTTPProvider,
 )
@@ -77,6 +80,18 @@ async def async_w3_http(geth_process, endpoint_uri):
     _web3 = Web3(
         AsyncHTTPProvider(endpoint_uri),
         middlewares=[],
+        modules={
+            'async_eth': (AsyncEth,),
+        })
+    return _web3
+
+
+@pytest.fixture(scope="module")
+async def aw3_gp(geth_process, endpoint_uri):
+    await wait_for_aiohttp(endpoint_uri)
+    _web3 = Web3(
+        AsyncHTTPProvider(endpoint_uri),
+        middlewares=[async_gas_price_strategy_middleware],
         modules={
             'async_eth': (AsyncEth,),
         })

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -84,9 +84,7 @@ async def async_w3(geth_process, endpoint_uri):
             async_gas_price_strategy_middleware,
             async_buffered_gas_estimate_middleware
         ],
-        modules={
-            'eth': (AsyncEth,),
-        })
+        modules={'eth': (AsyncEth,)})
     return _web3
 
 

--- a/web3/_utils/async_transactions.py
+++ b/web3/_utils/async_transactions.py
@@ -12,7 +12,7 @@ from web3.types import (
 
 if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
-    from web3.eth import AsyncEth, Eth  # noqa: F401
+    from web3.eth import AsyncEth  # noqa: F401
 
 
 async def get_block_gas_limit(
@@ -25,13 +25,13 @@ async def get_block_gas_limit(
 
 
 async def get_buffered_gas_estimate(
-    web3_eth: "Eth", transaction: TxParams, gas_buffer: Wei = Wei(100000)
+    web3: "Web3", transaction: TxParams, gas_buffer: Wei = Wei(100000)
 ) -> Wei:
     gas_estimate_transaction = cast(TxParams, dict(**transaction))
 
-    gas_estimate = await web3_eth.estimate_gas(gas_estimate_transaction)  # type: ignore
+    gas_estimate = await web3.eth.estimate_gas(gas_estimate_transaction)  # type: ignore
 
-    gas_limit = await get_block_gas_limit(web3_eth)  # type: ignore
+    gas_limit = await get_block_gas_limit(web3.eth)  # type: ignore
 
     if gas_estimate > gas_limit:
         raise ValueError(

--- a/web3/_utils/async_transactions.py
+++ b/web3/_utils/async_transactions.py
@@ -1,0 +1,43 @@
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+    cast,
+)
+
+from web3.types import (
+    BlockIdentifier,
+    TxParams,
+    Wei,
+)
+
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
+    from web3.eth import AsyncEth, Eth  # noqa: F401
+
+
+async def get_block_gas_limit(
+    web3_eth: "AsyncEth", block_identifier: Optional[BlockIdentifier] = None
+) -> Wei:
+    if block_identifier is None:
+        block_identifier = await web3_eth.block_number
+    block = await web3_eth.get_block(block_identifier)
+    return block['gasLimit']
+
+
+async def get_buffered_gas_estimate(
+    web3_eth: "Eth", transaction: TxParams, gas_buffer: Wei = Wei(100000)
+) -> Wei:
+    gas_estimate_transaction = cast(TxParams, dict(**transaction))
+
+    gas_estimate = await web3_eth.estimate_gas(gas_estimate_transaction)  # type: ignore
+
+    gas_limit = await get_block_gas_limit(web3_eth)  # type: ignore
+
+    if gas_estimate > gas_limit:
+        raise ValueError(
+            "Contract does not appear to be deployable within the "
+            "current network gas limits.  Estimated: {0}. Current gas "
+            "limit: {1}".format(gas_estimate, gas_limit)
+        )
+
+    return Wei(min(gas_limit, gas_estimate + gas_buffer))

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -110,6 +110,86 @@ class AsyncEthModuleTest:
 
         assert txn['gasPrice'] == 20
 
+    @pytest.mark.asyncio
+    async def test_eth_estimate_gas(
+        self, async_w3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        gas_estimate = await async_w3.async_eth.estimate_gas({
+            'from': unlocked_account_dual_type,
+            'to': unlocked_account_dual_type,
+            'value': Wei(1),
+        })
+        assert is_integer(gas_estimate)
+        assert gas_estimate > 0
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockByHash(
+        self, async_w3: "Web3", empty_block: BlockData
+    ) -> None:
+        block = await async_w3.async_eth.get_block(empty_block['hash'])
+        assert block['hash'] == empty_block['hash']
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockByHash_not_found(
+        self, async_w3: "Web3", empty_block: BlockData
+    ) -> None:
+        with pytest.raises(BlockNotFound):
+            await async_w3.async_eth.get_block(UNKNOWN_HASH)
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockByHash_pending(
+        self, async_w3: "Web3"
+    ) -> None:
+        block = await async_w3.async_eth.get_block('pending')
+        assert block['hash'] is None
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockByNumber_with_integer(
+        self, async_w3: "Web3", empty_block: BlockData
+    ) -> None:
+        block = await async_w3.async_eth.get_block(empty_block['number'])
+        assert block['number'] == empty_block['number']
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockByNumber_latest(
+        self, async_w3: "Web3", empty_block: BlockData
+    ) -> None:
+        current_block_number = await async_w3.async_eth.block_number
+        block = await async_w3.async_eth.get_block('latest')
+        assert block['number'] == current_block_number
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockByNumber_not_found(
+        self, async_w3: "Web3", empty_block: BlockData
+    ) -> None:
+        with pytest.raises(BlockNotFound):
+           await async_w3.async_eth.get_block(BlockNumber(12345))
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockByNumber_pending(
+        self, async_w3: "Web3", empty_block: BlockData
+    ) -> None:
+        current_block_number = await async_w3.async_eth.block_number
+        block = await async_w3.async_eth.get_block('pending')
+        assert block['number'] == current_block_number + 1
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockByNumber_earliest(
+        self, async_w3: "Web3", empty_block: BlockData
+    ) -> None:
+        genesis_block = await async_w3.async_eth.get_block(BlockNumber(0))
+        block = await async_w3.async_eth.get_block('earliest')
+        assert block['number'] == 0
+        assert block['hash'] == genesis_block['hash']
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockByNumber_full_transactions(
+        self, async_w3: "Web3", block_with_txn: BlockData
+    ) -> None:
+        block = await async_w3.async_eth.get_block(block_with_txn['number'], True)
+        transaction = block['transactions'][0]
+        assert transaction['hash'] == block_with_txn['transactions'][0]  # type: ignore
+
 
 class EthModuleTest:
     def test_eth_protocol_version(self, web3: "Web3") -> None:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -89,6 +89,21 @@ class AsyncEthModuleTest:
         assert txn['gas'] == 21000
         assert txn['gasPrice'] == txn_params['gasPrice']
 
+    @pytest.mark.asyncio
+    async def test_gas_price_strategy_middleware(
+        self, aw3_gp: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        txn_params: TxParams = {
+            'from': unlocked_account_dual_type,
+            'to': unlocked_account_dual_type,
+            'value': Wei(1),
+            'gas': Wei(21000),
+        }
+        txn_hash = await aw3_gp.async_eth.send_transaction(txn_params)
+        txn = await aw3_gp.async_eth.get_transaction(txn_hash)
+
+        assert txn['gasPrice'] == 1000000000
+
 
 class EthModuleTest:
     def test_eth_protocol_version(self, web3: "Web3") -> None:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
 class AsyncEthModuleTest:
     @pytest.mark.asyncio
     async def test_eth_gas_price(self, async_w3: "Web3") -> None:
-        gas_price = await async_w3.async_eth.gas_price
+        gas_price = await async_w3.eth.gas_price  # type: ignore
         assert gas_price > 0
 
     @pytest.mark.asyncio
@@ -78,10 +78,10 @@ class AsyncEthModuleTest:
             'to': unlocked_account_dual_type,
             'value': Wei(1),
             'gas': Wei(21000),
-            'gasPrice': await async_w3.async_eth.gas_price,
+            'gasPrice': await async_w3.eth.gas_price,  # type: ignore
         }
-        txn_hash = await async_w3.async_eth.send_transaction(txn_params)
-        txn = await async_w3.async_eth.get_transaction(txn_hash)
+        txn_hash = await async_w3.eth.send_transaction(txn_params)  # type: ignore
+        txn = await async_w3.eth.get_transaction(txn_hash)  # type: ignore
 
         assert is_same_address(txn['from'], cast(ChecksumAddress, txn_params['from']))
         assert is_same_address(txn['to'], cast(ChecksumAddress, txn_params['to']))
@@ -103,10 +103,10 @@ class AsyncEthModuleTest:
         def higher_gas_price_strategy(web3: "Web3", txn: TxParams) -> Wei:
             return Wei(20)
 
-        async_w3.async_eth.set_gas_price_strategy(higher_gas_price_strategy)
+        async_w3.eth.set_gas_price_strategy(higher_gas_price_strategy)
 
-        txn_hash = await async_w3.async_eth.send_transaction(txn_params)
-        txn = await async_w3.async_eth.get_transaction(txn_hash)
+        txn_hash = await async_w3.eth.send_transaction(txn_params)  # type: ignore
+        txn = await async_w3.eth.get_transaction(txn_hash)  # type: ignore
 
         assert txn['gasPrice'] == 20
 
@@ -114,7 +114,7 @@ class AsyncEthModuleTest:
     async def test_eth_estimate_gas(
         self, async_w3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
-        gas_estimate = await async_w3.async_eth.estimate_gas({
+        gas_estimate = await async_w3.eth.estimate_gas({  # type: ignore
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
@@ -126,7 +126,7 @@ class AsyncEthModuleTest:
     async def test_eth_getBlockByHash(
         self, async_w3: "Web3", empty_block: BlockData
     ) -> None:
-        block = await async_w3.async_eth.get_block(empty_block['hash'])
+        block = await async_w3.eth.get_block(empty_block['hash'])  # type: ignore
         assert block['hash'] == empty_block['hash']
 
     @pytest.mark.asyncio
@@ -134,28 +134,28 @@ class AsyncEthModuleTest:
         self, async_w3: "Web3", empty_block: BlockData
     ) -> None:
         with pytest.raises(BlockNotFound):
-            await async_w3.async_eth.get_block(UNKNOWN_HASH)
+            await async_w3.eth.get_block(UNKNOWN_HASH)  # type: ignore
 
     @pytest.mark.asyncio
     async def test_eth_getBlockByHash_pending(
         self, async_w3: "Web3"
     ) -> None:
-        block = await async_w3.async_eth.get_block('pending')
+        block = await async_w3.eth.get_block('pending')  # type: ignore
         assert block['hash'] is None
 
     @pytest.mark.asyncio
     async def test_eth_getBlockByNumber_with_integer(
         self, async_w3: "Web3", empty_block: BlockData
     ) -> None:
-        block = await async_w3.async_eth.get_block(empty_block['number'])
+        block = await async_w3.eth.get_block(empty_block['number'])  # type: ignore
         assert block['number'] == empty_block['number']
 
     @pytest.mark.asyncio
     async def test_eth_getBlockByNumber_latest(
         self, async_w3: "Web3", empty_block: BlockData
     ) -> None:
-        current_block_number = await async_w3.async_eth.block_number
-        block = await async_w3.async_eth.get_block('latest')
+        current_block_number = await async_w3.eth.block_number  # type: ignore
+        block = await async_w3.eth.get_block('latest')  # type: ignore
         assert block['number'] == current_block_number
 
     @pytest.mark.asyncio
@@ -163,22 +163,22 @@ class AsyncEthModuleTest:
         self, async_w3: "Web3", empty_block: BlockData
     ) -> None:
         with pytest.raises(BlockNotFound):
-            await async_w3.async_eth.get_block(BlockNumber(12345))
+            await async_w3.eth.get_block(BlockNumber(12345))  # type: ignore
 
     @pytest.mark.asyncio
     async def test_eth_getBlockByNumber_pending(
         self, async_w3: "Web3", empty_block: BlockData
     ) -> None:
-        current_block_number = await async_w3.async_eth.block_number
-        block = await async_w3.async_eth.get_block('pending')
+        current_block_number = await async_w3.eth.block_number  # type: ignore
+        block = await async_w3.eth.get_block('pending')  # type: ignore
         assert block['number'] == current_block_number + 1
 
     @pytest.mark.asyncio
     async def test_eth_getBlockByNumber_earliest(
         self, async_w3: "Web3", empty_block: BlockData
     ) -> None:
-        genesis_block = await async_w3.async_eth.get_block(BlockNumber(0))
-        block = await async_w3.async_eth.get_block('earliest')
+        genesis_block = await async_w3.eth.get_block(BlockNumber(0))  # type: ignore
+        block = await async_w3.eth.get_block('earliest')  # type: ignore
         assert block['number'] == 0
         assert block['hash'] == genesis_block['hash']
 
@@ -186,9 +186,9 @@ class AsyncEthModuleTest:
     async def test_eth_getBlockByNumber_full_transactions(
         self, async_w3: "Web3", block_with_txn: BlockData
     ) -> None:
-        block = await async_w3.async_eth.get_block(block_with_txn['number'], True)
+        block = await async_w3.eth.get_block(block_with_txn['number'], True)  # type: ignore
         transaction = block['transactions'][0]
-        assert transaction['hash'] == block_with_txn['transactions'][0]  # type: ignore
+        assert transaction['hash'] == block_with_txn['transactions'][0]
 
 
 class EthModuleTest:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -69,6 +69,26 @@ class AsyncEthModuleTest:
         is_connected = await async_w3_http.isConnected()  # type: ignore
         assert is_connected is True
 
+    @pytest.mark.asyncio
+    async def test_eth_send_transaction(
+        self, async_w3_http: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        txn_params: TxParams = {
+            'from': unlocked_account_dual_type,
+            'to': unlocked_account_dual_type,
+            'value': Wei(1),
+            'gas': Wei(21000),
+            'gasPrice': await async_w3_http.async_eth.gas_price,
+        }
+        txn_hash = await async_w3_http.async_eth.send_transaction(txn_params)
+        txn = await async_w3_http.async_eth.get_transaction(txn_hash)
+
+        assert is_same_address(txn['from'], cast(ChecksumAddress, txn_params['from']))
+        assert is_same_address(txn['to'], cast(ChecksumAddress, txn_params['to']))
+        assert txn['value'] == 1
+        assert txn['gas'] == 21000
+        assert txn['gasPrice'] == txn_params['gasPrice']
+
 
 class EthModuleTest:
     def test_eth_protocol_version(self, web3: "Web3") -> None:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -163,7 +163,7 @@ class AsyncEthModuleTest:
         self, async_w3: "Web3", empty_block: BlockData
     ) -> None:
         with pytest.raises(BlockNotFound):
-           await async_w3.async_eth.get_block(BlockNumber(12345))
+            await async_w3.async_eth.get_block(BlockNumber(12345))
 
     @pytest.mark.asyncio
     async def test_eth_getBlockByNumber_pending(

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -59,7 +59,6 @@ TRANSACTION_DEFAULTS = {
 
 if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
-    from web3.eth import Eth  # noqa: F401
 
 
 @curry
@@ -113,21 +112,21 @@ def wait_for_transaction_receipt(
     return txn_receipt
 
 
-def get_block_gas_limit(web3_eth: "Eth", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
+def get_block_gas_limit(web3: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
     if block_identifier is None:
-        block_identifier = web3_eth.block_number
-    block = web3_eth.get_block(block_identifier)
+        block_identifier = web3.eth.block_number
+    block = web3.eth.get_block(block_identifier)
     return block['gasLimit']
 
 
 def get_buffered_gas_estimate(
-    web3_eth: "Eth", transaction: TxParams, gas_buffer: Wei = Wei(100000)
+    web3: "Web3", transaction: TxParams, gas_buffer: Wei = Wei(100000)
 ) -> Wei:
     gas_estimate_transaction = cast(TxParams, dict(**transaction))
 
-    gas_estimate = web3_eth.estimate_gas(gas_estimate_transaction)
+    gas_estimate = web3.eth.estimate_gas(gas_estimate_transaction)
 
-    gas_limit = get_block_gas_limit(web3_eth)
+    gas_limit = get_block_gas_limit(web3)
 
     if gas_estimate > gas_limit:
         raise ValueError(

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -59,6 +59,7 @@ TRANSACTION_DEFAULTS = {
 
 if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
+    from web3.eth import AsyncEth, Eth  # noqa: F401
 
 
 @curry
@@ -112,7 +113,7 @@ def wait_for_transaction_receipt(
     return txn_receipt
 
 
-def get_block_gas_limit(web3_eth: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
+def get_block_gas_limit(web3_eth: "Eth", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
     if block_identifier is None:
         block_identifier = web3_eth.block_number
     block = web3_eth.get_block(block_identifier)
@@ -120,7 +121,7 @@ def get_block_gas_limit(web3_eth: "Web3", block_identifier: Optional[BlockIdenti
 
 
 def get_buffered_gas_estimate(
-    web3_eth: "Web3", transaction: TxParams, gas_buffer: Wei = Wei(100000)
+    web3_eth: "Eth", transaction: TxParams, gas_buffer: Wei = Wei(100000)
 ) -> Wei:
     gas_estimate_transaction = cast(TxParams, dict(**transaction))
 
@@ -138,14 +139,17 @@ def get_buffered_gas_estimate(
     return Wei(min(gas_limit, gas_estimate + gas_buffer))
 
 
-async def async_get_block_gas_limit(web3_eth: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
+async def async_get_block_gas_limit(
+    web3_eth: "AsyncEth", block_identifier: Optional[BlockIdentifier] = None
+) -> Wei:
     if block_identifier is None:
         block_identifier = await web3_eth.block_number
     block = await web3_eth.get_block(block_identifier)
     return block['gasLimit']
 
+
 async def async_get_buffered_gas_estimate(
-    web3_eth: "Web3", transaction: TxParams, gas_buffer: Wei = Wei(100000)
+    web3_eth: "AsyncEth", transaction: TxParams, gas_buffer: Wei = Wei(100000)
 ) -> Wei:
     gas_estimate_transaction = cast(TxParams, dict(**transaction))
 

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -59,7 +59,7 @@ TRANSACTION_DEFAULTS = {
 
 if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
-    from web3.eth import AsyncEth, Eth  # noqa: F401
+    from web3.eth import Eth  # noqa: F401
 
 
 @curry
@@ -128,34 +128,6 @@ def get_buffered_gas_estimate(
     gas_estimate = web3_eth.estimate_gas(gas_estimate_transaction)
 
     gas_limit = get_block_gas_limit(web3_eth)
-
-    if gas_estimate > gas_limit:
-        raise ValueError(
-            "Contract does not appear to be deployable within the "
-            "current network gas limits.  Estimated: {0}. Current gas "
-            "limit: {1}".format(gas_estimate, gas_limit)
-        )
-
-    return Wei(min(gas_limit, gas_estimate + gas_buffer))
-
-
-async def async_get_block_gas_limit(
-    web3_eth: "AsyncEth", block_identifier: Optional[BlockIdentifier] = None
-) -> Wei:
-    if block_identifier is None:
-        block_identifier = await web3_eth.block_number
-    block = await web3_eth.get_block(block_identifier)
-    return block['gasLimit']
-
-
-async def async_get_buffered_gas_estimate(
-    web3_eth: "AsyncEth", transaction: TxParams, gas_buffer: Wei = Wei(100000)
-) -> Wei:
-    gas_estimate_transaction = cast(TxParams, dict(**transaction))
-
-    gas_estimate = await web3_eth.estimate_gas(gas_estimate_transaction)
-
-    gas_limit = await async_get_block_gas_limit(web3_eth)
 
     if gas_estimate > gas_limit:
         raise ValueError(

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -112,21 +112,46 @@ def wait_for_transaction_receipt(
     return txn_receipt
 
 
-def get_block_gas_limit(web3: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
+def get_block_gas_limit(web3_eth: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
     if block_identifier is None:
-        block_identifier = web3.eth.block_number
-    block = web3.eth.get_block(block_identifier)
+        block_identifier = web3_eth.block_number
+    block = web3_eth.get_block(block_identifier)
     return block['gasLimit']
 
 
 def get_buffered_gas_estimate(
-    web3: "Web3", transaction: TxParams, gas_buffer: Wei = Wei(100000)
+    web3_eth: "Web3", transaction: TxParams, gas_buffer: Wei = Wei(100000)
 ) -> Wei:
     gas_estimate_transaction = cast(TxParams, dict(**transaction))
 
-    gas_estimate = web3.eth.estimate_gas(gas_estimate_transaction)
+    gas_estimate = web3_eth.estimate_gas(gas_estimate_transaction)
 
-    gas_limit = get_block_gas_limit(web3)
+    gas_limit = get_block_gas_limit(web3_eth)
+
+    if gas_estimate > gas_limit:
+        raise ValueError(
+            "Contract does not appear to be deployable within the "
+            "current network gas limits.  Estimated: {0}. Current gas "
+            "limit: {1}".format(gas_estimate, gas_limit)
+        )
+
+    return Wei(min(gas_limit, gas_estimate + gas_buffer))
+
+
+async def async_get_block_gas_limit(web3_eth: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
+    if block_identifier is None:
+        block_identifier = await web3_eth.block_number
+    block = await web3_eth.get_block(block_identifier)
+    return block['gasLimit']
+
+async def async_get_buffered_gas_estimate(
+    web3_eth: "Web3", transaction: TxParams, gas_buffer: Wei = Wei(100000)
+) -> Wei:
+    gas_estimate_transaction = cast(TxParams, dict(**transaction))
+
+    gas_estimate = await web3_eth.estimate_gas(gas_estimate_transaction)
+
+    gas_limit = await async_get_block_gas_limit(web3_eth)
 
     if gas_estimate > gas_limit:
         raise ValueError(

--- a/web3/main.py
+++ b/web3/main.py
@@ -71,7 +71,6 @@ from web3._utils.normalizers import (
     abi_ens_resolver,
 )
 from web3.eth import (
-    AsyncEth,
     Eth,
 )
 from web3.geth import (
@@ -222,7 +221,6 @@ class Web3:
     parity: Parity
     geth: Geth
     net: Net
-    async_eth: AsyncEth
 
     def __init__(
         self,

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -31,6 +31,7 @@ from web3.datastructures import (
 from web3.middleware import (
     abi_middleware,
     attrdict_middleware,
+    buffered_gas_estimate_middleware,
     gas_price_strategy_middleware,
     name_to_address_middleware,
     normalize_errors_middleware,
@@ -118,6 +119,7 @@ class RequestManager:
             (normalize_errors_middleware, 'normalize_errors'),  # Add async
             (validation_middleware, 'validation'),  # Add async
             (abi_middleware, 'abi'),  # Delete
+            (buffered_gas_estimate_middleware, 'gas_estimate'),
         ]
 
     #
@@ -175,9 +177,8 @@ class RequestManager:
         if "error" in response:
             apply_error_formatters(error_formatters, response)
             raise ValueError(response["error"])
-
-        if response['result'] is None:
-            raise ValueError(f"The call to {method} did not return a value.")
+        elif response['result'] is None:
+            apply_error_formatters(error_formatters, response, params)
 
         return response['result']
 

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -135,12 +135,12 @@ class RequestManager:
     async def _coro_make_request(
         self, method: Union[RPCEndpoint, Callable[..., RPCEndpoint]], params: Any
     ) -> RPCResponse:
-        request_func = self.provider.request_func(
+        # type ignored b/c request_func is an awaitable in async model
+        request_func = await self.provider.request_func(  # type: ignore
             self.web3,
             self.middleware_onion)
         self.logger.debug("Making request. Method: %s", method)
-        # type ignored b/c request_func is an awaitable in async model
-        return await request_func(method, params)  # type: ignore
+        return await request_func(method, params)
 
     def request_blocking(
         self,

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -44,6 +44,7 @@ from .formatting import (  # noqa: F401
 )
 from .gas_price_strategy import (  # noqa: F401
     gas_price_strategy_middleware,
+    async_gas_price_strategy_middleware,
 )
 from .geth_poa import (  # noqa: F401
     geth_poa_middleware,

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -89,3 +89,26 @@ def combine_middlewares(
         reversed(middlewares),
         provider_request_fn,
     )
+
+
+async def async_combine_middlewares(
+    middlewares: Sequence[Middleware],
+    web3: 'Web3',
+    provider_request_fn: Callable[[RPCEndpoint, Any], Any]
+) -> Callable[..., RPCResponse]:
+    """
+    Returns a callable function which will call the provider.provider_request
+    function wrapped with all of the middlewares.
+    """
+    accumulator_fn = provider_request_fn
+    for middleware in reversed(middlewares):
+        accumulator_fn = await construct_middleware(middleware, accumulator_fn, web3)
+    return accumulator_fn
+
+
+async def construct_middleware(
+    middleware: Middleware,
+    fn: Callable[..., RPCResponse],
+    w3: 'Web3'
+) -> Callable[[RPCEndpoint, Any], Any]:
+    return await middleware(fn, w3)

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -17,6 +17,10 @@ from .abi import (  # noqa: F401
 from .attrdict import (  # noqa: F401
     attrdict_middleware,
 )
+from .buffered_gas_estimate import (  # noqa: F401
+    async_buffered_gas_estimate_middleware,
+    buffered_gas_estimate_middleware,
+)
 from .cache import (  # noqa: F401
     _latest_block_based_cache_middleware as latest_block_based_cache_middleware,
     _simple_cache_middleware as simple_cache_middleware,
@@ -44,8 +48,6 @@ from .formatting import (  # noqa: F401
 )
 from .gas_price_strategy import (  # noqa: F401
     async_gas_price_strategy_middleware,
-    async_buffered_gas_estimate_middleware,
-    buffered_gas_estimate_middleware,
     gas_price_strategy_middleware,
 )
 from .geth_poa import (  # noqa: F401

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -43,8 +43,10 @@ from .formatting import (  # noqa: F401
     construct_formatting_middleware,
 )
 from .gas_price_strategy import (  # noqa: F401
-    gas_price_strategy_middleware,
     async_gas_price_strategy_middleware,
+    async_buffered_gas_estimate_middleware,
+    buffered_gas_estimate_middleware,
+    gas_price_strategy_middleware,
 )
 from .geth_poa import (  # noqa: F401
     geth_poa_middleware,

--- a/web3/middleware/buffered_gas_estimate.py
+++ b/web3/middleware/buffered_gas_estimate.py
@@ -9,8 +9,10 @@ from eth_utils.toolz import (
     assoc,
 )
 
+from web3._utils.async_transactions import (
+    get_buffered_gas_estimate as async_get_buffered_gas_estimate,
+)
 from web3._utils.transactions import (
-    async_get_buffered_gas_estimate,
     get_buffered_gas_estimate,
 )
 from web3.types import (
@@ -46,7 +48,7 @@ async def async_buffered_gas_estimate_middleware(
         if method == 'eth_sendTransaction':
             transaction = params[0]
             if 'gas' not in transaction:
-                gas_estimate = await async_get_buffered_gas_estimate(web3.async_eth, transaction)
+                gas_estimate = await async_get_buffered_gas_estimate(web3.eth, transaction)
                 transaction = assoc(
                     transaction,
                     'gas',

--- a/web3/middleware/buffered_gas_estimate.py
+++ b/web3/middleware/buffered_gas_estimate.py
@@ -34,7 +34,7 @@ def buffered_gas_estimate_middleware(
                 transaction = assoc(
                     transaction,
                     'gas',
-                    hex(get_buffered_gas_estimate(web3.eth, transaction)),
+                    hex(get_buffered_gas_estimate(web3, transaction)),
                 )
                 return make_request(method, [transaction])
         return make_request(method, params)
@@ -48,7 +48,7 @@ async def async_buffered_gas_estimate_middleware(
         if method == 'eth_sendTransaction':
             transaction = params[0]
             if 'gas' not in transaction:
-                gas_estimate = await async_get_buffered_gas_estimate(web3.eth, transaction)
+                gas_estimate = await async_get_buffered_gas_estimate(web3, transaction)
                 transaction = assoc(
                     transaction,
                     'gas',

--- a/web3/middleware/gas_price_strategy.py
+++ b/web3/middleware/gas_price_strategy.py
@@ -33,3 +33,21 @@ def gas_price_strategy_middleware(
                     return make_request(method, [transaction])
         return make_request(method, params)
     return middleware
+
+
+async def async_gas_price_strategy_middleware(
+    make_request: Callable[[RPCEndpoint, Any], Any], web3: "Web3"
+) -> Callable[[RPCEndpoint, Any], RPCResponse]:
+    """
+    Includes a gas price using the gas price strategy
+    """
+    async def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
+        if method == 'eth_sendTransaction':
+            transaction = params[0]
+            if 'gasPrice' not in transaction:
+                generated_gas_price = await web3.eth.generate_gas_price(transaction)
+                if generated_gas_price is not None:
+                    transaction = assoc(transaction, 'gasPrice', generated_gas_price)
+                    return make_request(method, [transaction])
+        return make_request(method, params)
+    return middleware

--- a/web3/middleware/gas_price_strategy.py
+++ b/web3/middleware/gas_price_strategy.py
@@ -46,7 +46,7 @@ async def async_gas_price_strategy_middleware(
         if method == 'eth_sendTransaction':
             transaction = params[0]
             if 'gasPrice' not in transaction:
-                generated_gas_price = await web3.async_eth.generate_gas_price(transaction)
+                generated_gas_price = await web3.eth.generate_gas_price(transaction)  # type: ignore
                 if generated_gas_price is not None:
                     transaction = assoc(transaction, 'gasPrice', hex(generated_gas_price))
                     return await make_request(method, [transaction])

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -7,6 +7,7 @@ from typing import (
     Tuple,
     cast,
 )
+import warnings
 
 from eth_utils import (
     to_bytes,
@@ -34,6 +35,11 @@ class AsyncBaseProvider:
     _middlewares: Tuple[Middleware, ...] = ()
     # a tuple of (all_middlewares, request_func)
     _request_func_cache: Tuple[Tuple[Middleware, ...], Callable[..., RPCResponse]] = (None, None)
+
+    def __init__(self) -> None:
+        warnings.warn(
+            "Async providers are still being developed and refined. "
+            "Expect breaking changes in minor releases.")
 
     @property
     def middlewares(self) -> Tuple[Middleware, ...]:

--- a/web3/providers/eth_tester/__init__.py
+++ b/web3/providers/eth_tester/__init__.py
@@ -1,4 +1,5 @@
 
 from .main import (  # noqa: F401
     EthereumTesterProvider,
+    AsyncEthereumTesterProvider,
 )

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -19,6 +19,9 @@ from web3._utils.compat import (
 from web3.providers import (
     BaseProvider,
 )
+from web3.providers.async_base import (
+    AsyncBaseProvider,
+)
 from web3.types import (
     RPCEndpoint,
     RPCResponse,
@@ -35,7 +38,7 @@ if TYPE_CHECKING:
     )
 
 
-class AsyncEthereumTesterProvider(BaseProvider):
+class AsyncEthereumTesterProvider(AsyncBaseProvider):
     """This is a placeholder.
 
     For now its purpose is to provide an awaitable request function
@@ -44,8 +47,7 @@ class AsyncEthereumTesterProvider(BaseProvider):
     def __init__(self) -> None:
         self.eth_tester = EthereumTesterProvider()
 
-    # type ignore b/c conflict w/ def in BaseProvider
-    async def make_request(  # type: ignore
+    async def make_request(
         self, method: RPCEndpoint, params: Any
     ) -> RPCResponse:
         return self.eth_tester.make_request(method, params)

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -39,11 +39,6 @@ if TYPE_CHECKING:
 
 
 class AsyncEthereumTesterProvider(AsyncBaseProvider):
-    """This is a placeholder.
-
-    For now its purpose is to provide an awaitable request function
-    for testing the async api execution.
-    """
     def __init__(self) -> None:
         self.eth_tester = EthereumTesterProvider()
 

--- a/web3/tools/benchmark/main.py
+++ b/web3/tools/benchmark/main.py
@@ -21,6 +21,12 @@ from web3 import (
 from web3.eth import (
     AsyncEth,
 )
+from web3.middleware import (
+    async_buffered_gas_estimate_middleware,
+    async_gas_price_strategy_middleware,
+    buffered_gas_estimate_middleware,
+    gas_price_strategy_middleware,
+)
 from web3.tools.benchmark.node import (
     GethBenchmarkFixture,
 )
@@ -47,7 +53,7 @@ parser.add_argument(
 
 def build_web3_http(endpoint_uri: str) -> Web3:
     wait_for_http(endpoint_uri)
-    _web3 = Web3(HTTPProvider(endpoint_uri), middlewares=[])
+    _web3 = Web3(HTTPProvider(endpoint_uri), middlewares=[gas_price_strategy_middleware, buffered_gas_estimate_middleware])
     return _web3
 
 
@@ -55,7 +61,7 @@ async def build_async_w3_http(endpoint_uri: str) -> Web3:
     await wait_for_aiohttp(endpoint_uri)
     _web3 = Web3(
         AsyncHTTPProvider(endpoint_uri),  # type: ignore
-        middlewares=[],
+        middlewares=[async_gas_price_strategy_middleware, async_buffered_gas_estimate_middleware],
         modules={"async_eth": (AsyncEth,)},
     )
     return _web3

--- a/web3/tools/benchmark/main.py
+++ b/web3/tools/benchmark/main.py
@@ -109,6 +109,7 @@ def unlocked_account(w3: "Web3") -> ChecksumAddress:
 
 
 async def async_unlocked_account(w3: Web3, w3_eth: Eth) -> ChecksumAddress:
+    # change w3_eth type to w3_eth: AsyncEth once AsyncEth reflects Eth
     coinbase = await w3_eth.coinbase  # type: ignore
     w3.geth.personal.unlock_account(coinbase, KEYFILE_PW)
     return coinbase


### PR DESCRIPTION
### What was wrong?
The Async RPC provider didn't accept any middleware. 

Related to Issue #1987, #1988, #2000

### How was it fixed?
Added the ability for the AsyncHTTPProvider to accept middleware and added an async `gas_price_strategy` middleware to test it out. Also adds session caching, and now the `EthereumTesterProvider` inherits from the `AsyncBaseProvider`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://images-na.ssl-images-amazon.com/images/I/717LZIXhlAL._AC_SL1024_.jpg)
