### PR TITLE
Add async chain_id setter

### DIFF
--- a/newsfragments/2376.bugfix.rst
+++ b/newsfragments/2376.bugfix.rst
@@ -1,0 +1,1 @@
+Add async default_chain_id and chain_id setter

--- a/tests/core/eth-module/test_eth_properties.py
+++ b/tests/core/eth-module/test_eth_properties.py
@@ -1,5 +1,23 @@
 import pytest
 
+from web3 import Web3
+from web3.eth import (
+    AsyncEth,
+)
+from web3.providers.eth_tester.main import (
+    AsyncEthereumTesterProvider,
+)
+
+
+@pytest.fixture
+def async_w3():
+    return Web3(
+        AsyncEthereumTesterProvider(),
+        middlewares=[],
+        modules={
+            'eth': (AsyncEth,),
+        })
+
 
 def test_eth_protocol_version(w3):
     with pytest.warns(DeprecationWarning):
@@ -28,3 +46,14 @@ def test_set_chain_id(w3):
 
     w3.eth.chain_id = None
     assert w3.eth.chain_id == 61
+
+
+@pytest.mark.asyncio
+async def test_async_set_chain_id(async_w3):
+    assert await async_w3.eth.chain_id == 61
+
+    async_w3.eth.chain_id = 72
+    assert await async_w3.eth.chain_id == 72
+
+    async_w3.eth.chain_id = None
+    assert await async_w3.eth.chain_id == 61

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -358,7 +358,14 @@ class AsyncEth(BaseEth):
 
     @property
     async def chain_id(self) -> int:
-        return await self._chain_id()  # type: ignore
+        if self._default_chain_id is None:
+            return await self._chain_id()  # type: ignore
+        else:
+            return self._default_chain_id
+
+    @chain_id.setter
+    def chain_id(self, value: int) -> None:
+        self._default_chain_id = value
 
     @property
     async def coinbase(self) -> ChecksumAddress:


### PR DESCRIPTION
### What was wrong?
The new chain_id flow wasn't available on async eth.

Related to Issue #2207 

### How was it fixed?
Added it!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/d6/da/34/d6da340463fb90b992dbb9672edcaaf5.jpg)
