### PR TITLE
Add Infura example to middleware docs

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -458,7 +458,7 @@ this middleware to have any effect.
    >>> w3.middleware_onion.add(construct_sign_and_send_raw_middleware(acct))
    >>> w3.eth.default_account = acct.address
 
-The Infura Ethereum API only supports signed transactions. This often results in ``send_raw_transaction`` being used repeatedly, instead we can automate this process with ``construct_sign_and_send_raw_middleware(private_key_or_account)``.
+:ref:`Hosted nodes<local_vs_hosted>` (like Infura or Alchemy) only support signed transactions. This often results in ``send_raw_transaction`` being used repeatedly. Instead, we can automate this process with ``construct_sign_and_send_raw_middleware(private_key_or_account)``.
 
 .. code-block:: python
 

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -463,7 +463,7 @@ this middleware to have any effect.
 .. code-block:: python
 
     >>> from web3 import Web3
-    >>> w3 = Web3(Web3.HTTPProvider('INFURA_ENDPOINT'))
+    >>> w3 = Web3(Web3.HTTPProvider('HTTP_ENDPOINT'))
     >>> from web3.middleware import construct_sign_and_send_raw_middleware
     >>> from eth_account import Account
     >>> import os

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -467,7 +467,7 @@ The Infura Ethereum API only supports signed transactions. This often results in
     >>> from web3.middleware import construct_sign_and_send_raw_middleware
     >>> from eth_account import Account
     >>> import os
-    >>> acct = Account.from_key(os.environ.get('PRIVATE_KEY'))
+    >>> acct = w3.eth.account.from_key(os.environ.get('PRIVATE_KEY'))
     >>> w3.middleware_onion.add(construct_sign_and_send_raw_middleware(acct))
     >>> w3.eth.default_account = acct.address
 

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -458,6 +458,19 @@ this middleware to have any effect.
    >>> w3.middleware_onion.add(construct_sign_and_send_raw_middleware(acct))
    >>> w3.eth.default_account = acct.address
 
+The Infura Ethereum API only supports signed transactions. This often results in ``send_raw_transaction`` being used repeatedly, instead we can automate this process with ``construct_sign_and_send_raw_middleware(private_key_or_account)``.
+
+.. code-block:: python
+
+    >>> from web3 import Web3
+    >>> w3 = Web3(Web3.HTTPProvider('INFURA_ENDPOINT'))
+    >>> from web3.middleware import construct_sign_and_send_raw_middleware
+    >>> from eth_account import Account
+    >>> import os
+    >>> acct = Account.from_key(os.environ.get('PRIVATE_KEY'))
+    >>> w3.middleware_onion.add(construct_sign_and_send_raw_middleware(acct))
+    >>> w3.eth.default_account = acct.address
+
 Now you can send a transaction from acct.address without having to build and sign each raw transaction.
 
 When making use of this signing middleware, when sending dynamic fee transactions (recommended over legacy transactions),

--- a/newsfragments/2410.doc.rst
+++ b/newsfragments/2410.doc.rst
@@ -1,0 +1,1 @@
+Add example for the ``construct_sign_and_send_raw_middleware`` when connected to a hosted node


### PR DESCRIPTION
### What was wrong?

There wasn't an example of using Infura with `construct_sign_and_send_raw_middleware` middleware.

Related to Issue #

https://github.com/ethereum/web3.py/issues/2155

### How was it fixed?

I added an example to the middleware docs.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.photographytalk.com/images/apple/71animalfaces/animalfaces21.jpg)
