### PR TITLE
fix: include backend type for tester param in eth test provider ctor

### DIFF
--- a/newsfragments/2191.misc.rst
+++ b/newsfragments/2191.misc.rst
@@ -1,0 +1,1 @@
+Add BaseChainBackend type annotation to EthereumTesterProvider tester constructor parameter

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -4,6 +4,7 @@ from typing import (
     Callable,
     Dict,
     Optional,
+    Union,
 )
 
 from eth_abi import (
@@ -34,7 +35,10 @@ from .middleware import (
 
 if TYPE_CHECKING:
     from eth_tester import (  # noqa: F401
-        EthereumTester,
+        EthereumTester
+    )
+    from eth_tester.backends.base import (  # noqa: F401
+        BaseChainBackend
     )
 
 
@@ -58,7 +62,7 @@ class EthereumTesterProvider(BaseProvider):
 
     def __init__(
         self,
-        ethereum_tester: Optional["EthereumTester"] = None,
+        ethereum_tester: Optional[Union["EthereumTester", "BaseChainBackend"]] = None,
         api_endpoints: Optional[Dict[str, Dict[str, Callable[..., RPCResponse]]]] = None
     ) -> None:
         # do not import eth_tester until runtime, it is not a default dependency


### PR DESCRIPTION
### What was wrong?

fixes: #2191 

The parameter type seems to also permit `BaseChainBackend` by certain static type checkers fussed over it because it was not included in the type annotation.

### How was it fixed?

Add `BaseChainBackend` to the type annotation fort the tester parameter.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.google.com/search?q=google+images+cute+frog&source=lnms&tbm=isch&sa=X&ved=2ahUKEwj-xo_n4u_zAhVGaM0KHbuIDB4Q_AUoAXoECAEQAw&biw=1792&bih=1020&dpr=2#imgrc=31W061nNJV8WLM)

