### PR TITLE
Fixes #2259

### DIFF
--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -54,8 +54,8 @@ def test_build_transaction_not_paying_to_nonpayable_function(
         'to': payable_tester_contract.address,
         'data': '0xe4cb8f5c',
         'value': 0,
-        'maxFeePerGas': 2750000000,
-        'maxPriorityFeePerGas': 10 ** 9,
+        'maxFeePerGas': 1875000000,
+        'maxPriorityFeePerGas': 125000000,
         'chainId': 61,
     }
 
@@ -76,8 +76,8 @@ def test_build_transaction_with_contract_no_arguments(web3, math_contract, build
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'maxFeePerGas': 2750000000,
-        'maxPriorityFeePerGas': 10 ** 9,
+        'maxFeePerGas': 1875000000,
+        'maxPriorityFeePerGas': 125000000,
         'chainId': 61,
     }
 
@@ -88,8 +88,8 @@ def test_build_transaction_with_contract_fallback_function(web3, fallback_functi
         'to': fallback_function_contract.address,
         'data': '0x',
         'value': 0,
-        'maxFeePerGas': 2750000000,
-        'maxPriorityFeePerGas': 10 ** 9,
+        'maxFeePerGas': 1875000000,
+        'maxPriorityFeePerGas': 125000000,
         'chainId': 61,
     }
 
@@ -108,8 +108,8 @@ def test_build_transaction_with_contract_class_method(
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'maxFeePerGas': 2750000000,
-        'maxPriorityFeePerGas': 10 ** 9,
+        'maxFeePerGas': 1875000000,
+        'maxPriorityFeePerGas': 125000000,
         'chainId': 61,
     }
 
@@ -123,8 +123,8 @@ def test_build_transaction_with_contract_default_account_is_set(
         'to': math_contract.address,
         'data': '0xd09de08a',
         'value': 0,
-        'maxFeePerGas': 2750000000,
-        'maxPriorityFeePerGas': 10 ** 9,
+        'maxFeePerGas': 1875000000,
+        'maxPriorityFeePerGas': 125000000,
         'chainId': 61,
     }
 
@@ -167,14 +167,14 @@ def test_build_transaction_with_contract_to_address_supplied_errors(web3,
         (
             {}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'maxFeePerGas': 2750000000, 'maxPriorityFeePerGas': 1000000000,
+                'value': 0, 'maxFeePerGas': 1875000000, 'maxPriorityFeePerGas': 125000000,
                 'chainId': 61,
             }, False
         ),
         (
             {'gas': 800000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'maxFeePerGas': 2750000000, 'maxPriorityFeePerGas': 1000000000,
+                'value': 0, 'maxFeePerGas': 1875000000, 'maxPriorityFeePerGas': 125000000,
                 'chainId': 61,
             }, False
         ),
@@ -194,14 +194,14 @@ def test_build_transaction_with_contract_to_address_supplied_errors(web3,
         (
             {'nonce': 7}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 0, 'maxFeePerGas': 2750000000, 'maxPriorityFeePerGas': 1000000000,
+                'value': 0, 'maxFeePerGas': 1875000000, 'maxPriorityFeePerGas': 125000000,
                 'nonce': 7, 'chainId': 61,
             }, True
         ),
         (
             {'value': 20000}, (5,), {}, {
                 'data': '0x7cf5dab00000000000000000000000000000000000000000000000000000000000000005',  # noqa: E501
-                'value': 20000, 'maxFeePerGas': 2750000000, 'maxPriorityFeePerGas': 1000000000,
+                'value': 20000, 'maxFeePerGas': 1875000000, 'maxPriorityFeePerGas': 125000000,
                 'chainId': 61,
             }, False
         ),

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -201,11 +201,6 @@ class BaseEth(Module):
         mungers=[default_root_munger]
     )
 
-    _max_priority_fee: Method[Callable[..., Wei]] = Method(
-        RPC.eth_maxPriorityFeePerGas,
-        mungers=None,
-    )
-
     def get_block_munger(
         self, block_identifier: BlockIdentifier, full_transactions: bool = False
     ) -> Tuple[BlockIdentifier, bool]:
@@ -306,7 +301,10 @@ class AsyncEth(BaseEth):
 
     @property
     async def max_priority_fee(self) -> Wei:
-        return await self._max_priority_fee()  # type: ignore
+        gas_price = await self.gas_price
+        latest_block = await self.get_block('latest')
+        latest_base_fee = latest_block['baseFeePerGas']
+        return Wei(gas_price - latest_base_fee)
 
     @property
     async def mining(self) -> bool:
@@ -558,7 +556,10 @@ class Eth(BaseEth, Module):
 
     @property
     def max_priority_fee(self) -> Wei:
-        return self._max_priority_fee()
+        gas_price = self.gas_price
+        latest_block = self.get_block('latest')
+        latest_base_fee = latest_block['baseFeePerGas']
+        return Wei(gas_price - latest_base_fee)
 
     def get_storage_at_munger(
         self,


### PR DESCRIPTION
### What was wrong?

Dependency on eth_maxPriorityFeePerGas

Related to Issue #2259

### How was it fixed?

See analysis on issue #2259, eth_maxPriorityFeePerGas == (gas_price - latest block base fee)

Tests expected results were updated to new logic implemented, and verified they make sense against test provider api 
endpoint defaults. When connected to ethereum network, this will be a no-impact change to an api supporting eth_maxPriorityFeePerGas

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://files.worldwildlife.org/wwfcmsprod/images/Baby_Sloth_Hanging_iStock_3_12_2014/portrait_overview/4zhzw2pmf0_iStock_000016816803XLarge_mini.jpg)
