### PR TITLE
Remove default gasPrice when 1559 params present

### DIFF
--- a/newsfragments/2092.bugfix.rst
+++ b/newsfragments/2092.bugfix.rst
@@ -1,0 +1,1 @@
+``fill_transaction_defaults()`` no longer sets a default ``gasPrice`` if 1559 fees are present in the transaction parameters. This fixes sign-and-send middleware issues with 1559 fees.

--- a/newsfragments/2092.doc.rst
+++ b/newsfragments/2092.doc.rst
@@ -1,0 +1,1 @@
+Updated the sign-and-send middleware docs to include EIP-1559 as well as legacy transaction examples

--- a/tests/core/utilities/test_valid_transaction_params.py
+++ b/tests/core/utilities/test_valid_transaction_params.py
@@ -3,19 +3,23 @@ import pytest
 from web3._utils.transactions import (
     assert_valid_transaction_params,
     extract_valid_transaction_params,
+    fill_transaction_defaults,
 )
 
 
 def test_assert_valid_transaction_params_all_params():
     assert_valid_transaction_params({
+        'chainId': 1,
+        'type': '0x2',
         'from': '0x0',
         'to': '0x0',
         'gas': 21000,
         'gasPrice': 5000000,
+        'maxFeePerGas': 2000000000,
+        'maxPriorityFeePerGas': 1000000000,
         'value': 1,
         'data': '0x0',
         'nonce': 2,
-        'chainId': 1,
     })
 
 
@@ -38,10 +42,14 @@ def test_assert_valid_transaction_params_invalid_param():
 
 
 FULL_TXN_DICT = {
+    'chainId': 1,
+    'type': '0x2',
     'from': '0x0',
     'to': '0x1',
     'gas': 21000,
     'gasPrice': 5000000,
+    'maxFeePerGas': 2000000000,
+    'maxPriorityFeePerGas': 1000000000,
     'data': '0x2',
     'value': 3,
     'nonce': 2,
@@ -77,18 +85,60 @@ def test_extract_valid_transaction_params_invalid(transaction_params, expected_e
 
 def test_extract_valid_transaction_params_includes_invalid():
     input = {
+        'chainId': 1,
+        'type': '0x2',
         'from': '0x0',
         'to': '0x0',
         'gas': 21000,
         'gasPrice': 5000000,
+        'maxFeePerGas': 2000000000,
+        'maxPriorityFeePerGas': 1000000000,
         'value': 1,
         'tokens': 9000,
     }
     valid_transaction_params = extract_valid_transaction_params(input)
     assert valid_transaction_params == {
+        'chainId': 1,
+        'type': '0x2',
         'from': '0x0',
         'to': '0x0',
         'gas': 21000,
         'gasPrice': 5000000,
+        'maxFeePerGas': 2000000000,
+        'maxPriorityFeePerGas': 1000000000,
         'value': 1,
+    }
+
+
+def test_fill_transaction_defaults_for_all_params(web3):
+    default_transaction = fill_transaction_defaults(web3, {})
+
+    assert default_transaction == {
+        'chainId': web3.eth.chain_id,
+        'data': b'',
+        'gas': web3.eth.estimate_gas({}),
+        'gasPrice': web3.eth.gas_price,
+        'value': 0,
+    }
+
+
+def test_fill_transaction_defaults_sets_type_from_1559_params_and_no_gas_price(web3):
+    transaction_1559 = {
+        'chainId': 1,
+        'data': b'123',
+        'gas': 21000,
+        'maxFeePerGas': 2000000000,
+        'maxPriorityFeePerGas': 1000000000,
+        'value': 2,
+    }
+    transaction_1559_type_added = fill_transaction_defaults(web3, transaction_1559)
+
+    assert transaction_1559_type_added == {
+        'chainId': 1,
+        'data': b'123',
+        'gas': 21000,
+        'maxFeePerGas': 2000000000,
+        'maxPriorityFeePerGas': 1000000000,
+        'type': '0x2',  # type is added and defaults to '0x2' when 1559 params are present
+        'value': 2,
     }

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -202,6 +202,7 @@ RECEIPT_FORMATTERS = {
     'logsBloom': to_hexbytes(256),
     'from': apply_formatter_if(is_not_null, to_checksum_address),
     'to': apply_formatter_if(is_address, to_checksum_address),
+    'effectiveGasPrice': to_integer_if_hex,
 }
 
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -2027,6 +2027,10 @@ class EthModuleTest:
         assert receipt['from'] is not None
         assert is_checksum_address(receipt['from'])
 
+        effective_gas_price = receipt['effectiveGasPrice']
+        assert isinstance(effective_gas_price, int)
+        assert effective_gas_price > 0
+
     def test_eth_getTransactionReceipt_mined_deprecated(
         self, web3: "Web3", block_with_txn: BlockData, mined_txn_hash: HexStr
     ) -> None:

--- a/web3/types.py
+++ b/web3/types.py
@@ -219,6 +219,7 @@ TxReceipt = TypedDict("TxReceipt", {
     "blockNumber": BlockNumber,
     "contractAddress": Optional[ChecksumAddress],
     "cumulativeGasUsed": int,
+    "effectiveGasPrice": int,
     "gasUsed": Wei,
     "from": ChecksumAddress,
     "logs": List[LogReceipt],

--- a/web3/types.py
+++ b/web3/types.py
@@ -176,6 +176,7 @@ TxData = TypedDict("TxData", {
     "s": HexBytes,
     "to": ChecksumAddress,
     "transactionIndex": int,
+    "type": Union[int, HexStr],
     "v": int,
     "value": Wei,
 }, total=False)
@@ -196,6 +197,7 @@ TxParams = TypedDict("TxParams", {
     "nonce": Nonce,
     # addr or ens
     "to": Union[Address, ChecksumAddress, str],
+    "type": Union[int, HexStr],
     "value": Wei,
 }, total=False)
 


### PR DESCRIPTION
### What was wrong?

- `sign_and_send_raw_middleware` was broken for EIP-1559 transactions since it made use of `fill_transaction_defaults()` and this was always adding a `gasPrice` if none was present. This would cause both legacy and 1559 params to be present leading to errors.

### How was it fixed?

- For code making use of `fill_transaction_defaults()`, removed the default value for `gasPrice` when 1559 parameters are present. This keeps things backwards compatible and also provides support for 1559 for the signing middleware.
- `fill_transaction_defaults()` also defaults the transaction `type` to `'0x2'` when 1559 params are present as this implies a 1559-style transaction. This is important because transaction signing (done via `eth-account`) relies on the `type` for validating 1559 transactions. We don't require the `type` for `send_transaction` so this makes the user experience smoother when using this middleware since they may already be used to sending transactions without providing a `type`.


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![11](https://user-images.githubusercontent.com/3532824/127563885-3f35be0f-7eb8-4650-8b7b-81934910d241.jpg)

