### PR TITLE
Async eth.get_balance, eth.get_code, eth.get_transaction_count

### DIFF
--- a/newsfragments/2056.feature.rst
+++ b/newsfragments/2056.feature.rst
@@ -1,0 +1,1 @@
+Add async ``eth.get_balance``, ``eth.get_code``, ``eth.get_transaction_count`` methods.

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -374,6 +374,18 @@ class AsyncEthModuleTest:
         with pytest.raises(TransactionNotFound, match=f"Transaction with hash: '{UNKNOWN_HASH}'"):
             web3.eth.get_raw_transaction(UNKNOWN_HASH)
 
+    @pytest.mark.asyncio
+    async def test_eth_get_balance(self, async_w3: "Web3") -> None:
+        coinbase = await async_w3.eth.coinbase
+
+        with pytest.raises(InvalidAddress):
+            await async_w3.eth.get_balance(ChecksumAddress(HexAddress(HexStr(coinbase.lower()))))
+
+        balance = await async_w3.eth.get_balance(coinbase)
+
+        assert is_integer(balance)
+        assert balance >= 0
+
 
 class EthModuleTest:
     def test_eth_protocol_version(self, web3: "Web3") -> None:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -386,6 +386,45 @@ class AsyncEthModuleTest:
         assert is_integer(balance)
         assert balance >= 0
 
+    @pytest.mark.asyncio
+    async def test_eth_get_code(self, async_w3: "Web3", math_contract_address: ChecksumAddress) -> None:
+        code = await async_w3.eth.get_code(math_contract_address)
+        assert isinstance(code, HexBytes)
+        assert len(code) > 0
+
+    # @pytest.mark.asyncio
+    # def test_eth_get_code_ens_address(
+    #     self, async_w3: "Web3", math_contract_address: ChecksumAddress
+    # ) -> None:
+    #     with ens_addresses(
+    #         async_w3, {'mathcontract.eth': math_contract_address}
+    #     ):
+    #         code = await async_w3.eth.get_code('mathcontract.eth')
+    #         assert isinstance(code, HexBytes)
+    #         assert len(code) > 0
+
+    @pytest.mark.asyncio
+    async def test_eth_get_code_invalid_address(self, async_w3: "Web3", math_contract: "Contract") -> None:
+        with pytest.raises(InvalidAddress):
+            await async_w3.eth.get_code(ChecksumAddress(HexAddress(HexStr(math_contract.address.lower()))))
+
+    @pytest.mark.asyncio
+    async def test_eth_get_code_with_block_identifier(
+        self, async_w3: "Web3", emitter_contract: "Contract"
+    ) -> None:
+        block_id = await async_w3.eth.block_number
+        code = await async_w3.eth.get_code(emitter_contract.address, block_id)
+        assert isinstance(code, HexBytes)
+        assert len(code) > 0
+
+    @pytest.mark.asyncio
+    async def test_eth_get_transaction_count(
+        self, async_w3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        transaction_count = await async_w3.eth.get_transaction_count(unlocked_account_dual_type)
+        assert is_integer(transaction_count)
+        assert transaction_count >= 0
+
 
 class EthModuleTest:
     def test_eth_protocol_version(self, web3: "Web3") -> None:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -376,33 +376,41 @@ class AsyncEthModuleTest:
 
     @pytest.mark.asyncio
     async def test_eth_get_balance(self, async_w3: "Web3") -> None:
-        coinbase = await async_w3.eth.coinbase
+        coinbase = await async_w3.eth.coinbase  # type: ignore
 
         with pytest.raises(InvalidAddress):
-            await async_w3.eth.get_balance(ChecksumAddress(HexAddress(HexStr(coinbase.lower()))))
+            await async_w3.eth.get_balance(  # type: ignore
+                ChecksumAddress(HexAddress(HexStr(coinbase.lower())))
+            )
 
-        balance = await async_w3.eth.get_balance(coinbase)
+        balance = await async_w3.eth.get_balance(coinbase)  # type: ignore
 
         assert is_integer(balance)
         assert balance >= 0
 
     @pytest.mark.asyncio
-    async def test_eth_get_code(self, async_w3: "Web3", math_contract_address: ChecksumAddress) -> None:
-        code = await async_w3.eth.get_code(math_contract_address)
+    async def test_eth_get_code(
+        self, async_w3: "Web3", math_contract_address: ChecksumAddress
+    ) -> None:
+        code = await async_w3.eth.get_code(math_contract_address)  # type: ignore
         assert isinstance(code, HexBytes)
         assert len(code) > 0
 
     @pytest.mark.asyncio
-    async def test_eth_get_code_invalid_address(self, async_w3: "Web3", math_contract: "Contract") -> None:
+    async def test_eth_get_code_invalid_address(
+        self, async_w3: "Web3", math_contract: "Contract"
+    ) -> None:
         with pytest.raises(InvalidAddress):
-            await async_w3.eth.get_code(ChecksumAddress(HexAddress(HexStr(math_contract.address.lower()))))
+            await async_w3.eth.get_code(  # type: ignore
+                ChecksumAddress(HexAddress(HexStr(math_contract.address.lower())))
+            )
 
     @pytest.mark.asyncio
     async def test_eth_get_code_with_block_identifier(
         self, async_w3: "Web3", emitter_contract: "Contract"
     ) -> None:
-        block_id = await async_w3.eth.block_number
-        code = await async_w3.eth.get_code(emitter_contract.address, block_id)
+        block_id = await async_w3.eth.block_number  # type: ignore
+        code = await async_w3.eth.get_code(emitter_contract.address, block_id)  # type: ignore
         assert isinstance(code, HexBytes)
         assert len(code) > 0
 
@@ -410,7 +418,7 @@ class AsyncEthModuleTest:
     async def test_eth_get_transaction_count(
         self, async_w3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
-        transaction_count = await async_w3.eth.get_transaction_count(unlocked_account_dual_type)
+        transaction_count = await async_w3.eth.get_transaction_count(unlocked_account_dual_type)  # type: ignore # noqa E501
         assert is_integer(transaction_count)
         assert transaction_count >= 0
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -392,17 +392,6 @@ class AsyncEthModuleTest:
         assert isinstance(code, HexBytes)
         assert len(code) > 0
 
-    # @pytest.mark.asyncio
-    # def test_eth_get_code_ens_address(
-    #     self, async_w3: "Web3", math_contract_address: ChecksumAddress
-    # ) -> None:
-    #     with ens_addresses(
-    #         async_w3, {'mathcontract.eth': math_contract_address}
-    #     ):
-    #         code = await async_w3.eth.get_code('mathcontract.eth')
-    #         assert isinstance(code, HexBytes)
-    #         assert len(code) > 0
-
     @pytest.mark.asyncio
     async def test_eth_get_code_invalid_address(self, async_w3: "Web3", math_contract: "Contract") -> None:
         with pytest.raises(InvalidAddress):

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -285,6 +285,13 @@ class AsyncEth(BaseEth):
     ) -> Wei:
         return await self._get_balance(account, block_identifier)
 
+    async def get_code(
+        self,
+        account: Union[Address, ChecksumAddress, ENS],
+        block_identifier: Optional[BlockIdentifier] = None
+    ) -> HexBytes:
+        return await self._get_code(account, block_identifier)
+
     async def get_transaction_count(
         self,
         account: Union[Address, ChecksumAddress, ENS],

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -105,12 +105,23 @@ from web3.types import (
 
 class BaseEth(Module):
     _default_account: Union[ChecksumAddress, Empty] = empty
+    _default_block: BlockIdentifier = "latest"
     gasPriceStrategy = None
 
     _gas_price: Method[Callable[[], Wei]] = Method(
         RPC.eth_gasPrice,
         mungers=None,
     )
+
+    """ property default_block """
+    @property
+    def default_block(self) -> BlockIdentifier:
+        return self._default_block
+
+    @default_block.setter
+    def default_block(self, value: BlockIdentifier) -> None:
+        self._default_block = value
+
 
     @property
     def default_account(self) -> Union[ChecksumAddress, Empty]:
@@ -284,7 +295,6 @@ class AsyncEth(BaseEth):
 
 class Eth(BaseEth, Module):
     account = Account()
-    _default_block: BlockIdentifier = "latest"
     defaultContractFactory: Type[Union[Contract, ConciseContract, ContractCaller]] = Contract  # noqa: E704,E501
     iban = Iban
 
@@ -420,16 +430,6 @@ class Eth(BaseEth, Module):
             category=DeprecationWarning,
         )
         self._default_account = account
-
-    """ property default_block """
-
-    @property
-    def default_block(self) -> BlockIdentifier:
-        return self._default_block
-
-    @default_block.setter
-    def default_block(self, value: BlockIdentifier) -> None:
-        self._default_block = value
 
     @property
     def defaultBlock(self) -> BlockIdentifier:

--- a/web3/method.py
+++ b/web3/method.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
     from web3.module import Module  # noqa: F401
 
+
 Munger = Callable[..., Any]
 
 
@@ -154,7 +155,7 @@ class Method(Generic[TFunc]):
     def input_munger(
         self, module: "Module", args: Any, kwargs: Any
     ) -> List[Any]:
-        # This function takes the "root_munger" - the first munger in
+        # This function takes the "root_munger" - (the first munger in
         # the list of mungers) and then pipes the return value of the
         # previous munger as an argument to the next munger to return
         # an array of arguments that have been formatted.


### PR DESCRIPTION
### What was wrong?

Added async `eth.get_balance`, `eth.get_code`, and `eth.get_transaction_count` (all methods that use the `block_id_munger`). 

Related to Issue #1413 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Manual Testing

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/16/e4/f7/16e4f78c476a793d007e09944b958bcf.jpg)
