### PR TITLE
Add gzip support for HTTP responses

### DIFF
--- a/web3/providers/async_rpc.py
+++ b/web3/providers/async_rpc.py
@@ -63,6 +63,7 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
     def get_request_headers(self) -> Dict[str, str]:
         return {
             'Content-Type': 'application/json',
+            'Accept-Encoding': 'gzip, deflate',
             'User-Agent': construct_user_agent(str(type(self))),
         }
 

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -78,6 +78,7 @@ class HTTPProvider(JSONBaseProvider):
     def get_request_headers(self) -> Dict[str, str]:
         return {
             'Content-Type': 'application/json',
+            'Accept-Encoding': 'gzip, deflate',
             'User-Agent': construct_user_agent(str(type(self))),
         }
 


### PR DESCRIPTION
### What was wrong?
Client doesn't advertise support for gzip compression in requests

Related to Issue #
#2332 - Partial Support (sending gzip compressed requests is more complex than I can address)

### How was it fixed?
Adding `"Accept-Encoding: gzip, deflate"` to the headers tells the server that the client can support gzip compression - the server is free to ignore this, or respond with gzip compressed data. Since `requests` supports this and deals with this automatically - we can benefit from significantly reduced bandwidth when the server supports this.

Some debugs can be GBs in size, but compress exceptionally well, down to MBs, bandwidth becomes a bottleneck there. I'm fairly confident that this change is non-breaking.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://memegenerator.net/img/instances/38594878/i-used-gzip-once-it-was-awful.jpg)
