### PR TITLE
Bump eth-tester version to newly released v0.6.0-beta.4

### DIFF
--- a/newsfragments/2197.misc.rst
+++ b/newsfragments/2197.misc.rst
@@ -1,1 +1,0 @@
-Bump eth-tester version to v0.6.0-beta.2 which includes London support

--- a/newsfragments/2212.misc.rst
+++ b/newsfragments/2212.misc.rst
@@ -1,0 +1,1 @@
+Bump eth-tester version to v0.6.0-beta.4 which includes London support

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import (
 
 extras_require = {
     'tester': [
-        "eth-tester[py-evm]==v0.6.0-beta.2",
+        "eth-tester[py-evm]==v0.6.0-beta.4",
         "py-geth>=3.6.0,<4",
     ],
     'linter': [


### PR DESCRIPTION
### What was wrong?

- eth-tester `v0.6.0-beta.4` is out

### How was it fixed?

- bumped version to `v0.6.0-beta.4`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20211119_100456](https://user-images.githubusercontent.com/3532824/142662800-40826d6c-10bb-47c8-83b8-9e39c1804b32.jpg)
