### PR TITLE
Fix typo web3.pm.rst

### DIFF
--- a/docs/web3.pm.rst
+++ b/docs/web3.pm.rst
@@ -27,7 +27,7 @@ The ``web3.pm`` object exposes methods to interact with Packages as defined by `
 
    .. code-block:: python
 
-      >>> web3.enable_unstable_package_management_api()
+      >>> w3.enable_unstable_package_management_api()
       >>> w3.pm
       <web3.pm.PM at 0x....>
 

--- a/newsfragments/2208.doc.rst
+++ b/newsfragments/2208.doc.rst
@@ -1,0 +1,1 @@
+Doc update to make it clearer that enable_unstable_package_management()  method is on the web3 instance


### PR DESCRIPTION
### What was wrong?

using web3.enable_unstable_package_management_api() had no effect and the AttributeError persisted when trying to access
w3.pm object.

### How was it fixed?

Fixed the typo, so now the enable...() method is called on the import w3 object instead of the w3 library. After this change the pm.PM object is now accessible.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.discordapp.com/attachments/858042508939493398/899979984414842910/IMG-20210724-WA0023.jpg)
