### PR TITLE
add non-ens normalize_address func

### DIFF
--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -253,6 +253,12 @@ def normalize_address(ens: ENS, address: ChecksumAddress) -> ChecksumAddress:
     return address
 
 
+def normalize_address_no_ens(address: ChecksumAddress) -> ChecksumAddress:
+    if address:
+        validate_address(address)
+    return address
+
+
 def normalize_bytecode(bytecode: bytes) -> HexBytes:
     if bytecode:
         bytecode = HexBytes(bytecode)


### PR DESCRIPTION
### What was wrong?

`normalize_address` depends on `ens`, but isn't asyncified yet. 

### How was it fixed?

Created `normalize_address_no_ens` to allow `contract` to be asyncified separately from `ens`

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/5199899/157337102-880ca22a-d281-4d6d-a674-450091143e37.png)


