### PR TITLE
Increase timout on IPC and WS providers for Geth Integration tests

### DIFF
--- a/tests/integration/go_ethereum/test_goethereum_ipc.py
+++ b/tests/integration/go_ethereum/test_goethereum_ipc.py
@@ -54,7 +54,7 @@ def geth_ipc_path(datadir):
 @pytest.fixture(scope="module")
 def web3(geth_process, geth_ipc_path):
     wait_for_socket(geth_ipc_path)
-    _web3 = Web3(Web3.IPCProvider(geth_ipc_path))
+    _web3 = Web3(Web3.IPCProvider(geth_ipc_path, timeout=20))
     return _web3
 
 

--- a/tests/integration/go_ethereum/test_goethereum_ws.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws.py
@@ -65,7 +65,7 @@ def geth_command_arguments(geth_binary,
 @pytest.fixture(scope="module")
 def web3(geth_process, endpoint_uri, event_loop):
     event_loop.run_until_complete(wait_for_ws(endpoint_uri, event_loop))
-    _web3 = Web3(Web3.WebsocketProvider(endpoint_uri))
+    _web3 = Web3(Web3.WebsocketProvider(endpoint_uri, websocket_timeout=20))
     return _web3
 
 


### PR DESCRIPTION
### What was wrong?
Websocket and IPC integration tests were failing and having to be re-run more often than they weren't. 


### How was it fixed?
Increased the timeout on the IPC and Websocket providers. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://d2xcq4qphg1ge9.cloudfront.net/assets/133035/3827711/original_husky_20puppy.jpg)
