### PR TITLE
Don't require modules to inherit from the Module class

### DIFF
--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -385,10 +385,10 @@ Check Encodability
         False
 
 
-RPC APIS
-~~~~~~~~
+RPC API Modules
+~~~~~~~~~~~~~~~
 
-Each ``Web3`` instance also exposes these namespaced APIs.
+Each ``Web3`` instance also exposes these namespaced API modules.
 
 
 .. py:attribute:: Web3.eth
@@ -412,21 +412,34 @@ Each ``Web3`` instance also exposes these namespaced APIs.
     See :doc:`./web3.parity`
 
 
+These internal modules inherit from the ``web3.module.Module`` class which give them some configurations internal to the
+web3.py library.
+
+
 Attaching Modules
 ~~~~~~~~~~~~~~~~~
 
-Modules that inherit from the ``web3.module.Module`` class may be attached to the ``Web3`` instance either at
-instantiation or by making use of the ``attach_modules()`` method.
+External modules may be attached to the ``Web3`` instance either at instantiation or by making use of the
+``attach_modules()`` method. External modules need not inherit from the ``web3.module.Module`` class. This allows for a
+good deal of flexibility even in defining what a module means to the user. An external module could technically provide
+any bit of functionality that the user desires. Consequently, external modules need not be RPC APIs - though this does
+provide the ability to attach an RPC API library, specific to your chain of choice, to the ``Web3`` instance.
 
 To instantiate the ``Web3`` instance with external modules:
 
 .. code-block:: python
 
-    >>> from web3 import Web3, EthereumTesterProvider
+    >>> from web3 import Web3, HTTPProvider
+    >>> from external_module_library import (
+    ...     ModuleClass1,
+    ...     ModuleClass2,
+    ...     ModuleClass3,
+    ...     ModuleClass4,
+    ...     ModuleClass5,
+    ... )
     >>> w3 = Web3(
-    ...     EthereumTesterProvider(),
+    ...     HTTPProvider(provider_uri),
     ...     external_modules={
-    ...         # ModuleClass objects in this example inherit from the `web3.module.Module` class
     ...         'module1': ModuleClass1,
     ...         'module2': (ModuleClass2, {
     ...             'submodule1': ModuleClass3,
@@ -455,12 +468,17 @@ To instantiate the ``Web3`` instance with external modules:
     themselves, if there are no submodules, or two-item tuples with the module class as the 0th index and a similarly
     built `dict` containing the submodule information as the 1st index. This pattern may be repeated as necessary.
 
-    .. note:: Module classes must inherit from the ``web3.module.Module`` class.
-
     .. code-block:: python
 
-        >>> from web3 import Web3, EthereumTesterProvider
-        >>> w3 = Web3(EthereumTesterProvider())
+        >>> from web3 import Web3, HTTPProvider
+        >>> from external_module_library import (
+        ...     ModuleClass1,
+        ...     ModuleClass2,
+        ...     ModuleClass3,
+        ...     ModuleClass4,
+        ...     ModuleClass5,
+        ... )
+        >>> w3 = Web3(HTTPProvider(provider_uri))
 
         >>> w3.attach_modules({
         ...     'module1': ModuleClass1,  # the module class itself may be used for a single module with no submodules

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -416,14 +416,29 @@ These internal modules inherit from the ``web3.module.Module`` class which give 
 web3.py library.
 
 
-Attaching Modules
-~~~~~~~~~~~~~~~~~
+External Modules
+~~~~~~~~~~~~~~~~
 
-External modules may be attached to the ``Web3`` instance either at instantiation or by making use of the
-``attach_modules()`` method. External modules need not inherit from the ``web3.module.Module`` class. This allows for a
-good deal of flexibility even in defining what a module means to the user. An external module could technically provide
-any bit of functionality that the user desires. Consequently, external modules need not be RPC APIs - though this does
-provide the ability to attach an RPC API library, specific to your chain of choice, to the ``Web3`` instance.
+External modules can be used to introduce custom or third-party APIs to your ``Web3`` instance. Adding external modules
+can occur either at instantiation of the ``Web3`` instance or by making use of the ``attach_modules()`` method.
+
+Unlike the native modules, external modules need not inherit from the ``web3.module.Module`` class. The only requirement
+is that a Module must be a class and, if you'd like to make use of the parent ``Web3`` instance, it must be passed into
+the ``__init__`` function. For example:
+
+.. code-block:: python
+
+    >>> class ExampleModule():
+    ...
+    ...     def __init__(self, w3):
+    ...         self.w3 = w3
+    ...
+    ...     def print_balance_of_shaq(self):
+    ...         print(self.w3.eth.get_balance('shaq.eth'))
+
+
+.. warning:: Given the flexibility of external modules, use caution and only import modules from trusted third parties
+   and open source code you've vetted!
 
 To instantiate the ``Web3`` instance with external modules:
 

--- a/newsfragments/2304.feature.rst
+++ b/newsfragments/2304.feature.rst
@@ -1,0 +1,1 @@
+external modules are no longer required to inherit from the ``web3.module.Module`` class

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -4,6 +4,8 @@ from web3.module import (
     Module,
 )
 
+# --- inherit from `web3.module.Module` class --- #
+
 
 @pytest.fixture(scope='module')
 def module1():
@@ -38,4 +40,39 @@ def module3():
 def module4():
     class Module4(Module):
         f = 'f'
+    return Module4
+
+
+# --- do not inherit from `web3.module.Module` class --- #
+
+
+@pytest.fixture(scope='module')
+def module1_unique():
+    class Module1:
+        a = 'a'
+    return Module1
+
+
+@pytest.fixture(scope='module')
+def module2_unique():
+    class Module2:
+        b = 'b'
+
+        @staticmethod
+        def c():
+            return 'c'
+    return Module2
+
+
+@pytest.fixture(scope='module')
+def module3_unique():
+    class Module3:
+        d = 'd'
+    return Module3
+
+
+@pytest.fixture(scope='module')
+def module4_unique():
+    class Module4:
+        e = 'e'
     return Module4

--- a/tests/core/utilities/test_attach_modules.py
+++ b/tests/core/utilities/test_attach_modules.py
@@ -127,3 +127,38 @@ def test_attach_external_modules_multiple_levels_deep(module1, module2, module3,
     assert w3.module2.submodule1.e == 'e'
     assert hasattr(w3.module2.submodule1, 'submodule2')
     assert w3.module2.submodule1.submodule2.f == 'f'
+
+
+def test_attach_external_modules_that_do_not_inherit_from_module_class(
+    module1_unique, module2_unique, module3_unique, module4_unique,
+):
+    w3 = Web3(
+        EthereumTesterProvider(),
+        external_modules={
+            'module1': module1_unique,
+            'module2': (module2_unique, {
+                'submodule1': (module3_unique, {
+                    'submodule2': module4_unique,
+                }),
+            })
+        }
+    )
+
+    # assert module1 attached
+    assert hasattr(w3, 'module1')
+    assert w3.module1.a == 'a'
+
+    # assert module2 + submodules attached
+    assert hasattr(w3, 'module2')
+    assert w3.module2.b == 'b'
+    assert w3.module2.c() == 'c'
+
+    assert hasattr(w3.module2, 'submodule1')
+    assert w3.module2.submodule1.d == 'd'
+    assert hasattr(w3.module2.submodule1, 'submodule2')
+    assert w3.module2.submodule1.submodule2.e == 'e'
+
+    # assert default modules intact
+    assert hasattr(w3, 'geth')
+    assert hasattr(w3, 'eth')
+    assert is_integer(w3.eth.chain_id)

--- a/tests/core/web3-module/test_attach_modules.py
+++ b/tests/core/web3-module/test_attach_modules.py
@@ -32,3 +32,37 @@ def test_attach_modules(web3, module1, module2, module3, module4):
     assert hasattr(web3, 'geth')
     assert hasattr(web3, 'eth')
     assert is_integer(web3.eth.chain_id)
+
+
+def test_attach_modules_that_do_not_inherit_from_module_class(
+    web3, module1_unique, module2_unique, module3_unique, module4_unique,
+):
+    web3.attach_modules(
+        {
+            'module1': module1_unique,
+            'module2': (module2_unique, {
+                'submodule1': (module3_unique, {
+                    'submodule2': module4_unique,
+                }),
+            })
+        }
+    )
+
+    # assert module1 attached
+    assert hasattr(web3, 'module1')
+    assert web3.module1.a == 'a'
+
+    # assert module2 + submodules attached
+    assert hasattr(web3, 'module2')
+    assert web3.module2.b == 'b'
+    assert web3.module2.c() == 'c'
+
+    assert hasattr(web3.module2, 'submodule1')
+    assert web3.module2.submodule1.d == 'd'
+    assert hasattr(web3.module2.submodule1, 'submodule2')
+    assert web3.module2.submodule1.submodule2.e == 'e'
+
+    # assert default modules intact
+    assert hasattr(web3, 'geth')
+    assert hasattr(web3, 'eth')
+    assert is_integer(web3.eth.chain_id)

--- a/web3/main.py
+++ b/web3/main.py
@@ -335,8 +335,7 @@ class Web3:
         self, modules: Optional[Dict[str, Union[Type[Module], Sequence[Any]]]]
     ) -> None:
         """
-        Attach modules to the `Web3` instance. Modules should inherit from the `web3.module.Module`
-        class.
+        Attach modules to the `Web3` instance.
         """
         _attach_modules(self, modules)
 


### PR DESCRIPTION
### What was wrong?

- All attached modules needed to inherit from the `web3.module.Module` class

Related to Issues #2231, #2288

### How was it fixed?

- Remove requirement for all modules to inherit from the `Module` class

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Add a cute animal picture
- [x] @marcgarreau, take a look at the doc descriptions / changes around modules in general. I added a bit to try to make more clear what modules are but I think this could use some love. Maybe in a separate PR, but if you have suggestions feel free to comment here or push commits to this PR.

#### Cute Animal Picture

![20220113_091916](https://user-images.githubusercontent.com/3532824/149812962-f2420cb4-f5ac-40cd-894a-426417929ea3.jpg)

