### PR TITLE
fix: support dynamic txn schema in eth tester middleware

### DIFF
--- a/newsfragments/2203.bugfix.rst
+++ b/newsfragments/2203.bugfix.rst
@@ -1,0 +1,1 @@
+Issue when trying to use the latest eth-tester middleware where it did include the new transaction properties in the mapping.

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -214,7 +214,7 @@ API_ENDPOINTS = {
         'hashrate': static_return(0),
         'chainId': static_return('0x3d'),
         'feeHistory': not_implemented,
-        'maxPriorityFeePerGas': not_implemented,
+        'maxPriorityFeePerGas': static_return(1),
         'gasPrice': static_return(1),
         'accounts': call_eth_tester('get_accounts'),
         'blockNumber': compose(

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -71,6 +71,8 @@ TRANSACTION_KEY_MAPPINGS = {
     'block_hash': 'blockHash',
     'block_number': 'blockNumber',
     'gas_price': 'gasPrice',
+    'max_fee_per_gas': 'maxFeePerGas',
+    'max_priority_fee_per_gas': 'maxPriorityFeePerGas',
     'transaction_hash': 'transactionHash',
     'transaction_index': 'transactionIndex',
 }
@@ -115,6 +117,7 @@ BLOCK_KEY_MAPPINGS = {
     'total_difficulty': 'totalDifficulty',
     'extra_data': 'extraData',
     'gas_used': 'gasUsed',
+    'base_fee_per_gas': 'baseFeePerGas'
 }
 
 
@@ -123,6 +126,8 @@ block_key_remapper = apply_key_map(BLOCK_KEY_MAPPINGS)
 
 TRANSACTION_PARAMS_MAPPING = {
     'gasPrice': 'gas_price',
+    'maxFeePerGas': 'max_fee_per_gas',
+    'maxPriorityFeePerGas': 'max_priority_fee_per_gas',
 }
 
 
@@ -132,6 +137,8 @@ transaction_params_remapper = apply_key_map(TRANSACTION_PARAMS_MAPPING)
 TRANSACTION_PARAMS_FORMATTERS = {
     'gas': to_integer_if_hex,
     'gasPrice': to_integer_if_hex,
+    'maxFeePerGas': to_integer_if_hex,
+    'maxPriorityFeePerGas': to_integer_if_hex,
     'value': to_integer_if_hex,
     'nonce': to_integer_if_hex,
 }


### PR DESCRIPTION
### What was wrong?

Keys related to txns with dynamic fees, the new schema, were not working because they were not getting mapped correctly.

### How was it fixed?

Added the new keys to the mappings.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![baby_giraffe](https://user-images.githubusercontent.com/19540978/141350900-37e5cd7e-431d-4ed4-9a75-206f5f5ba565.jpeg)

