### PR TITLE
set maxFeePerGas if not provided

### DIFF
--- a/newsfragments/2055.bugfix.rst
+++ b/newsfragments/2055.bugfix.rst
@@ -1,0 +1,1 @@
+Set a default maxFeePerGas value consistent with Geth

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -942,12 +942,13 @@ class EthModuleTest:
     def test_1559_no_max_fee(
         self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
+        maxPriorityFeePerGas = web3.toWei(2, 'gwei')
         txn_params: TxParams = {
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
             'gas': Wei(21000),
-            'maxPriorityFeePerGas': Wei(2 * 10**9),
+            'maxPriorityFeePerGas': maxPriorityFeePerGas,
         }
         txn_hash = web3.eth.send_transaction(txn_params)
         txn = web3.eth.get_transaction(txn_hash)
@@ -958,9 +959,7 @@ class EthModuleTest:
         assert txn['gas'] == 21000
 
         block = web3.eth.get_block('latest')
-        # TODO: what if base_fee < tip?
-        assert txn['maxFeePerGas'] >= block['baseFeePerGas']
-        #  assert txn['maxFeePerGas'] == base_fee * 2
+        assert txn['maxFeePerGas'] == maxPriorityFeePerGas + 2 * block['baseFeePerGas']
 
     def test_1559_max_fee_less_than_tip(
         self, web3: "Web3", unlocked_account_dual_type: ChecksumAddress

--- a/web3/middleware/gas_price_strategy.py
+++ b/web3/middleware/gas_price_strategy.py
@@ -45,16 +45,12 @@ def gas_price_strategy_middleware(
                     raise InvalidTransaction("maxFeePerGas must be >= maxPriorityFeePerGas")
             # 1559 - no max fee:
             elif 'maxFeePerGas' not in transaction and 'maxPriorityFeePerGas' in transaction:
-                try:
-                    block = web3.eth.get_block('latest')
-                    base_fee = block['baseFeePerGas']
-                    priority_fee = int(transaction['maxPriorityFeePerGas'], 16)
-                    max_fee_per_gas = priority_fee + 2 * base_fee
-                    transaction = assoc(transaction, 'maxFeePerGas', hex(max_fee_per_gas))
-                    return make_request(method, [transaction])
-                except Exception:
-                    # If unable to calculate maxFeePerGas, allow the client to decide
-                    pass
+                latest_block = web3.eth.get_block('latest')
+                base_fee = latest_block['baseFeePerGas']
+                priority_fee = int(transaction['maxPriorityFeePerGas'], 16)
+                max_fee_per_gas = priority_fee + 2 * base_fee
+                transaction = assoc(transaction, 'maxFeePerGas', hex(max_fee_per_gas))
+                return make_request(method, [transaction])
             # 1559 - no priority fee:
             elif 'maxFeePerGas' in transaction and 'maxPriorityFeePerGas' not in transaction:
                 raise InvalidTransaction(


### PR DESCRIPTION
### What was wrong?

One of the 1559 TODOs was to determine an appropriate `maxFeePerGas` if one was not provided, but a `maxPriorityFeePerGas` was.  (Related to #2054)

### How was it fixed?

This follows Geth's behavior to set the `maxFeePerGas` to `maxPriorityFeePerGas + 2*baseFee`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://www.thesun.co.uk/wp-content/uploads/2016/12/nintchdbpict000288708286.jpg?w=1240)
