### PR TITLE
asyncify eth.get_logs

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -418,6 +418,7 @@ Eth
 - :meth:`web3.eth.get_balance() <web3.eth.Eth.get_balance>`
 - :meth:`web3.eth.get_block() <web3.eth.Eth.get_block>`
 - :meth:`web3.eth.get_code() <web3.eth.Eth.get_code>`
+- :meth:`web3.eth.get_logs() <web3.eth.Eth.get_logs>`
 - :meth:`web3.eth.get_raw_transaction() <web3.eth.Eth.get_raw_transaction>`
 - :meth:`web3.eth.get_raw_transaction_by_block() <web3.eth.Eth.get_raw_transaction_by_block>`
 - :meth:`web3.eth.get_transaction() <web3.eth.Eth.get_transaction>`

--- a/newsfragments/2310.feature.rst
+++ b/newsfragments/2310.feature.rst
@@ -1,0 +1,1 @@
+Add async `eth.get_logs` method

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -83,6 +83,22 @@ def mine_pending_block(web3: "Web3") -> None:
     web3.geth.miner.stop()  # type: ignore
 
 
+def _assert_contains_log(
+    result: Sequence[LogReceipt],
+    block_with_txn_with_log: BlockData,
+    emitter_contract_address: ChecksumAddress,
+    txn_hash_with_log: HexStr,
+) -> None:
+    assert len(result) == 1
+    log_entry = result[0]
+    assert log_entry['blockNumber'] == block_with_txn_with_log['number']
+    assert log_entry['blockHash'] == block_with_txn_with_log['hash']
+    assert log_entry['logIndex'] == 0
+    assert is_same_address(log_entry['address'], emitter_contract_address)
+    assert log_entry['transactionIndex'] == 0
+    assert log_entry['transactionHash'] == HexBytes(txn_hash_with_log)
+
+
 class AsyncEthModuleTest:
     @pytest.mark.asyncio
     async def test_eth_gas_price(self, async_w3: "Web3") -> None:
@@ -897,15 +913,6 @@ class AsyncEthModuleTest:
         emitter_contract_address: ChecksumAddress,
         txn_hash_with_log: HexStr,
     ) -> None:
-        def assert_contains_log(result: Sequence[LogReceipt]) -> None:
-            assert len(result) == 1
-            log_entry = result[0]
-            assert log_entry['blockNumber'] == block_with_txn_with_log['number']
-            assert log_entry['blockHash'] == block_with_txn_with_log['hash']
-            assert log_entry['logIndex'] == 0
-            assert is_same_address(log_entry['address'], emitter_contract_address)
-            assert log_entry['transactionIndex'] == 0
-            assert log_entry['transactionHash'] == HexBytes(txn_hash_with_log)
 
         # Test with block range
 
@@ -915,14 +922,24 @@ class AsyncEthModuleTest:
             "toBlock": block_with_txn_with_log['number'],
         }
         result = await async_w3.eth.get_logs(filter_params)  # type: ignore
-        assert_contains_log(result)
+        _assert_contains_log(
+            result,
+            block_with_txn_with_log,
+            emitter_contract_address,
+            txn_hash_with_log
+        )
 
         # specify only `from_block`. by default `to_block` should be 'latest'
         filter_params = {
             "fromBlock": BlockNumber(0),
         }
         result = await async_w3.eth.get_logs(filter_params)  # type: ignore
-        assert_contains_log(result)
+        _assert_contains_log(
+            result,
+            block_with_txn_with_log,
+            emitter_contract_address,
+            txn_hash_with_log
+        )
 
         # Test with `address`
 
@@ -940,15 +957,6 @@ class AsyncEthModuleTest:
         emitter_contract_address: ChecksumAddress,
         txn_hash_with_log: HexStr,
     ) -> None:
-        def assert_contains_log(result: Sequence[LogReceipt]) -> None:
-            assert len(result) == 1
-            log_entry = result[0]
-            assert log_entry['blockNumber'] == block_with_txn_with_log['number']
-            assert log_entry['blockHash'] == block_with_txn_with_log['hash']
-            assert log_entry['logIndex'] == 0
-            assert is_same_address(log_entry['address'], emitter_contract_address)
-            assert log_entry['transactionIndex'] == 0
-            assert log_entry['transactionHash'] == HexBytes(txn_hash_with_log)
 
         # Test with None event sig
 
@@ -960,7 +968,12 @@ class AsyncEthModuleTest:
         }
 
         result = await async_w3.eth.get_logs(filter_params)  # type: ignore
-        assert_contains_log(result)
+        _assert_contains_log(
+            result,
+            block_with_txn_with_log,
+            emitter_contract_address,
+            txn_hash_with_log
+        )
 
         # Test with None indexed arg
         filter_params = {
@@ -970,7 +983,12 @@ class AsyncEthModuleTest:
                 None],
         }
         result = await async_w3.eth.get_logs(filter_params)  # type: ignore
-        assert_contains_log(result)
+        _assert_contains_log(
+            result,
+            block_with_txn_with_log,
+            emitter_contract_address,
+            txn_hash_with_log
+        )
 
     @pytest.mark.asyncio
     async def test_async_eth_get_logs_with_logs_none_topic_args(self, async_w3: "Web3") -> None:
@@ -2853,15 +2871,6 @@ class EthModuleTest:
         emitter_contract_address: ChecksumAddress,
         txn_hash_with_log: HexStr,
     ) -> None:
-        def assert_contains_log(result: Sequence[LogReceipt]) -> None:
-            assert len(result) == 1
-            log_entry = result[0]
-            assert log_entry['blockNumber'] == block_with_txn_with_log['number']
-            assert log_entry['blockHash'] == block_with_txn_with_log['hash']
-            assert log_entry['logIndex'] == 0
-            assert is_same_address(log_entry['address'], emitter_contract_address)
-            assert log_entry['transactionIndex'] == 0
-            assert log_entry['transactionHash'] == HexBytes(txn_hash_with_log)
 
         # Test with block range
 
@@ -2871,14 +2880,24 @@ class EthModuleTest:
             "toBlock": block_with_txn_with_log['number'],
         }
         result = web3.eth.get_logs(filter_params)
-        assert_contains_log(result)
+        _assert_contains_log(
+            result,
+            block_with_txn_with_log,
+            emitter_contract_address,
+            txn_hash_with_log
+        )
 
         # specify only `from_block`. by default `to_block` should be 'latest'
         filter_params = {
             "fromBlock": BlockNumber(0),
         }
         result = web3.eth.get_logs(filter_params)
-        assert_contains_log(result)
+        _assert_contains_log(
+            result,
+            block_with_txn_with_log,
+            emitter_contract_address,
+            txn_hash_with_log
+        )
 
         # Test with `address`
 
@@ -2895,15 +2914,6 @@ class EthModuleTest:
         emitter_contract_address: ChecksumAddress,
         txn_hash_with_log: HexStr,
     ) -> None:
-        def assert_contains_log(result: Sequence[LogReceipt]) -> None:
-            assert len(result) == 1
-            log_entry = result[0]
-            assert log_entry['blockNumber'] == block_with_txn_with_log['number']
-            assert log_entry['blockHash'] == block_with_txn_with_log['hash']
-            assert log_entry['logIndex'] == 0
-            assert is_same_address(log_entry['address'], emitter_contract_address)
-            assert log_entry['transactionIndex'] == 0
-            assert log_entry['transactionHash'] == HexBytes(txn_hash_with_log)
 
         # Test with None event sig
 
@@ -2915,7 +2925,12 @@ class EthModuleTest:
         }
 
         result = web3.eth.get_logs(filter_params)
-        assert_contains_log(result)
+        _assert_contains_log(
+            result,
+            block_with_txn_with_log,
+            emitter_contract_address,
+            txn_hash_with_log
+        )
 
         # Test with None indexed arg
         filter_params = {
@@ -2925,7 +2940,12 @@ class EthModuleTest:
                 None],
         }
         result = web3.eth.get_logs(filter_params)
-        assert_contains_log(result)
+        _assert_contains_log(
+            result,
+            block_with_txn_with_log,
+            emitter_contract_address,
+            txn_hash_with_log
+        )
 
     def test_eth_get_logs_with_logs_none_topic_args(self, web3: "Web3") -> None:
         # Test with None overflowing

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -401,6 +401,17 @@ class AsyncEth(BaseEth):
     ) -> HexBytes:
         return await self._get_code(account, block_identifier)
 
+    _get_logs: Method[Callable[[FilterParams], Awaitable[List[LogReceipt]]]] = Method(
+        RPC.eth_getLogs,
+        mungers=[default_root_munger]
+    )
+
+    async def get_logs(
+        self,
+        filter_params: FilterParams,
+    ) -> List[LogReceipt]:
+        return await self._get_logs(filter_params)
+
     _get_transaction_count: Method[Callable[..., Awaitable[Nonce]]] = Method(
         RPC.eth_getTransactionCount,
         mungers=[BaseEth.block_id_munger],


### PR DESCRIPTION
### What was wrong?

Related to Issue #2129

### How was it fixed?

Added async get_logs method based on original method

### Todo:
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.etsystatic.com/24874323/r/il/b6f9c8/2918868992/il_794xN.2918868992_hax9.jpg)
