### PR TITLE
fix eth.account documentation to reflect required EIP-1559 params

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -858,6 +858,8 @@ The following methods are available on the ``web3.eth`` namespace.
             to='0xd3CdA913deB6f67967B99D67aCDFa1712C293601',
             value=12345,
             data=b'',
+            type=2,
+            chainId=1,
           ),
           private_key_for_senders_account,
         )


### PR DESCRIPTION
### What was wrong?

- In the documentation for `send_raw_transaction()`, the example `account.sign_transaction()` call was missing the `type` and `chainId` arguments.

### How was it fixed?

- Added the arguments to the sample method call.


#### Cute Animal Picture

![](https://media.tegna-media.com/assets/WPMT/images/169be237-308c-429e-87ee-b424130c33da/169be237-308c-429e-87ee-b424130c33da_750x422.png)
