### PR TITLE
Eth tester london updates

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -699,8 +699,8 @@ Taking the following contract code as an example:
 
     >>> array_contract.functions.getBytes2Value().call()
     [b'b\x00']
-    >>> array_contract.functions.setBytes2Value([b'a']).transact({'gas': 420000, 'gasPrice': 21000})
-    HexBytes('0x89f9b3a00651e406c568e85c1d2336c66b4ec40ba82c5e72726fbd072230a41c')
+    >>> array_contract.functions.setBytes2Value([b'a']).transact({'gas': 420000, 'gasPrice': Web3.toWei(1, 'gwei')})
+    HexBytes('0xc5377ba25224bd763ceedc0ee455cc14fc57b23dbc6b6409f40a557a009ff5f4')
     >>> array_contract.functions.getBytes2Value().call()
     [b'a\x00']
     >>> w3.enable_strict_bytes_type_checking()
@@ -1078,8 +1078,8 @@ Event Log Object
     alice, bob = w3.eth.accounts[0], w3.eth.accounts[1]
     assert alice == '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf', alice
     assert bob == '0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF', bob
-    tx_hash = my_token_contract.constructor(1000000).transact({'from': alice, 'gas': 899000, 'gasPrice': 320000})
-    assert tx_hash == HexBytes('0x611aa2d5c3e51f08d0665c4529c5520ed32520d8a48ba2cf2aff3f2fce3f26e4'), tx_hash
+    tx_hash = my_token_contract.constructor(1000000).transact({'from': alice, 'gas': 899000, 'gasPrice': Web3.toWei(1, 'gwei')})
+    assert tx_hash == HexBytes('0x49e3da72a95e4074a9eaea7b438c73ca154627d317e58abeae914e3769a15044'), tx_hash
     txn_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     assert txn_receipt['contractAddress'] == '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b', txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']
@@ -1087,7 +1087,7 @@ Event Log Object
     total_supply = contract.functions.totalSupply().call()
     decimals = 10 ** 18
     assert total_supply == 1000000 * decimals, total_supply
-    tx_hash = contract.functions.transfer(alice, 10).transact({'gas': 899000, 'gasPrice': 200000})
+    tx_hash = contract.functions.transfer(alice, 10).transact({'gas': 899000, 'gasPrice': Web3.toWei(1, 'gwei')})
     tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
 
 .. doctest:: createFilter
@@ -1120,15 +1120,15 @@ Event Log Object
       'blockHash': HexBytes('...'),
       'blockNumber': 3})]
      >>> transfer_filter.get_all_entries()
-     [AttributeDict({'args': AttributeDict({'from': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
+    [AttributeDict({'args': AttributeDict({'from': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
       'to': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
       'value': 10}),
       'event': 'Transfer',
       'logIndex': 0,
       'transactionIndex': 0,
-      'transactionHash': HexBytes('0x0005643c2425552308b4a28814a4dedafb5d340a811b3d2b1c019b290ffd7410'),
+      'transactionHash': HexBytes('0x9da859237e7259832b913d51cb128c8d73d1866056f7a41b52003c953e749678'),
       'address': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
-      'blockHash': HexBytes('...'),
+      'blockHash': HexBytes('0xc9c32c3250f77aa3fba2fea1cdeeb0397e7dc68b444747e6eb3db65708aaacd8'),
       'blockNumber': 2}),
       AttributeDict({'args': AttributeDict({'from': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
       'to': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -492,8 +492,8 @@ contract which conforms to this standard.
     alice, bob = w3.eth.accounts[0], w3.eth.accounts[1]
     assert alice == '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf', alice
     assert bob == '0x2B5AD5c4795c026514f8317c7a215E218DcCD6cF', bob
-    tx_hash = factory.constructor(1000000).transact({'from': alice, 'gas': 899000, 'gasPrice': 320000})
-    assert tx_hash == HexBytes('0x611aa2d5c3e51f08d0665c4529c5520ed32520d8a48ba2cf2aff3f2fce3f26e4'), tx_hash
+    tx_hash = factory.constructor(1000000).transact({'from': alice, 'gas': 899000, 'gasPrice': Web3.toWei(1, 'gwei')})
+    assert tx_hash == HexBytes('0x49e3da72a95e4074a9eaea7b438c73ca154627d317e58abeae914e3769a15044'), tx_hash
     txn_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     assert txn_receipt['contractAddress'] == '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b', txn_receipt['contractAddress']
     contract_address = txn_receipt['contractAddress']

--- a/newsfragments/2197.misc.rst
+++ b/newsfragments/2197.misc.rst
@@ -1,0 +1,1 @@
+Bump eth-tester version to v0.6.0-beta.2 which includes London support

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'tester': [
-        "eth-tester[py-evm]==v0.6.0-beta.1",
+        "eth-tester[py-evm]==v0.6.0-beta.2",
         "py-geth>=3.6.0,<4",
     ],
     'linter': [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'tester': [
-        "eth-tester[py-evm]==v0.5.0-beta.4",
+        "eth-tester[py-evm]==v0.6.0-beta.1",
         "py-geth>=3.6.0,<4",
     ],
     'linter': [

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -54,7 +54,7 @@ def test_build_transaction_not_paying_to_nonpayable_function(
         'to': payable_tester_contract.address,
         'data': '0xe4cb8f5c',
         'value': 0,
-        'gasPrice': 1,
+        'gasPrice': 10 ** 9,
         'chainId': 61,
     }
 
@@ -75,7 +75,7 @@ def test_build_transaction_with_contract_no_arguments(web3, math_contract, build
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'gasPrice': 1,
+        'gasPrice': 10 ** 9,
         'chainId': 61,
     }
 
@@ -86,7 +86,7 @@ def test_build_transaction_with_contract_fallback_function(web3, fallback_functi
         'to': fallback_function_contract.address,
         'data': '0x',
         'value': 0,
-        'gasPrice': 1,
+        'gasPrice': 10 ** 9,
         'chainId': 61,
     }
 
@@ -105,7 +105,7 @@ def test_build_transaction_with_contract_class_method(
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'gasPrice': 1,
+        'gasPrice': 10 ** 9,
         'chainId': 61,
     }
 
@@ -119,7 +119,7 @@ def test_build_transaction_with_contract_default_account_is_set(
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'gasPrice': 1,
+        'gasPrice': 10 ** 9,
         'chainId': 61,
     }
 
@@ -162,31 +162,31 @@ def test_build_transaction_with_contract_to_address_supplied_errors(web3,
         (
             {}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'chainId': 61,
+                'value': 0, 'gasPrice': 10 ** 9, 'chainId': 61,
             }, False
         ),
         (
             {'gas': 800000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'chainId': 61,
+                'value': 0, 'gasPrice': 10 ** 9, 'chainId': 61,
             }, False
         ),
         (
-            {'gasPrice': 21000000000}, (5,), {}, {
+            {'gasPrice': 10 ** 9}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 21000000000, 'chainId': 61,
+                'value': 0, 'gasPrice': 10 ** 9, 'chainId': 61,
             }, False
         ),
         (
             {'nonce': 7}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 1, 'nonce': 7, 'chainId': 61,
+                'value': 0, 'gasPrice': 10 ** 9, 'nonce': 7, 'chainId': 61,
             }, True
         ),
         (
             {'value': 20000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 20000, 'gasPrice': 1, 'chainId': 61,
+                'value': 20000, 'gasPrice': 10 ** 9, 'chainId': 61,
             }, False
         ),
     ),

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -21,11 +21,6 @@ from web3.providers.eth_tester import (
 )
 
 
-@pytest.fixture()
-def tester_snapshot(web3):
-    return web3.provider.ethereum_tester.take_snapshot()
-
-
 @pytest.fixture(
     scope='function',
     params=[True, False],
@@ -81,7 +76,7 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_convers
     deploy_txn_hash = Emitter.constructor().transact({
         'from': web3.eth.coinbase,
         'gas': 1000000,
-        'gasPrice': 1})
+        'gasPrice': 10 ** 9})
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 

--- a/tests/core/filtering/test_contract_data_filters.py
+++ b/tests/core/filtering/test_contract_data_filters.py
@@ -70,7 +70,7 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_convers
     deploy_txn_hash = Emitter.constructor().transact({
         'from': web3.eth.coinbase,
         'gas': 1000000,
-        'gasPrice': 1})
+        'gasPrice': 10 ** 9})
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
@@ -130,14 +130,6 @@ def array_values(draw):
     return (matching, non_matching)
 
 
-def clear_chain_state(web3, snapshot):
-    """Clear chain state
-    Hypothesis doesn't allow function scoped fixtures to re-run between test runs
-    so chain state needs to be explicitly cleared
-    """
-    web3.provider.ethereum_tester.revert_to_snapshot(snapshot)
-
-
 @pytest.mark.parametrize('api_style', ('v4', 'build_filter'))
 @given(vals=dynamic_values())
 @settings(max_examples=5, deadline=None)
@@ -147,10 +139,7 @@ def test_data_filters_with_dynamic_arguments(
         create_filter,
         emitter,
         api_style,
-        tester_snapshot,
         vals):
-    clear_chain_state(web3, tester_snapshot)
-
     if api_style == 'build_filter':
         filter_builder = emitter.events.LogDynamicArgs.build_filter()
         filter_builder.args['arg1'].match_single(vals['matching'])
@@ -164,10 +153,10 @@ def test_data_filters_with_dynamic_arguments(
     txn_hashes = [
         emitter.functions.logDynamicArgs(
             arg0=vals['matching'], arg1=vals['matching']).transact(
-                {'gasPrice': 1, 'gas': 400000, 'nonce': 0}),
+                {'gasPrice': 10 ** 9, 'gas': 400000}),
         emitter.functions.logDynamicArgs(
             arg0=vals['non_matching'][0], arg1=vals['non_matching'][0]).transact(
-                {'gasPrice': 1, 'gas': 400000, 'nonce': 1}),
+                {'gasPrice': 10 ** 9, 'gas': 400000}),
     ]
 
     for txn_hash in txn_hashes:
@@ -188,10 +177,7 @@ def test_data_filters_with_fixed_arguments(
         create_filter,
         api_style,
         vals,
-        tester_snapshot,
-        request):
-    clear_chain_state(web3, tester_snapshot)
-
+):
     if api_style == 'build_filter':
         filter_builder = emitter.events.LogQuadrupleArg.build_filter()
         filter_builder.args['arg0'].match_single(vals['matching'][0])
@@ -214,13 +200,13 @@ def test_data_filters_with_fixed_arguments(
         arg0=vals['matching'][0],
         arg1=vals['matching'][1],
         arg2=vals['matching'][2],
-        arg3=vals['matching'][3]).transact({'gasPrice': 1, 'gas': 100000, 'nonce': 0}))
+        arg3=vals['matching'][3]).transact({'gasPrice': 10 ** 9, 'gas': 100000}))
     txn_hashes.append(emitter.functions.logQuadruple(
         which=5,
         arg0=vals['non_matching'][0],
         arg1=vals['non_matching'][1],
         arg2=vals['non_matching'][2],
-        arg3=vals['non_matching'][3]).transact({'gasPrice': 1, 'gas': 100000, 'nonce': 1}))
+        arg3=vals['non_matching'][3]).transact({'gasPrice': 10 ** 9, 'gas': 100000}))
 
     for txn_hash in txn_hashes:
         wait_for_transaction(web3, txn_hash)
@@ -242,10 +228,7 @@ def test_data_filters_with_list_arguments(
         create_filter,
         api_style,
         vals,
-        tester_snapshot,
-        request):
-    clear_chain_state(web3, tester_snapshot)
-
+):
     matching, non_matching = vals
 
     if api_style == 'build_filter':
@@ -256,16 +239,16 @@ def test_data_filters_with_list_arguments(
         txn_hashes = []
         txn_hashes.append(emitter.functions.logListArgs(
             arg0=matching,
-            arg1=matching).transact({'gasPrice': 1, 'nonce': 0}))
+            arg1=matching).transact({'gasPrice': 10 ** 9}))
         txn_hashes.append(emitter.functions.logListArgs(
             arg0=non_matching,
-            arg1=non_matching).transact({'gasPrice': 1, 'nonce': 1}))
+            arg1=non_matching).transact({'gasPrice': 10 ** 9}))
         txn_hashes.append(emitter.functions.logListArgs(
             arg0=non_matching,
-            arg1=matching).transact({'gasPrice': 1, 'nonce': 2}))
+            arg1=matching).transact({'gasPrice': 10 ** 9}))
         txn_hashes.append(emitter.functions.logListArgs(
             arg0=matching,
-            arg1=non_matching).transact({'gasPrice': 1, 'nonce': 3}))
+            arg1=non_matching).transact({'gasPrice': 10 ** 9}))
 
         for txn_hash in txn_hashes:
             wait_for_transaction(web3, txn_hash)
@@ -276,7 +259,7 @@ def test_data_filters_with_list_arguments(
         assert log_entries[1]['transactionHash'] == txn_hashes[2]
     else:
         with pytest.raises(TypeError):
-            event_filter = create_filter(emitter, [
+            create_filter(emitter, [
                 'LogListArgs', {
                     'filter': {
                         'arg1': matching}}])

--- a/tests/core/gas-strategies/test_rpc_gas_pricing_strategies.py
+++ b/tests/core/gas-strategies/test_rpc_gas_pricing_strategies.py
@@ -7,8 +7,8 @@ def test_default_rpc_gas_price_strategy(web3):
     assert rpc_gas_price_strategy(web3, {
         'to': '0x0',
         'value': 1
-    }) == 1
+    }) == 10 ** 9
 
 
 def test_default_rpc_gas_price_strategy_callable_without_transaction(web3):
-    assert rpc_gas_price_strategy(web3) == 1
+    assert rpc_gas_price_strategy(web3) == 10 ** 9

--- a/tests/core/middleware/test_transaction_signing.py
+++ b/tests/core/middleware/test_transaction_signing.py
@@ -14,6 +14,9 @@ from eth_utils import (
     to_bytes,
     to_hex,
 )
+from eth_utils.exceptions import (
+    ValidationError as EthUtilsValidationError,
+)
 from eth_utils.toolz import (
     assoc,
     dissoc,
@@ -149,7 +152,7 @@ def test_sign_and_send_raw_middleware(
         'to': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
         'from': from_,
         'gas': 21000,
-        'gasPrice': 0,
+        'gasPrice': 10 ** 9,
         'value': 1,
         'nonce': 0
     }
@@ -238,7 +241,7 @@ def fund_account(w3):
         (
             {
                 'gas': 21000,
-                'gasPrice': 0,
+                'gasPrice': 10 ** 9,
                 'value': 1
             },
             -1,
@@ -273,31 +276,35 @@ def fund_account(w3):
             '0x0000',
         ),
         (
-            # TODO: Once eth-tester supports dynamic fee txn params, this test should fail
-            #  and we will need to update this to appropriately test 'maxFeePerGas' and
-            #  'maxPriorityFeePerGas' as well as the transaction 'type'
+            {
+                'gas': 21000,
+                'gasPrice': 0,
+                'value': 1
+            },
+            EthUtilsValidationError,
+            MIXED_KEY_MIXED_TYPE,
+            ADDRESS_1,
+        ),
+        (
             {
                 'type': '0x2',
                 'value': 22,
                 'maxFeePerGas': 2000000000,
-                'maxPriorityFeePerGas': 1000000000,
+                'maxPriorityFeePerGas': 10 ** 9,
             },
-            ValidationError,
+            -1,
             SAME_KEY_MIXED_TYPE,
-            ADDRESS_2,
+            ADDRESS_1,
         ),
         (
-            # TODO: eth-tester support for dynamic fees message above applies to this test as well.
-            # type should default to '0x2` and send successfully based on dynamic fee transaction
-            # params being present
             {
                 'value': 22,
-                'maxFeePerGas': 2000000000,
-                'maxPriorityFeePerGas': 1000000000,
+                'maxFeePerGas': 20 ** 9,
+                'maxPriorityFeePerGas': 10 ** 9,
             },
-            ValidationError,
+            -1,
             SAME_KEY_MIXED_TYPE,
-            ADDRESS_2,
+            ADDRESS_1,
         )
     ),
     ids=[
@@ -305,6 +312,7 @@ def fund_account(w3):
         'with no set gas',
         'with mismatched sender',
         'with invalid sender',
+        'with gasPrice lower than base fee',
         'with txn type and dynamic fee txn params',
         'with dynamic fee txn params and no type',
     ]

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -12,9 +12,6 @@ from eth_utils import (
     is_dict,
     is_integer,
 )
-from eth_utils.exceptions import (
-    ValidationError,
-)
 
 from web3 import Web3
 from web3._utils.module_testing import (

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -276,7 +276,6 @@ class TestEthereumTesterEthModule(EthModuleTest):
         EthModuleTest.test_eth_get_raw_transaction, ValueError)
     test_eth_get_raw_transaction_raises_error = not_implemented(
         EthModuleTest.test_eth_get_raw_transaction, ValueError)
-    test_eth_max_priority_fee = not_implemented(EthModuleTest.test_eth_max_priority_fee, ValueError)
     test_eth_replace_transaction_already_mined = not_implemented(
         EthModuleTest.test_eth_replace_transaction_already_mined, ValueError
     )

--- a/web3/_utils/formatters.py
+++ b/web3/_utils/formatters.py
@@ -14,8 +14,6 @@ from typing import (
 from eth_typing import (
     HexStr,
 )
-from toolz import assoc
-
 from eth_utils import (
     is_dict,
     is_list_like,
@@ -35,8 +33,6 @@ from eth_utils.toolz import (
 from web3._utils.decorators import (
     reject_recursive_repeats,
 )
-from web3.constants import DYNAMIC_FEE_TXN_PARAMS
-
 
 TReturn = TypeVar("TReturn")
 TValue = TypeVar("TValue")
@@ -126,17 +122,6 @@ def is_array_of_dicts(value: Any) -> bool:
     if not is_list_like(value):
         return False
     return all((is_dict(item) for item in value))
-
-
-@curry
-def add_param_if_missing(
-    key: Any, value: Any, input_dict: Dict[Any, Any]
-) -> Dict[Any, Any]:
-    if key not in input_dict:
-        return assoc(input_dict, key, value)
-    else:
-        return input_dict
-
 
 
 @curry

--- a/web3/_utils/formatters.py
+++ b/web3/_utils/formatters.py
@@ -14,6 +14,8 @@ from typing import (
 from eth_typing import (
     HexStr,
 )
+from toolz import assoc
+
 from eth_utils import (
     is_dict,
     is_list_like,
@@ -33,6 +35,8 @@ from eth_utils.toolz import (
 from web3._utils.decorators import (
     reject_recursive_repeats,
 )
+from web3.constants import DYNAMIC_FEE_TXN_PARAMS
+
 
 TReturn = TypeVar("TReturn")
 TValue = TypeVar("TValue")
@@ -122,6 +126,17 @@ def is_array_of_dicts(value: Any) -> bool:
     if not is_list_like(value):
         return False
     return all((is_dict(item) for item in value))
+
+
+@curry
+def add_param_if_missing(
+    key: Any, value: Any, input_dict: Dict[Any, Any]
+) -> Dict[Any, Any]:
+    if key not in input_dict:
+        return assoc(input_dict, key, value)
+    else:
+        return input_dict
+
 
 
 @curry

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1901,7 +1901,8 @@ class EthModuleTest:
     def test_eth_send_raw_transaction(
         self, web3: "Web3", unlocked_account: ChecksumAddress
     ) -> None:
-        signed_tx = web3.eth.account.sign_transaction({
+        signed_tx = web3.eth.account.sign_transaction(
+            {
                 'to': '0x0000000000000000000000000000000000000000',
                 'value': 0,
                 'nonce': web3.eth.get_transaction_count(unlocked_account),

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -215,7 +215,7 @@ API_ENDPOINTS = {
         'chainId': static_return('0x3d'),
         'feeHistory': not_implemented,
         'maxPriorityFeePerGas': not_implemented,
-        'gasPrice': static_return(1),
+        'gasPrice': static_return(10 ** 9),  # must be >= base fee post-London
         'accounts': call_eth_tester('get_accounts'),
         'blockNumber': compose(
             operator.itemgetter('number'),

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -214,7 +214,7 @@ API_ENDPOINTS = {
         'hashrate': static_return(0),
         'chainId': static_return('0x3d'),
         'feeHistory': not_implemented,
-        'maxPriorityFeePerGas': not_implemented,
+        'maxPriorityFeePerGas': static_return(10 ** 9),
         'gasPrice': static_return(10 ** 9),  # must be >= base fee post-London
         'accounts': call_eth_tester('get_accounts'),
         'blockNumber': compose(


### PR DESCRIPTION
### What was wrong?

- Need to update `eth-tester` version to newly released `v0.6.0-beta.2` which includes London support
- Turn on London integration tests and update key mappings for newly introduced params in London (max fees, base fee, effective gas price, etc...)
- Update core tests and integration tests to reflect London changes for eth-tester

### How was it fixed?

- eth-tester version bumped to `v0.6.0-beta.2`
- London core tests updated for eth-tester
- Key mappings updated in `providers/eth-tester/middleware` to match new params for integration tests
- gas price values updated across tests to be >= genesis base fee

### Todo:
- [x] Fill in this template
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![IMG_20211021_085817](https://user-images.githubusercontent.com/3532824/141200991-a8ba4815-f58b-4ce2-87e8-4e9dbaae4fca.jpg)

