### PR TITLE
Add optional strict mode for ENS reverse resolution

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -142,7 +142,7 @@ class ENS:
         :raises InvalidName: if `name` has invalid syntax
         """
         return cast(ChecksumAddress, self.resolve(name, 'addr'))
-        
+
     def name(
         self, address: ChecksumAddress, strict: Optional[bool] = False
     ) -> Optional[str]:
@@ -151,7 +151,7 @@ class ENS:
         reverse lookup. Reverse lookup is opt-in for name owners.
 
         :param hex-string address: the address to look up
-        :param strict bool: perform a strict check which will confirm that forward and 
+        :param strict bool: perform a strict check which will confirm that forward and
             reverse resolution matches
         """
         reversed_domain = address_to_reverse_domain(address)

--- a/ens/main.py
+++ b/ens/main.py
@@ -142,17 +142,25 @@ class ENS:
         :raises InvalidName: if `name` has invalid syntax
         """
         return cast(ChecksumAddress, self.resolve(name, 'addr'))
-
-    def name(self, address: ChecksumAddress) -> Optional[str]:
+        
+    def name(
+        self, address: ChecksumAddress, strict: Optional[bool] = False
+    ) -> Optional[str]:
         """
         Look up the name that the address points to, using a
         reverse lookup. Reverse lookup is opt-in for name owners.
 
-        :param address:
-        :type address: hex-string
+        :param hex-string address: the address to look up
+        :param strict bool: perform a strict check which will confirm that forward and 
+            reverse resolution matches
         """
         reversed_domain = address_to_reverse_domain(address)
-        return self.resolve(reversed_domain, get='name')
+        name = self.resolve(reversed_domain, get="name")
+
+        if strict:
+            return name if address == self.address(name) else None
+
+        return name
 
     def setup_address(
         self,

--- a/tests/ens/test_setup_name.py
+++ b/tests/ens/test_setup_name.py
@@ -69,6 +69,17 @@ def test_setup_name(ens, name, normalized_name, namehash_hex):
     # check that the correct owner is set:
     assert ens.owner(name) == owner
 
+    # check that strict mode works when name resolution is changed
+    new_address = ens.w3.eth.accounts[4]
+    ens.setup_address(name, None)
+    ens.setup_name(name, new_address)
+
+    assert ens.name(address) == normalized_name
+    assert ens.name(new_address) == normalized_name
+
+    assert not ens.name(address, strict=True)
+    assert ens.name(new_address, strict=True) == normalized_name
+
     ens.setup_name(None, address)
     ens.setup_address(name, None)
     assert not ens.name(address)


### PR DESCRIPTION
### What was wrong?

We started using the ens library of web3.py at OpenSea and noticed an issue when doing reverse resolutions. In order to accurately determine the reverse resolution, a forward resolution must be checked agains as stated in the ENS docs:
```
ENS does not enforce the accuracy of reverse records - for instance, anyone may claim that the name for their address is 'alice.eth'. To be certain that the claim is accurate, you must always perform a forward resolution for the returned name and check it matches the original address.
```

I don't know what the ideal solution here is. For now, in this PR I have made this an optional lookup using the `strict` param. I'm assuming everyone would want the correct resolution so maybe we should make it the default behavior? Open to discussion.

### How was it fixed?

Added an optional forward resolution check to validate the lookup is correct.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/4983318/162511218-ea3930c7-4eda-4273-989a-56daf78b1307.png)