### PR TITLE
Validate forward resolution for reverse resolution by default

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -152,7 +152,11 @@ class ENS:
         :type address: hex-string
         """
         reversed_domain = address_to_reverse_domain(address)
-        return self.resolve(reversed_domain, get='name')
+        name = self.resolve(reversed_domain, get='name')
+
+        # To be absolutely certain of the name, via reverse resolution, the address must match in
+        # the forward resolution
+        return name if to_checksum_address(address) == self.address(name) else None
 
     def setup_address(
         self,

--- a/newsfragments/2420.feature.rst
+++ b/newsfragments/2420.feature.rst
@@ -1,0 +1,1 @@
+For ``ENS.name()``, validate that the forward resolution returns the same address as provided by the user as per the ENS documentation recommendation for Reverse Resolution.

--- a/tests/ens/test_setup_name.py
+++ b/tests/ens/test_setup_name.py
@@ -69,6 +69,17 @@ def test_setup_name(ens, name, normalized_name, namehash_hex):
     # check that the correct owner is set:
     assert ens.owner(name) == owner
 
+    # setup name to point to new address
+    new_address = ens.w3.eth.accounts[4]
+    ens.setup_address(name, None)
+    ens.setup_name(name, new_address)
+
+    # validate that ens.name() only returns a name if the forward resolution also returns the
+    # address
+    assert ens.name(new_address) == normalized_name  # reverse resolution
+    assert ens.address(name) == new_address  # forward resolution
+    assert not ens.name(address)
+
     ens.setup_name(None, address)
     ens.setup_address(name, None)
     assert not ens.name(address)


### PR DESCRIPTION
### What was wrong?

As outlined in the warning in the ENS docs, for the reverse resolution of a name for an address to be accurate, the forward resolution address must also match. Source at the time of this commit is here: https://docs.ens.domains/dapp-developer-guide/resolving-names#reverse-resolution.

Related to Issue #2417, #2419 (`v5` implementation of this same concept. Use this as default logic for `v6`)

### How was it fixed?

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Add cute animal picture

#### Cute Animal Picture

![](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.swaindestinations.com%2Fblog%2Fwp-content%2Fuploads%2F2014%2F03%2F117533-4.jpg&f=1&nofb=1)