### PR TITLE
Add eth_feeHistory RPC endpoint

### DIFF
--- a/newsfragments/2038.feature.rst
+++ b/newsfragments/2038.feature.rst
@@ -1,0 +1,1 @@
+Add support for eth_feeHistory RPC method

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -283,6 +283,18 @@ class TestEthereumTesterEthModule(EthModuleTest):
         block = web3.eth.get_block('pending')
         assert block['hash'] is not None
 
+    @pytest.mark.xfail(reason='eth_feeHistory is not implemented on eth-tester')
+    def test_eth_fee_history(self, web3: "Web3"):
+        super().test_eth_fee_history(web3)
+
+    @pytest.mark.xfail(reason='eth_feeHistory is not implemented on eth-tester')
+    def test_eth_fee_history_with_integer(self, web3: "Web3"):
+        super().test_eth_fee_history_with_integer(web3)
+
+    @pytest.mark.xfail(reason='eth_feeHistory is not implemented on eth-tester')
+    def test_eth_fee_history_no_reward_percentiles(self, web3: "Web3"):
+        super().test_eth_fee_history_no_reward_percentiles(web3)
+
     @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
     def test_eth_get_transaction_receipt_unmined(self, eth_tester, web3, unlocked_account):
         super().test_eth_get_transaction_receipt_unmined(web3, unlocked_account)

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -278,11 +278,11 @@ transaction_pool_inspect_formatter = apply_formatters_to_dict(
 )
 
 FEE_HISTORY_FORMATTERS = {
-    'baseFeePerGas': apply_list_to_array_formatter(to_integer_if_hex),
-    'gasUsedRatio': apply_formatter_if(is_not_null, apply_list_to_array_formatter(float)),
+    'baseFeePerGas': apply_formatter_to_array(to_integer_if_hex),
+    'gasUsedRatio': apply_formatter_if(is_not_null, apply_formatter_to_array(float)),
     'oldestBlock': to_integer_if_hex,
-    "reward": apply_formatter_if(is_not_null, apply_list_to_array_formatter(
-        apply_list_to_array_formatter(to_integer_if_hex))),
+    'reward': apply_formatter_if(is_not_null, apply_formatter_to_array(
+        apply_formatter_to_array(to_integer_if_hex))),
 }
 
 fee_history_formatter = apply_formatters_to_dict(FEE_HISTORY_FORMATTERS)

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -277,6 +277,16 @@ transaction_pool_inspect_formatter = apply_formatters_to_dict(
     TRANSACTION_POOL_INSPECT_FORMATTERS
 )
 
+FEE_HISTORY_FORMATTERS = {
+    'baseFeePerGas': apply_list_to_array_formatter(to_integer_if_hex),
+    'gasUsedRatio': apply_formatter_if(is_not_null, apply_list_to_array_formatter(float)),
+    'oldestBlock': to_integer_if_hex,
+    "reward": apply_formatter_if(is_not_null, apply_list_to_array_formatter(
+        apply_list_to_array_formatter(to_integer_if_hex))),
+}
+
+fee_history_formatter = apply_formatters_to_dict(FEE_HISTORY_FORMATTERS)
+
 STORAGE_PROOF_FORMATTERS = {
     'key': HexBytes,
     'value': HexBytes,
@@ -381,6 +391,7 @@ geth_wallets_formatter = apply_formatters_to_dict(GETH_WALLETS_FORMATTER)
 
 PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     # Eth
+    RPC.eth_feeHistory: apply_formatter_at_index(to_hex_if_integer, 1),
     RPC.eth_getBalance: apply_formatter_at_index(to_hex_if_integer, 1),
     RPC.eth_getBlockByNumber: apply_formatter_at_index(to_hex_if_integer, 0),
     RPC.eth_getBlockTransactionCountByNumber: apply_formatter_at_index(
@@ -440,6 +451,7 @@ PYTHONIC_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_coinbase: to_checksum_address,
     RPC.eth_call: HexBytes,
     RPC.eth_estimateGas: to_integer_if_hex,
+    RPC.eth_feeHistory: fee_history_formatter,
     RPC.eth_gasPrice: to_integer_if_hex,
     RPC.eth_getBalance: to_integer_if_hex,
     RPC.eth_getBlockByHash: apply_formatter_if(is_not_null, block_formatter),

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -295,7 +295,7 @@ class AsyncEthModuleTest:
         assert gas_estimate > 0
 
     @pytest.mark.asyncio
-    async def test_eth_feeHistory(self, async_w3: "Web3") -> None:
+    async def test_eth_fee_history(self, async_w3: "Web3") -> None:
         fee_history = await async_w3.eth.fee_history(1, 'latest', [50])  # type: ignore
         assert is_list_like(fee_history['baseFeePerGas'])
         assert is_list_like(fee_history['gasUsedRatio'])

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -295,6 +295,36 @@ class AsyncEthModuleTest:
         assert gas_estimate > 0
 
     @pytest.mark.asyncio
+    async def test_eth_feeHistory(self, async_w3: "Web3") -> None:
+        fee_history = await async_w3.eth.fee_history(1, 'latest', [50])  # type: ignore
+        assert is_list_like(fee_history['baseFeePerGas'])
+        assert is_list_like(fee_history['gasUsedRatio'])
+        assert is_integer(fee_history['oldestBlock'])
+        assert fee_history['oldestBlock'] >= 0
+        assert is_list_like(fee_history['reward'])
+        assert is_list_like(fee_history['reward'][0])
+
+    @pytest.mark.asyncio
+    async def test_eth_fee_history_with_integer(
+        self, async_w3: "Web3", empty_block: BlockData
+    ) -> None:
+        fee_history = await async_w3.eth.fee_history(1, empty_block['number'], [50])  # type: ignore
+        assert is_list_like(fee_history['baseFeePerGas'])
+        assert is_list_like(fee_history['gasUsedRatio'])
+        assert is_integer(fee_history['oldestBlock'])
+        assert fee_history['oldestBlock'] >= 0
+        assert is_list_like(fee_history['reward'])
+        assert is_list_like(fee_history['reward'][0])
+
+    @pytest.mark.asyncio
+    async def test_eth_fee_history_no_reward_percentiles(self, async_w3: "Web3") -> None:
+        fee_history = await async_w3.eth.fee_history(1, 'latest')  # type: ignore
+        assert is_list_like(fee_history['baseFeePerGas'])
+        assert is_list_like(fee_history['gasUsedRatio'])
+        assert is_integer(fee_history['oldestBlock'])
+        assert fee_history['oldestBlock'] >= 0
+
+    @pytest.mark.asyncio
     async def test_eth_getBlockByHash(
         self, async_w3: "Web3", empty_block: BlockData
     ) -> None:
@@ -567,6 +597,33 @@ class EthModuleTest:
             chain_id = web3.eth.chainId
         # chain id value from geth fixture genesis file
         assert chain_id == 131277322940537
+
+    def test_eth_fee_history(self, web3: "Web3") -> None:
+        fee_history = web3.eth.fee_history(1, 'latest', [50])
+        assert is_list_like(fee_history['baseFeePerGas'])
+        assert is_list_like(fee_history['gasUsedRatio'])
+        assert is_integer(fee_history['oldestBlock'])
+        assert fee_history['oldestBlock'] >= 0
+        assert is_list_like(fee_history['reward'])
+        assert is_list_like(fee_history['reward'][0])
+
+    def test_eth_fee_history_with_integer(self,
+                                          web3: "Web3",
+                                          empty_block: BlockData) -> None:
+        fee_history = web3.eth.fee_history(1, empty_block['number'], [50])
+        assert is_list_like(fee_history['baseFeePerGas'])
+        assert is_list_like(fee_history['gasUsedRatio'])
+        assert is_integer(fee_history['oldestBlock'])
+        assert fee_history['oldestBlock'] >= 0
+        assert is_list_like(fee_history['reward'])
+        assert is_list_like(fee_history['reward'][0])
+
+    def test_eth_fee_history_no_reward_percentiles(self, web3: "Web3") -> None:
+        fee_history = web3.eth.fee_history(1, 'latest')
+        assert is_list_like(fee_history['baseFeePerGas'])
+        assert is_list_like(fee_history['gasUsedRatio'])
+        assert is_integer(fee_history['oldestBlock'])
+        assert fee_history['oldestBlock'] >= 0
 
     def test_eth_gas_price(self, web3: "Web3") -> None:
         gas_price = web3.eth.gas_price

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -46,6 +46,7 @@ class RPC:
     eth_chainId = RPCEndpoint("eth_chainId")
     eth_coinbase = RPCEndpoint("eth_coinbase")
     eth_estimateGas = RPCEndpoint("eth_estimateGas")
+    eth_feeHistory = RPCEndpoint("eth_feeHistory")
     eth_gasPrice = RPCEndpoint("eth_gasPrice")
     eth_getBalance = RPCEndpoint("eth_getBalance")
     eth_getBlockByHash = RPCEndpoint("eth_getBlockByHash")

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -87,7 +87,9 @@ from web3.types import (
     ENS,
     BlockData,
     BlockIdentifier,
+    BlockParams,
     CallOverrideParams,
+    FeeHistory,
     FilterParams,
     GasPriceStrategy,
     LogReceipt,
@@ -174,6 +176,11 @@ class BaseEth(Module):
     _estimate_gas: Method[Callable[..., Wei]] = Method(
         RPC.eth_estimateGas,
         mungers=[estimate_gas_munger]
+    )
+
+    _fee_history: Method[Callable[..., FeeHistory]] = Method(
+        RPC.eth_feeHistory,
+        mungers=[default_root_munger]
     )
 
     def get_block_munger(
@@ -697,6 +704,14 @@ class Eth(BaseEth, Module):
         block_identifier: Optional[BlockIdentifier] = None
     ) -> Wei:
         return self._estimate_gas(transaction, block_identifier)
+
+    def fee_history(
+        self,
+        block_count: int,
+        newest_block: Union[BlockParams, BlockNumber],
+        reward_percentiles: List[float]
+    ) -> FeeHistory:
+        return self._fee_history(block_count, newest_block, reward_percentiles)
 
     def filter_munger(
         self,

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -248,6 +248,15 @@ class AsyncEth(BaseEth):
         # types ignored b/c mypy conflict with BlockingEth properties
         return await self._gas_price()  # type: ignore
 
+    async def fee_history(
+            self,
+            block_count: int,
+            newest_block: Union[BlockParams, BlockNumber],
+            reward_percentiles: Optional[List[float]] = None
+    ) -> FeeHistory:
+        return await self._fee_history(  # type: ignore
+            block_count, newest_block, reward_percentiles)
+
     async def send_transaction(self, transaction: TxParams) -> HexBytes:
         # types ignored b/c mypy conflict with BlockingEth properties
         return await self._send_transaction(transaction)  # type: ignore
@@ -709,7 +718,7 @@ class Eth(BaseEth, Module):
         self,
         block_count: int,
         newest_block: Union[BlockParams, BlockNumber],
-        reward_percentiles: List[float]
+        reward_percentiles: Optional[List[float]] = None
     ) -> FeeHistory:
         return self._fee_history(block_count, newest_block, reward_percentiles)
 

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -213,6 +213,7 @@ API_ENDPOINTS = {
         'mining': static_return(False),
         'hashrate': static_return(0),
         'chainId': static_return('0x3d'),
+        'feeHistory': not_implemented,
         'gasPrice': static_return(1),
         'accounts': call_eth_tester('get_accounts'),
         'blockNumber': compose(

--- a/web3/types.py
+++ b/web3/types.py
@@ -144,6 +144,13 @@ class FilterParams(TypedDict, total=False):
     topics: Sequence[Optional[Union[_Hash32, Sequence[_Hash32]]]]
 
 
+class FeeHistory(TypedDict):
+    baseFeePerGas: List[Wei]
+    gasUsedRatio: List[float]
+    oldestBlock: BlockNumber
+    reward: List[List[Wei]]
+
+
 class LogReceipt(TypedDict):
     address: ChecksumAddress
     blockHash: HexBytes


### PR DESCRIPTION
### What was wrong?
Post-london RPC endpoint `eth_feeHistory` is not currently supported. This PR adds support for it with `fee_history` in the eth module.
Related to Issue #2038

### How was it fixed?
Following the [eth1.0-specs](https://github.com/ethereum/eth1.0-specs/blob/master/json-rpc/spec.json), `fee_history` function was added to the eth module.

### Todo:
- [x] Add support to async eth module
- [x] Testing
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.redd.it/qrkuicdu22d11.jpg)
