### PR TITLE
Edit some ValueError() messages for more clarity

### DIFF
--- a/newsfragments/2146.doc.rst
+++ b/newsfragments/2146.doc.rst
@@ -1,0 +1,1 @@
+Clarify some contract ``ValueError`` error messages.

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -689,7 +689,9 @@ class ContractConstructor:
     ) -> None:
         keys_found = set(transaction.keys()) & set(forbidden_keys)
         if keys_found:
-            raise ValueError("Cannot set '{}' field in transaction".format(', '.join(keys_found)))
+            raise ValueError(
+                "Cannot set '{}' field(s) in transaction".format(', '.join(keys_found))
+            )
 
 
 class ConciseMethod:

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -689,7 +689,7 @@ class ContractConstructor:
     ) -> None:
         keys_found = set(transaction.keys()) & set(forbidden_keys)
         if keys_found:
-            raise ValueError("Cannot set {} in transaction".format(', '.join(keys_found)))
+            raise ValueError("Cannot set '{}' field in transaction".format(', '.join(keys_found)))
 
 
 class ConciseMethod:
@@ -932,7 +932,7 @@ class ContractFunction:
             call_transaction = cast(TxParams, dict(**transaction))
 
         if 'data' in call_transaction:
-            raise ValueError("Cannot set data in call transaction")
+            raise ValueError("Cannot set 'data' field in call transaction")
 
         if self.address:
             call_transaction.setdefault('to', self.address)
@@ -975,7 +975,7 @@ class ContractFunction:
             transact_transaction = cast(TxParams, dict(**transaction))
 
         if 'data' in transact_transaction:
-            raise ValueError("Cannot set data in transact transaction")
+            raise ValueError("Cannot set 'data' field in transact transaction")
 
         if self.address is not None:
             transact_transaction.setdefault('to', self.address)
@@ -1015,7 +1015,7 @@ class ContractFunction:
             estimate_gas_transaction = cast(TxParams, dict(**transaction))
 
         if 'data' in estimate_gas_transaction:
-            raise ValueError("Cannot set data in estimateGas transaction")
+            raise ValueError("Cannot set 'data' field in estimateGas transaction")
         if 'to' in estimate_gas_transaction:
             raise ValueError("Cannot set to in estimateGas transaction")
 
@@ -1058,7 +1058,7 @@ class ContractFunction:
             built_transaction = cast(TxParams, dict(**transaction))
 
         if 'data' in built_transaction:
-            raise ValueError("Cannot set data in build transaction")
+            raise ValueError("Cannot set 'data' field in build transaction")
 
         if not self.address and 'to' not in built_transaction:
             raise ValueError(
@@ -1066,7 +1066,7 @@ class ContractFunction:
                 "you must provide a `to` address with the transaction"
             )
         if self.address and 'to' in built_transaction:
-            raise ValueError("Cannot set to in contract call build transaction")
+            raise ValueError("Cannot set 'to' field in contract call build transaction")
 
         if self.address:
             built_transaction.setdefault('to', self.address)


### PR DESCRIPTION
### What was wrong?
A few of the error messages were confusing

### How was it fixed?
With additional formatting and clarification

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

### Background
Errors such as "Cannot set data in estimateGas transaction" make me think that estimateGas() failed to set some data values in transaction provided to it. While instead what it means is that I myself, as an operator, am not supposed to set transaction['data'] field. And should leave it blank. This might be obvious to those experienced with web3.py, but it's extremely confusing to me.
Same with the generic ValueError at line 693. It took me an extra hour to understand what the error was actually saying, because of the format it was in: "cannot set to in estimateGas transaction", for example. Just how the hell is one supposed to understand that line? It is VERY confusing.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/8/8e/Four_sea_otters.JPG)
