### PR TITLE
Update mypy to 0.910

### DIFF
--- a/newsfragments/2242.misc.rst
+++ b/newsfragments/2242.misc.rst
@@ -1,0 +1,1 @@
+Update mypy==0.910

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,10 @@ extras_require = {
     'linter': [
         "flake8==3.8.3",
         "isort>=4.2.15,<4.3.5",
-        "mypy==0.812",
+        "mypy==0.910",
+        "types-setuptools>=57.4.4,<58",
+        "types-requests>=2.26.1,<3",
+        "types-protobuf>=3.18.2,<4",
     ],
     'docs': [
         "mock",

--- a/web3/_utils/datatypes.py
+++ b/web3/_utils/datatypes.py
@@ -37,13 +37,13 @@ class PropertyCheckingFactory(type):
         super().__init__(name, bases, namespace)
 
     # __new__ must return a class instance
-    def __new__(  # type: ignore
+    def __new__(
         mcs,
         name: str,
         bases: Tuple[type],
         namespace: Dict[str, Any],
         normalizers: Optional[Dict[str, Any]] = None
-    ) -> Type['PropertyCheckingFactory']:
+    ) -> 'PropertyCheckingFactory':
         all_bases = set(concat(base.__mro__ for base in bases))
         all_keys = set(concat(base.__dict__.keys() for base in all_bases))
 


### PR DESCRIPTION
### What was wrong?

Somewhere along the way in a downstream library, the `typing-extensions` version requirement got updated.

### How was it fixed?

mypy needs to be updated, along with the py-trie dependency in py-evm. The py-trie dependency has already been merged into py-evm. Once we release py-evm, we'll need to update eth-tester, and pull that in here. Then we can bump `typing-extensions` to v4+.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.akc.org/content/article-body-image/siberian_husky_cute_puppies.jpg)
