### PR TITLE
JSON RPC request id from 1.

### DIFF
--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -82,7 +82,7 @@ class BaseProvider:
 
 class JSONBaseProvider(BaseProvider):
     def __init__(self) -> None:
-        self.request_counter = itertools.count()
+        self.request_counter = itertools.count(start=1)
 
     def decode_rpc_response(self, raw_response: bytes) -> RPCResponse:
         text_response = to_text(raw_response)


### PR DESCRIPTION
Since https://cloudflare-eth.com can not parse id from 0.

### What was wrong?

Related to Issue #2145.

Change request_counter start from 1.

