### PR TITLE
Add flaky decorator to geth estimate_gas

### DIFF
--- a/newsfragments/2418.misc.rst
+++ b/newsfragments/2418.misc.rst
@@ -1,0 +1,1 @@
+Add flaky decorator to Geth gas estimation tests.

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -67,6 +67,12 @@ class GoEthereumEthModuleTest(EthModuleTest):
     ) -> None:
         super().test_eth_estimateGas_deprecated(w3, unlocked_account_dual_type)
 
+    @flaky(max_runs=3)
+    def test_eth_estimate_gas_with_block(
+        self, w3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        super().test_eth_estimate_gas_with_block(w3, unlocked_account_dual_type)
+
 
 class GoEthereumVersionModuleTest(VersionModuleTest):
     @pytest.mark.xfail(reason='eth_protocolVersion was removed in Geth 1.10.0')

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -1,4 +1,14 @@
 import pytest
+from typing import (
+    TYPE_CHECKING,
+)
+
+from eth_typing import (
+    ChecksumAddress,
+)
+from flaky import (
+    flaky,
+)
 
 from web3._utils.module_testing import (  # noqa: F401
     AsyncEthModuleTest,
@@ -12,6 +22,11 @@ from web3._utils.module_testing import (  # noqa: F401
     VersionModuleTest,
     Web3ModuleTest,
 )
+
+if TYPE_CHECKING:
+    from web3 import (  # noqa: F401
+        Web3,
+    )
 
 
 class GoEthereumTest(Web3ModuleTest):
@@ -39,6 +54,18 @@ class GoEthereumEthModuleTest(EthModuleTest):
     @pytest.mark.xfail(reason='eth_protocolVersion was removed in Geth 1.10.0')
     def test_eth_protocolVersion(self, w3):
         super().test_eth_protocolVersion(w3)
+
+    @flaky(max_runs=3)
+    def test_eth_estimate_gas(
+        self, w3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        super().test_eth_estimate_gas(w3, unlocked_account_dual_type)
+
+    @flaky(max_runs=3)
+    def test_eth_estimateGas_deprecated(
+        self, w3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        super().test_eth_estimateGas_deprecated(w3, unlocked_account_dual_type)
 
 
 class GoEthereumVersionModuleTest(VersionModuleTest):

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -1,18 +1,9 @@
 import pytest
 
 import pytest_asyncio
-from flaky import (
-    flaky,
-)
 
-from eth_typing import (
-    ChecksumAddress,
-)
 from tests.utils import (
     get_open_port,
-)
-from typing import (
-    TYPE_CHECKING,
 )
 from web3 import Web3
 from web3._utils.module_testing.go_ethereum_admin_module import (
@@ -58,10 +49,6 @@ from .utils import (
     wait_for_aiohttp,
     wait_for_http,
 )
-
-
-if TYPE_CHECKING:
-    from web3 import Web3  # noqa: F401
 
 
 @pytest.fixture(scope="module")
@@ -171,11 +158,8 @@ class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):
 
 
 class TestGoEthereumEthModuleTest(GoEthereumEthModuleTest):
-    @flaky(max_runs=3)
-    def test_eth_estimate_gas(
-        self, w3: "Web3", unlocked_account_dual_type: ChecksumAddress
-    ) -> None:
-        pass
+    pass
+
 
 class TestGoEthereumVersionModuleTest(GoEthereumVersionModuleTest):
     pass

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -1,9 +1,18 @@
 import pytest
 
 import pytest_asyncio
+from flaky import (
+    flaky,
+)
 
+from eth_typing import (
+    ChecksumAddress,
+)
 from tests.utils import (
     get_open_port,
+)
+from typing import (
+    TYPE_CHECKING,
 )
 from web3 import Web3
 from web3._utils.module_testing.go_ethereum_admin_module import (
@@ -49,6 +58,10 @@ from .utils import (
     wait_for_aiohttp,
     wait_for_http,
 )
+
+
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
 
 
 @pytest.fixture(scope="module")
@@ -158,8 +171,11 @@ class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):
 
 
 class TestGoEthereumEthModuleTest(GoEthereumEthModuleTest):
-    pass
-
+    @flaky(max_runs=3)
+    def test_eth_estimate_gas(
+        self, w3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        pass
 
 class TestGoEthereumVersionModuleTest(GoEthereumVersionModuleTest):
     pass


### PR DESCRIPTION
### What was wrong?
Geth integration tests started failing an annoying amount again.

Related to Issue #

### How was it fixed?
Added a `flaky` decorator with a default of 3 runs. If that doesn't fix it, I think the next step would be do something like: 

`@pytest.mark.xfail(strict=False)`

I ran the suite a bunch of times and didn't see any failures, so we'll see how it goes. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://lh5.ggpht.com/_gKQKwLZ8XUs/S4rX4w7HgRI/AAAAAAAACIk/zOnblLezsvE/s800/Amazing-Caterpillars-Fluffy.jpg)
