### PR TITLE
Pull in new py-evm and eth-tester

### DIFF
--- a/newsfragments/2320.feature.rst
+++ b/newsfragments/2320.feature.rst
@@ -1,0 +1,1 @@
+Update eth-tester and eth-account dependencies to pull in bugfix from eth-keys

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     install_requires=[
         "aiohttp>=3.7.4.post0,<4",
         "eth-abi>=2.0.0b6,<3.0.0",
-        "eth-account>=0.5.6,<0.6.0",
+        "eth-account>=0.5.7,<0.6.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.9.5,<2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ from setuptools import (
 
 extras_require = {
     'tester': [
-        "eth-tester[py-evm]==v0.6.0-beta.4",
+        # "eth-tester[py-evm]==v0.6.0-beta.4",
+        'eth-tester[py-evm]@git+ssh://git@github.com/kclowes/eth-tester@revert-deps#egg=some-pkg',
         "py-geth>=3.7.0,<4",
     ],
     'linter': [

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,7 @@ from setuptools import (
 
 extras_require = {
     'tester': [
-        # "eth-tester[py-evm]==v0.6.0-beta.4",
-        'eth-tester[py-evm]@git+ssh://git@github.com/kclowes/eth-tester@revert-deps#egg=some-pkg',
+        "eth-tester[py-evm]==v0.6.0-beta.6",
         "py-geth>=3.7.0,<4",
     ],
     'linter': [

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -415,20 +415,6 @@ class TestEthereumTesterEthModule(EthModuleTest):
         assert is_integer(chain_id)
         assert chain_id == 61
 
-    @pytest.mark.xfail(raises=KeyError, reason="ethereum tester doesn't return 'to' key")
-    def test_eth_get_transaction_receipt_mined(self, web3, block_with_txn, mined_txn_hash):
-        super().test_eth_get_transaction_receipt_mined(web3, block_with_txn, mined_txn_hash)
-
-    @pytest.mark.xfail(raises=KeyError, reason="ethereum tester doesn't return 'to' key")
-    def test_eth_getTransactionReceipt_mined_deprecated(self, web3, block_with_txn, mined_txn_hash):
-        super().test_eth_getTransactionReceipt_mined_deprecated(web3,
-                                                                block_with_txn,
-                                                                mined_txn_hash)
-
-    @pytest.mark.xfail(raises=KeyError, reason="ethereum tester doesn't return 'to' key")
-    def test_eth_wait_for_transaction_receipt_mined(self, web3, block_with_txn, mined_txn_hash):
-        super().test_eth_wait_for_transaction_receipt_mined(web3, block_with_txn, mined_txn_hash)
-
     @disable_auto_mine
     def test_eth_wait_for_transaction_receipt_unmined(self,
                                                       eth_tester,


### PR DESCRIPTION
### What was wrong?
There are a couple non-breaking features that we want to pull in from `py-evm` and `eth-tester`. I also jumped the gun on breaking dependency updates in py-evm 0.5.0a2 and eth-tester 0.6.0b5. Breaking dependency updates were fixed in 0.5.0a3 and eth-tester 0.6.0b6. I'll release a new version of py-evm and eth-tester with the correct semver soon.

Fixes #2295

### How was it fixed?
Bumped `eth-tester` and the `eth-account`. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/gettyimages-937042456-1580320856.jpg?crop=0.670xw:1.00xh;0.106xw,0&resize=480:*)
