### PR TITLE
fix timeout typing to float in web3.eth.wait_for_transaction_receipt

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -668,7 +668,7 @@ class Eth(BaseEth, Module):
         return self.wait_for_transaction_receipt(transaction_hash, timeout, poll_latency)
 
     def wait_for_transaction_receipt(
-        self, transaction_hash: _Hash32, timeout: int = 120, poll_latency: float = 0.1
+        self, transaction_hash: _Hash32, timeout: float = 120, poll_latency: float = 0.1
     ) -> TxReceipt:
         try:
             return wait_for_transaction_receipt(self.web3, transaction_hash, timeout, poll_latency)


### PR DESCRIPTION
What was wrong?
The typing for the timeout input to the exposed wait_for_transaction_receipt is falsely listed as int, seeing as the internal function it calls of the same name from _utils.transactions accepts float.

Exposed function falsely showing int:

web3.py/web3/eth.py

Line 670 in e01e6ca

 def wait_for_transaction_receipt( 
Internal function accepting float:

web3.py/web3/_utils/transactions.py

Line 129 in e01e6ca

 def wait_for_transaction_receipt( 
How can it be fixed?
Simply change line 671 of the eth module to use float instead of int for the timeout parameter.
