### PR TITLE
Clarify that using `block_identifier` with .call() comes with its caveats

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -826,6 +826,11 @@ Methods
 
         # You can check the state after your pending transactions (if supported by your node):
         >>> token_contract.functions.myBalance().call(block_identifier='pending')
+        
+     Passing `block_identifier` parameter for past block numbers requires that your Ethereum API node 
+     is running an more expensive archive node mode. Normally synced Ethereum nodes will fail with 
+     `missing trie node` error, because Ethereum node may have purged the past state from its database.
+     `More information about archival nodes here <https://ethereum.stackexchange.com/a/84200/620>`_.
 
 .. py:method:: ContractFunction.estimateGas(transaction, block_identifier=None)
 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -826,10 +826,10 @@ Methods
 
         # You can check the state after your pending transactions (if supported by your node):
         >>> token_contract.functions.myBalance().call(block_identifier='pending')
-        
-    Passing `block_identifier` parameter for past block numbers requires that your Ethereum API node 
-    is running an more expensive archive node mode. Normally synced Ethereum nodes will fail with 
-    `missing trie node` error, because Ethereum node may have purged the past state from its database.
+
+    Passing the ``block_identifier`` parameter for past block numbers requires that your Ethereum API node
+    is running in the more expensive archive node mode. Normally synced Ethereum nodes will fail with
+    a "missing trie node" error, because Ethereum node may have purged the past state from its database.
     `More information about archival nodes here <https://ethereum.stackexchange.com/a/84200/620>`_.
 
 .. py:method:: ContractFunction.estimateGas(transaction, block_identifier=None)

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -827,10 +827,10 @@ Methods
         # You can check the state after your pending transactions (if supported by your node):
         >>> token_contract.functions.myBalance().call(block_identifier='pending')
         
-     Passing `block_identifier` parameter for past block numbers requires that your Ethereum API node 
-     is running an more expensive archive node mode. Normally synced Ethereum nodes will fail with 
-     `missing trie node` error, because Ethereum node may have purged the past state from its database.
-     `More information about archival nodes here <https://ethereum.stackexchange.com/a/84200/620>`_.
+    Passing `block_identifier` parameter for past block numbers requires that your Ethereum API node 
+    is running an more expensive archive node mode. Normally synced Ethereum nodes will fail with 
+    `missing trie node` error, because Ethereum node may have purged the past state from its database.
+    `More information about archival nodes here <https://ethereum.stackexchange.com/a/84200/620>`_.
 
 .. py:method:: ContractFunction.estimateGas(transaction, block_identifier=None)
 

--- a/newsfragments/2048.doc.rst
+++ b/newsfragments/2048.doc.rst
@@ -1,0 +1,2 @@
+Clarify that a missing trie node error could occur when using ``block_identifier`` with ``.call()``
+on a node that isn't running in archive mode


### PR DESCRIPTION
To manage the expectations of the client library users.

### What was wrong?

Programmers were using `call` with a block number, but did not know it might not work as it.

### How was it fixed?

Document `block_identifier` behavior with various Ethereum nodes.

#### Cute Animal Picture

```
-=[ bull ]=-  12/96

   ,/         \,
  ((__,-"""-,__))
   `--)~   ~(--`
  .-'(       )`-,
  `~~`d\   /b`~~`
      |     |
 jgs  (6___6)
       `---`
```
