### PR TITLE
Upgrade websockets dependency to v10+

### DIFF
--- a/newsfragments/2324.breaking-change.rst
+++ b/newsfragments/2324.breaking-change.rst
@@ -1,0 +1,1 @@
+Update ``websockets`` dependency to v10+

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         "requests>=2.16.0,<3.0.0",
         # remove typing_extensions after python_requires>=3.8, see web3._utils.compat
         "typing-extensions>=3.7.4.1,<5;python_version<'3.8'",
-        "websockets>=9.1,<10",
+        "websockets>=10.0.0,<11",
     ],
     python_requires='>=3.7,<3.10',
     extras_require=extras_require,

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -37,7 +37,9 @@ def start_websocket_server(open_port):
             data = await websocket.recv()
             await asyncio.sleep(0.02)
             await websocket.send(data)
-        server = websockets.serve(empty_server, '127.0.0.1', open_port, loop=event_loop)
+
+        asyncio.set_event_loop(event_loop)
+        server = websockets.serve(empty_server, '127.0.0.1', open_port)
         event_loop.run_until_complete(server)
         event_loop.run_forever()
 
@@ -54,7 +56,7 @@ def w3(open_port, start_websocket_server):
     # need new event loop as the one used by server is already running
     event_loop = asyncio.new_event_loop()
     endpoint_uri = 'ws://127.0.0.1:{}'.format(open_port)
-    event_loop.run_until_complete(wait_for_ws(endpoint_uri, event_loop))
+    event_loop.run_until_complete(wait_for_ws(endpoint_uri))
     provider = WebsocketProvider(endpoint_uri, websocket_timeout=0.01)
     return Web3(provider)
 

--- a/tests/integration/go_ethereum/test_goethereum_ws.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from tests.integration.common import (
@@ -63,8 +64,9 @@ def geth_command_arguments(geth_binary,
 
 
 @pytest.fixture(scope="module")
-def web3(geth_process, endpoint_uri, event_loop):
-    event_loop.run_until_complete(wait_for_ws(endpoint_uri, event_loop))
+def web3(geth_process, endpoint_uri):
+    event_loop = asyncio.new_event_loop()
+    event_loop.run_until_complete(wait_for_ws(endpoint_uri))
     _web3 = Web3(Web3.WebsocketProvider(endpoint_uri, websocket_timeout=30))
     return _web3
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,11 +13,11 @@ def get_open_port():
     return str(port)
 
 
-async def wait_for_ws(endpoint_uri, event_loop, timeout=60):
+async def wait_for_ws(endpoint_uri, timeout=10):
     start = time.time()
     while time.time() < start + timeout:
         try:
-            async with websockets.connect(uri=endpoint_uri, loop=event_loop):
+            async with websockets.connect(uri=endpoint_uri):
                 pass
         except (ConnectionRefusedError, OSError):
             await asyncio.sleep(0.01)

--- a/web3/providers/websocket.py
+++ b/web3/providers/websocket.py
@@ -60,17 +60,16 @@ def get_default_endpoint() -> URI:
 class PersistentWebSocket:
 
     def __init__(
-        self, endpoint_uri: URI, loop: asyncio.AbstractEventLoop, websocket_kwargs: Any
+        self, endpoint_uri: URI, websocket_kwargs: Any
     ) -> None:
         self.ws: WebSocketClientProtocol = None
         self.endpoint_uri = endpoint_uri
-        self.loop = loop
         self.websocket_kwargs = websocket_kwargs
 
     async def __aenter__(self) -> WebSocketClientProtocol:
         if self.ws is None:
             self.ws = await connect(
-                uri=self.endpoint_uri, loop=self.loop, **self.websocket_kwargs
+                uri=self.endpoint_uri, **self.websocket_kwargs
             )
         return self.ws
 
@@ -113,7 +112,7 @@ class WebsocketProvider(JSONBaseProvider):
                     'found: {1}'.format(RESTRICTED_WEBSOCKET_KWARGS, found_restricted_keys)
                 )
         self.conn = PersistentWebSocket(
-            self.endpoint_uri, WebsocketProvider._loop, websocket_kwargs
+            self.endpoint_uri, websocket_kwargs
         )
         super().__init__()
 


### PR DESCRIPTION
### What was wrong?

websockets has a v10 out and users are running into dependency issues because third party projects require v10+.

Fixes #2272, #2178

### How was it fixed?

Pinned the websockets dependency to v10+ now that we've dropped python 3.6. This included dropping the loop parameter as well. The fix was to make a new loop, and then set it before it's used. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.guim.co.uk/img/media/43352be36da0eb156e8551d775a57fadba8ae6d7/0_0_1440_864/master/1440.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=1829611852af3ffc6460b4068e20bcbc)
