### PR TITLE
Fix Error Formatter for Null Response

### DIFF
--- a/newsfragments/2022.bugfix.rst
+++ b/newsfragments/2022.bugfix.rst
@@ -1,0 +1,3 @@
+Bugfix where an error response got passed to a function expecting a block identifier.
+
+Split out null result formatters from the error formatters and added some tests.

--- a/tests/core/manager/test_response_formatters.py
+++ b/tests/core/manager/test_response_formatters.py
@@ -1,0 +1,164 @@
+import pytest
+
+from eth_utils.toolz import (
+    identity,
+)
+
+from web3._utils.method_formatters import (
+    raise_block_not_found,
+    raise_block_not_found_for_uncle_at_index,
+)
+from web3.exceptions import (
+    BlockNotFound,
+    ContractLogicError,
+)
+
+ERROR_RESPONSE = {
+    'jsonrpc': '2.0',
+    'error': {
+        'code': -32000,
+        'message': 'Requested block number is in a range that is not available yet, '
+                   'because the ancient block sync is still in progress.'
+    }
+}
+
+
+NONE_RESPONSE = {"jsonrpc": "2.0", "id": 1, "result": None}
+
+
+def raise_contract_logic_error(response):
+    raise ContractLogicError
+
+
+@pytest.mark.parametrize(
+    'response,params,error_formatters,null_result_formatters,error',
+    [
+        (
+            # Error response with no result formatters raises a ValueError
+            ERROR_RESPONSE,
+            (),
+            identity,
+            identity,
+            ValueError,
+        ),
+        (
+            # Error response with error formatters raises error in formatter
+            ERROR_RESPONSE,
+            (),
+            raise_contract_logic_error,
+            identity,
+            ContractLogicError,
+        ),
+        (
+            # Error response with no error formatters raises ValueError
+            ERROR_RESPONSE,
+            (),
+            identity,
+            raise_block_not_found,
+            ValueError,
+        ),
+        (
+            # None result raises error if there is a null_result_formatter
+            NONE_RESPONSE,
+            (),
+            identity,
+            raise_block_not_found,
+            BlockNotFound,
+        ),
+        (
+            # Params are handled with a None result
+            NONE_RESPONSE,
+            ('0x03',),
+            identity,
+            raise_block_not_found,
+            BlockNotFound,
+        ),
+        (
+            # Multiple params are handled with a None result
+            NONE_RESPONSE,
+            ('0x03', '0x01'),
+            identity,
+            raise_block_not_found_for_uncle_at_index,
+            BlockNotFound,
+        ),
+        (
+            # Raise function handles missing param
+            NONE_RESPONSE,
+            ('0x01',),
+            identity,
+            raise_block_not_found_for_uncle_at_index,
+            BlockNotFound,
+        ),
+    ],
+)
+def test_formatted_response_raises_errors(web3,
+                                          response,
+                                          params,
+                                          error_formatters,
+                                          null_result_formatters,
+                                          error):
+    with pytest.raises(error):
+        web3.manager.formatted_response(response,
+                                        params,
+                                        error_formatters,
+                                        null_result_formatters)
+
+
+@pytest.mark.parametrize(
+    'response,params,error_formatters,null_result_formatters,error,error_message',
+    [
+        (
+            NONE_RESPONSE,
+            ('0x01',),
+            identity,
+            raise_block_not_found_for_uncle_at_index,
+            BlockNotFound,
+            "Unknown block identifier or uncle index",
+        ),
+        (
+            NONE_RESPONSE,
+            ('0x01', '0x00'),
+            identity,
+            raise_block_not_found_for_uncle_at_index,
+            BlockNotFound,
+            "Uncle at index: 0 of block with id: '0x01' not found."
+        ),
+    ],
+)
+def test_formatted_response_raises_correct_error_message(response,
+                                                         web3,
+                                                         params,
+                                                         error_formatters,
+                                                         null_result_formatters,
+                                                         error,
+                                                         error_message):
+
+    with pytest.raises(error, match=error_message):
+        web3.manager.formatted_response(response, params, error_formatters, null_result_formatters)
+
+
+@pytest.mark.parametrize(
+    'response,params,error_formatters,null_result_formatters,expected',
+    [
+        (
+            # Response with a result of None doesn't raise if there is no null result formatter
+            NONE_RESPONSE,
+            ('0x03'),
+            identity,
+            identity,
+            NONE_RESPONSE['result'],
+        ),
+    ],
+)
+def test_formatted_response(response,
+                            web3,
+                            params,
+                            error_formatters,
+                            null_result_formatters,
+                            expected):
+
+    formatted_resp = web3.manager.formatted_response(response,
+                                                     params,
+                                                     error_formatters,
+                                                     null_result_formatters)
+    assert formatted_resp == expected

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -302,9 +302,7 @@ class AsyncEthModuleTest:
         assert block['hash'] == empty_block['hash']
 
     @pytest.mark.asyncio
-    async def test_eth_getBlockByHash_not_found(
-        self, async_w3: "Web3", empty_block: BlockData
-    ) -> None:
+    async def test_eth_getBlockByHash_not_found(self, async_w3: "Web3") -> None:
         with pytest.raises(BlockNotFound):
             await async_w3.eth.get_block(UNKNOWN_HASH)  # type: ignore
 

--- a/web3/module.py
+++ b/web3/module.py
@@ -53,8 +53,11 @@ def retrieve_blocking_method_call_fn(
             (method_str, params), response_formatters = method.process_params(module, *args, **kwargs)  # noqa: E501
         except _UseExistingFilter as err:
             return LogFilter(eth_module=module, filter_id=err.filter_id)
-        result_formatters, error_formatters = response_formatters
-        result = w3.manager.request_blocking(method_str, params, error_formatters)
+        result_formatters, error_formatters, null_result_formatters = response_formatters
+        result = w3.manager.request_blocking(method_str,
+                                             params,
+                                             error_formatters,
+                                             null_result_formatters)
         return apply_result_formatters(result_formatters, result)
     return caller
 
@@ -65,8 +68,11 @@ def retrieve_async_method_call_fn(
 ) -> Callable[..., Coroutine[Any, Any, RPCResponse]]:
     async def caller(*args: Any, **kwargs: Any) -> RPCResponse:
         (method_str, params), response_formatters = method.process_params(module, *args, **kwargs)
-        result_formatters, error_formatters = response_formatters
-        result = await w3.manager.coro_request(method_str, params, error_formatters)
+        result_formatters, error_formatters, null_result_formatters = response_formatters
+        result = await w3.manager.coro_request(method_str,
+                                               params,
+                                               error_formatters,
+                                               null_result_formatters)
         return apply_result_formatters(result_formatters, result)
     return caller
 


### PR DESCRIPTION
### What was wrong?
Fixes #2010 - OE sends back an error response if it isn't done syncing and the user makes a `get_block` request with a block number that is outside of what's been synced. 


### How was it fixed?

Fixed the logic to handle both cases. Instead of having a reallly long `if` statement, I split out the response formatters for the case where a `result: None` is returned, and the case that we get back an actual error response.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/ryn2tp72v6h41.jpg)
