### PR TITLE
Improve upon issues with session caching

### DIFF
--- a/newsfragments/2407.misc.rst
+++ b/newsfragments/2407.misc.rst
@@ -1,0 +1,1 @@
+Moved the requests session cache to the new `SessionCache` class.

--- a/newsfragments/2407.misc.rst
+++ b/newsfragments/2407.misc.rst
@@ -1,1 +1,0 @@
-Moved the requests session cache to the new `SessionCache` class.

--- a/newsfragments/2409.bugfix.rst
+++ b/newsfragments/2409.bugfix.rst
@@ -1,0 +1,1 @@
+Improve upon issues with session caching - better support for multithreading and make sure session eviction from cache does not happen prematurely.

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -14,8 +14,8 @@ from web3.providers.async_rpc import (
 
 @pytest.mark.asyncio
 async def test_user_provided_session() -> None:
-
     session = ClientSession()
     provider = AsyncHTTPProvider(endpoint_uri="http://mynode.local:8545")
-    await provider.cache_async_session(session)
+    cached_session = await provider.cache_async_session(session)
     assert len(request._async_session_cache) == 1
+    assert cached_session == session

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -38,7 +38,7 @@ def test_user_provided_session():
     w3 = Web3(provider)
     assert w3.manager.provider == provider
 
-    session = request.get_session(URI)
+    session = request.cache_and_return_session(URI)
     adapter = session.get_adapter(URI)
     assert isinstance(adapter, HTTPAdapter)
     assert adapter._pool_connections == 20

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -15,6 +15,9 @@ from requests.adapters import (
 from web3._utils import (
     request,
 )
+from web3._utils.caching import (
+    generate_cache_key,
+)
 from web3._utils.request import (
     SessionCache,
 )
@@ -51,7 +54,8 @@ def test_make_post_request_no_args(mocker):
     response = request.make_post_request(URI, data=b"request")
     assert response == "content"
     assert len(request._session_cache) == 1
-    session = request._session_cache.values()[0]
+    cache_key = generate_cache_key(URI)
+    session = request._session_cache.get_cache_entry(cache_key)
     session.post.assert_called_once_with(URI, data=b"request", timeout=10)
 
     # Ensure the adapter was created with default values

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -158,7 +158,7 @@ async def test_async_cache_does_not_close_session_before_a_call():
     session_cache_default = request._async_session_cache
     timeout_default = request.DEFAULT_TIMEOUT
 
-    # set cache size to 1 + set future session close thread time to 0.02s
+    # set cache size to 1 + set future session close thread time to 0.01s
     request._async_session_cache = SessionCache(1)
     _timeout_for_testing = 0.01
     request.DEFAULT_TIMEOUT = _timeout_for_testing
@@ -166,7 +166,7 @@ async def test_async_cache_does_not_close_session_before_a_call():
     async def cache_uri_and_return_evicted_session(uri):
         _session = await get_async_session(uri)
 
-        # sort of simulate a call taking 0.1s to return a response
+        # sort of simulate a call taking 0.01s to return a response
         await asyncio.sleep(0.01)
 
         assert not _session.closed

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -26,8 +26,8 @@ from web3._utils.compat import (
     Literal,
 )
 from web3._utils.request import (
-    get_async_session,
-    get_session,
+    cache_and_return_async_session,
+    cache_and_return_session,
 )
 from web3.types import (
     BlockData,
@@ -103,7 +103,7 @@ def mock_offchain_lookup_request_response(
             return MockedResponse()
 
         # else, make a normal request (no mocking)
-        session = get_session(url_from_args)
+        session = cache_and_return_session(url_from_args)
         return session.request(method=http_method.upper(), url=url_from_args, **kwargs)
 
     monkeypatch.setattr(
@@ -153,7 +153,7 @@ def async_mock_offchain_lookup_request_response(
             return AsyncMockedResponse()
 
         # else, make a normal request (no mocking)
-        session = await get_async_session(url_from_args)
+        session = await cache_and_return_async_session(url_from_args)
         return await session.request(
             method=http_method.upper(), url=url_from_args, **kwargs
         )

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -81,7 +81,7 @@ def get_session(
             evicted_items = _session_cache.cache(cache_key, requests.Session())
 
         if evicted_items is not None:
-            for key, session in evicted_items.items():
+            for _key, session in evicted_items.items():
                 session.close()
         return _session_cache.get_cache_entry(cache_key)
 
@@ -136,7 +136,7 @@ async def get_async_session(
             )
 
         if evicted_items is not None:
-            for key, session in evicted_items.items():
+            for _key, session in evicted_items.items():
                 await session.close()
         return _async_session_cache.get_cache_entry(cache_key)
 

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -17,7 +17,6 @@ from aiohttp import (
 from eth_typing import (
     URI,
 )
-import lru
 import requests
 
 from web3._utils.caching import (
@@ -48,6 +47,9 @@ class SessionCache:
     def get_cache_entry(self, key: str) -> Any:
         return self._data[key]
 
+    def clear(self) -> None:
+        self._data.clear()
+
     def __contains__(self, item: str) -> bool:
         return item in self._data
 
@@ -59,23 +61,29 @@ def get_default_http_endpoint() -> URI:
     return URI(os.environ.get("WEB3_HTTP_PROVIDER_URI", "http://localhost:8545"))
 
 
+_session_cache = SessionCache(size=20)
+_session_cache_lock = threading.Lock()
+
+
 def cache_session(endpoint_uri: URI, session: requests.Session) -> None:
+    get_session(endpoint_uri, session)
+
+
+def get_session(
+    endpoint_uri: URI, session: requests.Session = None
+) -> requests.Session:
     cache_key = generate_cache_key(endpoint_uri)
-    _session_cache[cache_key] = session
+    with _session_cache_lock:
+        evicted_items = None
+        if session is not None:
+            evicted_items = _session_cache.cache(cache_key, session)
+        elif cache_key not in _session_cache:
+            evicted_items = _session_cache.cache(cache_key, requests.Session())
 
-
-def _remove_session(_key: str, session: requests.Session) -> None:
-    session.close()
-
-
-_session_cache = lru.LRU(8, callback=_remove_session)
-
-
-def get_session(endpoint_uri: URI) -> requests.Session:
-    cache_key = generate_cache_key(endpoint_uri)
-    if cache_key not in _session_cache:
-        _session_cache[cache_key] = requests.Session()
-    return _session_cache[cache_key]
+        if evicted_items is not None:
+            for key, session in evicted_items.items():
+                session.close()
+        return _session_cache.get_cache_entry(cache_key)
 
 
 def get_response_from_get_request(
@@ -106,24 +114,31 @@ def make_post_request(
 
 # --- async --- #
 
-_async_session_cache_lock = threading.Lock()
 _async_session_cache = SessionCache(size=20)
+_async_session_cache_lock = threading.Lock()
 
 
 async def cache_async_session(endpoint_uri: URI, session: ClientSession) -> None:
+    await get_async_session(endpoint_uri, session)
+
+
+async def get_async_session(
+    endpoint_uri: URI, session: ClientSession = None
+) -> ClientSession:
     cache_key = generate_cache_key(endpoint_uri)
     with _async_session_cache_lock:
-        evicted_items = _async_session_cache.cache(cache_key, session)
+        evicted_items = None
+        if session is not None:
+            evicted_items = _async_session_cache.cache(cache_key, session)
+        elif cache_key not in _async_session_cache:
+            evicted_items = _async_session_cache.cache(
+                cache_key, ClientSession(raise_for_status=True)
+            )
+
         if evicted_items is not None:
             for key, session in evicted_items.items():
                 await session.close()
-
-
-async def get_async_session(endpoint_uri: URI) -> ClientSession:
-    cache_key = generate_cache_key(endpoint_uri)
-    if cache_key not in _async_session_cache:
-        await cache_async_session(endpoint_uri, ClientSession(raise_for_status=True))
-    return _async_session_cache.get_cache_entry(cache_key)
+        return _async_session_cache.get_cache_entry(cache_key)
 
 
 async def async_get_response_from_get_request(

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -14,6 +14,7 @@ from typing import (
     AsyncGenerator,
     Dict,
     List,
+    Optional,
     Union,
 )
 
@@ -31,8 +32,7 @@ from web3._utils.caching import (
     generate_cache_key,
 )
 
-logger = logging.Logger(__file__)
-logger.addHandler(logging.StreamHandler())
+logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 10
 
@@ -78,31 +78,42 @@ _session_cache = SessionCache(size=20)
 _session_cache_lock = threading.Lock()
 
 
-def cache_session(endpoint_uri: URI, session: requests.Session) -> None:
-    get_session(endpoint_uri, session)
-
-
-def get_session(
+def cache_and_return_session(
     endpoint_uri: URI, session: requests.Session = None
 ) -> requests.Session:
     cache_key = generate_cache_key(endpoint_uri)
-    with _session_cache_lock:
-        evicted_items = None
-        if session is not None:
-            evicted_items = _session_cache.cache(cache_key, session)
-        elif cache_key not in _session_cache:
-            evicted_items = _session_cache.cache(cache_key, requests.Session())
 
-        if evicted_items is not None:
-            [session.close() for session in evicted_items.values()]
-        return _session_cache.get_cache_entry(cache_key)
+    evicted_items = None
+    with _session_cache_lock:
+        if cache_key not in _session_cache:
+            if session is None:
+                session = requests.Session()
+
+            evicted_items = _session_cache.cache(cache_key, session)
+            logger.debug(f"Session cached: {endpoint_uri}, {session}")
+
+        cached_session = _session_cache.get_cache_entry(cache_key)
+
+    if evicted_items is not None:
+        evicted_sessions = evicted_items.values()
+        for evicted_session in evicted_sessions:
+            logger.debug(
+                f"Session cache full. Session evicted from cache: {evicted_session}",
+            )
+        threading.Timer(
+            DEFAULT_TIMEOUT + 0.1,
+            _close_evicted_sessions,
+            args=[evicted_sessions],
+        ).start()
+
+    return cached_session
 
 
 def get_response_from_get_request(
     endpoint_uri: URI, *args: Any, **kwargs: Any
 ) -> requests.Response:
     kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
-    session = get_session(endpoint_uri)
+    session = cache_and_return_session(endpoint_uri)
     response = session.get(endpoint_uri, *args, **kwargs)
     return response
 
@@ -111,7 +122,7 @@ def get_response_from_post_request(
     endpoint_uri: URI, *args: Any, **kwargs: Any
 ) -> requests.Response:
     kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
-    session = get_session(endpoint_uri)
+    session = cache_and_return_session(endpoint_uri)
     response = session.post(endpoint_uri, *args, **kwargs)
     return response
 
@@ -124,6 +135,12 @@ def make_post_request(
     return response.content
 
 
+def _close_evicted_sessions(evicted_sessions: List[requests.Session]) -> None:
+    for evicted_session in evicted_sessions:
+        evicted_session.close()
+        logger.debug(f"Closed evicted session: {evicted_session}")
+
+
 # --- async --- #
 
 
@@ -132,8 +149,46 @@ _async_session_cache_lock = threading.Lock()
 _pool = ThreadPoolExecutor(max_workers=1)
 
 
-async def cache_async_session(endpoint_uri: URI, session: ClientSession) -> None:
-    await get_async_session(endpoint_uri, session)
+async def cache_and_return_async_session(
+    endpoint_uri: URI,
+    session: Optional[ClientSession] = None,
+) -> ClientSession:
+    cache_key = generate_cache_key(endpoint_uri)
+
+    evicted_items = None
+    async with async_lock(_async_session_cache_lock):
+        if cache_key not in _async_session_cache:
+            if session is None:
+                session = ClientSession(raise_for_status=True)
+
+            evicted_items = _async_session_cache.cache(cache_key, session)
+            logger.debug(f"Async session cached: {endpoint_uri}, {session}")
+
+        cached_session = _async_session_cache.get_cache_entry(cache_key)
+
+    if evicted_items is not None:
+        # At this point the evicted sessions are already popped out of the cache and
+        # just stored in the `evicted_sessions` dict. So we can kick off a future task
+        # to close them and it should be safe to pop out of the lock here.
+        evicted_sessions = evicted_items.values()
+        for evicted_session in evicted_sessions:
+            logger.debug(
+                "Async session cache full. Session evicted from cache: "
+                f"{evicted_session}",
+            )
+        # Kick off a future task, in a separate thread, to close the evicted
+        # sessions. In the case that the cache filled very quickly and some
+        # sessions have been evicted before their original request has been made,
+        # we set the timer to a bit more than the `DEFAULT_TIMEOUT` for a call. This
+        # should make it so that any call from an evicted session can still be made
+        # before the session is closed.
+        threading.Timer(
+            DEFAULT_TIMEOUT + 0.1,
+            _async_close_evicted_sessions,
+            args=[evicted_sessions],
+        ).start()
+
+    return cached_session
 
 
 @contextlib.asynccontextmanager
@@ -146,51 +201,11 @@ async def async_lock(lock: threading.Lock) -> AsyncGenerator[None, None]:
         lock.release()
 
 
-async def get_async_session(
-    endpoint_uri: URI, session: ClientSession = None
-) -> ClientSession:
-    cache_key = generate_cache_key(endpoint_uri)
-    async with async_lock(_async_session_cache_lock):
-        evicted_items = None
-        if session is not None:
-            evicted_items = _async_session_cache.cache(cache_key, session)
-        elif cache_key not in _async_session_cache:
-            evicted_items = _async_session_cache.cache(
-                cache_key, ClientSession(raise_for_status=True)
-            )
-
-        session = _async_session_cache.get_cache_entry(cache_key)
-        logger.debug(f"Session cached: {endpoint_uri}, {session}")
-
-    if evicted_items is not None:
-        # At this point the evicted sessions are already popped out of the cache and
-        # just stored in the `evicted_sessions` dict. So we can kick off a future task
-        # to close them and it should be safe to pop out of the lock here.
-        evicted_sessions = [session for session in evicted_items.values()]
-        for session in evicted_sessions:
-            logger.debug(
-                f"Session cache full. Session evicted from cache: {session}",
-            )
-        # Kick off a future task, in a separate thread, to close the evicted
-        # sessions. In the case that the cache filled very quickly and some
-        # sessions have been evicted before their original request has been made,
-        # we set the timer to a bit more than the `DEFAULT_TIMEOUT` for a call. This
-        # should make it so that any call from an evicted session can still be made
-        # before the session is closed.
-        threading.Timer(
-            DEFAULT_TIMEOUT + 0.1,
-            _close_evicted_async_sessions,
-            args=[evicted_sessions],
-        ).start()
-
-    return session
-
-
 async def async_get_response_from_get_request(
     endpoint_uri: URI, *args: Any, **kwargs: Any
 ) -> ClientResponse:
     kwargs.setdefault("timeout", ClientTimeout(DEFAULT_TIMEOUT))
-    session = await get_async_session(endpoint_uri)
+    session = await cache_and_return_async_session(endpoint_uri)
     response = await session.get(endpoint_uri, *args, **kwargs)
     return response
 
@@ -199,8 +214,9 @@ async def async_get_response_from_post_request(
     endpoint_uri: URI, *args: Any, **kwargs: Any
 ) -> ClientResponse:
     kwargs.setdefault("timeout", ClientTimeout(DEFAULT_TIMEOUT))
-    session = await get_async_session(endpoint_uri)
+    session = await cache_and_return_async_session(endpoint_uri)
     response = await session.post(endpoint_uri, *args, **kwargs)
+
     return response
 
 
@@ -219,16 +235,15 @@ async def async_get_json_from_client_response(
     return await response.json()
 
 
-def _close_evicted_async_sessions(evicted_sessions: List[ClientSession]) -> None:
+def _async_close_evicted_sessions(evicted_sessions: List[ClientSession]) -> None:
     loop = asyncio.new_event_loop()
 
     for evicted_session in evicted_sessions:
         loop.run_until_complete(evicted_session.close())
-        logger.debug(f"Closed evicted session: {evicted_session}")
+        logger.debug(f"Closed evicted async session: {evicted_session}")
 
     if any(not evicted_session.closed for evicted_session in evicted_sessions):
         logger.warning(
-            f"Some evicted sessions were not properly closed: {evicted_sessions}"
+            f"Some evicted async sessions were not properly closed: {evicted_sessions}"
         )
-
     loop.close()

--- a/web3/providers/async_rpc.py
+++ b/web3/providers/async_rpc.py
@@ -23,7 +23,7 @@ from web3._utils.http import (
 )
 from web3._utils.request import (
     async_make_post_request,
-    cache_async_session as _cache_async_session,
+    cache_and_return_async_session as _cache_and_return_async_session,
     get_default_http_endpoint,
 )
 from web3.types import (
@@ -55,8 +55,8 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
 
         super().__init__()
 
-    async def cache_async_session(self, session: ClientSession) -> None:
-        await _cache_async_session(self.endpoint_uri, session)
+    async def cache_async_session(self, session: ClientSession) -> ClientSession:
+        return await _cache_and_return_async_session(self.endpoint_uri, session)
 
     def __str__(self) -> str:
         return f"RPC connection {self.endpoint_uri}"

--- a/web3/providers/rpc.py
+++ b/web3/providers/rpc.py
@@ -19,7 +19,7 @@ from web3._utils.http import (
     construct_user_agent,
 )
 from web3._utils.request import (
-    cache_session,
+    cache_and_return_session,
     get_default_http_endpoint,
     make_post_request,
 )
@@ -62,7 +62,7 @@ class HTTPProvider(JSONBaseProvider):
         self._request_kwargs = request_kwargs or {}
 
         if session:
-            cache_session(self.endpoint_uri, session)
+            cache_and_return_session(self.endpoint_uri, session)
 
         super().__init__()
 


### PR DESCRIPTION
### What was wrong?

@dbfreem:
- This could possibly fix #2407 but I can not be sure.

@fselmo:
- Multithreading was not being supported with the current implementation, nor with the initial commits here.

### How was it fixed?

@dbfreem:
- Moved the requests session cache to the new `SessionCache` class.

@fselmo:
- Use a future thread with a bit more than the default call timeout to close evicted sessions so they aren't closed before a call is finished. This allows for multithreading support for both sync and async.
- Add testing for multi threading
- Combine ``cache_session`` and ``get_session`` methods for sync and async


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [ ] Fix newsfragment message to reflect all changes here