### PR TITLE
fix: add missing type

### DIFF
--- a/newsfragments/2348.misc.rst
+++ b/newsfragments/2348.misc.rst
@@ -1,0 +1,1 @@
+Add `AsyncEth` as valid type for the `eth` module.

--- a/web3/main.py
+++ b/web3/main.py
@@ -72,7 +72,8 @@ from web3._utils.normalizers import (
     abi_ens_resolver,
 )
 from web3.eth import (
-    Eth,
+    Eth, 
+    AsyncEth,
 )
 from web3.geth import (
     Geth,
@@ -226,7 +227,7 @@ class Web3:
         return to_checksum_address(value)
 
     # mypy Types
-    eth: Eth
+    eth: Union[Eth, AsyncEth]
     parity: Parity
     geth: Geth
     net: Net

--- a/web3/main.py
+++ b/web3/main.py
@@ -72,7 +72,7 @@ from web3._utils.normalizers import (
     abi_ens_resolver,
 )
 from web3.eth import (
-    Eth, 
+    Eth,
     AsyncEth,
 )
 from web3.geth import (


### PR DESCRIPTION
### What was wrong?
I encountered a typing warning when initializing the `eth` module with an `AsyncEth` instance.

### How was it fixed?
Adding an additional type to the `eth` definition of a Web3 instance. Alternatively, one could also create `async_eth: AsyncEth`, but I think this breaks existing code where `web3.eth.xxx` is used.

Another alternative would be to use `BaseEth`. Please let me know if you prefer this approach.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
(https://www.pinterest.com/pin/443252788328237881/)
