### PR TITLE
Add sync chain_id to simple cache

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -216,6 +216,18 @@ The following properties are available on the ``web3.eth`` namespace.
        >>> web3.eth.chain_id
        61
 
+   .. note::
+
+      This property gets called frequently in validation middleware,
+      but `chain_id` is added to the ``simple_cache_middleware`` by default.
+      Add the :meth:`simple_cache_middleware<web3.middleware.construct_simple_cache_middleware>`
+      to the ``middleware_onion`` to increase performance:
+
+       .. code-block:: python
+
+          >>> from web3.middleware import simple_cache_middleware
+          >>> w3.middleware_onion.add(simple_cache_middleare)
+
 
 .. py:attribute:: Eth.chainId
 

--- a/newsfragments/2207.feature.rst
+++ b/newsfragments/2207.feature.rst
@@ -1,1 +1,0 @@
-Add setter for the Eth.chain_id property

--- a/newsfragments/2376.bugfix.rst
+++ b/newsfragments/2376.bugfix.rst
@@ -1,1 +1,0 @@
-Add async default_chain_id and chain_id setter

--- a/newsfragments/2425.feature.rst
+++ b/newsfragments/2425.feature.rst
@@ -1,0 +1,1 @@
+Add sync chain_id to ``simple_middleware_cache``

--- a/tests/core/eth-module/test_eth_properties.py
+++ b/tests/core/eth-module/test_eth_properties.py
@@ -1,23 +1,5 @@
 import pytest
 
-from web3 import Web3
-from web3.eth import (
-    AsyncEth,
-)
-from web3.providers.eth_tester.main import (
-    AsyncEthereumTesterProvider,
-)
-
-
-@pytest.fixture
-def async_w3():
-    return Web3(
-        AsyncEthereumTesterProvider(),
-        middlewares=[],
-        modules={
-            'eth': (AsyncEth,),
-        })
-
 
 def test_eth_protocol_version(w3):
     with pytest.warns(DeprecationWarning):
@@ -36,24 +18,3 @@ def test_eth_chain_id(w3):
 def test_eth_chainId(w3):
     with pytest.warns(DeprecationWarning):
         assert w3.eth.chainId == 61
-
-
-def test_set_chain_id(w3):
-    assert w3.eth.chain_id == 61
-
-    w3.eth.chain_id = 72
-    assert w3.eth.chain_id == 72
-
-    w3.eth.chain_id = None
-    assert w3.eth.chain_id == 61
-
-
-@pytest.mark.asyncio
-async def test_async_set_chain_id(async_w3):
-    assert await async_w3.eth.chain_id == 61
-
-    async_w3.eth.chain_id = 72
-    assert await async_w3.eth.chain_id == 72
-
-    async_w3.eth.chain_id = None
-    assert await async_w3.eth.chain_id == 61

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -114,7 +114,6 @@ from web3.types import (
 class BaseEth(Module):
     _default_account: Union[ChecksumAddress, Empty] = empty
     _default_block: BlockIdentifier = "latest"
-    _default_chain_id: Optional[int] = None
     gasPriceStrategy = None
 
     _gas_price: Method[Callable[[], Wei]] = Method(
@@ -358,14 +357,7 @@ class AsyncEth(BaseEth):
 
     @property
     async def chain_id(self) -> int:
-        if self._default_chain_id is None:
-            return await self._chain_id()  # type: ignore
-        else:
-            return self._default_chain_id
-
-    @chain_id.setter
-    def chain_id(self, value: int) -> None:
-        self._default_chain_id = value
+        return await self._chain_id()  # type: ignore
 
     @property
     async def coinbase(self) -> ChecksumAddress:
@@ -637,14 +629,7 @@ class Eth(BaseEth):
 
     @property
     def chain_id(self) -> int:
-        if self._default_chain_id is None:
-            return self._chain_id()
-        else:
-            return self._default_chain_id
-
-    @chain_id.setter
-    def chain_id(self, value: int) -> None:
-        self._default_chain_id = value
+        return self._chain_id()
 
     @property
     def chainId(self) -> int:

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -82,6 +82,7 @@ SIMPLE_CACHE_RPC_WHITELIST = cast(Set[RPCEndpoint], {
     # 'eth_getWork',
     # 'eth_submitWork',
     # 'eth_submitHashrate',
+    'eth_chainId',
 })
 
 


### PR DESCRIPTION
### What was wrong?

See #2425. This is just the v6 port. 

### How was it fixed?

Added `eth_chainId` to the `simple_cache_middleware`. Had to take out the async `_default_chain_id` flow for consistency between the two modules, and will add caching for async `chain_id` after the `simple_cache_middleware` gets asyncified.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/photos/cute-caterpillar-on-green-leaf-closeup-of-photo-picture-id852063044?k=20&m=852063044&s=170667a&w=0&h=FrCsV4HrJzjEgDILNkb1lvEEpvEsxHbFkZIVAbVxSIQ=)
