### PR TITLE
Align NamedTuples

### DIFF
--- a/newsfragments/2312.feature.rst
+++ b/newsfragments/2312.feature.rst
@@ -1,0 +1,1 @@
+Allow NamedTuples in ABI inputs

--- a/tests/core/utilities/test_abi.py
+++ b/tests/core/utilities/test_abi.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from typing import NamedTuple
 
 from web3._utils.abi import (
     abi_data_tree,
@@ -39,6 +40,15 @@ from web3._utils.normalizers import (
 )
 def test_get_tuple_type_str_parts(input, expected):
     assert get_tuple_type_str_parts(input) == expected
+
+
+MyXYTuple = NamedTuple(
+    "MyXYTuple",
+    [
+        ("x", int),
+        ("y", int),
+    ]
+)
 
 
 TEST_FUNCTION_ABI_JSON = """
@@ -163,6 +173,15 @@ GET_ABI_INPUTS_TESTS = (
             (11, 12),
             13,
         ),
+        GET_ABI_INPUTS_OUTPUT,
+    ),
+    (
+        TEST_FUNCTION_ABI,
+        {
+            's': {'a': 1, 'b': [2, 3, 4], 'c': [(5, 6), (7, 8), MyXYTuple(x=9, y=10)]},
+            't': MyXYTuple(x=11, y=12),
+            'a': 13,
+        },
         GET_ABI_INPUTS_OUTPUT,
     ),
     (

--- a/tests/core/utilities/test_abi.py
+++ b/tests/core/utilities/test_abi.py
@@ -1,6 +1,8 @@
 import json
 import pytest
-from typing import NamedTuple
+from typing import (
+    NamedTuple,
+)
 
 from web3._utils.abi import (
     abi_data_tree,

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -550,8 +550,11 @@ def _align_abi_input(arg_abi: ABIFunctionParams, arg: Any) -> Tuple[Any, ...]:
                 aligned_arg,
             ),
         )
+    
+    # convert NamedTuple to regular tuple
+    typing = tuple if isinstance(aligned_arg, tuple) else type(aligned_arg)
 
-    return type(aligned_arg)(
+    return typing(
         _align_abi_input(sub_abi, sub_arg)
         for sub_abi, sub_arg in zip(sub_abis, aligned_arg)
     )

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -550,7 +550,7 @@ def _align_abi_input(arg_abi: ABIFunctionParams, arg: Any) -> Tuple[Any, ...]:
                 aligned_arg,
             ),
         )
-    
+
     # convert NamedTuple to regular tuple
     typing = tuple if isinstance(aligned_arg, tuple) else type(aligned_arg)
 


### PR DESCRIPTION
### What was wrong?
Using the Python NamedTuple structure, the ABI is not recognised.

### How was it fixed?
Converted named tuples to tuples. Given a NamedTuple with name "MyTuple", `isinstance(t, tuple)` is True for both a regular tuple and a MyTuple object, but type(t) will be "tuple" for regular tuples and "MyTuple" respectively. This means the typing should be adapted.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.giphy.com/media/ZeHqFM9JNauty/giphy.gif)
