### PR TITLE
json rpc request id from 1

### DIFF
--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -82,7 +82,7 @@ class BaseProvider:
 
 class JSONBaseProvider(BaseProvider):
     def __init__(self) -> None:
-        self.request_counter = itertools.count()
+        self.request_counter = itertools.count(start=1)
 
     def decode_rpc_response(self, raw_response: bytes) -> RPCResponse:
         text_response = to_text(raw_response)


### PR DESCRIPTION
Since https://cloudflare-eth.com can not parse id from 0.

### What was wrong?

Related to Issue #

### How was it fixed?

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
