### PR TITLE
async support for formatting, validation, and geth poa middlewares

### DIFF
--- a/newsfragments/2098.feature.rst
+++ b/newsfragments/2098.feature.rst
@@ -1,0 +1,1 @@
+async support for formatting, validation, and geth poa middlewares

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -18,6 +18,7 @@ from web3.geth import (
 from web3.middleware import (
     async_buffered_gas_estimate_middleware,
     async_gas_price_strategy_middleware,
+    async_validation_middleware,
 )
 from web3.net import (
     AsyncNet,
@@ -95,8 +96,9 @@ async def async_w3(geth_process, endpoint_uri):
     _web3 = Web3(
         AsyncHTTPProvider(endpoint_uri),
         middlewares=[
+            async_buffered_gas_estimate_middleware,
             async_gas_price_strategy_middleware,
-            async_buffered_gas_estimate_middleware
+            async_validation_middleware,
         ],
         modules={'eth': AsyncEth,
                  'async_net': AsyncNet,

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1018,6 +1018,13 @@ class AsyncEthModuleTest:
             "fromBlock": BlockNumber(0),
             "address": emitter_contract_address,
         }
+        result = await async_w3.eth.get_logs(filter_params)  # type: ignore
+        _assert_contains_log(
+            result,
+            block_with_txn_with_log,
+            emitter_contract_address,
+            txn_hash_with_log
+        )
 
     @pytest.mark.asyncio
     async def test_async_eth_get_logs_with_logs_topic_args(

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -128,11 +128,11 @@ class RequestManager:
         """
         return [
             (request_parameter_normalizer, 'request_param_normalizer'),  # Delete
-            (gas_price_strategy_middleware, 'gas_price_strategy'),  # Add Async
+            (gas_price_strategy_middleware, 'gas_price_strategy'),
             (name_to_address_middleware(web3), 'name_to_address'),  # Add Async
             (attrdict_middleware, 'attrdict'),  # Delete
             (pythonic_middleware, 'pythonic'),  # Delete
-            (validation_middleware, 'validation'),  # Add async
+            (validation_middleware, 'validation'),
             (abi_middleware, 'abi'),  # Delete
             (buffered_gas_estimate_middleware, 'gas_estimate'),
         ]
@@ -159,8 +159,8 @@ class RequestManager:
         self.logger.debug("Making request. Method: %s", method)
         return await request_func(method, params)
 
+    @staticmethod
     def formatted_response(
-        self,
         response: RPCResponse,
         params: Any,
         error_formatters: Optional[Callable[..., Any]] = None,

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -51,6 +51,7 @@ from .gas_price_strategy import (  # noqa: F401
     gas_price_strategy_middleware,
 )
 from .geth_poa import (  # noqa: F401
+    async_geth_poa_middleware,
     geth_poa_middleware,
 )
 from .names import (  # noqa: F401
@@ -69,6 +70,7 @@ from .stalecheck import (  # noqa: F401
     make_stalecheck_middleware,
 )
 from .validation import (  # noqa: F401
+    async_validation_middleware,
     validation_middleware,
 )
 

--- a/web3/middleware/buffered_gas_estimate.py
+++ b/web3/middleware/buffered_gas_estimate.py
@@ -2,7 +2,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Coroutine,
 )
 
 from eth_utils.toolz import (
@@ -16,6 +15,7 @@ from web3._utils.transactions import (
     get_buffered_gas_estimate,
 )
 from web3.types import (
+    AsyncMiddleware,
     RPCEndpoint,
     RPCResponse,
 )
@@ -43,7 +43,7 @@ def buffered_gas_estimate_middleware(
 
 async def async_buffered_gas_estimate_middleware(
     make_request: Callable[[RPCEndpoint, Any], Any], web3: "Web3"
-) -> Callable[[RPCEndpoint, Any], Coroutine[Any, Any, RPCResponse]]:
+) -> AsyncMiddleware:
     async def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
         if method == 'eth_sendTransaction':
             transaction = params[0]

--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -2,18 +2,20 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Coroutine,
     Optional,
 )
 
 from eth_utils.toolz import (
     assoc,
-    curry,
     merge,
 )
 
 from web3.types import (
+    AsyncMiddleware,
     Formatters,
     FormattersDict,
+    Literal,
     Middleware,
     RPCEndpoint,
     RPCResponse,
@@ -22,6 +24,38 @@ from web3.types import (
 if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
 
+FORMATTER_DEFAULTS: FormattersDict = {
+    "request_formatters": {},
+    "result_formatters": {},
+    "error_formatters": {},
+}
+
+
+def _apply_response_formatters(
+    method: RPCEndpoint,
+    response: RPCResponse,
+    result_formatters: Formatters,
+    error_formatters: Formatters,
+) -> RPCResponse:
+
+    def _format_response(
+        response_type: Literal["result", "error"],
+        method_response_formatter: Callable[..., Any]
+    ) -> RPCResponse:
+        appropriate_response = response[response_type]
+        return assoc(
+            response, response_type, method_response_formatter(appropriate_response)
+        )
+
+    if "result" in response and method in result_formatters:
+        return _format_response("result", result_formatters[method])
+    elif "error" in response and method in error_formatters:
+        return _format_response("error", error_formatters[method])
+    else:
+        return response
+
+
+# --- sync -- #
 
 def construct_formatting_middleware(
     request_formatters: Optional[Formatters] = None,
@@ -29,7 +63,7 @@ def construct_formatting_middleware(
     error_formatters: Optional[Formatters] = None
 ) -> Middleware:
     def ignore_web3_in_standard_formatters(
-        w3: "Web3",
+        _w3: "Web3", _method: RPCEndpoint,
     ) -> FormattersDict:
         return dict(
             request_formatters=request_formatters or {},
@@ -41,55 +75,67 @@ def construct_formatting_middleware(
 
 
 def construct_web3_formatting_middleware(
-    web3_formatters_builder: Callable[["Web3"], FormattersDict]
+    web3_formatters_builder: Callable[["Web3", RPCEndpoint], FormattersDict],
 ) -> Middleware:
     def formatter_middleware(
-        make_request: Callable[[RPCEndpoint, Any], Any], w3: "Web3"
+        make_request: Callable[[RPCEndpoint, Any], Any],
+        w3: "Web3",
     ) -> Callable[[RPCEndpoint, Any], RPCResponse]:
-        formatters = merge(
-            {
-                "request_formatters": {},
-                "result_formatters": {},
-                "error_formatters": {},
-            },
-            web3_formatters_builder(w3),
-        )
-        return apply_formatters(make_request=make_request, **formatters)
+        def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
+            formatters = merge(
+                FORMATTER_DEFAULTS,
+                web3_formatters_builder(w3, method),
+            )
+            request_formatters = formatters.pop('request_formatters')
 
+            if method in request_formatters:
+                formatter = request_formatters[method]
+                params = formatter(params)
+            response = make_request(method, params)
+
+            return _apply_response_formatters(method=method, response=response, **formatters)
+        return middleware
     return formatter_middleware
 
 
-@curry
-def apply_formatters(
-    method: RPCEndpoint,
-    params: Any,
-    make_request: Callable[[RPCEndpoint, Any], RPCResponse],
-    request_formatters: Formatters,
-    result_formatters: Formatters,
-    error_formatters: Formatters,
-) -> RPCResponse:
-    if method in request_formatters:
-        formatter = request_formatters[method]
-        formatted_params = formatter(params)
-        response = make_request(method, formatted_params)
-    else:
-        response = make_request(method, params)
+# --- async --- #
 
-    if "result" in response and method in result_formatters:
-        formatter = result_formatters[method]
-        formatted_response = assoc(
-            response,
-            "result",
-            formatter(response["result"]),
+async def async_construct_formatting_middleware(
+    request_formatters: Optional[Formatters] = None,
+    result_formatters: Optional[Formatters] = None,
+    error_formatters: Optional[Formatters] = None
+) -> Middleware:
+    async def ignore_web3_in_standard_formatters(
+        _w3: "Web3", _method: RPCEndpoint,
+    ) -> FormattersDict:
+        return dict(
+            request_formatters=request_formatters or {},
+            result_formatters=result_formatters or {},
+            error_formatters=error_formatters or {},
         )
-        return formatted_response
-    elif "error" in response and method in error_formatters:
-        formatter = error_formatters[method]
-        formatted_response = assoc(
-            response,
-            "error",
-            formatter(response["error"]),
-        )
-        return formatted_response
-    else:
-        return response
+    return await async_construct_web3_formatting_middleware(ignore_web3_in_standard_formatters)
+
+
+async def async_construct_web3_formatting_middleware(
+    async_web3_formatters_builder:
+        Callable[["Web3", RPCEndpoint], Coroutine[Any, Any, FormattersDict]]
+) -> Callable[[Callable[[RPCEndpoint, Any], Any], "Web3"], Coroutine[Any, Any, AsyncMiddleware]]:
+    async def formatter_middleware(
+        make_request: Callable[[RPCEndpoint, Any], Any],
+        async_w3: "Web3",
+    ) -> AsyncMiddleware:
+        async def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
+            formatters = merge(
+                FORMATTER_DEFAULTS,
+                await async_web3_formatters_builder(async_w3, method),
+            )
+            request_formatters = formatters.pop('request_formatters')
+
+            if method in request_formatters:
+                formatter = request_formatters[method]
+                params = formatter(params)
+            response = await make_request(method, params)
+
+            return _apply_response_formatters(method=method, response=response, **formatters)
+        return middleware
+    return formatter_middleware

--- a/web3/middleware/gas_price_strategy.py
+++ b/web3/middleware/gas_price_strategy.py
@@ -2,7 +2,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Coroutine,
 )
 
 from eth_utils.toolz import (
@@ -22,6 +21,7 @@ from web3.exceptions import (
     TransactionTypeMismatch,
 )
 from web3.types import (
+    AsyncMiddleware,
     BlockData,
     RPCEndpoint,
     RPCResponse,
@@ -94,7 +94,7 @@ def gas_price_strategy_middleware(
 
 async def async_gas_price_strategy_middleware(
     make_request: Callable[[RPCEndpoint, Any], Any], web3: "Web3"
-) -> Callable[[RPCEndpoint, Any], Coroutine[Any, Any, RPCResponse]]:
+) -> AsyncMiddleware:
     """
     - Uses a gas price strategy if one is set. This is only supported for legacy transactions.
       It is recommended to send dynamic fee transactions (EIP-1559) whenever possible.

--- a/web3/middleware/geth_poa.py
+++ b/web3/middleware/geth_poa.py
@@ -1,3 +1,9 @@
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+)
+
 from eth_utils.curried import (
     apply_formatter_if,
     apply_formatters_to_dict,
@@ -16,8 +22,16 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.middleware.formatting import (
+    async_construct_formatting_middleware,
     construct_formatting_middleware,
 )
+from web3.types import (
+    AsyncMiddleware,
+    RPCEndpoint,
+)
+
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
 
 is_not_null = complement(is_null)
 
@@ -31,9 +45,22 @@ pythonic_geth_poa = apply_formatters_to_dict({
 
 geth_poa_cleanup = compose(pythonic_geth_poa, remap_geth_poa_fields)
 
+
 geth_poa_middleware = construct_formatting_middleware(
     result_formatters={
         RPC.eth_getBlockByHash: apply_formatter_if(is_not_null, geth_poa_cleanup),
         RPC.eth_getBlockByNumber: apply_formatter_if(is_not_null, geth_poa_cleanup),
     },
 )
+
+
+async def async_geth_poa_middleware(
+    make_request: Callable[[RPCEndpoint, Any], Any], web3: "Web3"
+) -> AsyncMiddleware:
+    middleware = await async_construct_formatting_middleware(
+        result_formatters={
+            RPC.eth_getBlockByHash: apply_formatter_if(is_not_null, geth_poa_cleanup),
+            RPC.eth_getBlockByNumber: apply_formatter_if(is_not_null, geth_poa_cleanup),
+        },
+    )
+    return await middleware(make_request, web3)

--- a/web3/types.py
+++ b/web3/types.py
@@ -2,6 +2,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Coroutine,
     Dict,
     List,
     NewType,
@@ -135,13 +136,14 @@ class RPCResponse(TypedDict, total=False):
 
 
 Middleware = Callable[[Callable[[RPCEndpoint, Any], RPCResponse], "Web3"], Any]
+AsyncMiddleware = Callable[[RPCEndpoint, Any], Coroutine[Any, Any, RPCResponse]]
 MiddlewareOnion = NamedElementOnion[str, Middleware]
 
 
 class FormattersDict(TypedDict, total=False):
-    error_formatters: Formatters
-    request_formatters: Formatters
-    result_formatters: Formatters
+    error_formatters: Optional[Formatters]
+    request_formatters: Optional[Formatters]
+    result_formatters: Optional[Formatters]
 
 
 class FilterParams(TypedDict, total=False):


### PR DESCRIPTION
### What was wrong?
- validation, formatting, and geth poa middlewares do not have async support
- closes #2305
- closes #2232 

### How was it fixed?
- Async support added to:
    - formatting middleware
    - validation middleware
    - geth poa middleware


### Todo:
- [x] Refactored code to extract the chainId earlier in the validation process so we do not have to create async methods for every step of the way before the actual web3 call
- [x] Added async support but due to the nature of the validation + formatting middleware relationship (functools) this is not in an ideal state. Ideally we can provide it in the same manner as the middlewares with current async support
- [x] Due to explanation in previous bullet, possibly refactor the code so there is no need to await the middleware as it is being passed into the Web3 intance
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20220202_120437](https://user-images.githubusercontent.com/3532824/152450428-6e97e11a-7dcd-46b5-9896-1845e5979f5a.jpg)

