### PR TITLE
Move middlewares to third argument -> no longer breaking change

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -101,8 +101,8 @@ class ENS:
     def __init__(
         self,
         provider: 'BaseProvider' = cast('BaseProvider', default),
-        middlewares: Optional[Sequence[Tuple['Middleware', str]]] = None,
         addr: ChecksumAddress = None,
+        middlewares: Optional[Sequence[Tuple['Middleware', str]]] = None,
     ) -> None:
         """
         :param provider: a single provider used to connect to Ethereum
@@ -127,7 +127,7 @@ class ENS:
         """
         provider = web3.manager.provider
         middlewares = web3.middleware_onion.middlewares
-        return cls(provider, middlewares, addr=addr)
+        return cls(provider, addr=addr, middlewares=middlewares)
 
     def address(self, name: str) -> Optional[ChecksumAddress]:
         """


### PR DESCRIPTION
### What was wrong?

Related to Issue #2239
- Breaking change if ENS was instantiated with `provider` and `addr` as positional arguments as such:

``` python
ens = ENS(web3.manager.provider, address)
```

### How was it fixed?

- Move the new `middlewares` argument to the third positional argument in order to avoid a breaking change.


#### Cute Animal Picture

![20211206_151001](https://user-images.githubusercontent.com/3532824/145305447-2cd32d5c-2177-42c9-9e79-3574d8ee222b.jpg)

