### PR TITLE
Fix string interpolation issues in exception message.

### DIFF
--- a/newsfragments/2096.bugfix.rst
+++ b/newsfragments/2096.bugfix.rst
@@ -1,0 +1,1 @@
+Hot fix for string interpolation issue with contract function call decoding exception to facilitate extracting a meaningful message from the eth_call response

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1524,8 +1524,8 @@ def call_contract_function(
             )
         else:
             msg = (
-                f"Could not decode contract function call {function_identifier} "
-                f"return data {return_data!r} for output_types {output_types}"
+                f"Could not decode contract function call to {function_identifier} with "
+                f"return data: {str(return_data)}, output_types: {output_types}"
             )
         raise BadFunctionCallOutput(msg) from e
 


### PR DESCRIPTION
### What was wrong?
- Exception message for calling a contract function did not return data in a manner where a meaningful exception message could be extracted even though we used to return it in this way (breaking change)

Related to Issue #2069

### How was it fixed?
- Print the result_data as bytes in exception message in order to extract a meaningful exception message from the data. This is how we used to return this message and some users were using it to extract the meaningful exception message and were no longer able to.

### Todo:
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://miro.medium.com/max/3840/1*2FKxVJVqsWgeXAhshAprHg.jpeg)
