### PR TITLE
Add `chain_id` setter to avoid `eth_chainId` requests

### DIFF
--- a/newsfragments/2207.feature.rst
+++ b/newsfragments/2207.feature.rst
@@ -1,0 +1,1 @@
+Add setter for the Eth.chain_id property

--- a/tests/core/eth-module/test_eth_properties.py
+++ b/tests/core/eth-module/test_eth_properties.py
@@ -2,7 +2,8 @@ import pytest
 
 
 def test_eth_protocol_version(w3):
-    assert w3.eth.protocol_version == '63'
+    with pytest.warns(DeprecationWarning):
+        assert w3.eth.protocol_version == '63'
 
 
 def test_eth_protocolVersion(w3):
@@ -17,3 +18,13 @@ def test_eth_chain_id(w3):
 def test_eth_chainId(w3):
     with pytest.warns(DeprecationWarning):
         assert w3.eth.chainId == 61
+
+
+def test_set_chain_id(w3):
+    assert w3.eth.chain_id == 61
+
+    w3.eth.chain_id = 72
+    assert w3.eth.chain_id == 72
+
+    w3.eth.chain_id = None
+    assert w3.eth.chain_id == 61

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -114,6 +114,7 @@ from web3.types import (
 class BaseEth(Module):
     _default_account: Union[ChecksumAddress, Empty] = empty
     _default_block: BlockIdentifier = "latest"
+    _default_chain_id: Optional[int] = None
     gasPriceStrategy = None
 
     _gas_price: Method[Callable[[], Wei]] = Method(
@@ -629,7 +630,14 @@ class Eth(BaseEth):
 
     @property
     def chain_id(self) -> int:
-        return self._chain_id()
+        if self._default_chain_id is None:
+            return self._chain_id()
+        else:
+            return self._default_chain_id
+
+    @chain_id.setter
+    def chain_id(self, value: int) -> None:
+        self._default_chain_id = value
 
     @property
     def chainId(self) -> int:


### PR DESCRIPTION
### What was wrong?
Every time the `chain_id` property is called, an `eth_chainId` request is triggered.

### How was it fixed?
By manually specifying the `chain_id`, the request can be avoided. 
```
web3 = Web3(HTTPProvider(...))
web3.eth.chain_id = 1 # mainnet
```

As a further improvement, it may be beneficial to cache the result of the first `eth_chainId` request.
The current change is intentionally conservative: there is no behavioral change if the setter is not used.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![cute otter](https://i.imgur.com/D6n7l04.png)
