### PR TITLE
Update ipfshttpclient to 0.8.0a2

### DIFF
--- a/newsfragments/2110.misc.rst
+++ b/newsfragments/2110.misc.rst
@@ -1,0 +1,1 @@
+Update ipfshttpclient to v0.8.0a2

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.9.5,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
-        "ipfshttpclient==0.7.0",
+        "ipfshttpclient==0.8.0a2",
         "jsonschema>=3.2.0,<4.0.0",
         "lru-dict>=1.1.6,<2.0.0",
         "protobuf>=3.10.0,<4",


### PR DESCRIPTION
### What was wrong?
The `ipfshttpclient` library relies on the `go-ipfs` daemon to access ipfs files. The `go-ipfs` lib updated to v0.9.0 and the `ipfshttpclient` library threw an error in v0.7.x if the version of `go-ipfs` is greater than 0.8.x. 

### How was it fixed?

The ipfshttpclient team changed the error to a warning in the 0.8.x line, so updated here and made a PR on the ipfshttpclient library to allow for the 0.9.x versions.


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/6540608/130120069-72a4d37d-efd0-44cc-b4a4-b04c077d7cd8.png)


