### PR TITLE
Resolve Typo in documentation.

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -112,7 +112,7 @@ will return a new :class:`BlockFilter` object.
 ``TransactionFilter`` is a subclass of :class:`Filter`.
 
 You can setup a filter for new blocks using ``web3.eth.filter('pending')`` which
-will return a new :class:`BlockFilter` object.
+will return a new :class:`TransactionFilter` object.
 
     .. code-block:: python
 

--- a/newsfragments/2444.doc.rst
+++ b/newsfragments/2444.doc.rst
@@ -1,0 +1,1 @@
+Doc fix: Pending transaction filter returns a ``TransactionFilter`` not a ``BlockFilter``


### PR DESCRIPTION
### What was wrong?

Related to Issue #2443

### How was it fixed?

Correct typo in the documentation.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://ichef.bbci.co.uk/images/ic/256xn/p03t1zjb.jpg)
