### PR TITLE
Fix link for websockets documentation

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -316,7 +316,7 @@ WebsocketProvider
     use the ``websocket_kwargs`` to do so.  See the `websockets documentation`_ for
     available arguments.
 
-    .. _`websockets documentation`: https://websockets.readthedocs.io/en/stable/reference/client.html#websockets.client.connect
+    .. _`websockets documentation`: https://websockets.readthedocs.io/en/stable/reference/client.html#websockets.client.WebSocketClientProtocol
 
     Unlike HTTP connections, the timeout for WS connections is controlled by a
     separate ``websocket_timeout`` argument, as shown below.

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -316,7 +316,7 @@ WebsocketProvider
     use the ``websocket_kwargs`` to do so.  See the `websockets documentation`_ for
     available arguments.
 
-    .. _`websockets documentation`: https://websockets.readthedocs.io/en/stable/api.html#websockets.protocol.WebSocketCommonProtocol
+    .. _`websockets documentation`: https://websockets.readthedocs.io/en/stable/reference/client.html#websockets.client.connect
 
     Unlike HTTP connections, the timeout for WS connections is controlled by a
     separate ``websocket_timeout`` argument, as shown below.

--- a/newsfragments/2173.doc.rst
+++ b/newsfragments/2173.doc.rst
@@ -1,0 +1,1 @@
+Correct link to Websocket library documentation


### PR DESCRIPTION
Previous link to websockets library docs was incorrect.