### PR TITLE
Fix tests from 1835 changes and default to 1559 fields for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ develop-eggs
 lib
 lib64
 venv*
+.python-version
 
 # Installer logs
 pip-log.txt

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -126,7 +126,7 @@ with the exception of ``self`` and ``cls`` as seen in the following example.
         self.reset()
 
 
-Running the tests
+Running The Tests
 ~~~~~~~~~~~~~~~~~
 
 A great way to explore the code base is to run the tests.
@@ -136,7 +136,7 @@ First, install the test dependencies:
 
 .. code:: sh
 
-    $ pip install -e ".[test]"
+    $ pip install -e ".[tester]"
 
 You can run all tests with:
 
@@ -171,6 +171,73 @@ linting errors locally:
 It is important to understand that each pull request must pass the full test
 suite as part of the CI check. This test suite will run in the CI anytime a
 pull request is opened or updated.
+
+
+Writing Tests
+~~~~~~~~~~~~~
+
+We strongly encourage contributors to write good tests for their code as
+part of the code review process. This helps ensure that your code is doing
+what it should be doing.
+
+We strongly encourage you to use our existing tests for both guidance and
+homogeneity / consistency across our tests. We use ``pytest`` for our tests.
+For more specific pytest guidance, please refer to the `pytest documentation`_.
+
+Within the ``pytest`` scope, :file:`conftest.py` files are used for common code
+shared between modules that exist within the same directory as that particular
+:file:`conftest.py` file.
+
+Unit Testing
+^^^^^^^^^^^^
+
+Unit tests are meant to test the logic of smaller chunks (or units) of the
+codebase without having to be wired up to a client. Most of the time this
+means testing selected methods on their own. They are meant to test the logic
+of your code and make sure that you get expected outputs out of selected inputs.
+
+Our unit tests live under appropriately named child directories within the
+``/tests`` directory. The core of the unit tests live under ``/tests/core``.
+Do your best to follow the existing structure when choosing where to add
+your unit test.
+
+Integration Testing
+^^^^^^^^^^^^^^^^^^^
+
+Our integration test suite setup lives under the ``/tests/integration`` directory.
+The integration test suite is dependent on what we call "fixtures" (not to be
+confused with pytest fixtures). These zip file fixtures, which also live in the
+``/tests/integration`` directory, are configured to run the specific client we are
+testing against along with a genesis configuration that gives our tests some
+pre-determined useful objects (like unlocked, pre-loaded accounts) to be able to
+interact with the client and run our tests.
+
+Though the setup lives in ``/tests/integration``, our integration module tests are
+written across different files within ``/web3/_utils/module_testing``. The tests
+are written there but run configurations exist across the different files within
+``/tests/integration/``. The parent ``/integration`` directory houses some common
+configuration shared across all client tests, whereas the ``/go_ethereum`` and
+``/parity`` directories house common code to be shared among each respective client
+tests.
+
+* :file:`common.py` files within the client directories contain code that is shared across
+  all provider tests (http, ipc, and ws). This is mostly used to override tests that span
+  across all providers.
+* :file:`conftest.py` files within each of these directories contain mostly code that can
+  be *used* by all test files that exist within the same directory as the :file:`conftest.py`
+  file. This is mostly used to house pytest fixtures to be shared among our tests. Refer to
+  the `pytest documentation on fixtures`_ for more information.
+* :file:`test_{client}_{provider}.py` (e.g. :file:`test_goethereum_http.py`) files are where
+  client-and-provider-specific test configurations exist. This is mostly used to override tests
+  specific to the provider type for the respective client.
+
+Sometimes the client may be bogged down with pending transactions or anything else that may
+interfere with your particular test. In this case, it may be useful to run your test at the
+front of the test suite. If you feel it makes sense to run a particular test at a specific
+position in the test suite, there is a handy ``pytest`` hook that allows us to somewhat
+customize the order of our integration tests. This ``pytest_collection_modifyitems`` hook
+can be defined within the appropriate ``conftest.py`` file, depending on the scope of the
+test suite you want it to affect.
 
 
 Manual Testing
@@ -217,7 +284,7 @@ If possible, the change to the release notes file should be included in the
 commit that introduces the feature or bugfix.
 
 
-Generating new fixtures
+Generating New Fixtures
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Our integration tests make use of Geth and Parity/OpenEthereum private networks.
@@ -228,7 +295,7 @@ Before generating new fixtures, make sure you have the test dependencies install
 
 .. code:: sh
 
-    $ pip install -e ".[test]"
+    $ pip install -e ".[tester]"
 
 .. note::
 
@@ -237,7 +304,7 @@ Before generating new fixtures, make sure you have the test dependencies install
     testing Web3.py functionality against.
 
 
-Geth fixtures
+Geth Fixtures
 ^^^^^^^^^^^^^
 
 1. Install the desired Geth version on your machine locally. We recommend `py-geth`_ for
@@ -265,7 +332,7 @@ Geth fixtures
    you may again include the ``GETH_BINARY`` environment variable.
 
 
-CI testing with a nightly Geth build
+CI Testing With a Nightly Geth Build
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Occasionally you'll want to have CI run the test suite against an unreleased version of Geth,
@@ -291,7 +358,7 @@ an unstable client.
 6. Create a PR and let CI do its thing.
 
 
-Parity/OpenEthereum fixtures
+Parity/OpenEthereum Fixtures
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 1. The most reliable way to get a specific Parity/OE binary is to download
@@ -323,7 +390,7 @@ Parity/OpenEthereum fixtures
 Releasing
 ~~~~~~~~~
 
-Final test before each release
+Final Test Before Each Release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Before releasing a new version, build and test the package that will be released.
@@ -349,7 +416,7 @@ virtualenv for smoke testing:
     >>> ...
 
 
-Verify the latest documentation 
+Verify The Latest Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To preview the documentation that will get published:
@@ -359,7 +426,7 @@ To preview the documentation that will get published:
     $ make docs
 
 
-Preview the release notes
+Preview The Release Notes
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: sh
@@ -367,7 +434,7 @@ Preview the release notes
    $ towncrier --draft
 
 
-Compile the release notes
+Compile The Release Notes
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After confirming that the release package looks okay, compile the release notes:
@@ -381,7 +448,7 @@ You may need to fix up any broken release note fragments before committing. Keep
 running ``make build-docs`` until it passes, then commit and carry on.
 
 
-Push the release to GitHub & PyPI
+Push The Release to GitHub & PyPI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After committing the compiled release notes and pushing them to the master
@@ -392,7 +459,7 @@ branch, release a new version:
     $ make release bump=$$VERSION_PART_TO_BUMP$$
 
 
-Which version part to bump
+Which Version Part to Bump
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The version format for this repo is ``{major}.{minor}.{patch}`` for
@@ -418,3 +485,5 @@ version explicitly, like ``make release bump="--new-version 4.0.0-alpha.1 devnum
 .. _py-geth: https://github.com/ethereum/py-geth
 .. _Github releases: https://github.com/openethereum/openethereum/releases
 .. _Build the binary: https://github.com/openethereum/openethereum/#3-building-
+.. _pytest documentation: https://docs.pytest.org/en/latest
+.. _pytest documentation on fixtures: https://docs.pytest.org/en/latest/how-to/fixtures.html

--- a/newsfragments/2053.bugfix.rst
+++ b/newsfragments/2053.bugfix.rst
@@ -1,0 +1,1 @@
+Fix broken tests and use the new 1559 params for most of our test transactions.

--- a/newsfragments/2053.doc.rst
+++ b/newsfragments/2053.doc.rst
@@ -1,0 +1,1 @@
+Added general documentation on unit and integration testing and how to contribute to our test suite.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,6 +15,30 @@ from web3._utils.module_testing.revert_contract import (
 )
 
 
+def pytest_collection_modifyitems(items):
+    """
+    Certain tests have issues running after most of our test suite has run. If we run
+    these tests in the beginning, we can ensure that the client isn't overloaded with
+    context from our other tests and therefore reduce the noise for these more sensitive
+    tests. We can somewhat control when tests are run by overriding this pytest hook and
+    customizing the test order. You may find it helpful to move a conflicting test to
+    the beginning of the test suite or configure the test order in some other way here.
+    """
+    test_names_to_append_to_start = [
+        'test_eth_get_logs_with_logs',
+        'test_eth_call_old_contract_state',
+    ]
+    for index, item in enumerate(items):
+        # We run two versions of some tests that end with [<lambda>] or [address_conversion_func1].
+        # This step cleans up the name depending on whether or not they exist as two separate
+        # tests or just one without the bracketed "[]" suffix.
+        test_name = item.name if "[" not in item.name else item.name[:item.name.find("[")]
+
+        if test_name in test_names_to_append_to_start:
+            test_item = items.pop(index)
+            items.insert(0, test_item)
+
+
 @pytest.fixture(scope="module")
 def math_contract_factory(web3):
     contract_factory = web3.eth.contract(abi=MATH_ABI, bytecode=MATH_BYTECODE)

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -1,6 +1,3 @@
-#  from concurrent.futures._base import (
-#  TimeoutError as FuturesTimeoutError,
-#  )
 import pytest
 
 from web3._utils.module_testing import (  # noqa: F401
@@ -20,20 +17,16 @@ class GoEthereumTest(Web3ModuleTest):
 
 
 class GoEthereumEthModuleTest(EthModuleTest):
-    #  @pytest.mark.xfail(
-    #  strict=False,
-    #  raises=FuturesTimeoutError,
-    #  reason='Sometimes a TimeoutError is hit when waiting for the txn to be mined',
-    #  )
-    @pytest.mark.skip(reason="London TODO: crashes on [address_conversion_func1]")
+    @pytest.mark.xfail(
+        strict=False,
+        reason='Sometimes a TimeoutError is hit when waiting for the txn to be mined',
+    )
     def test_eth_replace_transaction_already_mined(self, web3, unlocked_account_dual_type):
-        web3.geth.miner.start()
-        super().test_eth_replace_transaction_already_mined(web3, unlocked_account_dual_type)
-        web3.geth.miner.stop()
-
-    @pytest.mark.skip(reason="London TODO: pending call isn't found")
-    def test_eth_call_old_contract_state(self, web3, math_contract, unlocked_account):
-        super().test_eth_call_old_contract_state(web3, math_contract, unlocked_account)
+        try:
+            web3.geth.miner.start()
+            super().test_eth_replace_transaction_already_mined(web3, unlocked_account_dual_type)
+        finally:
+            web3.geth.miner.stop()
 
     @pytest.mark.xfail(reason='eth_signTypedData has not been released in geth')
     def test_eth_sign_typed_data(self, web3, unlocked_account_dual_type):

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -272,18 +272,34 @@ class TestEthereumTesterEthModule(EthModuleTest):
         assert block['hash'] is not None
 
     @disable_auto_mine
+    @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
     def test_eth_get_transaction_receipt_unmined(self, eth_tester, web3, unlocked_account):
         super().test_eth_get_transaction_receipt_unmined(web3, unlocked_account)
 
     @disable_auto_mine
-    def test_eth_replaceTransaction_deprecated(self, eth_tester, web3, unlocked_account):
-        super().test_eth_replaceTransaction_deprecated(web3, unlocked_account)
+    def test_eth_replace_transaction_legacy(self, eth_tester, web3, unlocked_account):
+        super().test_eth_replace_transaction_legacy(web3, unlocked_account)
 
     @disable_auto_mine
+    @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
     def test_eth_replace_transaction(self, eth_tester, web3, unlocked_account):
         super().test_eth_replace_transaction(web3, unlocked_account)
 
+    @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
+    def test_eth_replace_transaction_underpriced(self, web3, emitter_contract_address):
+        super().test_eth_replace_transaction_underpriced(web3, emitter_contract_address)
+
     @disable_auto_mine
+    @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
+    def test_eth_replaceTransaction_deprecated(self, eth_tester, web3, unlocked_account):
+        super().test_eth_replaceTransaction_deprecated(web3, unlocked_account)
+
+    @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
+    def test_eth_replace_transaction_already_mined(self, web3, emitter_contract_address):
+        super().test_eth_replace_transaction_already_mined(web3, emitter_contract_address)
+
+    @disable_auto_mine
+    @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
     def test_eth_replace_transaction_incorrect_nonce(self, eth_tester, web3, unlocked_account):
         super().test_eth_replace_transaction_incorrect_nonce(web3, unlocked_account)
 
@@ -429,24 +445,32 @@ class TestEthereumTesterEthModule(EthModuleTest):
             web3.eth.estimate_gas(txn_params)
 
     @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
-    def test_1559_default_fees(self, web3, emitter_contract_address):
-        super().test_1559_default_fees(web3, emitter_contract_address)
+    def test_eth_send_transaction(self, web3, emitter_contract_address):
+        super().test_eth_send_transaction(web3, emitter_contract_address)
 
     @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
-    def test_1559_canonical(self, web3, emitter_contract_address):
-        super().test_1559_canonical(web3, emitter_contract_address)
+    def test_eth_sendTransaction_deprecated(self, web3, emitter_contract_address):
+        super().test_eth_sendTransaction_deprecated(web3, emitter_contract_address)
 
     @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
-    def test_1559_hex_fees(self, web3, emitter_contract_address):
-        super().test_1559_hex_fees(web3, emitter_contract_address)
+    def test_eth_send_transaction_with_nonce(self, web3, emitter_contract_address):
+        super().test_eth_send_transaction_with_nonce(web3, emitter_contract_address)
 
     @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
-    def test_1559_no_gas(self, web3, emitter_contract_address):
-        super().test_1559_no_gas(web3, emitter_contract_address)
+    def test_eth_send_transaction_default_fees(self, web3, emitter_contract_address):
+        super().test_eth_send_transaction_default_fees(web3, emitter_contract_address)
 
     @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
-    def test_1559_no_max_fee(self, web3, emitter_contract_address):
-        super().test_1559_no_max_fee(web3, emitter_contract_address)
+    def test_eth_send_transaction_hex_fees(self, web3, emitter_contract_address):
+        super().test_eth_send_transaction_hex_fees(web3, emitter_contract_address)
+
+    @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
+    def test_eth_send_transaction_no_gas(self, web3, emitter_contract_address):
+        super().test_eth_send_transaction_no_gas(web3, emitter_contract_address)
+
+    @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
+    def test_eth_send_transaction_no_max_fee(self, web3, emitter_contract_address):
+        super().test_eth_send_transaction_no_max_fee(web3, emitter_contract_address)
 
 
 class TestEthereumTesterVersionModule(VersionModuleTest):

--- a/web3/_utils/module_testing/math_contract.py
+++ b/web3/_utils/module_testing/math_contract.py
@@ -95,11 +95,12 @@ MATH_ABI = [
 contract Contract {
     function main() {
         memory[0x40:0x60] = 0x60;
-    
+
         if (!msg.data.length) { stop(); }
-    
-        var var0 = msg.data[0x00:0x20] / 0x0100000000000000000000000000000000000000000000000000000000;
-    
+
+        var var0 =
+            msg.data[0x00:0x20] / 0x0100000000000000000000000000000000000000000000000000000000;
+
         if (var0 == 0x16216f39) {
             // Dispatch table entry for return13()
             var var1 = 0x0083;
@@ -154,36 +155,36 @@ contract Contract {
             return memory[temp11:temp11 + (temp10 + 0x20) - temp11];
         } else { stop(); }
     }
-    
+
     function return13() returns (var r0) {
         var var0 = 0x0d;
         return var0;
     }
-    
+
     function counter() returns (var r0) { return storage[0x00]; }
-    
+
     function increment(var arg0) returns (var r0) {
         storage[0x00] = storage[0x00] + arg0;
         var temp0 = memory[0x40:0x60];
         memory[temp0:temp0 + 0x20] = storage[0x00];
         var temp1 = memory[0x40:0x60];
-        log(memory[temp1:temp1 + (temp0 + 0x20) - temp1], [0x3496c3ede4ec3ab3686712aa1c238593ea6a42df83f98a5ec7df9834cfa577c5]);
+        log(memory[temp1:temp1 + (temp0 + 0x20) - temp1],
+            [0x3496c3ede4ec3ab3686712aa1c238593ea6a42df83f98a5ec7df9834cfa577c5]);
         var var0 = storage[0x00];
-        return var0;
-    }
-    
+        return var0;}
+
     function add(var arg0, var arg1) returns (var r0) {
         var var0 = arg0 + arg1;
         return var0;
     }
-    
+
     function increment() returns (var r0) {
         var var0 = 0x00;
         var var1 = 0x020d;
         var var2 = 0x01;
         return increment(var2);
     }
-    
+
     function multiply7(var arg0) returns (var r0) {
         var var0 = arg0 * 0x07;
         return var0;

--- a/web3/_utils/module_testing/math_contract.py
+++ b/web3/_utils/module_testing/math_contract.py
@@ -89,3 +89,104 @@ MATH_ABI = [
         "type": "event",
     },
 ]
+
+# The de-compiled math contract, for reference:
+'''
+contract Contract {
+    function main() {
+        memory[0x40:0x60] = 0x60;
+    
+        if (!msg.data.length) { stop(); }
+    
+        var var0 = msg.data[0x00:0x20] / 0x0100000000000000000000000000000000000000000000000000000000;
+    
+        if (var0 == 0x16216f39) {
+            // Dispatch table entry for return13()
+            var var1 = 0x0083;
+            var1 = return13();
+            var temp0 = memory[0x40:0x60];
+            memory[temp0:temp0 + 0x20] = var1;
+            var temp1 = memory[0x40:0x60];
+            return memory[temp1:temp1 + (temp0 + 0x20) - temp1];
+        } else if (var0 == 0x61bc221a) {
+            // Dispatch table entry for counter()
+            var1 = 0x00a6;
+            var var2 = counter();
+            var temp2 = memory[0x40:0x60];
+            memory[temp2:temp2 + 0x20] = var2;
+            var temp3 = memory[0x40:0x60];
+            return memory[temp3:temp3 + (temp2 + 0x20) - temp3];
+        } else if (var0 == 0x7cf5dab0) {
+            // Dispatch table entry for increment(uint256)
+            var1 = 0x00d2;
+            var2 = msg.data[0x04:0x24];
+            var1 = increment(var2);
+            var temp4 = memory[0x40:0x60];
+            memory[temp4:temp4 + 0x20] = var1;
+            var temp5 = memory[0x40:0x60];
+            return memory[temp5:temp5 + (temp4 + 0x20) - temp5];
+        } else if (var0 == 0xa5f3c23b) {
+            // Dispatch table entry for add(int256,int256)
+            var1 = 0x0107;
+            var2 = msg.data[0x04:0x24];
+            var var3 = msg.data[0x24:0x44];
+            var1 = add(var2, var3);
+            var temp6 = memory[0x40:0x60];
+            memory[temp6:temp6 + 0x20] = var1;
+            var temp7 = memory[0x40:0x60];
+            return memory[temp7:temp7 + (temp6 + 0x20) - temp7];
+        } else if (var0 == 0xd09de08a) {
+            // Dispatch table entry for increment()
+            var1 = 0x012a;
+            var1 = increment();
+            var temp8 = memory[0x40:0x60];
+            memory[temp8:temp8 + 0x20] = var1;
+            var temp9 = memory[0x40:0x60];
+            return memory[temp9:temp9 + (temp8 + 0x20) - temp9];
+        } else if (var0 == 0xdcf537b1) {
+            // Dispatch table entry for multiply7(int256)
+            var1 = 0x0156;
+            var2 = msg.data[0x04:0x24];
+            var1 = multiply7(var2);
+            var temp10 = memory[0x40:0x60];
+            memory[temp10:temp10 + 0x20] = var1;
+            var temp11 = memory[0x40:0x60];
+            return memory[temp11:temp11 + (temp10 + 0x20) - temp11];
+        } else { stop(); }
+    }
+    
+    function return13() returns (var r0) {
+        var var0 = 0x0d;
+        return var0;
+    }
+    
+    function counter() returns (var r0) { return storage[0x00]; }
+    
+    function increment(var arg0) returns (var r0) {
+        storage[0x00] = storage[0x00] + arg0;
+        var temp0 = memory[0x40:0x60];
+        memory[temp0:temp0 + 0x20] = storage[0x00];
+        var temp1 = memory[0x40:0x60];
+        log(memory[temp1:temp1 + (temp0 + 0x20) - temp1], [0x3496c3ede4ec3ab3686712aa1c238593ea6a42df83f98a5ec7df9834cfa577c5]);
+        var var0 = storage[0x00];
+        return var0;
+    }
+    
+    function add(var arg0, var arg1) returns (var r0) {
+        var var0 = arg0 + arg1;
+        return var0;
+    }
+    
+    function increment() returns (var r0) {
+        var var0 = 0x00;
+        var var1 = 0x020d;
+        var var2 = 0x01;
+        return increment(var2);
+    }
+    
+    function multiply7(var arg0) returns (var r0) {
+        var var0 = arg0 * 0x07;
+        return var0;
+    }
+}
+'''

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -193,9 +193,14 @@ def prepare_replacement_transaction(
     if 'nonce' not in new_transaction:
         new_transaction = assoc(new_transaction, 'nonce', current_transaction['nonce'])
 
-    if 'gasPrice' in new_transaction:
+    if 'maxFeePerGas' in new_transaction or 'maxPriorityFeePerGas' in new_transaction:
+        # for now, the client decides if a 1559 txn can replace the existing txn or not
+        pass
+
+    elif 'gasPrice' in new_transaction and current_transaction['gasPrice'] is not None:
         if new_transaction['gasPrice'] <= current_transaction['gasPrice']:
             raise ValueError('Supplied gas price must exceed existing transaction gas price')
+
     else:
         generated_gas_price = web3.eth.generate_gas_price(new_transaction)
         minimum_gas_price = int(math.ceil(current_transaction['gasPrice'] * gas_multiplier))


### PR DESCRIPTION
### What was wrong?

Related to Issue #1835

1. We skipped some tests in order to create the working london branch. Needed to isolate what was going wrong.
2. We should update default params in our existing transactions in our tests to use the new fields

### How was it fixed?

1. Some older tests seemed to be breaking others because they did not meet updated requirements to be included in a pending block, seemingly creating a txn jam. Increasing `gasPrice` for these tests seemed to move things along. Another issue we have is that some tests have their context dirtied by other tests. I included a way to move some tests to the beginning of the test suite to prevent this dirtied context and allow these tests to pass.

2. Updated default tests to use the new 1559 fields for our transactions.

### Todo:
- [X] Fix broken / skipped tests from london branch creation
- [X] Update existing tests to use the new 1559 fields `maxFeePerGas` and `maxPriorityFeePerGas` over `gasPrice` as defaults
- [X] Added documentation on unit and integration testing and how to contribute to our test suite
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![IMG_20210615_092412_01](https://user-images.githubusercontent.com/3532824/123493631-4f013c80-d5da-11eb-8d01-577ef03f94d3.jpg)

