### PR TITLE
Encode `block_count` as hex in eth_feeHistory RPC

### DIFF
--- a/newsfragments/2117.bugfix.rst
+++ b/newsfragments/2117.bugfix.rst
@@ -1,0 +1,1 @@
+Encode block_count as hex before making eth_feeHistory RPC call

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -392,7 +392,10 @@ geth_wallets_formatter = apply_formatters_to_dict(GETH_WALLETS_FORMATTER)
 
 PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     # Eth
-    RPC.eth_feeHistory: apply_formatter_at_index(to_hex_if_integer, 1),
+    RPC.eth_feeHistory: compose(
+        apply_formatter_at_index(to_hex_if_integer, 0),
+        apply_formatter_at_index(to_hex_if_integer, 1)
+    ),
     RPC.eth_getBalance: apply_formatter_at_index(to_hex_if_integer, 1),
     RPC.eth_getBlockByNumber: apply_formatter_at_index(to_hex_if_integer, 0),
     RPC.eth_getBlockTransactionCountByNumber: apply_formatter_at_index(


### PR DESCRIPTION
### What was wrong?
`eth_feeHistory` RPC call was sending `block_count` as a raw integer instead of hex. This broke [hardhat](https://github.com/nomiclabs/hardhat) since it expects QUANTITIES (integers etc.) to be hex-encoded

### How was it fixed?
Modified `eth_feeHistory` formatter to encode `block_count` as hex before making the RPC call

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/27727946/130739992-d9bc20bd-88cf-4e4d-a5f7-74fd22d67a1b.png)
