### PR TITLE
Add all types of towncrier documents to pyproject.toml

### DIFF
--- a/newsfragments/2330.bugfix.rst
+++ b/newsfragments/2330.bugfix.rst
@@ -1,2 +1,1 @@
-- Fix types for ``gas``, and ``gasLimit`` (``Wei`` to ``int``)
-- Fix types for ``effectiveGasPrice``, (``int`` to ``Wei``)
+Fix types for ``gas``, and ``gasLimit``: ``Wei -> int``. Also fix types for ``effectiveGasPrice``: (``int -> Wei``)

--- a/newsfragments/2350.feature.rst
+++ b/newsfragments/2350.feature.rst
@@ -1,1 +1,1 @@
-+ Add async `eth.get_storage_at` method
+Add async `eth.get_storage_at` method

--- a/newsfragments/2365.misc.rst
+++ b/newsfragments/2365.misc.rst
@@ -1,0 +1,1 @@
+Towncrier stopped printing original types of newsfragments when the ``breaking-change`` and ``deprecation`` were added. Added them back.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,4 @@ showcontent=true
 [[tool.towncrier.type]]
 directory = "misc"
 name="Misc"
-showcontent=true
+showcontent=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,23 @@ showcontent=true
 directory = "deprecation"
 name = "Deprecations"
 showcontent = true
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name="Bugfixes"
+showcontent=true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name="Documentation Updates"
+showcontent=true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name="Features"
+showcontent=true
+
+[[tool.towncrier.type]]
+directory = "misc"
+name="Misc"
+showcontent=true


### PR DESCRIPTION
### What was wrong?
When I added the new `deprecation` and `breaking-change` towncrier types to `pyproject.toml`, it stopped showing the original types. 

### How was it fixed?
Added all types to `pyproject.toml`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/155802659-2cefb5d8-e315-4565-bc9b-855580a12ed8.png)

