### PR TITLE
[WIP] Split tests for parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,37 @@ version: 2.1
 
 # heavily inspired by https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
 
+parallel_common_core: &parallel_common_core
+  parallelism: 4
+  resource_class: large
+  working_directory: ~/repo
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: checkout ethpm-spec submodule
+        command: git submodule update --init --recursive
+    - run:
+        name: install dependencies
+        command: pip install --user tox
+    - run:
+        name: split tests
+        command: TEST_FILES=$(circleci tests glob "tests/core/**/test_*.py" | circleci tests split --split-by=filesize)
+    - run:
+        name: run tox
+        command: ~/.local/bin/tox -- $TEST_FILES
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+          - ./eggs
+          - ~/.ethash
+          - ~/.py-geth
+        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+
 common: &common
   working_directory: ~/repo
   steps:
@@ -17,7 +48,7 @@ common: &common
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: ~/.local/bin/tox
     - save_cache:
         paths:
           - .tox
@@ -90,7 +121,7 @@ geth_steps: &geth_steps
           geth makedag 0 $HOME/.ethash
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: ~/.local/bin/tox
     - save_cache:
         paths:
           - .tox
@@ -130,7 +161,7 @@ geth_custom_steps: &geth_custom_steps
           ./custom_geth makedag 0 $HOME/.ethash
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: ~/.local/bin/tox
     - save_cache:
         paths:
           - .tox
@@ -166,7 +197,7 @@ ethpm_steps: &ethpm_steps
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: ~/.local/bin/tox
     - save_cache:
         paths:
           - .tox
@@ -225,7 +256,7 @@ jobs:
   # Python 3.7
   #
   py37-core:
-    <<: *common
+    <<: *parallel_common_core
     docker:
       - image: circleci/python:3.7
     environment:
@@ -295,7 +326,7 @@ jobs:
   # Python 3.8
   #
   py38-core:
-    <<: *common
+    <<: *parallel_common_core
     docker:
       - image: circleci/python:3.8
     environment:
@@ -360,7 +391,7 @@ jobs:
   # Python 3.9
   #
   py39-core:
-    <<: *common
+    <<: *parallel_common_core
     docker:
       - image: circleci/python:3.9
     environment:
@@ -425,7 +456,7 @@ jobs:
   # Python 3.10
   #
   py310-core:
-    <<: *common
+    <<: *parallel_common_core
     docker:
       - image: circleci/python:3.10
     environment:

--- a/tox.ini
+++ b/tox.ini
@@ -30,13 +30,13 @@ whitelist_externals=/usr/bin/make
 install_command=python -m pip install --no-use-pep517 {opts} {packages}
 usedevelop=True
 commands=
-    core: pytest {posargs:tests/core}
-    ens: pytest {posargs:tests/ens}
-    ethpm: pytest {posargs:tests/ethpm}
-    integration-goethereum-ipc: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py}
-    integration-goethereum-http: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py}
-    integration-goethereum-ws: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py}
-    integration-ethtester: pytest {posargs:tests/integration/test_ethereum_tester.py}
+    core: pytest -r {posargs:tests/core}
+    ens: pytest -r {posargs:tests/ens}
+    ethpm: pytest -r {posargs:tests/ethpm}
+    integration-goethereum-ipc: pytest -r {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py}
+    integration-goethereum-http: pytest -r {posargs:tests/integration/go_ethereum/test_goethereum_http.py}
+    integration-goethereum-ws: pytest -r {posargs:tests/integration/go_ethereum/test_goethereum_ws.py}
+    integration-ethtester: pytest -r {posargs:tests/integration/test_ethereum_tester.py}
     docs: make -C {toxinidir} validate-docs
 deps =
     .[dev]


### PR DESCRIPTION
Signed-off-by: Harmouch101 <eng.mahmoudharmouch@gmail.com>

### What was wrong?

Related to PR #2379 

### How was it fixed?

Splitting tests by timings across 8 workers for `common` and 4 for others.

In the commits below, I was trying to fix the legacy python containers warning in CircleCi.

![image](https://user-images.githubusercontent.com/62179149/158874954-12b71ef6-edec-4695-8f20-56720ee02463.png)

update 1: it seems like it didn't split the tests.

update 2: splitting by timing didn't do anything, try splitting by filesize.

update 3: the problem seems to be related to tox. We need to find a way to tell `tox` to run different tests on different workers. But how? We are trying to find out.
 
update 4: playing with `resource_class` to see if it makes any significant difference in performance. From the results of the tests, it looks like the 4 workers are running the same tests, which means `tox` didn't take into consideration the `args` passed after `--` that should change the value `{posargs}` in `tox`.

update 5: transfer the `-r` from `config.yml` to `tox.ini`. 

update 6; now the split is working, however, we should split on the job level. Ex: 

```bash
circleci tests glob "tests/core/**/test_*.py" | circleci tests split --split-by=filesize 
circleci tests glob "tests/ens/**/test_*.py" | circleci tests split --split-by=filesize
.
.
.
```
update 7: testing core tests split.

update 8: giving up cause some tests are dependent on other files, which makes the splitting process completely infeasible, someone should carefully split the files. 

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

:dog: 
