### PR TITLE
[WIP] Revert eth.fee_history

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -116,40 +116,6 @@ The following properties are available on the ``web3.eth`` namespace.
         >>> web3.eth.hashrate
         906
 
-.. py:attribute:: Eth.fee_history
-
-    * Delegates to ``eth_feeHistory`` RPC Method
-
-    Returns transaction fee data for up to 1024 blocks.
-
-    Parameters:
-
-    * ``block_count``: The number of blocks in the requested range. This value is a number between 1 and 1024.
-      Less than requested may be returned if not all blocks are available.
-    * ``newest_block``: The newest, highest-numbered, block in the requested range.
-    * ``reward_percentiles`` (optional): A monotonically increasing list of percentile values to sample from each
-      block's effective priority fees per gas in ascending order, weighted by gas used.
-
-    Return data:
-
-    * ``oldestBlock``: The oldest, lowest-numbered, block in the range requested.
-    * ``baseFeePerGas``: An array of block base fees per gas. This includes the next block after the newest of the
-      returned range, because this value can be derived from the newest block. Zeroes are returned for pre-EIP-1559
-      blocks.
-    * ``gasUsedRatio``: An array of ``gasUsed``/``gasLimit`` values for the requested blocks.
-    * ``reward`` (optional): An array of effective priority fee per gas data points from a single block.
-      All zeroes are returned if the block is empty.
-
-    .. code-block:: python
-
-        >>> w3.eth.fee_history(4, 'latest', [10, 90])
-        AttributeDict({
-            'oldestBlock': 3,
-            'reward': [[220, 7145389], [1000000, 6000213], [550, 550], [125, 12345678]],
-            'baseFeePerGas': [202583058, 177634473, 155594425, 136217133, 119442408],
-            'gasUsedRatio': [0.007390479689642084, 0.0036988514889990873, 0.0018512333048507866, 0.00741217041320997]
-        })
-
 
 .. py:attribute:: Eth.max_priority_fee
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -116,6 +116,40 @@ The following properties are available on the ``web3.eth`` namespace.
         >>> web3.eth.hashrate
         906
 
+.. py:attribute:: Eth.fee_history
+
+    * Delegates to ``eth_feeHistory`` RPC Method
+
+    Returns transaction fee data for up to 1024 blocks.
+
+    Parameters:
+
+    * ``block_count``: The number of blocks in the requested range. This value is a number between 1 and 1024.
+      Less than requested may be returned if not all blocks are available.
+    * ``newest_block``: The newest, highest-numbered, block in the requested range.
+    * ``reward_percentiles`` (optional): A monotonically increasing list of percentile values to sample from each
+      block's effective priority fees per gas in ascending order, weighted by gas used.
+
+    Return data:
+
+    * ``oldestBlock``: The oldest, lowest-numbered, block in the range requested.
+    * ``baseFeePerGas``: An array of block base fees per gas. This includes the next block after the newest of the
+      returned range, because this value can be derived from the newest block. Zeroes are returned for pre-EIP-1559
+      blocks.
+    * ``gasUsedRatio``: An array of ``gasUsed``/``gasLimit`` values for the requested blocks.
+    * ``reward`` (optional): An array of effective priority fee per gas data points from a single block.
+      All zeroes are returned if the block is empty.
+
+    .. code-block:: python
+
+        >>> w3.eth.fee_history(4, 'latest', [10, 90])
+        AttributeDict({
+            'oldestBlock': 3,
+            'reward': [[220, 7145389], [1000000, 6000213], [550, 550], [125, 12345678]],
+            'baseFeePerGas': [202583058, 177634473, 155594425, 136217133, 119442408],
+            'gasUsedRatio': [0.007390479689642084, 0.0036988514889990873, 0.0018512333048507866, 0.00741217041320997]
+        })
+
 
 .. py:attribute:: Eth.max_priority_fee
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1051,27 +1051,25 @@ The following methods are available on the ``web3.eth`` namespace.
 
     * Delegates to ``eth_feeHistory`` RPC Method
 
-    Returns transaction fee data for up to 1,024 blocks.
+    Returns transaction fee data for up to 1024 blocks.
 
-    :param block_count: The number of blocks in the requested range. This value should be an :py:class:`int` between 1
-        and 1024. Less than requested may be returned if not all blocks are available.
-    :type block_count: int
-    :param newest_block: The newest, highest-numbered, block in the requested range. This value may be an
-        :py:class:`int` or one of the predefined block parameters ``'latest'``, ``'earliest'``, or ``'pending'``.
-    :type newest_block: int or BlockParams
-    :param reward_percentiles: *(optional)* A monotonically increasing list of percentile :py:class:`float` values to
-        sample from each block's effective priority fees per gas in ascending order, weighted by gas used.
-    :type reward_percentiles: List[float] or None
-    :return: An ``AttributeDict`` containing the following keys:
+    Parameters:
 
-    * **oldestBlock** *(int)* -- The oldest, lowest-numbered, block in the range requested as a ``BlockNumber`` type
-      with :py:class:`int` value.
-    * **baseFeePerGas** *(List[Wei])* -- An array of block base fees per gas. This includes the next block after the
-      newest of the returned range, because this value can be derived from the newest block. Zeroes are returned for
-      pre-EIP-1559 blocks.
-    * **gasUsedRatio** *(List[float])* -- An array of ``gasUsed``/``gasLimit`` float values for the requested blocks.
-    * **reward** *(List[List[Wei]])* -- *(optional)* A two-dimensional array of effective priority fees per gas at the
-      requested block percentiles.
+    * ``block_count``: The number of blocks in the requested range. This value is a number between 1 and 1024.
+      Less than requested may be returned if not all blocks are available.
+    * ``newest_block``: The newest, highest-numbered, block in the requested range.
+    * ``reward_percentiles`` (optional): A monotonically increasing list of percentile values to sample from each
+      block's effective priority fees per gas in ascending order, weighted by gas used.
+
+    Return data:
+
+    * ``oldestBlock``: The oldest, lowest-numbered, block in the range requested.
+    * ``baseFeePerGas``: An array of block base fees per gas. This includes the next block after the newest of the
+      returned range, because this value can be derived from the newest block. Zeroes are returned for pre-EIP-1559
+      blocks.
+    * ``gasUsedRatio``: An array of ``gasUsed``/``gasLimit`` values for the requested blocks.
+    * ``reward`` (optional): An array of effective priority fee per gas data points from a single block.
+      All zeroes are returned if the block is empty.
 
     .. code-block:: python
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1081,41 +1081,6 @@ The following methods are available on the ``web3.eth`` namespace.
     for a list of possible parameters.
 
 
-.. py:method:: Eth.fee_history(block_count, newest_block, reward_percentiles=None)
-
-    * Delegates to ``eth_feeHistory`` RPC Method
-
-    Returns transaction fee data for up to 1024 blocks.
-
-    Parameters:
-
-    * ``block_count``: The number of blocks in the requested range. This value is a number between 1 and 1024.
-      Less than requested may be returned if not all blocks are available.
-    * ``newest_block``: The newest, highest-numbered, block in the requested range.
-    * ``reward_percentiles`` (optional): A monotonically increasing list of percentile values to sample from each
-      block's effective priority fees per gas in ascending order, weighted by gas used.
-
-    Return data:
-
-    * ``oldestBlock``: The oldest, lowest-numbered, block in the range requested.
-    * ``baseFeePerGas``: An array of block base fees per gas. This includes the next block after the newest of the
-      returned range, because this value can be derived from the newest block. Zeroes are returned for pre-EIP-1559
-      blocks.
-    * ``gasUsedRatio``: An array of ``gasUsed``/``gasLimit`` values for the requested blocks.
-    * ``reward`` (optional): An array of effective priority fee per gas data points from a single block.
-      All zeroes are returned if the block is empty.
-
-    .. code-block:: python
-
-        >>> w3.eth.fee_history(4, 'latest', [10, 90])
-        AttributeDict({
-            'oldestBlock': 3,
-            'reward': [[220, 7145389], [1000000, 6000213], [550, 550], [125, 12345678]],
-            'baseFeePerGas': [202583058, 177634473, 155594425, 136217133, 119442408],
-            'gasUsedRatio': [0.007390479689642084, 0.0036988514889990873, 0.0018512333048507866, 0.00741217041320997]
-        })
-
-
 .. py:method:: Eth.estimate_gas(transaction, block_identifier=None)
 
     * Delegates to ``eth_estimateGas`` RPC Method

--- a/newsfragments/2038.feature.rst
+++ b/newsfragments/2038.feature.rst
@@ -1,1 +1,0 @@
-Add support for eth_feeHistory RPC method

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -284,18 +284,6 @@ class TestEthereumTesterEthModule(EthModuleTest):
         block = web3.eth.get_block('pending')
         assert block['hash'] is not None
 
-    @pytest.mark.xfail(reason='eth_feeHistory is not implemented on eth-tester')
-    def test_eth_fee_history(self, web3: "Web3"):
-        super().test_eth_fee_history(web3)
-
-    @pytest.mark.xfail(reason='eth_feeHistory is not implemented on eth-tester')
-    def test_eth_fee_history_with_integer(self, web3: "Web3"):
-        super().test_eth_fee_history_with_integer(web3)
-
-    @pytest.mark.xfail(reason='eth_feeHistory is not implemented on eth-tester')
-    def test_eth_fee_history_no_reward_percentiles(self, web3: "Web3"):
-        super().test_eth_fee_history_no_reward_percentiles(web3)
-
     @pytest.mark.xfail(reason='EIP 1559 is not implemented on eth-tester')
     def test_eth_get_transaction_receipt_unmined(self, eth_tester, web3, unlocked_account):
         super().test_eth_get_transaction_receipt_unmined(web3, unlocked_account)

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -278,16 +278,6 @@ transaction_pool_inspect_formatter = apply_formatters_to_dict(
     TRANSACTION_POOL_INSPECT_FORMATTERS
 )
 
-FEE_HISTORY_FORMATTERS = {
-    'baseFeePerGas': apply_formatter_to_array(to_integer_if_hex),
-    'gasUsedRatio': apply_formatter_if(is_not_null, apply_formatter_to_array(float)),
-    'oldestBlock': to_integer_if_hex,
-    'reward': apply_formatter_if(is_not_null, apply_formatter_to_array(
-        apply_formatter_to_array(to_integer_if_hex))),
-}
-
-fee_history_formatter = apply_formatters_to_dict(FEE_HISTORY_FORMATTERS)
-
 STORAGE_PROOF_FORMATTERS = {
     'key': HexBytes,
     'value': HexBytes,
@@ -392,7 +382,6 @@ geth_wallets_formatter = apply_formatters_to_dict(GETH_WALLETS_FORMATTER)
 
 PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     # Eth
-    RPC.eth_feeHistory: apply_formatter_at_index(to_hex_if_integer, 1),
     RPC.eth_getBalance: apply_formatter_at_index(to_hex_if_integer, 1),
     RPC.eth_getBlockByNumber: apply_formatter_at_index(to_hex_if_integer, 0),
     RPC.eth_getBlockTransactionCountByNumber: apply_formatter_at_index(
@@ -452,7 +441,6 @@ PYTHONIC_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_coinbase: to_checksum_address,
     RPC.eth_call: HexBytes,
     RPC.eth_estimateGas: to_integer_if_hex,
-    RPC.eth_feeHistory: fee_history_formatter,
     RPC.eth_maxPriorityFeePerGas: to_integer_if_hex,
     RPC.eth_gasPrice: to_integer_if_hex,
     RPC.eth_getBalance: to_integer_if_hex,

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -354,36 +354,6 @@ class AsyncEthModuleTest:
         assert gas_estimate > 0
 
     @pytest.mark.asyncio
-    async def test_eth_fee_history(self, async_w3: "Web3") -> None:
-        fee_history = await async_w3.eth.fee_history(1, 'latest', [50])  # type: ignore
-        assert is_list_like(fee_history['baseFeePerGas'])
-        assert is_list_like(fee_history['gasUsedRatio'])
-        assert is_integer(fee_history['oldestBlock'])
-        assert fee_history['oldestBlock'] >= 0
-        assert is_list_like(fee_history['reward'])
-        assert is_list_like(fee_history['reward'][0])
-
-    @pytest.mark.asyncio
-    async def test_eth_fee_history_with_integer(
-        self, async_w3: "Web3", empty_block: BlockData
-    ) -> None:
-        fee_history = await async_w3.eth.fee_history(1, empty_block['number'], [50])  # type: ignore
-        assert is_list_like(fee_history['baseFeePerGas'])
-        assert is_list_like(fee_history['gasUsedRatio'])
-        assert is_integer(fee_history['oldestBlock'])
-        assert fee_history['oldestBlock'] >= 0
-        assert is_list_like(fee_history['reward'])
-        assert is_list_like(fee_history['reward'][0])
-
-    @pytest.mark.asyncio
-    async def test_eth_fee_history_no_reward_percentiles(self, async_w3: "Web3") -> None:
-        fee_history = await async_w3.eth.fee_history(1, 'latest')  # type: ignore
-        assert is_list_like(fee_history['baseFeePerGas'])
-        assert is_list_like(fee_history['gasUsedRatio'])
-        assert is_integer(fee_history['oldestBlock'])
-        assert fee_history['oldestBlock'] >= 0
-
-    @pytest.mark.asyncio
     async def test_eth_max_priority_fee(self, async_w3: "Web3") -> None:
         max_priority_fee = await async_w3.eth.max_priority_fee  # type: ignore
         assert is_integer(max_priority_fee)
@@ -661,33 +631,6 @@ class EthModuleTest:
             chain_id = web3.eth.chainId
         # chain id value from geth fixture genesis file
         assert chain_id == 131277322940537
-
-    def test_eth_fee_history(self, web3: "Web3") -> None:
-        fee_history = web3.eth.fee_history(1, 'latest', [50])
-        assert is_list_like(fee_history['baseFeePerGas'])
-        assert is_list_like(fee_history['gasUsedRatio'])
-        assert is_integer(fee_history['oldestBlock'])
-        assert fee_history['oldestBlock'] >= 0
-        assert is_list_like(fee_history['reward'])
-        assert is_list_like(fee_history['reward'][0])
-
-    def test_eth_fee_history_with_integer(self,
-                                          web3: "Web3",
-                                          empty_block: BlockData) -> None:
-        fee_history = web3.eth.fee_history(1, empty_block['number'], [50])
-        assert is_list_like(fee_history['baseFeePerGas'])
-        assert is_list_like(fee_history['gasUsedRatio'])
-        assert is_integer(fee_history['oldestBlock'])
-        assert fee_history['oldestBlock'] >= 0
-        assert is_list_like(fee_history['reward'])
-        assert is_list_like(fee_history['reward'][0])
-
-    def test_eth_fee_history_no_reward_percentiles(self, web3: "Web3") -> None:
-        fee_history = web3.eth.fee_history(1, 'latest')
-        assert is_list_like(fee_history['baseFeePerGas'])
-        assert is_list_like(fee_history['gasUsedRatio'])
-        assert is_integer(fee_history['oldestBlock'])
-        assert fee_history['oldestBlock'] >= 0
 
     def test_eth_gas_price(self, web3: "Web3") -> None:
         gas_price = web3.eth.gas_price

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -46,7 +46,6 @@ class RPC:
     eth_chainId = RPCEndpoint("eth_chainId")
     eth_coinbase = RPCEndpoint("eth_coinbase")
     eth_estimateGas = RPCEndpoint("eth_estimateGas")
-    eth_feeHistory = RPCEndpoint("eth_feeHistory")
     eth_maxPriorityFeePerGas = RPCEndpoint("eth_maxPriorityFeePerGas")
     eth_gasPrice = RPCEndpoint("eth_gasPrice")
     eth_getBalance = RPCEndpoint("eth_getBalance")

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -87,9 +87,7 @@ from web3.types import (
     ENS,
     BlockData,
     BlockIdentifier,
-    BlockParams,
     CallOverrideParams,
-    FeeHistory,
     FilterParams,
     GasPriceStrategy,
     LogReceipt,
@@ -178,11 +176,6 @@ class BaseEth(Module):
         mungers=[estimate_gas_munger]
     )
 
-    _fee_history: Method[Callable[..., FeeHistory]] = Method(
-        RPC.eth_feeHistory,
-        mungers=[default_root_munger]
-    )
-
     _max_priority_fee: Method[Callable[..., Wei]] = Method(
         RPC.eth_maxPriorityFeePerGas,
         mungers=None,
@@ -256,15 +249,6 @@ class AsyncEth(BaseEth):
     @property
     async def max_priority_fee(self) -> Wei:
         return await self._max_priority_fee()  # type: ignore
-
-    async def fee_history(
-            self,
-            block_count: int,
-            newest_block: Union[BlockParams, BlockNumber],
-            reward_percentiles: Optional[List[float]] = None
-    ) -> FeeHistory:
-        return await self._fee_history(  # type: ignore
-            block_count, newest_block, reward_percentiles)
 
     async def send_transaction(self, transaction: TxParams) -> HexBytes:
         # types ignored b/c mypy conflict with BlockingEth properties
@@ -726,14 +710,6 @@ class Eth(BaseEth, Module):
         block_identifier: Optional[BlockIdentifier] = None
     ) -> Wei:
         return self._estimate_gas(transaction, block_identifier)
-
-    def fee_history(
-        self,
-        block_count: int,
-        newest_block: Union[BlockParams, BlockNumber],
-        reward_percentiles: Optional[List[float]] = None
-    ) -> FeeHistory:
-        return self._fee_history(block_count, newest_block, reward_percentiles)
 
     def filter_munger(
         self,

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -213,7 +213,6 @@ API_ENDPOINTS = {
         'mining': static_return(False),
         'hashrate': static_return(0),
         'chainId': static_return('0x3d'),
-        'feeHistory': not_implemented,
         'maxPriorityFeePerGas': not_implemented,
         'gasPrice': static_return(1),
         'accounts': call_eth_tester('get_accounts'),

--- a/web3/types.py
+++ b/web3/types.py
@@ -144,13 +144,6 @@ class FilterParams(TypedDict, total=False):
     topics: Sequence[Optional[Union[_Hash32, Sequence[_Hash32]]]]
 
 
-class FeeHistory(TypedDict):
-    baseFeePerGas: List[Wei]
-    gasUsedRatio: List[float]
-    oldestBlock: BlockNumber
-    reward: List[List[Wei]]
-
-
 class LogReceipt(TypedDict):
     address: ChecksumAddress
     blockHash: HexBytes


### PR DESCRIPTION
### What was wrong?

Geth has the fee history endpoint implemented inconsistently, but they have the PR up to fix. We'll put this endpoint and docs back once 1.10.7 is out.

### How was it fixed?
Removed the squashed commit (d722f3107612a4b713d8ad360a3ca2d637964721), and the doc commits that followed.


### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
