### PR TITLE
feat: add eth_maxPriorityFeePerGas RPC

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -396,6 +396,7 @@ Eth
 - :meth:`web3.eth.block_number <web3.eth.Eth.block_number>`
 - :meth:`web3.eth.coinbase <web3.eth.Eth.coinbase>`
 - :meth:`web3.eth.gas_price <web3.eth.Eth.gas_price>`
+- :meth:`web3.eth.max_priority_fee <web3.eth.Eth.max_priority_fee>`
 - :meth:`web3.eth.call() <web3.eth.Eth.call>`
 - :meth:`web3.eth.estimate_gas() <web3.eth.Eth.estimate_gas>`
 - :meth:`web3.eth.generate_gas_price() <web3.eth.Eth.generate_gas_price>`

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -120,8 +120,8 @@ The following properties are available on the ``web3.eth`` namespace.
 .. py:attribute:: Eth.max_priority_fee
 
     * Delegates to ``eth_maxPriorityFeePerGas`` RPC Method
-    
-    Returns a suggestion for a max priority fee for dynamic fee transactions.
+
+    Returns a suggestion for a max priority fee for dynamic fee transactions in Wei.
 
     .. code-block:: python
 
@@ -129,7 +129,7 @@ The following properties are available on the ``web3.eth`` namespace.
         2000000000
 
 
-.. py:attribute:: Eth.gas_price             
+.. py:attribute:: Eth.gas_price
 
     * Delegates to ``eth_gasPrice`` RPC Method
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -117,7 +117,19 @@ The following properties are available on the ``web3.eth`` namespace.
         906
 
 
-.. py:attribute:: Eth.gas_price
+.. py:attribute:: Eth.max_priority_fee
+
+    * Delegates to ``eth_maxPriorityFeePerGas`` RPC Method
+    
+    Returns a suggestion for a max priority fee for dynamic fee transactions.
+
+    .. code-block:: python
+
+        >>> web3.eth.max_priority_fee
+        2000000000
+
+
+.. py:attribute:: Eth.gas_price             
 
     * Delegates to ``eth_gasPrice`` RPC Method
 

--- a/newsfragments/2100.feature.rst
+++ b/newsfragments/2100.feature.rst
@@ -1,0 +1,1 @@
+Add support for eth_maxPriorityFeePerGas RPC method

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -276,6 +276,7 @@ class TestEthereumTesterEthModule(EthModuleTest):
         EthModuleTest.test_eth_get_raw_transaction, ValueError)
     test_eth_get_raw_transaction_raises_error = not_implemented(
         EthModuleTest.test_eth_get_raw_transaction, ValueError)
+    test_eth_max_priority_fee = not_implemented(EthModuleTest.test_eth_max_priority_fee, ValueError)
 
     def test_eth_getBlockByHash_pending(
         self, web3: "Web3"

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -453,6 +453,7 @@ PYTHONIC_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_call: HexBytes,
     RPC.eth_estimateGas: to_integer_if_hex,
     RPC.eth_feeHistory: fee_history_formatter,
+    RPC.eth_maxPriorityFeePerGas: to_integer_if_hex,
     RPC.eth_gasPrice: to_integer_if_hex,
     RPC.eth_getBalance: to_integer_if_hex,
     RPC.eth_getBlockByHash: apply_formatter_if(is_not_null, block_formatter),

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -325,6 +325,11 @@ class AsyncEthModuleTest:
         assert fee_history['oldestBlock'] >= 0
 
     @pytest.mark.asyncio
+    async def test_eth_max_priority_fee(self, async_w3: "Web3") -> None:
+        max_priority_fee = await async_w3.eth.max_priority_fee  # type: ignore
+        assert is_integer(max_priority_fee)
+
+    @pytest.mark.asyncio
     async def test_eth_getBlockByHash(
         self, async_w3: "Web3", empty_block: BlockData
     ) -> None:
@@ -635,6 +640,10 @@ class EthModuleTest:
             gas_price = web3.eth.gasPrice
         assert is_integer(gas_price)
         assert gas_price > 0
+
+    def test_eth_max_priority_fee(self, web3: "Web3") -> None:
+        max_priority_fee = web3.eth.max_priority_fee
+        assert is_integer(max_priority_fee)
 
     def test_eth_accounts(self, web3: "Web3") -> None:
         accounts = web3.eth.accounts

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -47,6 +47,7 @@ class RPC:
     eth_coinbase = RPCEndpoint("eth_coinbase")
     eth_estimateGas = RPCEndpoint("eth_estimateGas")
     eth_feeHistory = RPCEndpoint("eth_feeHistory")
+    eth_maxPriorityFeePerGas = RPCEndpoint("eth_maxPriorityFeePerGas")
     eth_gasPrice = RPCEndpoint("eth_gasPrice")
     eth_getBalance = RPCEndpoint("eth_getBalance")
     eth_getBlockByHash = RPCEndpoint("eth_getBlockByHash")

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -253,6 +253,10 @@ class AsyncEth(BaseEth):
         # types ignored b/c mypy conflict with BlockingEth properties
         return await self._gas_price()  # type: ignore
 
+    @property
+    async def max_priority_fee(self) -> Wei:
+        return await self._max_priority_fee()  # type: ignore
+
     async def fee_history(
             self,
             block_count: int,
@@ -261,10 +265,6 @@ class AsyncEth(BaseEth):
     ) -> FeeHistory:
         return await self._fee_history(  # type: ignore
             block_count, newest_block, reward_percentiles)
-
-    @property
-    async def max_priority_fee(self) -> Wei:
-        return await self._max_priority_fee()  # type: ignore
 
     async def send_transaction(self, transaction: TxParams) -> HexBytes:
         # types ignored b/c mypy conflict with BlockingEth properties
@@ -516,6 +516,10 @@ class Eth(BaseEth, Module):
         )
         self._default_block = value
 
+    @property
+    def max_priority_fee(self) -> Wei:
+        return self._max_priority_fee()
+
     def get_storage_at_munger(
         self,
         account: Union[Address, ChecksumAddress, ENS],
@@ -730,10 +734,6 @@ class Eth(BaseEth, Module):
         reward_percentiles: Optional[List[float]] = None
     ) -> FeeHistory:
         return self._fee_history(block_count, newest_block, reward_percentiles)
-
-    @property
-    def max_priority_fee(self) -> Wei:
-        return self._max_priority_fee()
 
     def filter_munger(
         self,

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -183,6 +183,11 @@ class BaseEth(Module):
         mungers=[default_root_munger]
     )
 
+    _max_priority_fee: Method[Callable[..., Wei]] = Method(
+        RPC.eth_maxPriorityFeePerGas,
+        mungers=None,
+    )
+
     def get_block_munger(
         self, block_identifier: BlockIdentifier, full_transactions: bool = False
     ) -> Tuple[BlockIdentifier, bool]:
@@ -256,6 +261,10 @@ class AsyncEth(BaseEth):
     ) -> FeeHistory:
         return await self._fee_history(  # type: ignore
             block_count, newest_block, reward_percentiles)
+
+    @property
+    async def max_priority_fee(self) -> Wei:
+        return await self._max_priority_fee()  # type: ignore
 
     async def send_transaction(self, transaction: TxParams) -> HexBytes:
         # types ignored b/c mypy conflict with BlockingEth properties
@@ -721,6 +730,10 @@ class Eth(BaseEth, Module):
         reward_percentiles: Optional[List[float]] = None
     ) -> FeeHistory:
         return self._fee_history(block_count, newest_block, reward_percentiles)
+
+    @property
+    def max_priority_fee(self) -> Wei:
+        return self._max_priority_fee()
 
     def filter_munger(
         self,

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -214,6 +214,7 @@ API_ENDPOINTS = {
         'hashrate': static_return(0),
         'chainId': static_return('0x3d'),
         'feeHistory': not_implemented,
+        'maxPriorityFeePerGas': not_implemented,
         'gasPrice': static_return(1),
         'accounts': call_eth_tester('get_accounts'),
         'blockNumber': compose(


### PR DESCRIPTION
### What was wrong?

Missing an RPC method complimentary to `eth_feeHistory`.

Related to Issue https://github.com/ledgerwatch/erigon/pull/2501

### How was it fixed?

I added `web3.eth.max_priority_fee` which suggests max priority fee for dynamic fee transactions.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img src="https://user-images.githubusercontent.com/4562643/128630375-73e5afe7-5eee-4ce9-833d-e7461be6f4b5.png" width="400px">