### PR TITLE
Feature/async geth personal

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -392,7 +392,8 @@ AsyncHTTPProvider
         ...     modules={'eth': (AsyncEth,),
         ...         'net': (AsyncNet,),
         ...         'geth': (Geth,
-        ...             {'txpool': (AsyncGethTxPool,)})
+        ...             {'txpool': (AsyncGethTxPool,),
+        ...              'personal': (AsyncGethPersonal,)})
         ...         },
         ...     middlewares=[])  # See supported middleware section below for middleware options
 
@@ -438,6 +439,15 @@ Net
 
 Geth
 ****
+- :meth:`web3.geth.personal.ec_recover()`
+- :meth:`web3.geth.personal.import_raw_key() <web3.geth.personal.import_raw_key>`
+- :meth:`web3.geth.personal.list_accounts() <web3.geth.personal.list_accounts>`
+- :meth:`web3.geth.personal.list_wallets() <web3.geth.personal.list_wallets()>`
+- :meth:`web3.geth.personal.lock_account() <web3.geth.personal.lock_account>`
+- :meth:`web3.geth.personal.new_account() <web3.geth.personal.new_account>`
+- :meth:`web3.geth.personal.send_transaction() <web3.geth.personal.send_transaction>`
+- :meth:`web3.geth.personal.sign()`
+- :meth:`web3.geth.personal.unlock_account() <web3.geth.personal.unlock_account>`
 - :meth:`web3.geth.txpool.inspect() <web3.geth.txpool.TxPool.inspect()>`
 - :meth:`web3.geth.txpool.content() <web3.geth.txpool.TxPool.content()>`
 - :meth:`web3.geth.txpool.status() <web3.geth.txpool.TxPool.status()>`

--- a/newsfragments/2299.feature.rst
+++ b/newsfragments/2299.feature.rst
@@ -1,0 +1,1 @@
+Added Async functions for Geth Personal module

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -4,10 +4,14 @@ from tests.utils import (
     get_open_port,
 )
 from web3 import Web3
+from web3._utils.module_testing.go_ethereum_personal_module import (
+    GoEthereumAsyncPersonalModuleTest,
+)
 from web3.eth import (
     AsyncEth,
 )
 from web3.geth import (
+    AsyncGethPersonal,
     AsyncGethTxPool,
     Geth,
 )
@@ -94,10 +98,11 @@ async def async_w3(geth_process, endpoint_uri):
             async_gas_price_strategy_middleware,
             async_buffered_gas_estimate_middleware
         ],
-        modules={'eth': (AsyncEth,),
-                 'async_net': (AsyncNet,),
+        modules={'eth': AsyncEth,
+                 'async_net': AsyncNet,
                  'geth': (Geth,
-                          {'txpool': (AsyncGethTxPool,)}
+                          {'txpool': (AsyncGethTxPool,),
+                           'personal': (AsyncGethPersonal,)}
                           )
                  }
     )
@@ -141,6 +146,10 @@ class TestGoEthereumAsyncNetModuleTest(GoEthereumAsyncNetModuleTest):
 
 
 class TestGoEthereumPersonalModuleTest(GoEthereumPersonalModuleTest):
+    pass
+
+
+class TestGoEthereumAsyncPersonalModuleTest(GoEthereumAsyncPersonalModuleTest):
     pass
 
 

--- a/web3/_utils/module_testing/__init__.py
+++ b/web3/_utils/module_testing/__init__.py
@@ -13,7 +13,7 @@ from .net_module import (  # noqa: F401
     AsyncNetModuleTest,
     NetModuleTest,
 )
-from .personal_module import (  # noqa: F401
+from .go_ethereum_personal_module import (  # noqa: F401
     GoEthereumPersonalModuleTest,
 )
 from .version_module import (  # noqa: F401

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -1,6 +1,19 @@
 from typing import (
     Any,
     Awaitable,
+    Dict,
+    List,
+    Optional,
+)
+
+from eth_typing.encoding import (
+    HexStr,
+)
+from eth_typing.evm import (
+    ChecksumAddress,
+)
+from hexbytes.main import (
+    HexBytes,
 )
 
 from web3._utils.admin import (
@@ -64,35 +77,150 @@ from web3.module import (
     Module,
 )
 from web3.types import (
+    GethWallet,
+    TxParams,
     TxPoolContent,
     TxPoolInspect,
     TxPoolStatus,
 )
 
 
-class GethPersonal(Module):
+class BaseGethPersonal(Module):
     """
     https://github.com/ethereum/go-ethereum/wiki/management-apis#personal
     """
-    ec_recover = ec_recover
-    import_raw_key = import_raw_key
-    list_accounts = list_accounts
-    list_wallets = list_wallets
-    lock_account = lock_account
-    new_account = new_account
-    send_transaction = send_transaction
-    sign = sign
-    sign_typed_data = sign_typed_data
-    unlock_account = unlock_account
+    _ec_recover = ec_recover
+    _import_raw_key = import_raw_key
+    _list_accounts = list_accounts
+    _list_wallets = list_wallets
+    _lock_account = lock_account
+    _new_account = new_account
+    _send_transaction = send_transaction
+    _sign = sign
+    _sign_typed_data = sign_typed_data
+    _unlock_account = unlock_account
     # deprecated
-    ecRecover = ecRecover
-    importRawKey = importRawKey
-    listAccounts = listAccounts
-    lockAccount = lockAccount
-    newAccount = newAccount
-    sendTransaction = sendTransaction
-    signTypedData = signTypedData
-    unlockAccount = unlockAccount
+    _ecRecover = ecRecover
+    _importRawKey = importRawKey
+    _listAccounts = listAccounts
+    _lockAccount = lockAccount
+    _newAccount = newAccount
+    _sendTransaction = sendTransaction
+    _signTypedData = signTypedData
+    _unlockAccount = unlockAccount
+
+
+class GethPersonal(BaseGethPersonal):
+    is_async = False
+
+    def ec_recover(self, message: str, signature: HexStr) -> ChecksumAddress:
+        return self._ec_recover(message, signature)
+
+    def import_raw_key(self, private_key: str, passphrase: str) -> ChecksumAddress:
+        return self._import_raw_key(private_key, passphrase)
+
+    def list_accounts(self) -> List[ChecksumAddress]:
+        return self._list_accounts()
+
+    def list_wallets(self) -> List[GethWallet]:
+        return self._list_wallets()
+
+    def lock_account(self, account: ChecksumAddress) -> bool:
+        return self._lock_account(account)
+
+    def new_account(self, passphrase: str) -> ChecksumAddress:
+        return self._new_account(passphrase)
+
+    def send_transaction(self, transaction: TxParams, passphrase: str) -> HexBytes:
+        return self._send_transaction(transaction, passphrase)
+
+    def sign(self, message: str, account: ChecksumAddress, password: Optional[str]) -> HexStr:
+        return self._sign(message, account, password)
+
+    def sign_typed_data(self,
+                        message: Dict[str, Any],
+                        account: ChecksumAddress,
+                        password: Optional[str]) -> HexStr:
+        return self._sign_typed_data(message, account, password)
+
+    def unlock_account(self,
+                       account: ChecksumAddress,
+                       passphrase: str,
+                       duration: Optional[int] = None) -> bool:
+        return self._unlock_account(account, passphrase, duration)
+
+    def ecRecover(self, message: str, signature: HexStr) -> ChecksumAddress:
+        return self._ecRecover(message, signature)
+
+    def importRawKey(self, private_key: str, passphrase: str) -> ChecksumAddress:
+        return self._importRawKey(private_key, passphrase)
+
+    def listAccounts(self) -> List[ChecksumAddress]:
+        return self._listAccounts()
+
+    def lockAccount(self, account: ChecksumAddress) -> bool:
+        return self._lockAccount(account)
+
+    def newAccount(self, passphrase: str) -> ChecksumAddress:
+        return self._newAccount(passphrase)
+
+    def sendTransaction(self, transaction: TxParams, passphrase: str) -> HexBytes:
+        return self._sendTransaction(transaction, passphrase)
+
+    def signTypedData(self,
+                      message: Dict[str, Any],
+                      account: ChecksumAddress,
+                      password: Optional[str] = None) -> HexStr:
+        return self._signTypedData(message, account, password)
+
+    def unlockAccount(self,
+                      account: ChecksumAddress,
+                      passphrase: str,
+                      duration: Optional[int] = None) -> bool:
+        return self._unlockAccount(account, passphrase, duration)
+
+
+class AsyncGethPersonal(BaseGethPersonal):
+    is_async = True
+
+    async def ec_recover(self, message: str, signature: HexStr) -> Awaitable[ChecksumAddress]:
+        return await self._ec_recover(message, signature)  # type: ignore
+
+    async def import_raw_key(self, private_key: str, passphrase: str) -> Awaitable[ChecksumAddress]:
+        return await self._import_raw_key(private_key, passphrase)  # type: ignore
+
+    async def list_accounts(self) -> Awaitable[List[ChecksumAddress]]:
+        return await self._list_accounts()  # type: ignore
+
+    async def list_wallets(self) -> Awaitable[List[GethWallet]]:
+        return await self._list_wallets()  # type: ignore
+
+    async def lock_account(self, account: ChecksumAddress) -> Awaitable[bool]:
+        return await self._lock_account(account)  # type: ignore
+
+    async def new_account(self, passphrase: str) -> Awaitable[ChecksumAddress]:
+        return await self._new_account(passphrase)  # type: ignore
+
+    async def send_transaction(self, transaction: TxParams, passphrase: str) -> Awaitable[HexBytes]:
+        return await self._send_transaction(transaction, passphrase)  # type: ignore
+
+    async def sign(self,
+                   message: str,
+                   account: ChecksumAddress,
+                   password: Optional[str]) -> Awaitable[HexStr]:
+        return await self._sign(message, account, password)  # type: ignore
+
+    async def sign_typed_data(self,
+                              message: Dict[str, Any],
+                              account: ChecksumAddress,
+                              password: Optional[str]) -> Awaitable[HexStr]:
+        return await self._sign_typed_data(message, account, password)  # type: ignore
+
+    async def unlock_account(self,
+                             account: ChecksumAddress,
+                             passphrase: str,
+                             duration: Optional[int] = None) -> Awaitable[bool]:
+        return await self._unlock_account(account, passphrase, duration)  # type: ignore
 
 
 class BaseTxPool(Module):


### PR DESCRIPTION
### What was wrong?

Added Async to Geth Personal

Related to Issue #1413 

From a testing standpoint I used the `GoEthereumPersonalModuleTest` as a starting point. Since a lot of the functionality was tested in `GoEthereumPersonalModuleTest` I put bare minimum test on the Async side. I was trying not to have duplicates of all the test but there may be a better approach here. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

I had a couple of outstanding questions about adding Async to Geth Personal

1. There are three methods that are not documented in `web3.geth.rst` so I couldn't add the links to them in the `providers.rst`
2. I did not implement the deprecated methods in the `AsyncGethPersonal` class. This seemed to fit what had been done in Eth with the deprecated methods not being implemented in the async class. 
3. `list_wallets` and `sign_typed_data` do not seem to be implemented in the [Geth Personal Namespace](https://geth.ethereum.org/docs/rpc/ns-personal). Should they be in the methods for Geth Personal?
4. I did not add a unit test for `signed_typed_data` since the test in the `GoEthereumPersonalModuleTest` class were marked as xfail. I can implement them if needed.
5. Was thinking about changing the name of  [personal_module](https://github.com/ethereum/web3.py/blob/master/web3/_utils/module_testing/personal_module.py) in module testing to `go_ethereum_personal_module` to align with the other Geth integration test but wanted to check first. 
6. How to handle the test for import_raw_key. I am currently going to remove it in `GoEthereumAsyncPersonalModuleTest` since it is failing because the key used in the test fixture is already imported. Should I generate a random key for testing in this test??