### PR TITLE
[WIP] Add eth.get_raw_transaction_by_block #2040

### DIFF
--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -444,10 +444,7 @@ PYTHONIC_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getFilterLogs: filter_result_formatter,
     RPC.eth_getLogs: filter_result_formatter,
     RPC.eth_getProof: apply_formatter_if(is_not_null, proof_formatter),
-    RPC.eth_getRawTransactionByBlockHashAndIndex: apply_formatter_if(
-        is_not_null,
-        transaction_formatter,
-    ),
+    RPC.eth_getRawTransactionByBlockHashAndIndex: HexBytes,
     RPC.eth_getRawTransactionByBlockNumberAndIndex: apply_formatter_if(
         is_not_null,
         transaction_formatter,
@@ -626,15 +623,6 @@ def raise_transaction_not_found_with_index(params: Tuple[BlockIdentifier, int]) 
     )
 
 
-def raise_raw_transaction_not_found_with_index(params: Tuple[BlockIdentifier, int]) -> NoReturn:
-    block_identifier = params[0]
-    raw_transaction_index = to_integer_if_hex(params[1])
-    raise TransactionNotFound(
-        f"Transaction index: {raw_transaction_index} "
-        f"on block id: {block_identifier!r} not found."
-    )
-
-
 NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getBlockByHash: raise_block_not_found,
     RPC.eth_getBlockByNumber: raise_block_not_found,
@@ -648,8 +636,8 @@ NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getTransactionByBlockHashAndIndex: raise_transaction_not_found_with_index,
     RPC.eth_getTransactionByBlockNumberAndIndex: raise_transaction_not_found_with_index,
     RPC.eth_getTransactionReceipt: raise_transaction_not_found,
-    RPC.eth_getRawTransactionByBlockHashAndIndex: raise_raw_transaction_not_found_with_index,
-    RPC.eth_getRawTransactionByBlockNumberAndIndex: raise_raw_transaction_not_found_with_index,
+    RPC.eth_getRawTransactionByBlockHashAndIndex: raise_transaction_not_found_with_index,
+    RPC.eth_getRawTransactionByBlockNumberAndIndex: raise_transaction_not_found_with_index,
 }
 
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -384,6 +384,10 @@ PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
         apply_formatter_at_index(to_hex_if_integer, 1),
     ),
     RPC.eth_getTransactionCount: apply_formatter_at_index(to_hex_if_integer, 1),
+    RPC.eth_getRawTransactionByBlockNumberAndIndex: compose(
+        apply_formatter_at_index(to_hex_if_integer, 0),
+        apply_formatter_at_index(to_hex_if_integer, 1),
+    ),
     RPC.eth_getUncleCountByBlockNumber: apply_formatter_at_index(to_hex_if_integer, 0),
     RPC.eth_getUncleByBlockNumberAndIndex: compose(
         apply_formatter_at_index(to_hex_if_integer, 0),
@@ -440,6 +444,14 @@ PYTHONIC_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getFilterLogs: filter_result_formatter,
     RPC.eth_getLogs: filter_result_formatter,
     RPC.eth_getProof: apply_formatter_if(is_not_null, proof_formatter),
+    RPC.eth_getRawTransactionByBlockHashAndIndex: apply_formatter_if(
+        is_not_null,
+        transaction_formatter,
+    ),
+    RPC.eth_getRawTransactionByBlockNumberAndIndex: apply_formatter_if(
+        is_not_null,
+        transaction_formatter,
+    ),
     RPC.eth_getStorageAt: HexBytes,
     RPC.eth_getTransactionByBlockHashAndIndex: apply_formatter_if(
         is_not_null,
@@ -614,6 +626,15 @@ def raise_transaction_not_found_with_index(params: Tuple[BlockIdentifier, int]) 
     )
 
 
+def raise_raw_transaction_not_found_with_index(params: Tuple[BlockIdentifier, int]) -> NoReturn:
+    block_identifier = params[0]
+    raw_transaction_index = to_integer_if_hex(params[1])
+    raise TransactionNotFound(
+        f"Transaction index: {raw_transaction_index} "
+        f"on block id: {block_identifier!r} not found."
+    )
+
+
 NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getBlockByHash: raise_block_not_found,
     RPC.eth_getBlockByNumber: raise_block_not_found,
@@ -627,6 +648,8 @@ NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getTransactionByBlockHashAndIndex: raise_transaction_not_found_with_index,
     RPC.eth_getTransactionByBlockNumberAndIndex: raise_transaction_not_found_with_index,
     RPC.eth_getTransactionReceipt: raise_transaction_not_found,
+    RPC.eth_getRawTransactionByBlockHashAndIndex: raise_raw_transaction_not_found_with_index,
+    RPC.eth_getRawTransactionByBlockNumberAndIndex: raise_raw_transaction_not_found_with_index,
 }
 
 

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -60,6 +60,8 @@ class RPC:
     eth_getStorageAt = RPCEndpoint("eth_getStorageAt")
     eth_getTransactionByBlockHashAndIndex = RPCEndpoint("eth_getTransactionByBlockHashAndIndex")
     eth_getTransactionByBlockNumberAndIndex = RPCEndpoint("eth_getTransactionByBlockNumberAndIndex")
+    eth_getRawTransactionByBlockHashAndIndex = RPCEndpoint("eth_getRawTransactionByBlockHashAndIndex")
+    eth_getRawTransactionByBlockNumberAndIndex = RPCEndpoint("eth_getRawTransactionByBlockNumberAndIndex")
     eth_getTransactionByHash = RPCEndpoint("eth_getTransactionByHash")
     eth_getTransactionCount = RPCEndpoint("eth_getTransactionCount")
     eth_getTransactionReceipt = RPCEndpoint("eth_getTransactionReceipt")
@@ -181,6 +183,7 @@ RPC_ABIS = {
     'eth_getTransactionByHash': ['bytes32'],
     'eth_getTransactionCount': ['address', None],
     'eth_getTransactionReceipt': ['bytes32'],
+    'eth_getRawTransactionByBlockHashAndIndex': ['bytes32', 'uint'],
     'eth_getUncleCountByBlockHash': ['bytes32'],
     'eth_newFilter': FILTER_PARAMS_ABIS,
     'eth_sendRawTransaction': ['bytes'],

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -60,8 +60,10 @@ class RPC:
     eth_getStorageAt = RPCEndpoint("eth_getStorageAt")
     eth_getTransactionByBlockHashAndIndex = RPCEndpoint("eth_getTransactionByBlockHashAndIndex")
     eth_getTransactionByBlockNumberAndIndex = RPCEndpoint("eth_getTransactionByBlockNumberAndIndex")
-    eth_getRawTransactionByBlockHashAndIndex = RPCEndpoint("eth_getRawTransactionByBlockHashAndIndex")
-    eth_getRawTransactionByBlockNumberAndIndex = RPCEndpoint("eth_getRawTransactionByBlockNumberAndIndex")
+    eth_getRawTransactionByBlockHashAndIndex = \
+        RPCEndpoint("eth_getRawTransactionByBlockHashAndIndex")
+    eth_getRawTransactionByBlockNumberAndIndex = \
+        RPCEndpoint("eth_getRawTransactionByBlockNumberAndIndex")
     eth_getTransactionByHash = RPCEndpoint("eth_getTransactionByHash")
     eth_getTransactionCount = RPCEndpoint("eth_getTransactionCount")
     eth_getTransactionReceipt = RPCEndpoint("eth_getTransactionReceipt")

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -519,6 +519,19 @@ class Eth(BaseEth, Module):
         mungers=[default_root_munger]
     )
 
+    """
+    `eth_getRawTransactionByBlockHashAndIndex`
+    `eth_getRawTransactionByBlockNumberAndIndex`
+    """
+    get_raw_transaction_by_block: Method[Callable[[BlockIdentifier], int]] = Method(
+        method_choice_depends_on_args=select_method_for_block_identifier(
+            if_predefined=RPC.eth_getRawTransactionByBlockNumberAndIndex,
+            if_hash=RPC.eth_getRawTransactionByBlockHashAndIndex,
+            if_number=RPC.eth_getRawTransactionByBlockNumberAndIndex,
+        ),
+        mungers=[default_root_munger]
+    )
+
     @deprecated_for("wait_for_transaction_receipt")
     def waitForTransactionReceipt(
         self, transaction_hash: _Hash32, timeout: int = 120, poll_latency: float = 0.1


### PR DESCRIPTION
### What was wrong?
RPC Methods ```eth_getRawTransactionByBlockHashAndIndex```, and ```eth_getRawTransactionByBlockNumberAndIndex``` are not supported. This PR adds support for it and also add eth.get_raw_transaction_by_block method to web3/eth.py

Related to Issue #2040 

### How was it fixed?
Implementation closely followed to that of ```eth.get_transaction_by_block```

### Todo:
- [X] Add ```eth.get_raw_transaction_by_block``` method in ```web3/eth.py``` 
- [x] Add ```eth_getRawTransactionByBlockHashAndIndex```, and ```eth_getRawTransactionByBlockNumberAndIndex``` methods in ```web3/_utils/rpc_abi.py```
- [x] Add ```eth_getRawTransactionByBlockHashAndIndex```, and ```eth_getRawTransactionByBlockNumberAndIndex``` method formatting and error handling in ```web3/_utils/method_formatters.py```
- [ ] Add tests


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/b3/67/03/b367039be15d14f61363bb59b3752ed2.jpg)
