### PR TITLE
correct misspellings and update referenced geth version

### DIFF
--- a/docs/web3.geth.rst
+++ b/docs/web3.geth.rst
@@ -309,7 +309,7 @@ The following methods are available on the ``web3.geth.personal`` namespace.
 
     Unlocks the given ``account`` for ``duration`` seconds.
     If ``duration`` is ``None``, then the account will remain unlocked
-    for 300 seconds (which is current default by Geth v1.9.5);
+    for 300 seconds (which is current default by Geth v1.10.15);
     if ``duration`` is set to ``0``, the account will remain unlocked indefinitely.
     Returns boolean as to whether the account was successfully unlocked.
 
@@ -356,7 +356,7 @@ The following methods are available on the ``web3.geth.txpool`` namespace.
     * Delegates to ``txpool_inspect`` RPC Method
 
     Returns a textual summary of all transactions currently pending for
-    inclusing in the next block(s) as will as ones that are scheduled for
+    inclusion in the next block(s) as well as ones that are scheduled for
     future execution.
 
     .. code-block:: python
@@ -418,7 +418,7 @@ The following methods are available on the ``web3.geth.txpool`` namespace.
     * Delegates to ``txpool_status`` RPC Method
 
     Returns a textual summary of all transactions currently pending for
-    inclusing in the next block(s) as will as ones that are scheduled for
+    inclusion in the next block(s) as well as ones that are scheduled for
     future execution.
 
     .. code-block:: python

--- a/newsfragments/2326.doc.rst
+++ b/newsfragments/2326.doc.rst
@@ -1,0 +1,1 @@
+fix typos and update referenced `geth` version


### PR DESCRIPTION
### What was wrong?

Found misspellings in the `web3.geth` docs, fixed 'em, and updated current geth version while in there.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/5199899/151610649-1752bee2-466d-4714-aa08-a36de45b2397.png)
