### PR TITLE
[v5] Resolve Typo in documentation. (#2444)

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -111,7 +111,7 @@ will return a new :class:`BlockFilter` object.
 ``TransactionFilter`` is a subclass of :class:`Filter`.
 
 You can setup a filter for new blocks using ``web3.eth.filter('pending')`` which
-will return a new :class:`BlockFilter` object.
+will return a new :class:`TransactionFilter` object.
 
     .. code-block:: python
 

--- a/newsfragments/2444.doc.rst
+++ b/newsfragments/2444.doc.rst
@@ -1,0 +1,1 @@
+Doc fix: Pending transaction filter returns a ``TransactionFilter`` not a ``BlockFilter``


### PR DESCRIPTION
v5 backport. See #2444 

* Resolve Typo in documentation.

* Add newsfragment for doc fix

Co-authored-by: kclowes <kclowes@users.noreply.github.com>