### PR TITLE
Fix usage of obsolete IOError exception

### DIFF
--- a/web3/_utils/windows.py
+++ b/web3/_utils/windows.py
@@ -17,12 +17,12 @@ class NamedPipe:
                 ipc_path, win32file.GENERIC_READ | win32file.GENERIC_WRITE,
                 0, None, win32file.OPEN_EXISTING, 0, None)
         except pywintypes.error as err:
-            raise IOError(err)
+            raise OSError(err)
 
     def recv(self, max_length: int) -> str:
         (err, data) = win32file.ReadFile(self.handle, max_length)
         if err:
-            raise IOError(err)
+            raise OSError(err)
         return data
 
     def sendall(self, data: str) -> Tuple[int, int]:

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -102,7 +102,7 @@ class AsyncJSONBaseProvider(AsyncBaseProvider):
     async def isConnected(self) -> bool:
         try:
             response = await self.make_request(RPCEndpoint('web3_clientVersion'), [])
-        except IOError:
+        except OSError:
             return False
 
         assert response['jsonrpc'] == '2.0'

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -89,7 +89,7 @@ class AutoProvider(BaseProvider):
     def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         try:
             return self._proxy_request(method, params)
-        except IOError:
+        except OSError:
             return self._proxy_request(method, params, use_cache=False)
 
     def isConnected(self) -> bool:

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -101,7 +101,7 @@ class JSONBaseProvider(BaseProvider):
     def isConnected(self) -> bool:
         try:
             response = self.make_request(RPCEndpoint('web3_clientVersion'), [])
-        except IOError:
+        except OSError:
             return False
 
         assert response['jsonrpc'] == '2.0'


### PR DESCRIPTION
### What was wrong?

Using an obsolete exception :smiling_imp: 

### How was it fixed?

`IOError` is an alias of `OSError` on Python 3.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/b7ZoPUqW7j8/maxresdefault.jpg)
