### PR TITLE
contract.call() block_identifier default change

### DIFF
--- a/web3/contract.py
+++ b/web3/contract.py
@@ -899,7 +899,7 @@ class ContractFunction:
 
     def call(
         self, transaction: Optional[TxParams] = None,
-        block_identifier: BlockIdentifier = 'latest',
+        block_identifier: BlockIdentifier = None,
         state_override: Optional[CallOverrideParams] = None,
     ) -> Any:
         """
@@ -1542,6 +1542,8 @@ def call_contract_function(
 
 
 def parse_block_identifier(web3: 'Web3', block_identifier: BlockIdentifier) -> BlockIdentifier:
+    if block_identifier is None:
+        return web3.eth.default_block
     if isinstance(block_identifier, int):
         return parse_block_identifier_int(web3, block_identifier)
     elif block_identifier in ['latest', 'earliest', 'pending']:


### PR DESCRIPTION
Changed default block_identifier in contract.call() to None.
Changed parse_block_identifier to use web3.eth.defaultBlock if None is passed in

### What was wrong?

https://github.com/ethereum/web3.py/issues/2334

### How was it fixed?

changed block_identifier default to None in contract.call
changed parse_block_identifier to parse None to web3.eth.default_block

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://stylecaster.com/wp-content/uploads/2017/01/arthur.jpg)
