### PR TITLE
Fix gas types

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -78,7 +78,7 @@ Buffered Gas Estimate
     This adds a gas estimate to transactions if ``gas`` is not present in the transaction
     parameters. Sets gas to:
     ``min(w3.eth.estimate_gas + gas_buffer, gas_limit)``
-    where the gas_buffer default is 100,000 Wei
+    where the gas_buffer default is 100,000
 
 HTTPRequestRetry
 ~~~~~~~~~~~~~~~~~~

--- a/newsfragments/2330.bugfix.rst
+++ b/newsfragments/2330.bugfix.rst
@@ -1,0 +1,2 @@
+- Fix types for ``gas``, and ``gasLimit`` (``Wei`` to ``int``)
+- Fix types for ``effectiveGasPrice``, (``int`` to ``Wei``)

--- a/web3/_utils/async_transactions.py
+++ b/web3/_utils/async_transactions.py
@@ -7,7 +7,6 @@ from typing import (
 from web3.types import (
     BlockIdentifier,
     TxParams,
-    Wei,
 )
 
 if TYPE_CHECKING:

--- a/web3/_utils/async_transactions.py
+++ b/web3/_utils/async_transactions.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 async def get_block_gas_limit(
     web3_eth: "AsyncEth", block_identifier: Optional[BlockIdentifier] = None
-) -> Wei:
+) -> int:
     if block_identifier is None:
         block_identifier = await web3_eth.block_number
     block = await web3_eth.get_block(block_identifier)
@@ -25,8 +25,8 @@ async def get_block_gas_limit(
 
 
 async def get_buffered_gas_estimate(
-    web3: "Web3", transaction: TxParams, gas_buffer: Wei = Wei(100000)
-) -> Wei:
+    web3: "Web3", transaction: TxParams, gas_buffer: int = 100000
+) -> int:
     gas_estimate_transaction = cast(TxParams, dict(**transaction))
 
     gas_estimate = await web3.eth.estimate_gas(gas_estimate_transaction)  # type: ignore
@@ -40,4 +40,4 @@ async def get_buffered_gas_estimate(
             "limit: {1}".format(gas_estimate, gas_limit)
         )
 
-    return Wei(min(gas_limit, gas_estimate + gas_buffer))
+    return min(gas_limit, gas_estimate + gas_buffer)

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -123,7 +123,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': await async_w3.eth.gas_price,  # type: ignore
         }
         txn_hash = await async_w3.eth.send_transaction(txn_params)  # type: ignore
@@ -143,7 +143,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': async_w3.toWei(3, 'gwei'),
             'maxPriorityFeePerGas': async_w3.toWei(1, 'gwei'),
         }
@@ -166,7 +166,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
         }
         txn_hash = await async_w3.eth.send_transaction(txn_params)  # type: ignore
         txn = await async_w3.eth.get_transaction(txn_hash)  # type: ignore
@@ -187,7 +187,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': hex(250 * 10**9),
             'maxPriorityFeePerGas': hex(2 * 10**9),
         }
@@ -228,7 +228,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': Wei(1),
             'maxFeePerGas': Wei(250 * 10**9),
             'maxPriorityFeePerGas': Wei(2 * 10**9),
@@ -244,7 +244,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': Wei(250 * 10**9),
         }
         with pytest.raises(InvalidTransaction, match='maxPriorityFeePerGas must be defined'):
@@ -259,7 +259,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxPriorityFeePerGas': maxPriorityFeePerGas,
         }
         txn_hash = await async_w3.eth.send_transaction(txn_params)  # type: ignore
@@ -281,7 +281,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': Wei(1 * 10**9),
             'maxPriorityFeePerGas': Wei(2 * 10**9),
         }
@@ -310,7 +310,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
         }
         two_gwei_in_wei = async_w3.toWei(2, 'gwei')
 
@@ -339,7 +339,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxPriorityFeePerGas': max_priority_fee,
         }
         if max_fee is not None:
@@ -368,7 +368,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': Wei(1000000000),
         }
 
@@ -778,7 +778,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': async_w3.toWei(3, 'gwei'),
             'maxPriorityFeePerGas': async_w3.toWei(1, 'gwei')
         })
@@ -839,7 +839,7 @@ class AsyncEthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': async_w3.toWei(3, 'gwei'),
             'maxPriorityFeePerGas': async_w3.toWei(1, 'gwei')
         })
@@ -1633,7 +1633,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': web3.eth.gas_price,
             'nonce': Nonce(0),
         }
@@ -1655,7 +1655,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': web3.toWei(2, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
             'nonce': Nonce(0),
@@ -1679,7 +1679,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': hex(web3.toWei(2, 'gwei')),
             'maxPriorityFeePerGas': hex(web3.toWei(1, 'gwei')),
             'nonce': Nonce(0),
@@ -1703,7 +1703,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': web3.eth.gas_price,
             'nonce': Nonce(0),
         }
@@ -1726,7 +1726,7 @@ class EthModuleTest:
                 'from': 'unlocked-account.eth',
                 'to': 'unlocked-account.eth',
                 'value': Wei(1),
-                'gas': Wei(21000),
+                'gas': 21000,
                 'maxFeePerGas': web3.toWei(2, 'gwei'),
                 'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
                 'nonce': Nonce(0),
@@ -1749,7 +1749,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': web3.toWei(2, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
         }
@@ -1769,7 +1769,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': web3.toWei(1, 'gwei'),  # post-london needs to be more than the base fee
         }
         txn_hash = web3.eth.send_transaction(txn_params)
@@ -1788,7 +1788,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': web3.toWei(3, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
         }
@@ -1810,7 +1810,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': web3.toWei(3, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
         }
@@ -1836,7 +1836,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             # unique maxFeePerGas to ensure transaction hash different from other tests
             'maxFeePerGas': web3.toWei(4.321, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
@@ -1861,7 +1861,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
         }
         txn_hash = web3.eth.send_transaction(txn_params)
         txn = web3.eth.get_transaction(txn_hash)
@@ -1881,7 +1881,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': hex(250 * 10**9),
             'maxPriorityFeePerGas': hex(2 * 10**9),
         }
@@ -1920,7 +1920,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': Wei(1),
             'maxFeePerGas': Wei(250 * 10**9),
             'maxPriorityFeePerGas': Wei(2 * 10**9),
@@ -1935,7 +1935,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': Wei(250 * 10**9),
         }
         with pytest.raises(InvalidTransaction, match='maxPriorityFeePerGas must be defined'):
@@ -1949,7 +1949,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxPriorityFeePerGas': maxPriorityFeePerGas,
         }
         txn_hash = web3.eth.send_transaction(txn_params)
@@ -1970,7 +1970,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': Wei(1 * 10**9),
             'maxPriorityFeePerGas': Wei(2 * 10**9),
         }
@@ -1992,7 +1992,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxPriorityFeePerGas': max_priority_fee,
         }
         if max_fee is not None:
@@ -2020,7 +2020,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': Wei(1000000000),
         }
 
@@ -2040,7 +2040,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': web3.toWei(1, 'gwei'),  # must be greater than base_fee post London
         }
         txn_hash = web3.eth.send_transaction(txn_params)
@@ -2065,7 +2065,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': two_gwei_in_wei,
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
         }
@@ -2091,7 +2091,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': web3.toWei(3, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(2, 'gwei'),
         }
@@ -2114,7 +2114,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': two_gwei_in_wei,
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
         }
@@ -2143,7 +2143,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': web3.toWei(3, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
         }
@@ -2160,7 +2160,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': web3.toWei(2, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
         }
@@ -2183,7 +2183,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': web3.toWei(2, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
         }
@@ -2203,7 +2203,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': web3.toWei(2, 'gwei'),
         }
         txn_hash = web3.eth.send_transaction(txn_params)
@@ -2221,7 +2221,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': gas_price,
         }
         txn_hash = web3.eth.send_transaction(txn_params)
@@ -2239,7 +2239,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': web3.toWei(1, 'gwei'),
         }
         txn_hash = web3.eth.send_transaction(txn_params)
@@ -2266,7 +2266,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': gas_price,
         }
         txn_hash = web3.eth.send_transaction(txn_params)
@@ -2290,7 +2290,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': web3.toWei(1, 'gwei'),  # must be greater than base_fee post London
         }
         txn_hash = web3.eth.send_transaction(txn_params)
@@ -2313,7 +2313,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei'),
             'maxFeePerGas': web3.toWei(2, 'gwei'),
         }
@@ -2342,7 +2342,7 @@ class EthModuleTest:
             'from': unlocked_account,
             'to': unlocked_account,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'gasPrice': web3.toWei(1, 'gwei'),
         }
         txn_hash = web3.eth.send_transaction(txn_params)
@@ -2701,7 +2701,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': web3.toWei(3, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei')
         })
@@ -2759,7 +2759,7 @@ class EthModuleTest:
             'from': unlocked_account_dual_type,
             'to': unlocked_account_dual_type,
             'value': Wei(1),
-            'gas': Wei(21000),
+            'gas': 21000,
             'maxFeePerGas': web3.toWei(3, 'gwei'),
             'maxPriorityFeePerGas': web3.toWei(1, 'gwei')
         })

--- a/web3/_utils/module_testing/go_ethereum_personal_module.py
+++ b/web3/_utils/module_testing/go_ethereum_personal_module.py
@@ -154,7 +154,7 @@ class GoEthereumPersonalModuleTest:
         txn_params: TxParams = {
             'from': unlockable_account_dual_type,
             'to': unlockable_account_dual_type,
-            'gas': Wei(21000),
+            'gas': 21000,
             'value': Wei(1),
             'gasPrice': web3.toWei(1, 'gwei'),
         }
@@ -178,7 +178,7 @@ class GoEthereumPersonalModuleTest:
         txn_params: TxParams = {
             'from': unlockable_account_dual_type,
             'to': unlockable_account_dual_type,
-            'gas': Wei(21000),
+            'gas': 21000,
             'value': Wei(1),
             'gasPrice': web3.toWei(1, 'gwei'),
         }

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -32,7 +32,6 @@ from web3.types import (
     BlockIdentifier,
     TxData,
     TxParams,
-    Wei,
     _Hash32,
 )
 

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -119,7 +119,7 @@ def fill_transaction_defaults(web3: "Web3", transaction: TxParams) -> TxParams:
     return merge(defaults, transaction)
 
 
-def get_block_gas_limit(web3: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> Wei:
+def get_block_gas_limit(web3: "Web3", block_identifier: Optional[BlockIdentifier] = None) -> int:
     if block_identifier is None:
         block_identifier = web3.eth.block_number
     block = web3.eth.get_block(block_identifier)
@@ -127,8 +127,8 @@ def get_block_gas_limit(web3: "Web3", block_identifier: Optional[BlockIdentifier
 
 
 def get_buffered_gas_estimate(
-    web3: "Web3", transaction: TxParams, gas_buffer: Wei = Wei(100000)
-) -> Wei:
+    web3: "Web3", transaction: TxParams, gas_buffer: int = 100000
+) -> int:
     gas_estimate_transaction = cast(TxParams, dict(**transaction))
 
     gas_estimate = web3.eth.estimate_gas(gas_estimate_transaction)
@@ -142,7 +142,7 @@ def get_buffered_gas_estimate(
             "limit: {1}".format(gas_estimate, gas_limit)
         )
 
-    return Wei(min(gas_limit, gas_estimate + gas_buffer))
+    return min(gas_limit, gas_estimate + gas_buffer)
 
 
 def get_required_transaction(web3: "Web3", transaction_hash: _Hash32) -> TxData:

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -231,7 +231,7 @@ class BaseEth(Module):
 
         return params
 
-    _estimate_gas: Method[Callable[..., Wei]] = Method(
+    _estimate_gas: Method[Callable[..., int]] = Method(
         RPC.eth_estimateGas,
         mungers=[estimate_gas_munger]
     )
@@ -417,7 +417,7 @@ class AsyncEth(BaseEth):
         self,
         transaction: TxParams,
         block_identifier: Optional[BlockIdentifier] = None
-    ) -> Wei:
+    ) -> int:
         # types ignored b/c mypy conflict with BlockingEth properties
         return await self._estimate_gas(transaction, block_identifier)  # type: ignore
 
@@ -847,7 +847,7 @@ class Eth(BaseEth):
         self,
         transaction: TxParams,
         block_identifier: Optional[BlockIdentifier] = None
-    ) -> Wei:
+    ) -> int:
         return self._estimate_gas(transaction, block_identifier)
 
     def fee_history(

--- a/web3/types.py
+++ b/web3/types.py
@@ -235,7 +235,7 @@ TxReceipt = TypedDict("TxReceipt", {
     "blockNumber": BlockNumber,
     "contractAddress": Optional[ChecksumAddress],
     "cumulativeGasUsed": int,
-    "effectiveGasPrice": int,
+    "effectiveGasPrice": Wei,
     "gasUsed": Wei,
     "from": ChecksumAddress,
     "logs": List[LogReceipt],

--- a/web3/types.py
+++ b/web3/types.py
@@ -181,7 +181,7 @@ TxData = TypedDict("TxData", {
     "chainId": int,
     "data": Union[bytes, HexStr],
     "from": ChecksumAddress,
-    "gas": Wei,
+    "gas": int,
     "gasPrice": Wei,
     "maxFeePerGas": Wei,
     "maxPriorityFeePerGas": Wei,
@@ -204,7 +204,7 @@ TxParams = TypedDict("TxParams", {
     "data": Union[bytes, HexStr],
     # addr or ens
     "from": Union[Address, ChecksumAddress, str],
-    "gas": Wei,
+    "gas": int,
     # legacy pricing
     "gasPrice": Wei,
     # dynamic fee pricing
@@ -236,7 +236,7 @@ TxReceipt = TypedDict("TxReceipt", {
     "contractAddress": Optional[ChecksumAddress],
     "cumulativeGasUsed": int,
     "effectiveGasPrice": Wei,
-    "gasUsed": Wei,
+    "gasUsed": int,
     "from": ChecksumAddress,
     "logs": List[LogReceipt],
     "logsBloom": HexBytes,
@@ -306,8 +306,8 @@ class BlockData(TypedDict, total=False):
     baseFeePerGas: Wei
     difficulty: int
     extraData: HexBytes
-    gasLimit: Wei
-    gasUsed: Wei
+    gasLimit: int
+    gasUsed: int
     hash: HexBytes
     logsBloom: HexBytes
     miner: ChecksumAddress


### PR DESCRIPTION
### What was wrong?

Fix Issue #2285

### How was it fixed?

- Changed type of `gas` from `Wei` to `int` where it appeared
- Changed type of `gasLimit` and `gas_limit` from `Wei` to `int` where they appeared
- Changed type of `effectiveGasPrice` from `int` to `Wei` where it appeared
- I used various regex to find other occurrences, please let me know if I missed any.
- I ran the tests in Docker, and got the exact same result before and after my commits: *31 failed, 2566 passed, 66 skipped, 71 xfailed, 30 warnings, 864 error*. Log attached. [Logs here](https://github.com/ethereum/web3.py/files/7988538/test-results.txt).
- I ran `mypy -p web3 -p ethpm -p ens --config-file ./mypy.ini` and got zero errors.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.abc.net.au/news/image/8188816-3x2-940x627.jpg)
