### PR TITLE
Benchmark Test Fix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,8 +66,8 @@ commands=
 basepython=python
 commands=
     python {toxinidir}/web3/tools/benchmark/main.py --num-calls 5
-    python {toxinidir}/web3/tools/benchmark/main.py --num-calls 50
-    python {toxinidir}/web3/tools/benchmark/main.py --num-calls 100
+    python {toxinidir}/web3/tools/benchmark/main.py --num-calls 25
+    python {toxinidir}/web3/tools/benchmark/main.py --num-calls 70
 
 [common-wheel-cli]
 deps=wheel

--- a/web3/tools/benchmark/main.py
+++ b/web3/tools/benchmark/main.py
@@ -81,26 +81,20 @@ async def build_async_w3_http(endpoint_uri: str) -> Web3:
 
 
 def sync_benchmark(func: Callable[..., Any], n: int) -> Union[float, str]:
-    try:
-        starttime = timeit.default_timer()
-        for _ in range(n):
-            func()
-        endtime = timeit.default_timer()
-        execution_time = endtime - starttime
-        return execution_time
-    except Exception:
-        return "N/A"
+    starttime = timeit.default_timer()
+    for _ in range(n):
+        func()
+    endtime = timeit.default_timer()
+    execution_time = endtime - starttime
+    return execution_time
 
 
 async def async_benchmark(func: Callable[..., Any], n: int) -> Union[float, str]:
-    try:
-        starttime = timeit.default_timer()
-        for result in asyncio.as_completed([func() for _ in range(n)]):
-            await result
-        execution_time = timeit.default_timer() - starttime
-        return execution_time
-    except Exception:
-        return "N/A"
+    starttime = timeit.default_timer()
+    for result in asyncio.as_completed([func() for _ in range(n)]):
+        await result
+    execution_time = timeit.default_timer() - starttime
+    return execution_time
 
 
 def unlocked_account(w3: "Web3") -> ChecksumAddress:


### PR DESCRIPTION
### What was wrong?

Related to Issue [#2234 ](https://github.com/ethereum/web3.py/issues/2234)

### How was it fixed?

Removed the try catch around the sync and async benchmark methods. This was causing the benchmark test to fail silently. 

### Todo:
Still need to figure out what is causing the POST request in request.py to timeout.