### PR TITLE
Fix for HypothesisDeprecationWarning in tox run test CircleCI #1729

### DIFF
--- a/newsfragments/1729.misc.rst
+++ b/newsfragments/1729.misc.rst
@@ -1,0 +1,1 @@
+Remove HypothesisDeprecationWarnings in tests

--- a/tests/core/filtering/test_contract_topic_filters.py
+++ b/tests/core/filtering/test_contract_topic_filters.py
@@ -5,6 +5,88 @@ from hypothesis import (
     settings,
     strategies as st,
 )
+from web3 import Web3
+from web3._utils.module_testing.emitter_contract import (
+    CONTRACT_EMITTER_ABI,
+    CONTRACT_EMITTER_CODE,
+    CONTRACT_EMITTER_RUNTIME,
+)
+from web3.middleware import (
+    local_filter_middleware,
+)
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
+
+
+@pytest.fixture(
+    scope='module',
+    params=[True, False],
+    ids=["local_filter_middleware", "node_based_filter"])
+def web3(request):
+    use_filter_middleware = request.param
+    provider = EthereumTesterProvider()
+    w3 = Web3(provider)
+    if use_filter_middleware:
+        w3.middleware_onion.add(local_filter_middleware)
+    return w3
+
+
+@pytest.fixture(autouse=True)
+def wait_for_mining_start(web3, wait_for_block):
+    wait_for_block(web3)
+
+
+@pytest.fixture(scope="module")
+def EMITTER_CODE():
+    return CONTRACT_EMITTER_CODE
+
+
+@pytest.fixture(scope="module")
+def EMITTER_RUNTIME():
+    return CONTRACT_EMITTER_RUNTIME
+
+
+@pytest.fixture(scope="module")
+def EMITTER_ABI():
+    return CONTRACT_EMITTER_ABI
+
+
+@pytest.fixture(scope="module")
+def EMITTER(EMITTER_CODE,
+            EMITTER_RUNTIME,
+            EMITTER_ABI):
+    return {
+        'bytecode': EMITTER_CODE,
+        'bytecode_runtime': EMITTER_RUNTIME,
+        'abi': EMITTER_ABI,
+    }
+
+
+@pytest.fixture(scope="module")
+def Emitter(web3, EMITTER):
+    return web3.eth.contract(**EMITTER)
+
+
+@pytest.fixture(scope="module")
+def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_conversion_func):
+    wait_for_block(web3)
+    deploy_txn_hash = Emitter.constructor().transact({
+        'from': web3.eth.coinbase,
+        'gas': 1000000,
+        'maxFeePerGas': 10 ** 9,
+        'maxPriorityFeePerGas': 10 ** 9,
+    })
+    deploy_receipt = wait_for_transaction(web3, deploy_txn_hash)
+    contract_address = address_conversion_func(deploy_receipt['contractAddress'])
+
+    bytecode = web3.eth.get_code(contract_address)
+    assert bytecode == Emitter.bytecode_runtime
+    _emitter = Emitter(address=contract_address)
+    assert _emitter.address == contract_address
+    return _emitter
+
+
 
 
 def not_empty_string(x):

--- a/tests/core/filtering/test_contract_topic_filters.py
+++ b/tests/core/filtering/test_contract_topic_filters.py
@@ -5,12 +5,13 @@ from hypothesis import (
     settings,
     strategies as st,
 )
+
+from web3 import Web3
 from web3._utils.module_testing.emitter_contract import (
     CONTRACT_EMITTER_ABI,
     CONTRACT_EMITTER_CODE,
     CONTRACT_EMITTER_RUNTIME,
 )
-from web3 import Web3
 from web3.middleware import (
     local_filter_middleware,
 )

--- a/tests/core/filtering/test_contract_topic_filters.py
+++ b/tests/core/filtering/test_contract_topic_filters.py
@@ -87,8 +87,6 @@ def emitter(web3, Emitter, wait_for_transaction, wait_for_block, address_convers
     return _emitter
 
 
-
-
 def not_empty_string(x):
     return x != ''
 

--- a/tests/core/filtering/test_contract_topic_filters.py
+++ b/tests/core/filtering/test_contract_topic_filters.py
@@ -5,12 +5,12 @@ from hypothesis import (
     settings,
     strategies as st,
 )
-from web3 import Web3
 from web3._utils.module_testing.emitter_contract import (
     CONTRACT_EMITTER_ABI,
     CONTRACT_EMITTER_CODE,
     CONTRACT_EMITTER_RUNTIME,
 )
+from web3 import Web3
 from web3.middleware import (
     local_filter_middleware,
 )

--- a/tests/core/utilities/conftest.py
+++ b/tests/core/utilities/conftest.py
@@ -7,6 +7,7 @@ from web3.providers.eth_tester import (
     EthereumTesterProvider,
 )
 
+
 @pytest.fixture(scope="module")
 def web3():
     provider = EthereumTesterProvider()

--- a/tests/core/utilities/conftest.py
+++ b/tests/core/utilities/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from web3.main import (
+    Web3,
+)
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
+
+@pytest.fixture(scope="module")
+def web3():
+    provider = EthereumTesterProvider()
+    return Web3(provider)


### PR DESCRIPTION
### What was wrong?
HypothesisDeprecationWarning in tox run test CircleCI
Related to Issue #[ 1729](https://github.com/ethereum/web3.py/issues/1729)

### How was it fixed?

I took some of the suggestions made by @kclows in the #1729  on how to fix this.

Added conftest.py to test/core/utilities and moved web3 fixture to it
Moved fixtures into test_contract_topic_filter.py
Both of these were to fix HypothesisDeprecationWarning while running test

### Todo
I only ran this against tox py38-core since I don't currently have all the interpreters that tox is looking for on my machine


Hope this helps!!
