### PR TITLE
Add 'get_text' method to look up ENS text record values

### DIFF
--- a/ens/abis.py
+++ b/ens/abis.py
@@ -1173,6 +1173,28 @@ RESOLVER = [
     "type": "function"
   },
   {
+    "constant": True,
+    "inputs": [
+      {
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "name": "key",
+        "type": "string"
+      }
+    ],
+    "name": "text",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": False,
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "name": "ensAddr",

--- a/ens/main.py
+++ b/ens/main.py
@@ -273,6 +273,21 @@ class ENS:
         node = raw_name_to_hash(name)
         return self.ens.caller.owner(node)
 
+    def get_text(self, name: str, key: str) -> str:
+        """
+        Get the value of a text record by key from an ENS name.
+
+        :param str name: ENS name to look up
+        :param str key: ENS name's text record key
+        :return:  ENS name's text record value
+        :rtype: str
+        """
+        node = normal_name_to_hash(name)
+        r = self.resolver(name)
+        if r:
+            return r.caller.text(node, key)
+        return f"{name} does not exist!"
+
     @dict_copy
     def setup_owner(
         self,

--- a/newsfragments/2286.feature.rst
+++ b/newsfragments/2286.feature.rst
@@ -1,0 +1,1 @@
+Add 'get_text' method to look up ENS text record values


### PR DESCRIPTION
### What was wrong?

Noticed this at https://docs.ens.domains/dapp-developer-guide/resolving-names

![image](https://user-images.githubusercontent.com/35845239/147947816-53eb969c-c4f0-4c06-816a-bac4c7c65d89.png)


### How was it fixed?

- added get_text method
- added related ABI entry

Usage: `ns.get_text('dragonhound.eth', "avatar")`
Returns: `https://i.imgur.com/gAD7BxX.jpg`

### Todo:
- [ ] Add entry to the [docs](https://web3py.readthedocs.io/en/latest/ens_overview.html)
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/35845239/147948931-76d8dc7f-32a6-4347-82d7-d39f4de1671f.png)

