### PR TITLE
Honor WEB3_PROVIDER_URI for geth auto dev connection

### DIFF
--- a/newsfragments/2023.bugfix.rst
+++ b/newsfragments/2023.bugfix.rst
@@ -1,0 +1,1 @@
+Have the geth dev IPC auto connection check for the ``WEB3_PROVIDER_URI`` environment variable.

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -17,6 +17,9 @@ from web3.providers import (
 from web3.providers.auto import (
     load_provider_from_environment,
 )
+from web3.providers.ipc import (
+    get_dev_ipc_path,
+)
 
 # Ugly hack to import infura now that API KEY is required
 os.environ['WEB3_INFURA_API_KEY'] = 'test'
@@ -49,6 +52,13 @@ def test_load_provider_from_env(monkeypatch, uri, expected_type, expected_attrs)
     assert isinstance(provider, expected_type)
     for attr, val in expected_attrs.items():
         assert getattr(provider, attr) == val
+
+
+def test_get_dev_ipc_path(monkeypatch, tmp_path):
+    uri = str(tmp_path)
+    monkeypatch.setenv('WEB3_PROVIDER_URI', uri)
+    path = get_dev_ipc_path()
+    assert path == uri
 
 
 @pytest.mark.parametrize('environ_name', ['WEB3_INFURA_API_KEY', 'WEB3_INFURA_PROJECT_ID'])

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -157,7 +157,11 @@ def get_default_ipc_path() -> str:  # type: ignore
 
 # type ignored b/c missing return statement is by design here
 def get_dev_ipc_path() -> str:  # type: ignore
-    if sys.platform == 'darwin':
+    if os.environ.get('WEB3_PROVIDER_URI', ''):
+        ipc_path = os.environ.get('WEB3_PROVIDER_URI')
+        if os.path.exists(ipc_path):
+            return ipc_path
+    elif sys.platform == 'darwin':
         tmpdir = os.environ.get('TMPDIR', '')
         ipc_path = os.path.expanduser(os.path.join(
             tmpdir,


### PR DESCRIPTION
### What was wrong?

Connecting via the gethdev auto provider didn't look first for the `WEB3_PROVIDER_URI` environment variable. 

Fixes #1817 

### How was it fixed?

Added a check at the beginning of the `get_dev_ipc_path` function for the WEB3_PROVIDER_URI environment variable. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://twistedsifter.com/wp-content/uploads/2012/05/adorable-baby-elephant-1.jpg)
