### PR TITLE
Update typing extensions to allow v4

### DIFF
--- a/newsfragments/2217.misc.rst
+++ b/newsfragments/2217.misc.rst
@@ -1,0 +1,1 @@
+Update ``typing-extensions`` dependency to allow for v4

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
         # remove typing_extensions after python_requires>=3.8, see web3._utils.compat
-        "typing-extensions>=4.0.0,<5;python_version<'3.8'",
+        "typing-extensions>=3.7.4.1,<5;python_version<'3.8'",
         "websockets>=9.1,<10",
     ],
     python_requires='>=3.6,<4',

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
         # remove typing_extensions after python_requires>=3.8, see web3._utils.compat
-        "typing-extensions>=3.7.4.1,<4;python_version<'3.8'",
+        "typing-extensions>=4.0.0,<5;python_version<'3.8'",
         "websockets>=9.1,<10",
     ],
     python_requires='>=3.6,<4',


### PR DESCRIPTION
### What was wrong?

Allow `typing-extensions` dependency to use v4.

Fixes #2216

### How was it fixed?

Loosened the dependency pinning. I did check for the removed modules listed here: https://github.com/python/typing/blob/master/typing_extensions/CHANGELOG, and we are not using any of them. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1591871937573-74dbba515c4c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxleHBsb3JlLWZlZWR8NXx8fGVufDB8fHx8&w=1000&q=80)

