### PR TITLE
Fix test for the web3_api

### DIFF
--- a/tests/core/web3-module/test_api.py
+++ b/tests/core/web3-module/test_api.py
@@ -1,2 +1,2 @@
 def test_web3_api(web3):
-    assert web3.api.startswith("5")
+    assert web3.api.startswith("6")


### PR DESCRIPTION
### What was wrong?
When I bumped web3 to version 6, our web3_api test started failing on master. 


### How was it fixed?
Updated the test. It would be nice to figure out a way to catch this before the new version is released, but deprioritizing for now.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images2.minutemediacdn.com/image/upload/c_crop,h_998,w_1500,x_0,y_3/v1555172614/shape/mentalfloss/iStock-177369626_1.jpg)
