### PR TITLE
Update docs for block_count arg

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1053,9 +1053,10 @@ The following methods are available on the ``web3.eth`` namespace.
 
     Returns transaction fee data for up to 1,024 blocks.
 
-    :param block_count: The number of blocks in the requested range. This value should be an :py:class:`int` between 1
-        and 1024. Less than requested may be returned if not all blocks are available.
-    :type block_count: int
+    :param block_count: The number of blocks in the requested range. Depending on the client, this
+        value should be either a :py:class:`int` between 1 and 1024 or a hexstring.
+        Less than requested may be returned if not all blocks are available.
+    :type block_count: int or hexstring
     :param newest_block: The newest, highest-numbered, block in the requested range. This value may be an
         :py:class:`int` or one of the predefined block parameters ``'latest'``, ``'earliest'``, or ``'pending'``.
     :type newest_block: int or BlockParams

--- a/newsfragments/2104.doc.rst
+++ b/newsfragments/2104.doc.rst
@@ -1,0 +1,1 @@
+Update feeHistory docs


### PR DESCRIPTION
### What was wrong?

There is some standardization lacking between clients in regards to the type of the `block_count` argument for `eth.feeHistory` RPC Method. In the next release Geth will accept a hexstring for the `block_count` argument, but some other clients only allow ints. 

Related to Issue: https://github.com/ethereum/eth1.0-apis/issues/20

### How was it fixed?
Added some docs to clarify that `block_count` may either take a hexstring or an int, depending on the client. @fselmo - let me know if you think this needs more/better/different clarification!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wallpaperaccess.com/full/4993366.jpg)
