### PR TITLE
Update AsyncHTTPProvider docs

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -382,8 +382,13 @@ AsyncHTTPProvider
 
     .. code-block:: python
 
-        >>> from web3 import Web3
-        >>> w3 = Web3(Web3.AsyncHTTPProvider("http://127.0.0.1:8545"))
+        >>> from web3 import Web3, AsyncHTTPProvider
+        >>> from web3.eth import AsyncEth
+        >>> from web3.net import AsyncNet
+
+        >>> w3 = Web3(AsyncHTTPProvider("http://127.0.0.1:8545"),
+        ...           modules={'eth', (AsyncEth,), 'net': (AsyncNet,)},
+        ...           middlewares=[])  # See supported middleware section below for middleware options
 
     Under the hood, the ``AsyncHTTPProvider`` uses the python
     `aiohttp <https://docs.aiohttp.org/en/stable/>`_ library for making requests.

--- a/newsfragments/2123.doc.rst
+++ b/newsfragments/2123.doc.rst
@@ -1,0 +1,1 @@
+Update AsyncHTTPProvider doc example to include modules and middlewares keyword arguments


### PR DESCRIPTION
### What was wrong?
The AsyncHTTPProvider docs were unclear and causing confusion. 

Closes #2121

### How was it fixed?
Added the `modules` and `middlewares` args

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/131165750-ff2f80ec-bad9-4890-bfa7-28ded72bebe8.png)

