### PR TITLE
docs: fix `simple_cache_middleware` example

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -226,7 +226,7 @@ The following properties are available on the ``web3.eth`` namespace.
        .. code-block:: python
 
           >>> from web3.middleware import simple_cache_middleware
-          >>> w3.middleware_onion.add(simple_cache_middleare)
+          >>> w3.middleware_onion.add(simple_cache_middleware)
 
 
 .. py:attribute:: Eth.chainId

--- a/newsfragments/2449.doc.rst
+++ b/newsfragments/2449.doc.rst
@@ -1,0 +1,1 @@
+Fix typo in simple_cache_middleware example


### PR DESCRIPTION
### What was wrong?

Fix example doc for using `simple_cache_middleware`

### How was it fixed?

w

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![download](https://user-images.githubusercontent.com/19540978/165957848-3897e385-a0ac-43fd-9273-3de6f7f64424.jpeg)

