### PR TITLE
Correct docs for transaction that hasn't been mined yet

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -263,7 +263,7 @@ Transaction receipts can be retrieved using the ``web3.eth.get_transaction_recei
     }
 
 
-If the transaction has not yet been mined then this method will return ``None``.
+If the transaction has not yet been mined then this method will raise a ``TransactionNotFound`` error.
 
 
 Working with Contracts

--- a/newsfragments/2199.doc.rst
+++ b/newsfragments/2199.doc.rst
@@ -1,0 +1,1 @@
+Fix example docs to show a TransactionNotFound error, instead of None


### PR DESCRIPTION
### What was wrong?
Docs were wrong. 

### How was it fixed?
Fixed them!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/7f/26/e7/7f26e71b2c84e6b16d4f6d3fd8a58bca.png)
