### PR TITLE
Peripheral London updates:

### DIFF
--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -313,7 +313,6 @@ To sign a transaction locally that will invoke a smart contract:
 
     >>> unicorn_txn
     {'value': 0,
-     'type': '0x2',
      'chainId': 1,
      'gas': 70000,
      'maxFeePerGas': 2000000000,

--- a/newsfragments/2205.misc.rst
+++ b/newsfragments/2205.misc.rst
@@ -1,0 +1,1 @@
+Updates to core tests and contract buildTransaction() method to default to dynamic fee transactions

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -54,7 +54,8 @@ def test_build_transaction_not_paying_to_nonpayable_function(
         'to': payable_tester_contract.address,
         'data': '0xe4cb8f5c',
         'value': 0,
-        'gasPrice': 10 ** 9,
+        'maxFeePerGas': 2750000000,
+        'maxPriorityFeePerGas': 10 ** 9,
         'chainId': 61,
     }
 
@@ -75,7 +76,8 @@ def test_build_transaction_with_contract_no_arguments(web3, math_contract, build
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'gasPrice': 10 ** 9,
+        'maxFeePerGas': 2750000000,
+        'maxPriorityFeePerGas': 10 ** 9,
         'chainId': 61,
     }
 
@@ -86,7 +88,8 @@ def test_build_transaction_with_contract_fallback_function(web3, fallback_functi
         'to': fallback_function_contract.address,
         'data': '0x',
         'value': 0,
-        'gasPrice': 10 ** 9,
+        'maxFeePerGas': 2750000000,
+        'maxPriorityFeePerGas': 10 ** 9,
         'chainId': 61,
     }
 
@@ -105,7 +108,8 @@ def test_build_transaction_with_contract_class_method(
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'gasPrice': 10 ** 9,
+        'maxFeePerGas': 2750000000,
+        'maxPriorityFeePerGas': 10 ** 9,
         'chainId': 61,
     }
 
@@ -119,7 +123,8 @@ def test_build_transaction_with_contract_default_account_is_set(
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'gasPrice': 10 ** 9,
+        'maxFeePerGas': 2750000000,
+        'maxPriorityFeePerGas': 10 ** 9,
         'chainId': 61,
     }
 
@@ -162,31 +167,42 @@ def test_build_transaction_with_contract_to_address_supplied_errors(web3,
         (
             {}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 10 ** 9, 'chainId': 61,
+                'value': 0, 'maxFeePerGas': 2750000000, 'maxPriorityFeePerGas': 1000000000,
+                'chainId': 61,
             }, False
         ),
         (
             {'gas': 800000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 10 ** 9, 'chainId': 61,
+                'value': 0, 'maxFeePerGas': 2750000000, 'maxPriorityFeePerGas': 1000000000,
+                'chainId': 61,
+            }, False
+        ),
+        (  # legacy transaction, explicit gasPrice
+            {'gasPrice': 22 ** 8}, (5,), {}, {
+                'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
+                'value': 0, 'gasPrice': 22 ** 8, 'chainId': 61,
             }, False
         ),
         (
-            {'gasPrice': 10 ** 9}, (5,), {}, {
+            {'maxFeePerGas': 22 ** 8, 'maxPriorityFeePerGas': 22 ** 8}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 10 ** 9, 'chainId': 61,
+                'value': 0, 'maxFeePerGas': 22 ** 8, 'maxPriorityFeePerGas': 22 ** 8,
+                'chainId': 61,
             }, False
         ),
         (
             {'nonce': 7}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'gasPrice': 10 ** 9, 'nonce': 7, 'chainId': 61,
+                'value': 0, 'maxFeePerGas': 2750000000, 'maxPriorityFeePerGas': 1000000000,
+                'nonce': 7, 'chainId': 61,
             }, True
         ),
         (
             {'value': 20000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 20000, 'gasPrice': 10 ** 9, 'chainId': 61,
+                'value': 20000, 'maxFeePerGas': 2750000000, 'maxPriorityFeePerGas': 1000000000,
+                'chainId': 61,
             }, False
         ),
     ),
@@ -194,6 +210,7 @@ def test_build_transaction_with_contract_to_address_supplied_errors(web3,
         'Standard',
         'Explicit Gas',
         'Explicit Gas Price',
+        'Explicit Dynamic Fees',
         'Explicit Nonce',
         'With Value',
     ]

--- a/tests/core/contracts/test_contract_caller_interface.py
+++ b/tests/core/contracts/test_contract_caller_interface.py
@@ -43,7 +43,8 @@ def transaction_dict(web3, address):
     return {
         'from': address,
         'gas': 210000,
-        'gasPrice': web3.toWei(.001, 'ether'),
+        'maxFeePerGas': web3.toWei(1, 'gwei'),
+        'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
         'value': 12345,
     }
 

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -293,6 +293,32 @@ def test_eth_account_sign(acct,
         (
             {
                 "gas": 100000,
+                "gasPrice": 1000000000,
+                "data": "0x5544",
+                "nonce": "0x2",
+                "to": "0x96216849c49358B10257cb55b28eA603c874b05E",
+                "value": "0x5af3107a4000",
+                "type": "0x1",
+                "accessList": (
+                    {
+                        "address": "0x0000000000000000000000000000000000000001",
+                        "storageKeys": (
+                            "0x0100000000000000000000000000000000000000000000000000000000000000",
+                        ),
+                    },
+                ),
+                "chainId": 1,
+            },
+            '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318',
+            HexBytes('0x01f8a70102843b9aca00830186a09496216849c49358b10257cb55b28ea603c874b05e865af3107a4000825544f838f7940000000000000000000000000000000000000001e1a0010000000000000000000000000000000000000000000000000000000000000080a059a827f04246489aca139510f2f82896fd5bd1d34f05228b3fe0c60141db4246a07a28a925eae2e3ee173cf691de2737cbff9160fc527ca4305740a31f154758c5'),  # noqa: 501
+            HexBytes('0x5daf67cf0dd95f338e98b7b8ee7635f3667b7127be8f42011536c239f8ed4f50'),
+            40552949476267726331782755436085615371483644858950895384477411974599262552646,
+            55254008827136682571969715431199989606887296450225146219777298167488873715909,
+            0,
+        ),
+        (
+            {
+                "gas": 100000,
                 "maxFeePerGas": 2000000000,
                 "maxPriorityFeePerGas": 2000000000,
                 "data": "0x5544",
@@ -337,7 +363,13 @@ def test_eth_account_sign(acct,
             0,
         )
     ),
-    ids=['web3js_example', '31byte_r_and_s', 'dynamic_fee_txn_example', 'dynamic_fee_txn_hex_fees'],
+    ids=[
+        'web3js_example',
+        '31byte_r_and_s',
+        'access_list_txn',
+        'dynamic_fee_txn',
+        'dynamic_fee_txn_hex_fees',
+    ],
 )
 def test_eth_account_sign_transaction(acct, txn, private_key, expected_raw_tx, tx_hash, r, s, v):
     signed = acct.sign_transaction(txn, private_key)

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -76,7 +76,9 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_convers
     deploy_txn_hash = Emitter.constructor().transact({
         'from': web3.eth.coinbase,
         'gas': 1000000,
-        'gasPrice': 10 ** 9})
+        'maxFeePerGas': 10 ** 9,
+        'maxPriorityFeePerGas': 10 ** 9,
+    })
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 

--- a/tests/core/filtering/test_contract_data_filters.py
+++ b/tests/core/filtering/test_contract_data_filters.py
@@ -70,7 +70,9 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_convers
     deploy_txn_hash = Emitter.constructor().transact({
         'from': web3.eth.coinbase,
         'gas': 1000000,
-        'gasPrice': 10 ** 9})
+        'maxFeePerGas': 10 ** 9,
+        'maxPriorityFeePerGas': 10 ** 9,
+    })
     deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
 
@@ -153,10 +155,10 @@ def test_data_filters_with_dynamic_arguments(
     txn_hashes = [
         emitter.functions.logDynamicArgs(
             arg0=vals['matching'], arg1=vals['matching']).transact(
-                {'gasPrice': 10 ** 9, 'gas': 400000}),
+                {'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9, 'gas': 400000}),
         emitter.functions.logDynamicArgs(
             arg0=vals['non_matching'][0], arg1=vals['non_matching'][0]).transact(
-                {'gasPrice': 10 ** 9, 'gas': 400000}),
+                {'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9, 'gas': 400000}),
     ]
 
     for txn_hash in txn_hashes:
@@ -200,13 +202,17 @@ def test_data_filters_with_fixed_arguments(
         arg0=vals['matching'][0],
         arg1=vals['matching'][1],
         arg2=vals['matching'][2],
-        arg3=vals['matching'][3]).transact({'gasPrice': 10 ** 9, 'gas': 100000}))
+        arg3=vals['matching'][3]).transact({
+            'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9, 'gas': 100000
+        }))
     txn_hashes.append(emitter.functions.logQuadruple(
         which=5,
         arg0=vals['non_matching'][0],
         arg1=vals['non_matching'][1],
         arg2=vals['non_matching'][2],
-        arg3=vals['non_matching'][3]).transact({'gasPrice': 10 ** 9, 'gas': 100000}))
+        arg3=vals['non_matching'][3]).transact({
+            'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9, 'gas': 100000
+        }))
 
     for txn_hash in txn_hashes:
         wait_for_transaction(web3, txn_hash)
@@ -239,16 +245,16 @@ def test_data_filters_with_list_arguments(
         txn_hashes = []
         txn_hashes.append(emitter.functions.logListArgs(
             arg0=matching,
-            arg1=matching).transact({'gasPrice': 10 ** 9}))
+            arg1=matching).transact({'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9}))
         txn_hashes.append(emitter.functions.logListArgs(
             arg0=non_matching,
-            arg1=non_matching).transact({'gasPrice': 10 ** 9}))
+            arg1=non_matching).transact({'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9}))
         txn_hashes.append(emitter.functions.logListArgs(
             arg0=non_matching,
-            arg1=matching).transact({'gasPrice': 10 ** 9}))
+            arg1=matching).transact({'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9}))
         txn_hashes.append(emitter.functions.logListArgs(
             arg0=matching,
-            arg1=non_matching).transact({'gasPrice': 10 ** 9}))
+            arg1=non_matching).transact({'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9}))
 
         for txn_hash in txn_hashes:
             wait_for_transaction(web3, txn_hash)

--- a/tests/core/filtering/test_contract_topic_filters.py
+++ b/tests/core/filtering/test_contract_topic_filters.py
@@ -81,10 +81,14 @@ def test_topic_filters_with_dynamic_arguments(
     txn_hashes = [
         emitter.functions.logDynamicArgs(
             arg0=vals['matching'],
-            arg1=vals['matching']).transact({'gasPrice': 10 ** 9, 'gas': 60000}),
+            arg1=vals['matching']).transact({
+                'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9, 'gas': 60000
+            }),
         emitter.functions.logDynamicArgs(
             arg0=vals['non_matching'][0],
-            arg1=vals['non_matching'][0]).transact({'gasPrice': 10 ** 9, 'gas': 60000})
+            arg1=vals['non_matching'][0]).transact({
+                'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9, 'gas': 60000
+            })
     ]
 
     for txn_hash in txn_hashes:
@@ -130,13 +134,17 @@ def test_topic_filters_with_fixed_arguments(
         arg0=vals['matching'][0],
         arg1=vals['matching'][1],
         arg2=vals['matching'][2],
-        arg3=vals['matching'][3]).transact({'gasPrice': 10 ** 9, 'gas': 60000}))
+        arg3=vals['matching'][3]).transact({
+            'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9, 'gas': 60000
+        }))
     txn_hashes.append(emitter.functions.logQuadruple(
         which=11,
         arg0=vals['non_matching'][0],
         arg1=vals['non_matching'][1],
         arg2=vals['non_matching'][2],
-        arg3=vals['non_matching'][3]).transact({'gasPrice': 10 ** 9, 'gas': 60000}))
+        arg3=vals['non_matching'][3]).transact({
+            'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9, 'gas': 60000
+        }))
 
     for txn_hash in txn_hashes:
         wait_for_transaction(web3, txn_hash)
@@ -167,10 +175,10 @@ def test_topic_filters_with_list_arguments(
         txn_hashes = []
         txn_hashes.append(emitter.functions.logListArgs(
             arg0=matching,
-            arg1=matching).transact({'gasPrice': 10 ** 9}))
+            arg1=matching).transact({'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9}))
         txn_hashes.append(emitter.functions.logListArgs(
             arg0=non_matching,
-            arg1=non_matching).transact({'gasPrice': 10 ** 9}))
+            arg1=non_matching).transact({'maxFeePerGas': 10 ** 9, 'maxPriorityFeePerGas': 10 ** 9}))
 
         for txn_hash in txn_hashes:
             wait_for_transaction(web3, txn_hash)

--- a/tests/core/utilities/test_valid_transaction_params.py
+++ b/tests/core/utilities/test_valid_transaction_params.py
@@ -17,6 +17,19 @@ def test_assert_valid_transaction_params_all_params():
         'gasPrice': 5000000,
         'maxFeePerGas': 2000000000,
         'maxPriorityFeePerGas': 1000000000,
+        'accessList': (
+            {
+                'address': '0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae',
+                'storageKeys': (
+                    '0x0000000000000000000000000000000000000000000000000000000000000003',
+                    '0x0000000000000000000000000000000000000000000000000000000000000007',
+                )
+            },
+            {
+                'address': '0xbb9bc244d798123fde783fcc1c72d3bb8c189413',
+                'storageKeys': ()
+            },
+        ),
         'value': 1,
         'data': '0x0',
         'nonce': 2,
@@ -54,6 +67,19 @@ FULL_TXN_DICT = {
     'value': 3,
     'nonce': 2,
     'chainId': 1,
+    'accessList': (
+        {
+            'address': '0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae',
+            'storageKeys': (
+                '0x0000000000000000000000000000000000000000000000000000000000000003',
+                '0x0000000000000000000000000000000000000000000000000000000000000007',
+            )
+        },
+        {
+            'address': '0xbb9bc244d798123fde783fcc1c72d3bb8c189413',
+            'storageKeys': ()
+        },
+    ),
 }
 
 
@@ -117,28 +143,9 @@ def test_fill_transaction_defaults_for_all_params(web3):
         'chainId': web3.eth.chain_id,
         'data': b'',
         'gas': web3.eth.estimate_gas({}),
-        'gasPrice': web3.eth.gas_price,
+        'maxFeePerGas': (
+            web3.eth.max_priority_fee + (2 * web3.eth.get_block('latest')['baseFeePerGas'])
+        ),
+        'maxPriorityFeePerGas': web3.eth.max_priority_fee,
         'value': 0,
-    }
-
-
-def test_fill_transaction_defaults_sets_type_with_dynamic_fee_txn_params_and_no_gas_price(web3):
-    dynamic_fee_transaction = {
-        'chainId': 1,
-        'data': b'123',
-        'gas': 21000,
-        'maxFeePerGas': 2000000000,
-        'maxPriorityFeePerGas': 1000000000,
-        'value': 2,
-    }
-    dynamic_fee_transaction_type_added = fill_transaction_defaults(web3, dynamic_fee_transaction)
-
-    assert dynamic_fee_transaction_type_added == {
-        'chainId': 1,
-        'data': b'123',
-        'gas': 21000,
-        'maxFeePerGas': 2000000000,
-        'maxPriorityFeePerGas': 1000000000,
-        'type': '0x2',  # type is added and defaults to '0x2' when dynamic fee txn params present
-        'value': 2,
     }

--- a/web3/types.py
+++ b/web3/types.py
@@ -60,6 +60,14 @@ Wei = NewType('Wei', int)
 Formatters = Dict[RPCEndpoint, Callable[..., Any]]
 
 
+class AccessListEntry(TypedDict):
+    address: HexStr
+    storageKeys: Sequence[HexStr]
+
+
+AccessList = NewType("AccessList", Sequence[AccessListEntry])
+
+
 # todo: move these to eth_typing once web3 is type hinted
 class ABIEventParams(TypedDict, total=False):
     indexed: bool
@@ -167,6 +175,7 @@ class LogReceipt(TypedDict):
 
 # syntax b/c "from" keyword not allowed w/ class construction
 TxData = TypedDict("TxData", {
+    "accessList": AccessList,
     "blockHash": HexBytes,
     "blockNumber": BlockNumber,
     "chainId": int,


### PR DESCRIPTION
### What was wrong?

Peripheral London updates across the library.

### How was it fixed?

- Updated contract `buildTransaction()` to default to dynamic fee transactions.
- Updated core tests to use dynamic fee transactions by default.
- Add default values for `maxFeePerGas` and `maxPriorityFeePerGas` for `fill_transaction_defaults()` when no gas price strategy is set and no `gasPrice` value is present (legacy transaction).

### Todo:
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![IMG_20211019_095131](https://user-images.githubusercontent.com/3532824/141593800-6622c49c-db2a-452f-8a13-5b1bc96815c0.jpg)