### PR TITLE
`tools/benchmark/utils`: Use `asyncio.sleep`

### DIFF
--- a/newsfragments/2233.misc.rst
+++ b/newsfragments/2233.misc.rst
@@ -1,0 +1,1 @@
+Use non-blocking ``asyncio.sleep`` instead of ``time.sleep``

--- a/web3/tools/benchmark/utils.py
+++ b/web3/tools/benchmark/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import signal
 import socket
 import time
@@ -40,7 +41,7 @@ async def wait_for_aiohttp(endpoint_uri: str, timeout: int = 60) -> None:
             async with aiohttp.ClientSession() as session:
                 await session.get(endpoint_uri)
         except aiohttp.client_exceptions.ClientConnectorError:
-            time.sleep(0.01)
+            await asyncio.sleep(0.01)
         else:
             break
 


### PR DESCRIPTION
### What was wrong?

In async functions, we should use async sleep instead to avoid blocking.

### How was it fixed?

Change `time.sleep` to `asyncio.sleep`. I choose `asyncio.sleep` since it is used in other modules as well. Please correct me if other async frameworks are more suitable.

