### PR TITLE
bump docker base image & rm parity env var!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM python:3.6
+FROM python:3.9
 
 # Set up code directory
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Install Linux dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   sandbox:
     build:
       context: .
-    environment:
-      PARITY_VERSION: v2.5.13
     volumes:
       - .:/code
     command: tail -f /dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
     environment:
-      PARITY_VERSION: v2.3.5
+      PARITY_VERSION: v2.5.13
     volumes:
       - .:/code
     command: tail -f /dev/null

--- a/newsfragments/2369.misc.rst
+++ b/newsfragments/2369.misc.rst
@@ -1,1 +1,1 @@
-bump docker base image to ``3.9`` and parity version to ``2.5.13``.
+bump docker base image to ``3.9`` and remove parity tests from docker.

--- a/newsfragments/2369.misc.rst
+++ b/newsfragments/2369.misc.rst
@@ -1,0 +1,1 @@
+bump docker base image to ``3.9`` and parity version to ``2.5.13``.


### PR DESCRIPTION
### What was wrong?

Related to PR #1753 & #2343

### How was it fixed?

As python 3.6 was dropped, it would make sense to bump the base image of the docker container. The same would apply to the parity version.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

:dog: 
