### PR TITLE
Bump the py-geth version to 3.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ geth_steps: &geth_steps
         name: build geth if missing
         command: |
           mkdir -p $HOME/.ethash
-          pip install --user py-geth>=3.4.0
+          pip install --user py-geth>=3.5.0
           export GOROOT=/usr/local/go
           echo $GETH_VERSION
           export GETH_BINARY="$HOME/.py-geth/geth-$GETH_VERSION/bin/geth"

--- a/newsfragments/2122.misc.rst
+++ b/newsfragments/2122.misc.rst
@@ -1,0 +1,1 @@
+Update project to use recently-released py-geth version 3.5.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import (
 extras_require = {
     'tester': [
         "eth-tester[py-evm]==v0.5.0-beta.4",
-        "py-geth>=3.4.0,<4",
+        "py-geth>=3.5.0,<4",
     ],
     'linter': [
         "flake8==3.8.3",
@@ -21,7 +21,7 @@ extras_require = {
         "click>=5.1",
         "configparser==3.5.0",
         "contextlib2>=0.5.4",
-        "py-geth>=3.4.0,<4",
+        "py-geth>=3.5.0,<4",
         "py-solc>=0.4.0",
         "pytest>=4.4.0,<5.0.0",
         "sphinx>=3.0,<4",


### PR DESCRIPTION
### What was wrong?

- py-geth version needed updating

### How was it fixed?

- bumped py-geth to 3.5.0

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fbloximages.newyork1.vip.townnews.com%2Festesparknews.com%2Fcontent%2Ftncms%2Fassets%2Fv3%2Feditorial%2F5%2Fb8%2F5b8f99f2-d274-11ea-b177-d717bb9e85e7%2F5f22dedc72303.image.jpg&f=1&nofb=1)
