### PR TITLE
:cherries: Cherry pick changes from `Harmouch101:rm-utf-8-enc` onto `Harmouch101:pick-v5` then PR into `web3:v5`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Web3.py documentation build configuration file, created by
 # sphinx-quickstart on Thu Oct 16 20:43:24 2014.

--- a/newsfragments/2353.misc.rst
+++ b/newsfragments/2353.misc.rst
@@ -1,0 +1,1 @@
+Clean up unnecessary UTF-8 encoding declarations.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from setuptools import (
     find_packages,
     setup,

--- a/tests/core/contracts/test_contract_buildTransaction.py
+++ b/tests/core/contracts/test_contract_buildTransaction.py
@@ -8,8 +8,6 @@ from web3.exceptions import (
     ValidationError,
 )
 
-# -*- coding: utf-8 -*-
-
 
 @pytest.fixture()
 def math_contract(web3, MathContract, address_conversion_func):

--- a/tests/core/contracts/test_contract_transact_interface.py
+++ b/tests/core/contracts/test_contract_transact_interface.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 
 from eth_utils import (

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import json
 import math
 import pytest


### PR DESCRIPTION
### What was wrong?

Related to Issue PR #2353 

### How was it fixed?

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

:dog:
