### PR TITLE
Update Sphinx

### DIFF
--- a/newsfragments/2362.breaking-change.rst
+++ b/newsfragments/2362.breaking-change.rst
@@ -1,0 +1,1 @@
+Update Sphinx requirement to ``>=4.2.0,<5``

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras_require = {
         "py-geth>=3.6.0,<4",
         "py-solc>=0.4.0",
         "pytest>=6.2.5,<7",
-        "sphinx>=3.0,<4",
+        "sphinx>=4.2.0,<5",
         "sphinx_rtd_theme>=0.1.9",
         "toposort>=1.4",
         "towncrier==18.5.0",


### PR DESCRIPTION
### What was wrong?
Sphinx <4.2 doesn't support Python 3.10.

### How was it fixed?
Bumped Sphinx version requirement to `>=4.2,<5`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.boredpanda.com/blog/wp-content/uploads/2015/07/baby-pandas-day-care-fb.jpg)
