### PR TITLE
Remove reference to multiple providers

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -80,16 +80,6 @@ HTTP or an IPC socket.  There is however nothing which requires providers to be
 RPC based, allowing for providers designed for testing purposes which use an
 in-memory EVM to fulfill requests.
 
-In most simple cases you will be using a single provider.  However, if you
-would like to use Web3 with multiple providers, you can simply pass them in as
-a list when instantiating your ``Web3`` object.
-
-
-.. code-block:: python
-
-    >>> w3 = Web3([provider_a, provider_b])
-
-
 
 Writing your own Provider
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/newsfragments/2018.doc.rst
+++ b/newsfragments/2018.doc.rst
@@ -1,0 +1,1 @@
+Remove reference to allowing multiple providers in docs


### PR DESCRIPTION
### What was wrong?
There was a stray reference to multiple providers which we no longer support. 


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://freedesignfile.com/upload/2018/09/Cute-fox-cub-Stock-Photo-03.jpg)
