### PR TITLE
fix: eip1559 validation incorrectly adds gas price field

### DIFF
--- a/newsfragments/2099.bugfix.rst
+++ b/newsfragments/2099.bugfix.rst
@@ -1,0 +1,1 @@
+Bypass adding a ``gasPrice`` via the gas price strategy, if one is set, when EIP-1559 transaction params are used for ``send_transaction``

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -474,6 +474,18 @@ class TestEthereumTesterEthModule(EthModuleTest):
         super().test_eth_send_transaction(web3, emitter_contract_address)
 
     @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
+    def test_gas_price_from_strategy_bypassed_for_1559_txn(self, emitter_contract_address):
+        super().test_gas_price_from_strategy_bypassed_for_eip_1559_txn(
+            self, web3, emitter_contract_address, None, None, None
+        )
+
+    @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
+    def test_gas_price_from_strategy_bypassed_for_1559_txn_no_tip(self, emitter_contract_address):
+        super().test_gas_price_from_strategy_bypassed_for_1559_txn_no_tip(
+            self, web3, emitter_contract_address, None, None, None
+        )
+
+    @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
     def test_eth_sendTransaction_deprecated(self, web3, emitter_contract_address):
         super().test_eth_sendTransaction_deprecated(web3, emitter_contract_address)
 

--- a/web3/middleware/gas_price_strategy.py
+++ b/web3/middleware/gas_price_strategy.py
@@ -29,7 +29,11 @@ def validate_transaction_params(
     transaction: TxParams, latest_block: BlockData, generated_gas_price: Wei
 ) -> TxParams:
     # gas price strategy explicitly set:
-    if generated_gas_price is not None and 'gasPrice' not in transaction:
+    if (
+        generated_gas_price is not None
+        and 'gasPrice' not in transaction
+        and all(_ not in transaction for _ in ('maxFeePerGas', 'maxPriorityFeePerGas'))
+    ):
         transaction = assoc(transaction, 'gasPrice', hex(generated_gas_price))
 
     # legacy and 1559 tx variables used:


### PR DESCRIPTION
### What was wrong?

When passing a correct EIP-1559 transaction with:
```python
{'maxFeePerGas': '0x174876e800', 'maxPriorityFeePerGas': '0x77359400', 'type': '0x2'}
```
`validate_transaction_params` appends `gasPrice` to it, which causes the subsequent check for mixed transaction type to fail.
```python
{'maxFeePerGas': '0x174876e800', 'maxPriorityFeePerGas': '0x77359400', 'type': '0x2', 'gasPrice': '0x6977bbb6'}
```

### How was it fixed?

Expanded the condition to skip adding `gasPrice` when `maxPriorityFeePerGas` key is present.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)