### PR TITLE
Asyncify eth.hashrate

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -414,6 +414,7 @@ Eth
 - :meth:`web3.eth.get_transaction_count() <web3.eth.Eth.get_transaction_count>`
 - :meth:`web3.eth.send_transaction() <web3.eth.Eth.send_transaction>`
 - :meth:`web3.eth.send_raw_transaction() <web3.eth.Eth.send_raw_transaction>`
+- :meth:`web3.eth.hashrate <web3.eth.Eth.hashrate>`
 
 Net
 ***

--- a/newsfragments/2243.doc.rst
+++ b/newsfragments/2243.doc.rst
@@ -1,1 +1,0 @@
-Update AsyncHTTPProvider doc Supported Methods to include ``web3.eth.hashrate``.

--- a/newsfragments/2243.doc.rst
+++ b/newsfragments/2243.doc.rst
@@ -1,0 +1,1 @@
+Update AsyncHTTPProvider doc Supported Methods to include ``web3.eth.hashrate``.

--- a/newsfragments/2243.feature.rst
+++ b/newsfragments/2243.feature.rst
@@ -1,0 +1,1 @@
+Add async ``eth.hashrate`` method

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -679,6 +679,14 @@ class AsyncEthModuleTest:
             )
             await async_w3.eth.call(txn_params)  # type: ignore
 
+    @pytest.mark.asyncio
+    async def test_eth_hashrate(
+        self,
+        async_w3: "Web3"
+    ) -> None:
+        hashrate  = await async_w3.eth.hashrate
+        assert is_integer(hashrate)
+
 
 class EthModuleTest:
     def test_eth_protocol_version(self, web3: "Web3") -> None:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -680,12 +680,13 @@ class AsyncEthModuleTest:
             await async_w3.eth.call(txn_params)  # type: ignore
 
     @pytest.mark.asyncio
-    async def test_eth_hashrate(
+    async def test_async_eth_hashrate(
         self,
         async_w3: "Web3"
     ) -> None:
         hashrate = await async_w3.eth.hashrate  # type: ignore
         assert is_integer(hashrate)
+        assert hashrate >= 0
 
 
 class EthModuleTest:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -684,7 +684,7 @@ class AsyncEthModuleTest:
         self,
         async_w3: "Web3"
     ) -> None:
-        hashrate  = await async_w3.eth.hashrate
+        hashrate = await async_w3.eth.hashrate  # type: ignore
         assert is_integer(hashrate)
 
 

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -262,6 +262,11 @@ class BaseEth(Module):
         else:
             return (transaction, block_identifier, state_override)
 
+    _get_hashrate: Method[Callable[[], int]] = Method(
+        RPC.eth_hashrate,
+        mungers=None,
+    )
+
 
 class AsyncEth(BaseEth):
     is_async = True
@@ -384,6 +389,10 @@ class AsyncEth(BaseEth):
     ) -> Union[bytes, bytearray]:
         return await self._call(transaction, block_identifier, state_override)
 
+    @property
+    async def hashrate(self) -> int:
+        return await self._get_hashrate()  # type: ignore
+
 
 class Eth(BaseEth, Module):
     account = Account()
@@ -439,14 +448,9 @@ class Eth(BaseEth, Module):
     def mining(self) -> bool:
         return self.is_mining()
 
-    get_hashrate: Method[Callable[[], int]] = Method(
-        RPC.eth_hashrate,
-        mungers=None,
-    )
-
     @property
     def hashrate(self) -> int:
-        return self.get_hashrate()
+        return self._get_hashrate()
 
     @property
     def gas_price(self) -> Wei:

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -340,6 +340,10 @@ class AsyncEth(BaseEth):
         # types ignored b/c mypy conflict with BlockingEth properties
         return await self.get_coinbase()  # type: ignore
 
+    @property
+    async def hashrate(self) -> int:
+        return await self._get_hashrate()  # type: ignore
+
     _get_balance: Method[Callable[..., Awaitable[Wei]]] = Method(
         RPC.eth_getBalance,
         mungers=[BaseEth.block_id_munger],
@@ -388,10 +392,6 @@ class AsyncEth(BaseEth):
         state_override: Optional[CallOverrideParams] = None,
     ) -> Union[bytes, bytearray]:
         return await self._call(transaction, block_identifier, state_override)
-
-    @property
-    async def hashrate(self) -> int:
-        return await self._get_hashrate()  # type: ignore
 
 
 class Eth(BaseEth, Module):


### PR DESCRIPTION
### What was wrong?
Added async `eth.hashrate`.

Related to Issue #1413

### How was it fixed?

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md![image]

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/5199899/145488381-3da09cbe-4005-4288-a7cc-562e8b735ff5.png)
