### PR TITLE
typo fix for explanation of async http provider

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -387,7 +387,7 @@ AsyncHTTPProvider
         >>> from web3.net import AsyncNet
 
         >>> w3 = Web3(AsyncHTTPProvider("http://127.0.0.1:8545"),
-        ...           modules={'eth', (AsyncEth,), 'net': (AsyncNet,)},
+        ...           modules={'eth': (AsyncEth,), 'net': (AsyncNet,)},
         ...           middlewares=[])  # See supported middleware section below for middleware options
 
     Under the hood, the ``AsyncHTTPProvider`` uses the python

--- a/newsfragments/2131.doc.rst
+++ b/newsfragments/2131.doc.rst
@@ -1,0 +1,1 @@
+Fix typo in AsyncHTTPProvider docs


### PR DESCRIPTION
### What was wrong?

documentation on how to create an async http provider in https://github.com/ethereum/web3.py/pull/2123 was incorrect

### How was it fixed?

changed comma to colon

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.superiorwallpapers.com/download/cute-panda-bear-cub-wild-animals-wallpaper-3500x2833.jpg)
