### PR TITLE
fix: add chainId to txn params

### DIFF
--- a/newsfragments/2450.misc.rst
+++ b/newsfragments/2450.misc.rst
@@ -1,0 +1,1 @@
+Add ``chainId`` to tx params to ``TRANSACTION_PARAMS_ABI``

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -163,6 +163,7 @@ TRANSACTION_PARAMS_ABIS = {
     'nonce': 'uint',
     'to': 'address',
     'value': 'uint',
+    'chainId': 'uint',
 }
 
 FILTER_PARAMS_ABIS = {

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -55,11 +55,12 @@ to_integer_if_hex = apply_formatter_if(is_string, hex_to_integer)
 
 @curry
 def _validate_chain_id(web3_chain_id: int, chain_id: int) -> int:
-    if to_integer_if_hex(chain_id) == web3_chain_id:
+    chain_id_int = to_integer_if_hex(chain_id)
+    if chain_id_int == web3_chain_id:
         return chain_id
     else:
         raise ValidationError(
-            f"The transaction declared chain ID {chain_id!r}, "
+            f"The transaction declared chain ID {chain_id_int!r}, "
             f"but the connected node is on {web3_chain_id!r}"
         )
 


### PR DESCRIPTION
### What was wrong?

I noticed even when caching `chain_id`, the request occurs multiple times. I figured out this happens because I am calling `estimate_gas()` and passing it a transaction and the RPC method's defined txn schema does not inclue `chainId` so it makes the request againt to add the chainId at some point (this is only deduced).. By adding `chainId` to the params, I can avoid an extra RPC call to get the chain ID`

### How was it fixed?

Add `'chainId': 'uint',` in `TRANSACTION_PARAMS_ABIS`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![baby_bats](https://user-images.githubusercontent.com/19540978/165994541-fc87f858-c5c1-43dc-9d86-209a2a83616c.jpeg)



![Put a link to a cute animal picture inside the parenthesis-->]()
