### PR TITLE
explicitly add output_values to compile_source example

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -62,7 +62,8 @@ You should now be set up to run the contract deployment example below:
     ...             return greeting;
     ...         }
     ...     }
-    ...     '''
+    ...     ''',
+    ...     output_values=['abi', 'bin']
     ... )
 
     # retrieve the contract interface

--- a/newsfragments/2293.doc.rst
+++ b/newsfragments/2293.doc.rst
@@ -1,0 +1,1 @@
+explicitly add `output_values` to contracts example


### PR DESCRIPTION
### What was wrong?

A change from solc (see [here](https://github.com/iamdefinitelyahuman/py-solc-x/pull/140)) caused our contracts example to break.

### How was it fixed?

Explicitly defining the `output_values` fixes our example without waiting for `py-solc-x` to fix it on their end and makes it more clear where we get those values later in the example.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![image](https://user-images.githubusercontent.com/5199899/148588684-642f490c-d4f6-4a5b-b953-5d8265288732.png)

