### PR TITLE
fixed link

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -29,7 +29,7 @@ The :meth:`web3.eth.Eth.filter` method can be used to setup filters for:
 
         event_filter = mycontract.events.myEvent.createFilter(fromBlock='latest', argument_filters={'arg1':10})
 
-    Or built manually by supplying `valid filter params <https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter/>`_:
+    Or built manually by supplying `valid filter params <https://github.com/ethereum/execution-apis/blob/bea0266c42919a2fb3ee524fb91e624a23bc17c5/src/schemas/filter.json#L28>`_:
 
     .. code-block:: python
 

--- a/newsfragments/2303.doc.rst
+++ b/newsfragments/2303.doc.rst
@@ -1,0 +1,1 @@
+fixed broken link to filter schema


### PR DESCRIPTION
### What was wrong?

I realized when looking at #2303 that the link to how to build a filter was broken. The wiki link didn't work so pointed it to the schema for the filter in ethereum/execution_apis
