### PR TITLE
Feature/ens request

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -245,7 +245,7 @@ class ENS:
             address = lookup_function(namehash).call()
             if is_none_or_zero_address(address):
                 return None
-            return lookup_function(namehash).call()
+            return address
         else:
             return None
 

--- a/newsfragments/2318.bugfix.rst
+++ b/newsfragments/2318.bugfix.rst
@@ -1,0 +1,1 @@
+In ENS the contract function to resolve an ENS address was being called twice in error. One of those calls was removed.


### PR DESCRIPTION
### What was wrong?

Related Issue #2318 

I was looking at what it would take to async the resolver in ens so it can be used with the name_to_address_middleware when I noticed that the ens contract function to resolve an address was called twice

On line 245 in the [main.py](https://github.com/ethereum/web3.py/blob/master/ens/main.py#L245-L248) for ens the contract function is called to resolve the ChecksumAddress. It is called again in the return statement on line 248

### How was it fixed?

removed the second call and just returned `address`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

