### PR TITLE
Added eth.get_raw_transaction_by_block method

### DIFF
--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -406,6 +406,8 @@ PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
         apply_formatter_at_index(to_hex_if_integer, 1),
     ),
     RPC.eth_getTransactionCount: apply_formatter_at_index(to_hex_if_integer, 1),
+    RPC.eth_getRawTransactionByBlockNumberAndIndex: HexBytes,
+     RPC.eth_getRawTransactionByBlockHashAndIndex: HexBytes,
     RPC.eth_getUncleCountByBlockNumber: apply_formatter_at_index(to_hex_if_integer, 0),
     RPC.eth_getUncleByBlockNumberAndIndex: compose(
         apply_formatter_at_index(to_hex_if_integer, 0),
@@ -645,6 +647,16 @@ def raise_transaction_not_found(params: Tuple[_Hash32]) -> NoReturn:
 
     raise TransactionNotFound(message)
 
+def raise_raw_transaction_not_found_with_index(params: Tuple[BlockIdentifier, int]) -> NoReturn:
+    try:
+        transaction_hash = params[0]
+        message = f"Transaction with hash: {transaction_hash!r} not found."
+    except IndexError:
+        message = "Unknown transaction hash"
+
+    raise TransactionNotFound(message)
+
+
 
 def raise_transaction_not_found_with_index(params: Tuple[BlockIdentifier, int]) -> NoReturn:
     try:
@@ -673,6 +685,8 @@ NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getTransactionByBlockHashAndIndex: raise_transaction_not_found_with_index,
     RPC.eth_getTransactionByBlockNumberAndIndex: raise_transaction_not_found_with_index,
     RPC.eth_getTransactionReceipt: raise_transaction_not_found,
+    RPC.eth_getRawTransactionByBlockHashAndIndex: raise_raw_transaction_not_found_with_index,
+    RPC.eth_getRawTransactionByBlockNumberAndIndex: raise_raw_transaction_not_found_with_index,
     RPC.eth_getRawTransactionByHash: raise_transaction_not_found,
 }
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -407,7 +407,7 @@ PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     ),
     RPC.eth_getTransactionCount: apply_formatter_at_index(to_hex_if_integer, 1),
     RPC.eth_getRawTransactionByBlockNumberAndIndex: HexBytes,
-     RPC.eth_getRawTransactionByBlockHashAndIndex: HexBytes,
+    RPC.eth_getRawTransactionByBlockHashAndIndex: HexBytes,
     RPC.eth_getUncleCountByBlockNumber: apply_formatter_at_index(to_hex_if_integer, 0),
     RPC.eth_getUncleByBlockNumberAndIndex: compose(
         apply_formatter_at_index(to_hex_if_integer, 0),
@@ -647,6 +647,7 @@ def raise_transaction_not_found(params: Tuple[_Hash32]) -> NoReturn:
 
     raise TransactionNotFound(message)
 
+
 def raise_raw_transaction_not_found_with_index(params: Tuple[BlockIdentifier, int]) -> NoReturn:
     try:
         transaction_hash = params[0]
@@ -655,7 +656,6 @@ def raise_raw_transaction_not_found_with_index(params: Tuple[BlockIdentifier, in
         message = "Unknown transaction hash"
 
     raise TransactionNotFound(message)
-
 
 
 def raise_transaction_not_found_with_index(params: Tuple[BlockIdentifier, int]) -> NoReturn:

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -63,6 +63,10 @@ class RPC:
     eth_getStorageAt = RPCEndpoint("eth_getStorageAt")
     eth_getTransactionByBlockHashAndIndex = RPCEndpoint("eth_getTransactionByBlockHashAndIndex")
     eth_getTransactionByBlockNumberAndIndex = RPCEndpoint("eth_getTransactionByBlockNumberAndIndex")
+    eth_getRawTransactionByBlockHashAndIndex = \
+        RPCEndpoint("eth_getRawTransactionByBlockHashAndIndex")
+    eth_getRawTransactionByBlockNumberAndIndex = \
+        RPCEndpoint("eth_getRawTransactionByBlockNumberAndIndex")
     eth_getTransactionByHash = RPCEndpoint("eth_getTransactionByHash")
     eth_getTransactionCount = RPCEndpoint("eth_getTransactionCount")
     eth_getTransactionReceipt = RPCEndpoint("eth_getTransactionReceipt")
@@ -185,6 +189,7 @@ RPC_ABIS = {
     'eth_getTransactionByHash': ['bytes32'],
     'eth_getTransactionCount': ['address', None],
     'eth_getTransactionReceipt': ['bytes32'],
+    'eth_getRawTransactionByBlockHashAndIndex': ['bytes32', 'uint'],
     'eth_getUncleCountByBlockHash': ['bytes32'],
     'eth_newFilter': FILTER_PARAMS_ABIS,
     'eth_sendRawTransaction': ['bytes'],

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -629,13 +629,13 @@ class Eth(BaseEth, Module):
     )
 
     get_raw_transaction_by_block: Method[Callable[[BlockIdentifier], int]] = Method(
-         method_choice_depends_on_args=select_method_for_block_identifier(
-             if_predefined=RPC.eth_getRawTransactionByBlockNumberAndIndex,
-             if_hash=RPC.eth_getRawTransactionByBlockHashAndIndex,
-             if_number=RPC.eth_getRawTransactionByBlockNumberAndIndex,
-         ),
-         mungers=[default_root_munger]
-     )
+        method_choice_depends_on_args=select_method_for_block_identifier(
+            if_predefined=RPC.eth_getRawTransactionByBlockNumberAndIndex,
+            if_hash=RPC.eth_getRawTransactionByBlockHashAndIndex,
+            if_number=RPC.eth_getRawTransactionByBlockNumberAndIndex,
+        ),
+        mungers=[default_root_munger]
+    )
 
     @deprecated_for("wait_for_transaction_receipt")
     def waitForTransactionReceipt(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -628,6 +628,15 @@ class Eth(BaseEth, Module):
         mungers=[default_root_munger]
     )
 
+    get_raw_transaction_by_block: Method[Callable[[BlockIdentifier], int]] = Method(
+         method_choice_depends_on_args=select_method_for_block_identifier(
+             if_predefined=RPC.eth_getRawTransactionByBlockNumberAndIndex,
+             if_hash=RPC.eth_getRawTransactionByBlockHashAndIndex,
+             if_number=RPC.eth_getRawTransactionByBlockNumberAndIndex,
+         ),
+         mungers=[default_root_munger]
+     )
+
     @deprecated_for("wait_for_transaction_receipt")
     def waitForTransactionReceipt(
         self, transaction_hash: _Hash32, timeout: int = 120, poll_latency: float = 0.1


### PR DESCRIPTION
### What was wrong?
This PR adds support for it and also adds eth.get_raw_transaction_by_block method which wasn't supported previously.

Related to Issue #2040 

### How was it fixed?
It was added by following how the eth.get_transaction_by_block method was defined along with the respective RPC Methods.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/cute-baby-animals-1558535060.jpg?crop=1.00xw:0.669xh;0,0.158xh&resize=980:*)
