### PR TITLE
Implement ENS set_text and get_text

### DIFF
--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -162,3 +162,37 @@ Wait for the transaction to be mined, then:
 ::
 
     assert ns.name('0x5B2063246F2191f18F2675ceDB8b28102e957458') == 'jasoncarver.eth'
+
+Set Text Metadata for an ENS Record
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As the owner of an ENS record, you can add text metadata.
+A list of supported fields can be found in the
+`ENS documentation <https://docs.ens.domains/contract-api-reference/publicresolver#get-text-data>`_.
+You'll need to setup the address first, and then the text can be set:
+
+::
+
+    ns.setup_address('jasoncarver.eth', 0x5B2063246F2191f18F2675ceDB8b28102e957458)
+    ns.set_text('jasoncarver.eth', 'url', 'https://example.com')
+
+A transaction dictionary can be passed as the last argument if desired:
+
+::
+
+    transaction_dict = {'from': '0x123...'}
+    ns.set_text('jasoncarver.eth', 'url', 'https://example.com', transaction_dict)
+
+If the transaction dictionary is not passed, sensible defaults will be used, and if
+a transaction dictionary is passed but does not have a ``from`` value,
+the default will be the ``owner``.
+
+Read Text Metadata for an ENS Record
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Anyone can read the data from an ENS Record:
+
+::
+
+    url = ns.get_text('jasoncarver.eth', 'url')
+    assert url == 'https://example.com'

--- a/ens/abis.py
+++ b/ens/abis.py
@@ -1173,6 +1173,28 @@ RESOLVER = [
     "type": "function"
   },
   {
+    "constant": True,
+    "inputs": [
+      {
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "name": "key",
+        "type": "string"
+      }
+    ],
+    "name": "text",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": False,
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "name": "ensAddr",

--- a/ens/abis.py
+++ b/ens/abis.py
@@ -975,6 +975,29 @@ RESOLVER = [
       }
     ],
     "payable": False,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": False,
+    "inputs": [
+      {
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "name": "key",
+        "type": "string"
+      },
+      {
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "name": "setText",
+    "outputs": [],
+    "payable": False,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1001,6 +1024,7 @@ RESOLVER = [
       }
     ],
     "payable": False,
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1022,6 +1046,7 @@ RESOLVER = [
     "name": "setPubkey",
     "outputs": [],
     "payable": False,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1040,6 +1065,7 @@ RESOLVER = [
       }
     ],
     "payable": False,
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1058,6 +1084,30 @@ RESOLVER = [
       }
     ],
     "payable": False,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": True,
+    "inputs": [
+      {
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "name": "key",
+        "type": "string"
+      }
+    ],
+    "name": "text",
+    "outputs": [
+      {
+        "name": "ret",
+        "type": "string"
+      }
+    ],
+    "payable": False,
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1079,6 +1129,7 @@ RESOLVER = [
     "name": "setABI",
     "outputs": [],
     "payable": False,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1097,6 +1148,7 @@ RESOLVER = [
       }
     ],
     "payable": False,
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1114,6 +1166,7 @@ RESOLVER = [
     "name": "setName",
     "outputs": [],
     "payable": False,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1131,6 +1184,7 @@ RESOLVER = [
     "name": "setContent",
     "outputs": [],
     "payable": False,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1153,6 +1207,7 @@ RESOLVER = [
       }
     ],
     "payable": False,
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -1170,28 +1225,7 @@ RESOLVER = [
     "name": "setAddr",
     "outputs": [],
     "payable": False,
-    "type": "function"
-  },
-  {
-    "constant": True,
-    "inputs": [
-      {
-        "name": "node",
-        "type": "bytes32"
-      },
-      {
-        "name": "key",
-        "type": "string"
-      }
-    ],
-    "name": "text",
-    "outputs": [
-      {
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "payable": False,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1202,6 +1236,7 @@ RESOLVER = [
       }
     ],
     "payable": False,
+    "stateMutability": "nonpayable",
     "type": "constructor"
   },
   {
@@ -1292,6 +1327,28 @@ RESOLVER = [
       }
     ],
     "name": "PubkeyChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": False,
+    "inputs": [
+      {
+        "indexed": True,
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "indexed": True,
+        "name": "indexedKey",
+        "type": "string"
+      },
+      {
+        "indexed": False,
+        "name": "key",
+        "type": "string"
+      }
+    ],
+    "name": "TextChanged",
     "type": "event"
   }
 ]

--- a/ens/main.py
+++ b/ens/main.py
@@ -282,6 +282,21 @@ class ENS:
         node = raw_name_to_hash(name)
         return self.ens.caller.owner(node)
 
+    def get_text(self, name: str, key: str) -> str:
+        """
+        Get the value of a text record by key from an ENS name.
+
+        :param str name: ENS name to look up
+        :param str key: ENS name's text record key
+        :return:  ENS name's text record value
+        :rtype: str
+        """
+        node = normal_name_to_hash(name)
+        r = self.resolver(name)
+        if r:
+            return r.caller.text(node, key)
+        return f"{name} does not exist!"
+
     def setup_owner(
         self,
         name: str,

--- a/ens/main.py
+++ b/ens/main.py
@@ -293,10 +293,12 @@ class ENS:
         :param str key: ENS name's text record key
         :return:  ENS name's text record value
         :rtype: str
+        :raises UnownedName: if no one owns `name`
         """
         node = raw_name_to_hash(name)
+        normal_name = normalize_name(name)
 
-        r = self.resolver(name)
+        r = self.resolver(normal_name)
         if r:
             return r.caller.text(node, key)
         else:
@@ -323,10 +325,11 @@ class ENS:
         """
         owner = self.owner(name)
         node = raw_name_to_hash(name)
+        normal_name = normalize_name(name)
 
         transaction_dict = merge({'from': owner}, transact)
 
-        r = self.resolver(name)
+        r = self.resolver(normal_name)
         if r:
             return r.functions.setText(node, key, value).transact(transaction_dict)
         else:

--- a/newsfragments/2286.feature.rst
+++ b/newsfragments/2286.feature.rst
@@ -1,0 +1,1 @@
+Add 'get_text' method to look up ENS text record values

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
         "mypy==0.910",
         "types-setuptools>=57.4.4,<58",
         "types-requests>=2.26.1,<3",
-        "types-protobuf>=3.18.2,<4",
+        "types-protobuf==3.19.13",
     ],
     'docs': [
         "mock",

--- a/tests/ens/test_get_text.py
+++ b/tests/ens/test_get_text.py
@@ -1,0 +1,66 @@
+import pytest
+
+from eth_tester.exceptions import (
+    TransactionFailed,
+)
+
+from ens.exceptions import (
+    UnownedName,
+)
+from web3 import Web3
+
+
+@pytest.mark.parametrize('key,expected', (
+    ('avatar', 'tester.jpeg'),
+    ('email', 'user@example.com'),
+    ('url', 'http://example.com'),
+    ('description', 'a test'),
+    ('notice', 'this contract is a test contract'),
+),)
+def test_set_text_unowned_name(ens, key, expected):
+    with pytest.raises(UnownedName):
+        ens.set_text('tester.eth', key, expected)
+
+
+@pytest.mark.parametrize('key,expected', (
+    ('avatar', 'tester.jpeg'),
+    ('email', 'user@example.com'),
+    ('url', 'http://example.com'),
+    ('description', 'a test'),
+    ('notice', 'this contract is a test contract'),
+),)
+def test_get_text(ens, key, expected):
+    address = ens.w3.eth.accounts[2]
+    ens.setup_address('tester.eth', address)
+    owner = ens.owner('tester.eth')
+    assert address == owner
+    ens.set_text('tester.eth', key, expected)
+    assert ens.get_text('tester.eth', key) == expected
+
+    # teardown
+    ens.setup_address('tester.eth', None)
+
+
+def test_set_text_fails_with_bad_address(ens):
+    address = ens.w3.eth.accounts[2]
+    ens.setup_address('tester.eth', address)
+    zero_address = '0x' + '00' * 20
+    with pytest.raises(TransactionFailed):
+        ens.set_text('tester.eth', 'url', 'http://example.com', transact={'from': zero_address})
+
+
+def test_set_text_pass_in_transaction_dict(ens):
+    address = ens.w3.eth.accounts[2]
+    ens.setup_address('tester.eth', address)
+    ens.set_text('tester.eth', 'url', 'http://example.com', transact={'from': address})
+    ens.set_text(
+        'tester.eth',
+        'avatar',
+        'example.jpeg',
+        transact={'gasPrice': Web3.toWei(100, 'gwei')}
+    )
+    assert ens.get_text('tester.eth', 'url') == 'http://example.com'
+    assert ens.get_text('tester.eth', 'avatar') == 'example.jpeg'
+
+    # teardown
+    ens.setup_address('tester.eth', None)


### PR DESCRIPTION
### What was wrong?

See PR #2286. @smk762 implemented get_text, and to test I needed to implement set_text.

### How was it fixed?

I didn't have permissions to push directly to @smk762 's branch, so I cherry-picked them to this one and added `set_text`. There wasn't really a clean way to split the two PRs. 

I had to add a new resolver ABI, which I took from the current ENS public resolver. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

See #2286 :)
