### PR TITLE
move default_account and default_block to BaseEth

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -408,6 +408,8 @@ Eth
 - :meth:`web3.eth.block_number <web3.eth.Eth.block_number>`
 - :meth:`web3.eth.chain_id <web3.eth.Eth.chain_id>`
 - :meth:`web3.eth.coinbase <web3.eth.Eth.coinbase>`
+- :meth:`web3.eth.default_account <web3.eth.Eth.default_account>`
+- :meth:`web3.eth.default_block <web3.eth.Eth.default_block>`
 - :meth:`web3.eth.gas_price <web3.eth.Eth.gas_price>`
 - :meth:`web3.eth.hashrate <web3.eth.Eth.hashrate>`
 - :meth:`web3.eth.max_priority_fee <web3.eth.Eth.max_priority_fee>`

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -49,7 +49,7 @@ The following properties are available on the ``web3.eth`` namespace.
 .. py:attribute:: Eth.default_account
 
     The ethereum address that will be used as the default ``from`` address for
-    all transactions.
+    all transactions. Defaults to empty.
 
 
 .. py:attribute:: Eth.defaultAccount
@@ -61,7 +61,7 @@ The following properties are available on the ``web3.eth`` namespace.
 .. py:attribute:: Eth.default_block
 
     The default block number that will be used for any RPC methods that accept
-    a block identifier.  Defaults to ``'latest'``.
+    a block identifier. Defaults to ``'latest'``.
 
 
 .. py:attribute:: Eth.defaultBlock

--- a/newsfragments/2315.feature.rst
+++ b/newsfragments/2315.feature.rst
@@ -1,0 +1,1 @@
+add Async access to `default_account` and `default_block`

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -35,6 +35,9 @@ from hexbytes import (
     HexBytes,
 )
 
+from web3._utils.empty import (
+    empty,
+)
 from web3._utils.ens import (
     ens_addresses,
 )
@@ -844,6 +847,41 @@ class AsyncEthModuleTest:
             in accounts
         ))
         assert await async_w3.eth.coinbase in accounts  # type: ignore
+
+    def test_async_provider_default_account(
+        self,
+        async_w3: "Web3",
+        unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+
+        # check defaults to empty
+        default_account = async_w3.eth.default_account
+        assert default_account is empty
+
+        # check setter
+        async_w3.eth.default_account = unlocked_account_dual_type
+        default_account = async_w3.eth.default_account
+        assert default_account == unlocked_account_dual_type
+
+        # reset to default
+        async_w3.eth.default_account = empty
+
+    def test_async_provider_default_block(
+        self,
+        async_w3: "Web3",
+    ) -> None:
+
+        # check defaults to 'latest'
+        default_block = async_w3.eth.default_block
+        assert default_block == 'latest'
+
+        # check setter
+        async_w3.eth.default_block = BlockNumber(12345)
+        default_block = async_w3.eth.default_block
+        assert default_block == BlockNumber(12345)
+
+        # reset to default
+        async_w3.eth.default_block = 'latest'
 
 
 class EthModuleTest:
@@ -2919,3 +2957,38 @@ class EthModuleTest:
             )
         ):
             web3.eth.get_raw_transaction_by_block(unknown_identifier, 0)  # type: ignore
+
+    def test_default_account(
+        self,
+        web3: "Web3",
+        unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+
+        # check defaults to empty
+        default_account = web3.eth.default_account
+        assert default_account is empty
+
+        # check setter
+        web3.eth.default_account = unlocked_account_dual_type
+        default_account = web3.eth.default_account
+        assert default_account == unlocked_account_dual_type
+
+        # reset to default
+        web3.eth.default_account = empty
+
+    def test_default_block(
+        self,
+        web3: "Web3",
+    ) -> None:
+
+        # check defaults to 'latest'
+        default_block = web3.eth.default_block
+        assert default_block == 'latest'
+
+        # check setter
+        web3.eth.default_block = BlockNumber(12345)
+        default_block = web3.eth.default_block
+        assert default_block == BlockNumber(12345)
+
+        # reset to default
+        web3.eth.default_block = 'latest'

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -117,7 +117,6 @@ class BaseEth(Module):
         mungers=None,
     )
 
-    """ property default_block """
     @property
     def default_block(self) -> BlockIdentifier:
         return self._default_block
@@ -127,8 +126,44 @@ class BaseEth(Module):
         self._default_block = value
 
     @property
+    def defaultBlock(self) -> BlockIdentifier:
+        warnings.warn(
+            'defaultBlock is deprecated in favor of default_block',
+            category=DeprecationWarning,
+        )
+        return self._default_block
+
+    @defaultBlock.setter
+    def defaultBlock(self, value: BlockIdentifier) -> None:
+        warnings.warn(
+            'defaultBlock is deprecated in favor of default_block',
+            category=DeprecationWarning,
+        )
+        self._default_block = value
+
+    @property
     def default_account(self) -> Union[ChecksumAddress, Empty]:
         return self._default_account
+
+    @default_account.setter
+    def default_account(self, account: Union[ChecksumAddress, Empty]) -> None:
+        self._default_account = account
+
+    @property
+    def defaultAccount(self) -> Union[ChecksumAddress, Empty]:
+        warnings.warn(
+            'defaultAccount is deprecated in favor of default_account',
+            category=DeprecationWarning,
+        )
+        return self._default_account
+
+    @defaultAccount.setter
+    def defaultAccount(self, account: Union[ChecksumAddress, Empty]) -> None:
+        warnings.warn(
+            'defaultAccount is deprecated in favor of default_account',
+            category=DeprecationWarning,
+        )
+        self._default_account = account
 
     def send_transaction_munger(self, transaction: TxParams) -> Tuple[TxParams]:
         if 'from' not in transaction and is_checksum_address(self.default_account):
@@ -551,51 +586,10 @@ class Eth(BaseEth):
         )
         return self.chain_id
 
-    """ property default_account """
-    @property
-    def default_account(self) -> Union[ChecksumAddress, Empty]:
-        return self._default_account
-
-    @default_account.setter
-    def default_account(self, account: Union[ChecksumAddress, Empty]) -> None:
-        self._default_account = account
-
-    @property
-    def defaultAccount(self) -> Union[ChecksumAddress, Empty]:
-        warnings.warn(
-            'defaultAccount is deprecated in favor of default_account',
-            category=DeprecationWarning,
-        )
-        return self._default_account
-
-    @defaultAccount.setter
-    def defaultAccount(self, account: Union[ChecksumAddress, Empty]) -> None:
-        warnings.warn(
-            'defaultAccount is deprecated in favor of default_account',
-            category=DeprecationWarning,
-        )
-        self._default_account = account
-
     get_balance: Method[Callable[..., Wei]] = Method(
         RPC.eth_getBalance,
         mungers=[BaseEth.block_id_munger],
     )
-
-    @property
-    def defaultBlock(self) -> BlockIdentifier:
-        warnings.warn(
-            'defaultBlock is deprecated in favor of default_block',
-            category=DeprecationWarning,
-        )
-        return self._default_block
-
-    @defaultBlock.setter
-    def defaultBlock(self, value: BlockIdentifier) -> None:
-        warnings.warn(
-            'defaultBlock is deprecated in favor of default_block',
-            category=DeprecationWarning,
-        )
-        self._default_block = value
 
     @property
     def max_priority_fee(self) -> Wei:


### PR DESCRIPTION
### What was wrong?
AsyncEth didn't have access to default_account or default_block properties and setters

### How was it fixed?
I moved them to BaseEth

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]( 
https://user-images.githubusercontent.com/5199899/150431850-22bb7d93-03e0-4462-8b14-51796f211fb1.png
 )
