### PR TITLE
Don't apply geth poa field remapping if result is None

### DIFF
--- a/newsfragments/2064.bugfix.rst
+++ b/newsfragments/2064.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in geth PoA middleware where a ``None`` response should throw a ``BlockNotFound`` error, but was instead throwing an ``AttributeError``

--- a/tests/core/eth-module/test_poa.py
+++ b/tests/core/eth-module/test_poa.py
@@ -1,6 +1,7 @@
 import pytest
 
 from web3.exceptions import (
+    BlockNotFound,
     ExtraDataLengthError,
 )
 from web3.middleware import (
@@ -37,3 +38,13 @@ def test_geth_proof_of_authority(web3):
     block = web3.eth.get_block('latest')
     assert 'extraData' not in block
     assert block.proofOfAuthorityData == b'\xff' * 33
+
+
+def test_returns_none_response(web3):
+    return_none_response = construct_fixture_middleware({
+        'eth_getBlockByNumber': None,
+    })
+    web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+    web3.middleware_onion.inject(return_none_response, layer=0)
+    with pytest.raises(BlockNotFound):
+        web3.eth.get_block(100000000000)

--- a/web3/middleware/geth_poa.py
+++ b/web3/middleware/geth_poa.py
@@ -1,20 +1,25 @@
 from eth_utils.curried import (
+    apply_formatter_if,
     apply_formatters_to_dict,
     apply_key_map,
+    is_null,
 )
 from eth_utils.toolz import (
+    complement,
     compose,
 )
 from hexbytes import (
     HexBytes,
 )
 
+from web3._utils.rpc_abi import (
+    RPC,
+)
 from web3.middleware.formatting import (
     construct_formatting_middleware,
 )
-from web3.types import (
-    RPCEndpoint,
-)
+
+is_not_null = complement(is_null)
 
 remap_geth_poa_fields = apply_key_map({
     'extraData': 'proofOfAuthorityData',
@@ -28,7 +33,7 @@ geth_poa_cleanup = compose(pythonic_geth_poa, remap_geth_poa_fields)
 
 geth_poa_middleware = construct_formatting_middleware(
     result_formatters={
-        RPCEndpoint("eth_getBlockByHash"): geth_poa_cleanup,
-        RPCEndpoint("eth_getBlockByNumber"): geth_poa_cleanup,
+        RPC.eth_getBlockByHash: apply_formatter_if(is_not_null, geth_poa_cleanup),
+        RPC.eth_getBlockByNumber: apply_formatter_if(is_not_null, geth_poa_cleanup),
     },
 )


### PR DESCRIPTION
### What was wrong?
Geth POA middleware was erroring out if the response that came back was `None`.

Fixes #2063 

### How was it fixed?
Added a test that replicated the issue, and then added a null check to make sure that formatters weren't getting applied unless a dictionary is present.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.independent.co.uk/s3fs-public/thumbnails/image/2016/09/05/10/cubs9.jpg)
