### PR TITLE
Bump Geth Integration test WebsocketProvider timeout to 30s

### DIFF
--- a/newsfragments/2260.misc.rst
+++ b/newsfragments/2260.misc.rst
@@ -1,0 +1,1 @@
+Bump timeout for WebsocketProvider in Geth integration tests

--- a/tests/integration/go_ethereum/test_goethereum_ws.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws.py
@@ -65,7 +65,7 @@ def geth_command_arguments(geth_binary,
 @pytest.fixture(scope="module")
 def web3(geth_process, endpoint_uri, event_loop):
     event_loop.run_until_complete(wait_for_ws(endpoint_uri, event_loop))
-    _web3 = Web3(Web3.WebsocketProvider(endpoint_uri, websocket_timeout=20))
+    _web3 = Web3(Web3.WebsocketProvider(endpoint_uri, websocket_timeout=30))
     return _web3
 
 


### PR DESCRIPTION
### What was wrong?
More flaky tests. 

### How was it fixed?
Bumped the timeout a little bit more.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pbs.twimg.com/profile_images/477022793142267904/UTHgo6G7_400x400.jpeg)
