### PR TITLE
Add 'Breaking Changes' and 'Deprecation' to our valid newsfragment types

### DIFF
--- a/newsfragments/2340.feature.rst
+++ b/newsfragments/2340.feature.rst
@@ -1,0 +1,1 @@
+Added 'Breaking Changes' and 'Deprecations' categories to our release notes

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -12,6 +12,8 @@ ALLOWED_EXTENSIONS = {
     '.feature.rst',
     '.misc.rst',
     '.removal.rst',
+    '.breaking-change.rst',
+    '.deprecation.rst',
 }
 
 ALLOWED_FILES = {

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -11,7 +11,6 @@ ALLOWED_EXTENSIONS = {
     '.doc.rst',
     '.feature.rst',
     '.misc.rst',
-    '.removal.rst',
     '.breaking-change.rst',
     '.deprecation.rst',
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,13 @@
     underlines = ["-", "~", "^"]
     issue_format = "`#{issue} <https://github.com/ethereum/web3.py/issues/{issue}>`__"
     title_format = "v{version} ({project_date})"
+
+[[tool.towncrier.type]]
+directory = "breaking-change"
+name="Breaking Changes"
+showcontent=true
+
+[[tool.towncrier.type]]
+directory = "deprecation"
+name = "Deprecations"
+showcontent = true


### PR DESCRIPTION
### What was wrong?
Release notes didn't have a breaking changes category. Also added a Deprecation section


### How was it fixed?
Added them! Could take or leave the Deprecation section if anyone feels strongly. There's already a removal category, which is sort of the same thing. Could also remove `removal` since that would count in the wider Breaking Changes category. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/0WQFqtft9RE/hqdefault.jpg)
