### PR TITLE
Better support for custom methods for modules

### DIFF
--- a/newsfragments/2383.breaking-change.rst
+++ b/newsfragments/2383.breaking-change.rst
@@ -1,0 +1,1 @@
+Add ``attach_methods()`` to ``Module`` class to facilitate attaching methods to modules.

--- a/tests/core/module-class/test_module.py
+++ b/tests/core/module-class/test_module.py
@@ -1,0 +1,75 @@
+import pytest
+
+from web3 import (
+    EthereumTesterProvider,
+    Web3,
+)
+from web3.method import (
+    Method,
+)
+
+
+@pytest.fixture
+def web3_with_external_modules(module1, module2, module3):
+    return Web3(
+        EthereumTesterProvider(),
+        external_modules={
+            'module1': module1,
+            'module2': (module2, {
+                'submodule1': module3,
+            }),
+        }
+    )
+
+
+def test_attach_methods_to_module(web3_with_external_modules):
+    w3 = web3_with_external_modules
+
+    w3.module1.attach_methods({
+        # set `property1` on `module1` with `eth_chainId` RPC endpoint
+        'property1': Method('eth_chainId', is_property=True),
+        # set `method1` on `module1` with `eth_getBalance` RPC endpoint
+        'method1': Method('eth_getBalance'),
+    })
+
+    assert w3.eth.chain_id == 61
+    assert w3.module1.property1 == 61
+
+    coinbase = w3.eth.coinbase
+    assert w3.eth.get_balance(coinbase, 'latest') == 1000000000000000000000000
+    assert w3.module1.method1(coinbase, 'latest') == 1000000000000000000000000
+
+    w3.module2.submodule1.attach_methods({
+        # set `method2` on `module2.submodule1` with `eth_blockNumber` RPC endpoint
+        'method2': Method('eth_blockNumber', is_property=True)
+    })
+
+    assert w3.eth.block_number == 0
+    assert w3.module2.submodule1.method2 == 0
+
+    w3.eth.attach_methods({'get_block2': Method('eth_getBlockByNumber')})
+
+    assert w3.eth.get_block('latest')['number'] == 0
+    assert w3.eth.get_block('pending')['number'] == 1
+
+    assert w3.eth.get_block2('latest')['number'] == 0
+    assert w3.eth.get_block2('pending')['number'] == 1
+
+
+def test_attach_methods_with_mungers(web3_with_external_modules):
+    w3 = web3_with_external_modules
+
+    w3.module1.attach_methods({
+        'method1': Method('eth_getBlockByNumber', mungers=[
+            lambda _method, block_id, f, _z: (block_id, f),
+            lambda _m, block_id, _f: (block_id - 1,),
+        ]),
+    })
+
+    assert w3.eth.get_block(0)['baseFeePerGas'] == 1000000000
+    assert w3.eth.get_block(1)['baseFeePerGas'] == 875000000
+
+    # `method1` should take a higher block number than `eth_getBlockByNumber` due to mungers and no
+    # other params should matter
+    assert w3.module1.method1(1, False, '_is_never_used_')['baseFeePerGas'] == 1000000000
+    assert w3.module1.method1(2, '_will_be_overridden_', None)['baseFeePerGas'] == 875000000

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -45,7 +45,6 @@ __all__ = [
     "HTTPProvider",
     "IPCProvider",
     "WebsocketProvider",
-    "TestRPCProvider",
     "EthereumTesterProvider",
     "Account",
     "AsyncHTTPProvider",

--- a/web3/_utils/admin.py
+++ b/web3/_utils/admin.py
@@ -40,19 +40,19 @@ add_peer: Method[Callable[[EnodeURI], bool]] = Method(
 
 datadir: Method[Callable[[], str]] = Method(
     RPC.admin_datadir,
-    mungers=None,
+    is_property=True,
 )
 
 
 node_info: Method[Callable[[], NodeInfo]] = Method(
     RPC.admin_nodeInfo,
-    mungers=None,
+    is_property=True,
 )
 
 
 peers: Method[Callable[[], List[Peer]]] = Method(
     RPC.admin_peers,
-    mungers=None,
+    is_property=True,
 )
 
 
@@ -77,13 +77,13 @@ start_ws: Method[ServerConnection] = Method(
 
 stop_rpc: Method[Callable[[], bool]] = Method(
     RPC.admin_stopRPC,
-    mungers=None,
+    is_property=True,
 )
 
 
 stop_ws: Method[Callable[[], bool]] = Method(
     RPC.admin_stopWS,
-    mungers=None,
+    is_property=True,
 )
 
 #

--- a/web3/_utils/miner.py
+++ b/web3/_utils/miner.py
@@ -51,19 +51,19 @@ start: Method[Callable[[int], bool]] = Method(
 
 stop: Method[Callable[[], bool]] = Method(
     RPC.miner_stop,
-    mungers=None,
+    is_property=True,
 )
 
 
 start_auto_dag: Method[Callable[[], bool]] = Method(
     RPC.miner_startAutoDag,
-    mungers=None,
+    is_property=True,
 )
 
 
 stop_auto_dag: Method[Callable[[], bool]] = Method(
     RPC.miner_stopAutoDag,
-    mungers=None,
+    is_property=True,
 )
 
 

--- a/web3/_utils/personal.py
+++ b/web3/_utils/personal.py
@@ -44,13 +44,13 @@ new_account: Method[Callable[[str], ChecksumAddress]] = Method(
 
 list_accounts: Method[Callable[[], List[ChecksumAddress]]] = Method(
     RPC.personal_listAccounts,
-    mungers=None,
+    is_property=True,
 )
 
 
 list_wallets: Method[Callable[[], List[GethWallet]]] = Method(
     RPC.personal_listWallets,
-    mungers=None,
+    is_property=True,
 )
 
 

--- a/web3/_utils/txpool.py
+++ b/web3/_utils/txpool.py
@@ -16,17 +16,17 @@ from web3.types import (
 
 content: Method[Callable[[], TxPoolContent]] = Method(
     RPC.txpool_content,
-    mungers=None,
+    is_property=True,
 )
 
 
 inspect: Method[Callable[[], TxPoolInspect]] = Method(
     RPC.txpool_inspect,
-    mungers=None,
+    is_property=True,
 )
 
 
 status: Method[Callable[[], TxPoolStatus]] = Method(
     RPC.txpool_status,
-    mungers=None,
+    is_property=True,
 )

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -119,7 +119,7 @@ class BaseEth(Module):
 
     _gas_price: Method[Callable[[], Wei]] = Method(
         RPC.eth_gasPrice,
-        mungers=None,
+        is_property=True,
     )
 
     @property
@@ -244,7 +244,7 @@ class BaseEth(Module):
 
     _max_priority_fee: Method[Callable[..., Wei]] = Method(
         RPC.eth_maxPriorityFeePerGas,
-        mungers=None,
+        is_property=True,
     )
 
     def get_block_munger(
@@ -267,12 +267,12 @@ class BaseEth(Module):
 
     get_block_number: Method[Callable[[], BlockNumber]] = Method(
         RPC.eth_blockNumber,
-        mungers=None,
+        is_property=True,
     )
 
     get_coinbase: Method[Callable[[], ChecksumAddress]] = Method(
         RPC.eth_coinbase,
-        mungers=None,
+        is_property=True,
     )
 
     def block_id_munger(
@@ -315,27 +315,27 @@ class BaseEth(Module):
 
     _get_accounts: Method[Callable[[], Tuple[ChecksumAddress]]] = Method(
         RPC.eth_accounts,
-        mungers=None,
+        is_property=True,
     )
 
     _get_hashrate: Method[Callable[[], int]] = Method(
         RPC.eth_hashrate,
-        mungers=None,
+        is_property=True,
     )
 
     _chain_id: Method[Callable[[], int]] = Method(
         RPC.eth_chainId,
-        mungers=None,
+        is_property=True,
     )
 
     _is_mining: Method[Callable[[], bool]] = Method(
         RPC.eth_mining,
-        mungers=None,
+        is_property=True,
     )
 
     _is_syncing: Method[Callable[[], Union[SyncStatus, bool]]] = Method(
         RPC.eth_syncing,
-        mungers=None,
+        is_property=True,
     )
 
     _get_transaction_receipt: Method[Callable[[_Hash32], TxReceipt]] = Method(
@@ -565,7 +565,7 @@ class Eth(BaseEth):
 
     _protocol_version: Method[Callable[[], str]] = Method(
         RPC.eth_protocolVersion,
-        mungers=None,
+        is_property=True,
     )
 
     @property
@@ -983,7 +983,7 @@ class Eth(BaseEth):
 
     get_work: Method[Callable[[], List[HexBytes]]] = Method(
         RPC.eth_getWork,
-        mungers=None,
+        is_property=True,
     )
 
     @deprecated_for("generate_gas_price")

--- a/web3/method.py
+++ b/web3/method.py
@@ -61,14 +61,14 @@ def _munger_star_apply(fn: Callable[..., TReturn]) -> Callable[..., TReturn]:
     return inner
 
 
-def default_munger(module: "Module", *args: Any, **kwargs: Any) -> Tuple[()]:
+def default_munger(_module: "Module", *args: Any, **kwargs: Any) -> Tuple[()]:
     if not args and not kwargs:
         return ()
     else:
         raise TypeError("Parameters passed to method without parameter mungers defined.")
 
 
-def default_root_munger(module: "Module", *args: Any) -> List[Any]:
+def default_root_munger(_module: "Module", *args: Any) -> List[Any]:
     return [*args]
 
 
@@ -115,15 +115,14 @@ class Method(Generic[TFunc]):
     and the response formatters are applied to the output.
     """
     def __init__(
-            self,
-            json_rpc_method: Optional[RPCEndpoint] = None,
-            mungers: Optional[Sequence[Munger]] = None,
-            request_formatters: Optional[Callable[..., TReturn]] = None,
-            result_formatters: Optional[Callable[..., TReturn]] = None,
-            error_formatters: Optional[Callable[..., TReturn]] = None,
-            null_result_formatters: Optional[Callable[..., TReturn]] = None,
-            method_choice_depends_on_args: Optional[Callable[..., RPCEndpoint]] = None,
-            w3: Optional["Web3"] = None):
+        self,
+        json_rpc_method: Optional[RPCEndpoint] = None,
+        mungers: Optional[Sequence[Munger]] = None,
+        request_formatters: Optional[Callable[..., TReturn]] = None,
+        result_formatters: Optional[Callable[..., TReturn]] = None,
+        null_result_formatters: Optional[Callable[..., TReturn]] = None,
+        method_choice_depends_on_args: Optional[Callable[..., RPCEndpoint]] = None,
+    ):
 
         self.json_rpc_method = json_rpc_method
         self.mungers = mungers or [default_munger]
@@ -133,8 +132,9 @@ class Method(Generic[TFunc]):
         self.null_result_formatters = null_result_formatters or get_null_result_formatters
         self.method_choice_depends_on_args = method_choice_depends_on_args
 
-    def __get__(self, obj: Optional["Module"] = None,
-                obj_type: Optional[Type["Module"]] = None) -> TFunc:
+    def __get__(
+        self, obj: Optional["Module"] = None, obj_type: Optional[Type["Module"]] = None
+    ) -> TFunc:
         if obj is None:
             raise TypeError(
                 "Direct calls to methods are not supported. "
@@ -204,7 +204,7 @@ class Method(Generic[TFunc]):
         return request, response_formatters
 
 
-class DeprecatedMethod():
+class DeprecatedMethod:
     def __init__(self, method: Method[Callable[..., Any]], old_name: str, new_name: str) -> None:
         self.method = method
         self.old_name = old_name

--- a/web3/module.py
+++ b/web3/module.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Callable,
     Coroutine,
+    Dict,
     TypeVar,
     Union,
 )
@@ -91,3 +92,14 @@ class Module:
             self.retrieve_caller_fn = retrieve_blocking_method_call_fn(w3, self)
         self.w3 = w3
         self.codec: ABICodec = w3.codec
+
+    def attach_methods(
+        self,
+        methods: Dict[str, Method[Callable[..., Any]]],
+    ) -> None:
+        for method_name, method_class in methods.items():
+            klass = (
+                method_class.__get__(obj=self)() if method_class.is_property else
+                method_class.__get__(obj=self)
+            )
+            setattr(self, method_name, klass)

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -94,7 +94,7 @@ class Parity(Module):
 
     enode: Method[Callable[[], str]] = Method(
         RPC.parity_enode,
-        mungers=None,
+        is_property=True,
     )
 
     """ property default_block """
@@ -141,7 +141,7 @@ class Parity(Module):
 
     net_peers: Method[Callable[[], ParityNetPeers]] = Method(
         RPC.parity_netPeers,
-        mungers=None
+        is_property=True
     )
 
     add_reserved_peer: Method[Callable[[EnodeURI], bool]] = Method(
@@ -217,7 +217,7 @@ class Parity(Module):
 
     mode: Method[Callable[[], ParityMode]] = Method(
         RPC.parity_mode,
-        mungers=None
+        is_property=True
     )
 
     # Deprecated Methods


### PR DESCRIPTION
### What was wrong?


* Related to Issue #1755, #1797

### How was it fixed?

* Made attaching methods to a `module` a little easier. This should be easier to document as well although the documentation in #1797 is still relevant and would work. Good documentation is still needed for these updates, perhaps in a separate PR.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Add cute animal picture

#### Cute Animal Picture

![moog_shaved4](https://user-images.githubusercontent.com/3532824/157539464-7e701ec5-59ae-449f-b8e5-1b9578736e00.jpeg)
