### PR TITLE
chaged to 3.7+ support in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Python library for interacting with Ethereum, inspired by [web3.js](https://github.com/ethereum/web3.js).
 
-* Python 3.6+ support
+* Python 3.7+ support
 
 ---
 


### PR DESCRIPTION
updated the readme to show that web3.py only supports 3.7+ now. 