### PR TITLE
asyncify eth.syncing

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -415,6 +415,7 @@ Eth
 - :meth:`web3.eth.hashrate <web3.eth.Eth.hashrate>`
 - :meth:`web3.eth.max_priority_fee <web3.eth.Eth.max_priority_fee>`
 - :meth:`web3.eth.mining <web3.eth.Eth.mining>`
+- :meth:`web3.eth.syncing <web3.eth.Eth.syncing>`
 - :meth:`web3.eth.call() <web3.eth.Eth.call>`
 - :meth:`web3.eth.estimate_gas() <web3.eth.Eth.estimate_gas>`
 - :meth:`web3.eth.generate_gas_price() <web3.eth.Eth.generate_gas_price>`

--- a/newsfragments/2331.feature.rst
+++ b/newsfragments/2331.feature.rst
@@ -1,0 +1,1 @@
+Add async `eth.syncing` method

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1025,6 +1025,24 @@ class AsyncEthModuleTest:
         result = await async_w3.eth.get_logs(filter_params)  # type: ignore
         assert len(result) == 0
 
+    @pytest.mark.asyncio
+    async def test_async_eth_syncing(self, async_w3: "Web3") -> None:
+        syncing = await async_w3.eth.syncing  # type: ignore
+
+        assert is_boolean(syncing) or is_dict(syncing)
+
+        if is_boolean(syncing):
+            assert syncing is False
+        elif is_dict(syncing):
+            sync_dict = cast(SyncStatus, syncing)
+            assert 'startingBlock' in sync_dict
+            assert 'currentBlock' in sync_dict
+            assert 'highestBlock' in sync_dict
+
+            assert is_integer(sync_dict['startingBlock'])
+            assert is_integer(sync_dict['currentBlock'])
+            assert is_integer(sync_dict['highestBlock'])
+
     def test_async_provider_default_account(
         self,
         async_w3: "Web3",

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -322,6 +322,11 @@ class BaseEth(Module):
         mungers=None,
     )
 
+    _is_syncing: Method[Callable[[], Union[SyncStatus, bool]]] = Method(
+        RPC.eth_syncing,
+        mungers=None,
+    )
+
     _get_transaction_receipt: Method[Callable[[_Hash32], TxReceipt]] = Method(
         RPC.eth_getTransactionReceipt,
         mungers=[default_root_munger]
@@ -376,6 +381,10 @@ class AsyncEth(BaseEth):
     @property
     async def mining(self) -> bool:
         return await self._is_mining()  # type: ignore
+
+    @property
+    async def syncing(self) -> Union[SyncStatus, bool]:
+        return await self._is_syncing()  # type: ignore
 
     async def fee_history(
             self,
@@ -551,14 +560,9 @@ class Eth(BaseEth):
         )
         return self.protocol_version
 
-    is_syncing: Method[Callable[[], Union[SyncStatus, bool]]] = Method(
-        RPC.eth_syncing,
-        mungers=None,
-    )
-
     @property
     def syncing(self) -> Union[SyncStatus, bool]:
-        return self.is_syncing()
+        return self._is_syncing()
 
     @property
     def coinbase(self) -> ChecksumAddress:


### PR DESCRIPTION
Related to Issue #1413

### How was it fixed?

Added async `eth.syncing` method

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/5199899/152233898-942305d2-272f-4c33-b24f-2d4c2890ed48.png)
