### PR TITLE
Asyncify eth.get_transaction_receipt and eth.wait_for_transaction_receipt

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -415,8 +415,10 @@ Eth
 - :meth:`web3.eth.get_raw_transaction_by_block() <web3.eth.Eth.get_raw_transaction_by_block>`
 - :meth:`web3.eth.get_transaction() <web3.eth.Eth.get_transaction>`
 - :meth:`web3.eth.get_transaction_count() <web3.eth.Eth.get_transaction_count>`
+- :meth:`web3.eth.get_transaction_receipt() <web3.eth.Eth.get_transaction_receipt>`
 - :meth:`web3.eth.send_transaction() <web3.eth.Eth.send_transaction>`
 - :meth:`web3.eth.send_raw_transaction() <web3.eth.Eth.send_raw_transaction>`
+- :meth:`web3.eth.wait_for_transaction_receipt() <web3.eth.Eth.wait_for_transaction_receipt>`
 
 Net
 ***

--- a/newsfragments/2265.feature.rst
+++ b/newsfragments/2265.feature.rst
@@ -1,0 +1,1 @@
+Add async ``eth.get_transaction_receipt`` and ``eth.wait_for_transaction_receipt`` methods

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -704,7 +704,128 @@ class AsyncEthModuleTest:
     ) -> None:
         mining = await async_w3.eth.mining  # type: ignore
         assert is_boolean(mining)
+    
+    @pytest.mark.asyncio
+    async def test_async_eth_get_transaction_receipt_mined(
+        self,
+        async_w3: "Web3",
+        block_with_txn: BlockData,
+        mined_txn_hash: HexStr
+    ) -> None:
+        receipt = await async_w3.eth.get_transaction_receipt(mined_txn_hash)
+        assert is_dict(receipt)
+        assert receipt['blockNumber'] == block_with_txn['number']
+        assert receipt['blockHash'] == block_with_txn['hash']
+        assert receipt['transactionIndex'] == 0
+        assert receipt['transactionHash'] == HexBytes(mined_txn_hash)
+        assert is_checksum_address(receipt['to'])
+        assert receipt['from'] is not None
+        assert is_checksum_address(receipt['from'])
 
+        effective_gas_price = receipt['effectiveGasPrice']
+        assert isinstance(effective_gas_price, int)
+        assert effective_gas_price > 0
+
+    @pytest.mark.asyncio
+    async def test_async_eth_get_transaction_receipt_unmined(
+        self, async_w3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        txn_hash = await async_w3.eth.send_transaction({
+            'from': unlocked_account_dual_type,
+            'to': unlocked_account_dual_type,
+            'value': Wei(1),
+            'gas': Wei(21000),
+            'maxFeePerGas': async_w3.toWei(3, 'gwei'),
+            'maxPriorityFeePerGas': async_w3.toWei(1, 'gwei')
+        })
+        with pytest.raises(TransactionNotFound):
+            await async_w3.eth.get_transaction_receipt(txn_hash)
+
+    @pytest.mark.asyncio
+    async def test_async_eth_get_transaction_receipt_with_log_entry(
+        self,
+        async_w3: "Web3",
+        block_with_txn_with_log: BlockData,
+        emitter_contract: "Contract",
+        txn_hash_with_log: HexStr,
+    ) -> None:
+        receipt = await async_w3.eth.wait_for_transaction_receipt(txn_hash_with_log)
+        assert is_dict(receipt)
+        assert receipt['blockNumber'] == block_with_txn_with_log['number']
+        assert receipt['blockHash'] == block_with_txn_with_log['hash']
+        assert receipt['transactionIndex'] == 0
+        assert receipt['transactionHash'] == HexBytes(txn_hash_with_log)
+
+        assert len(receipt['logs']) == 1
+        log_entry = receipt['logs'][0]
+
+        assert log_entry['blockNumber'] == block_with_txn_with_log['number']
+        assert log_entry['blockHash'] == block_with_txn_with_log['hash']
+        assert log_entry['logIndex'] == 0
+        assert is_same_address(log_entry['address'], emitter_contract.address)
+        assert log_entry['transactionIndex'] == 0
+        assert log_entry['transactionHash'] == HexBytes(txn_hash_with_log)
+
+    @pytest.mark.asyncio
+    async def test_async_eth_wait_for_transaction_receipt_mined(
+        self,
+        async_w3: "Web3",
+        block_with_txn: BlockData,
+        mined_txn_hash: HexStr
+    ) -> None:
+        receipt = await async_w3.eth.wait_for_transaction_receipt(mined_txn_hash)
+        assert is_dict(receipt)
+        assert receipt['blockNumber'] == block_with_txn['number']
+        assert receipt['blockHash'] == block_with_txn['hash']
+        assert receipt['transactionIndex'] == 0
+        assert receipt['transactionHash'] == HexBytes(mined_txn_hash)
+        assert is_checksum_address(receipt['to'])
+        assert receipt['from'] is not None
+        assert is_checksum_address(receipt['from'])
+
+        effective_gas_price = receipt['effectiveGasPrice']
+        assert isinstance(effective_gas_price, int)
+        assert effective_gas_price > 0
+
+    @pytest.mark.asyncio
+    async def test_async_eth_wait_for_transaction_receipt_unmined(
+        self, async_w3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        txn_hash = await async_w3.eth.send_transaction({
+            'from': unlocked_account_dual_type,
+            'to': unlocked_account_dual_type,
+            'value': Wei(1),
+            'gas': Wei(21000),
+            'maxFeePerGas': async_w3.toWei(3, 'gwei'),
+            'maxPriorityFeePerGas': async_w3.toWei(1, 'gwei')
+        })
+        with pytest.raises(TransactionNotFound):
+            await async_w3.eth.wait_for_transaction_receipt(txn_hash)
+
+    @pytest.mark.asyncio
+    async def test_async_eth_get_transaction_receipt_with_log_entry(
+        self,
+        async_w3: "Web3",
+        block_with_txn_with_log: BlockData,
+        emitter_contract: "Contract",
+        txn_hash_with_log: HexStr,
+    ) -> None:
+        receipt = await async_w3.eth.get_transaction_receipt(txn_hash_with_log)
+        assert is_dict(receipt)
+        assert receipt['blockNumber'] == block_with_txn_with_log['number']
+        assert receipt['blockHash'] == block_with_txn_with_log['hash']
+        assert receipt['transactionIndex'] == 0
+        assert receipt['transactionHash'] == HexBytes(txn_hash_with_log)
+
+        assert len(receipt['logs']) == 1
+        log_entry = receipt['logs'][0]
+
+        assert log_entry['blockNumber'] == block_with_txn_with_log['number']
+        assert log_entry['blockHash'] == block_with_txn_with_log['hash']
+        assert log_entry['logIndex'] == 0
+        assert is_same_address(log_entry['address'], emitter_contract.address)
+        assert log_entry['transactionIndex'] == 0
+        assert log_entry['transactionHash'] == HexBytes(txn_hash_with_log)
 
 class EthModuleTest:
     def test_eth_protocol_version(self, web3: "Web3") -> None:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -47,6 +47,7 @@ from web3.exceptions import (
     InvalidAddress,
     InvalidTransaction,
     NameNotFound,
+    TimeExhausted,
     TransactionNotFound,
     TransactionTypeMismatch,
 )
@@ -704,7 +705,7 @@ class AsyncEthModuleTest:
     ) -> None:
         mining = await async_w3.eth.mining  # type: ignore
         assert is_boolean(mining)
-    
+
     @pytest.mark.asyncio
     async def test_async_eth_get_transaction_receipt_mined(
         self,
@@ -712,7 +713,7 @@ class AsyncEthModuleTest:
         block_with_txn: BlockData,
         mined_txn_hash: HexStr
     ) -> None:
-        receipt = await async_w3.eth.get_transaction_receipt(mined_txn_hash)
+        receipt = await async_w3.eth.get_transaction_receipt(mined_txn_hash)  # type: ignore
         assert is_dict(receipt)
         assert receipt['blockNumber'] == block_with_txn['number']
         assert receipt['blockHash'] == block_with_txn['hash']
@@ -730,7 +731,7 @@ class AsyncEthModuleTest:
     async def test_async_eth_get_transaction_receipt_unmined(
         self, async_w3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
-        txn_hash = await async_w3.eth.send_transaction({
+        txn_hash = await async_w3.eth.send_transaction({  # type: ignore
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
@@ -739,7 +740,7 @@ class AsyncEthModuleTest:
             'maxPriorityFeePerGas': async_w3.toWei(1, 'gwei')
         })
         with pytest.raises(TransactionNotFound):
-            await async_w3.eth.get_transaction_receipt(txn_hash)
+            await async_w3.eth.get_transaction_receipt(txn_hash)  # type: ignore
 
     @pytest.mark.asyncio
     async def test_async_eth_get_transaction_receipt_with_log_entry(
@@ -749,7 +750,7 @@ class AsyncEthModuleTest:
         emitter_contract: "Contract",
         txn_hash_with_log: HexStr,
     ) -> None:
-        receipt = await async_w3.eth.wait_for_transaction_receipt(txn_hash_with_log)
+        receipt = await async_w3.eth.wait_for_transaction_receipt(txn_hash_with_log)  # type: ignore
         assert is_dict(receipt)
         assert receipt['blockNumber'] == block_with_txn_with_log['number']
         assert receipt['blockHash'] == block_with_txn_with_log['hash']
@@ -773,7 +774,7 @@ class AsyncEthModuleTest:
         block_with_txn: BlockData,
         mined_txn_hash: HexStr
     ) -> None:
-        receipt = await async_w3.eth.wait_for_transaction_receipt(mined_txn_hash)
+        receipt = await async_w3.eth.wait_for_transaction_receipt(mined_txn_hash)  # type: ignore
         assert is_dict(receipt)
         assert receipt['blockNumber'] == block_with_txn['number']
         assert receipt['blockHash'] == block_with_txn['hash']
@@ -791,7 +792,7 @@ class AsyncEthModuleTest:
     async def test_async_eth_wait_for_transaction_receipt_unmined(
         self, async_w3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
-        txn_hash = await async_w3.eth.send_transaction({
+        txn_hash = await async_w3.eth.send_transaction({  # type: ignore
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
@@ -799,18 +800,18 @@ class AsyncEthModuleTest:
             'maxFeePerGas': async_w3.toWei(3, 'gwei'),
             'maxPriorityFeePerGas': async_w3.toWei(1, 'gwei')
         })
-        with pytest.raises(TransactionNotFound):
-            await async_w3.eth.wait_for_transaction_receipt(txn_hash)
+        with pytest.raises(TimeExhausted):
+            await async_w3.eth.wait_for_transaction_receipt(txn_hash, timeout=2)  # type: ignore
 
     @pytest.mark.asyncio
-    async def test_async_eth_get_transaction_receipt_with_log_entry(
+    async def test_async_eth_wait_for_transaction_receipt_with_log_entry(
         self,
         async_w3: "Web3",
         block_with_txn_with_log: BlockData,
         emitter_contract: "Contract",
         txn_hash_with_log: HexStr,
     ) -> None:
-        receipt = await async_w3.eth.get_transaction_receipt(txn_hash_with_log)
+        receipt = await async_w3.eth.wait_for_transaction_receipt(txn_hash_with_log)  # type: ignore
         assert is_dict(receipt)
         assert receipt['blockNumber'] == block_with_txn_with_log['number']
         assert receipt['blockHash'] == block_with_txn_with_log['hash']
@@ -826,6 +827,7 @@ class AsyncEthModuleTest:
         assert is_same_address(log_entry['address'], emitter_contract.address)
         assert log_entry['transactionIndex'] == 0
         assert log_entry['transactionHash'] == HexBytes(txn_hash_with_log)
+
 
 class EthModuleTest:
     def test_eth_protocol_version(self, web3: "Web3") -> None:

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -21,9 +21,6 @@ from hexbytes import (
 from web3._utils.compat import (
     Literal,
 )
-from web3._utils.threads import (
-    Timeout,
-)
 from web3._utils.utility_methods import (
     all_in_dict,
     any_in_dict,
@@ -31,14 +28,10 @@ from web3._utils.utility_methods import (
 from web3.constants import (
     DYNAMIC_FEE_TXN_PARAMS,
 )
-from web3.exceptions import (
-    TransactionNotFound,
-)
 from web3.types import (
     BlockIdentifier,
     TxData,
     TxParams,
-    TxReceipt,
     Wei,
     _Hash32,
 )
@@ -124,25 +117,6 @@ def fill_transaction_defaults(web3: "Web3", transaction: TxParams) -> TxParams:
 
             defaults[key] = default_val
     return merge(defaults, transaction)
-
-
-def wait_for_transaction_receipt(
-    web3: "Web3", txn_hash: _Hash32, timeout: float, poll_latency: float
-) -> TxReceipt:
-    with Timeout(timeout) as _timeout:
-        while True:
-            try:
-                txn_receipt = web3.eth.get_transaction_receipt(txn_hash)
-            except TransactionNotFound:
-                txn_receipt = None
-            # FIXME: The check for a null `blockHash` is due to parity's
-            # non-standard implementation of the JSON-RPC API and should
-            # be removed once the formal spec for the JSON-RPC endpoints
-            # has been finalized.
-            if txn_receipt is not None and txn_receipt['blockHash'] is not None:
-                break
-            _timeout.sleep(poll_latency)
-    return txn_receipt
 
 
 def get_block_gas_limit(web3: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> Wei:

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -431,11 +431,6 @@ class AsyncEth(BaseEth):
                         )
                     except TransactionNotFound:
                         tx_receipt = None
-                    # FIXME: The check for a null `blockHash` is due to parity's
-                    # non-standard implementation of the JSON-RPC API and should
-                    # be removed once the formal spec for the JSON-RPC endpoints
-                    # has been finalized.
-                    # if txn_receipt is not None and txn_receipt['blockHash'] is not None:
                     if tx_receipt is not None:
                         break
                     _timeout.sleep(poll_latency)
@@ -735,11 +730,6 @@ class Eth(BaseEth, Module):
                         tx_receipt = self._get_transaction_receipt(transaction_hash)
                     except TransactionNotFound:
                         tx_receipt = None
-                    # FIXME: The check for a null `blockHash` is due to parity's
-                    # non-standard implementation of the JSON-RPC API and should
-                    # be removed once the formal spec for the JSON-RPC endpoints
-                    # has been finalized.
-                    # if txn_receipt is not None and txn_receipt['blockHash'] is not None:
                     if tx_receipt is not None:
                         break
                     _timeout.sleep(poll_latency)


### PR DESCRIPTION
### What was wrong?

Added async `eth.get_transaction_receipt` and `eth.wait_for_transaction_receipt`

Related to Issue #1413 
Closes Issue #2129

### How was it fixed?

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/5199899/146455863-2ae0f1ba-eabb-46fb-b8fa-bbbcc4891014.png)

