### PR TITLE
[v5] Increase session cache size

### DIFF
--- a/newsfragments/2451.bugfix.rst
+++ b/newsfragments/2451.bugfix.rst
@@ -1,0 +1,1 @@
+Increase SessionCache size

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -78,7 +78,7 @@ def _remove_session(key: str, session: requests.Session) -> None:
 
 _session_cache = lru.LRU(8, callback=_remove_session)
 _async_session_cache_lock = threading.Lock()
-_async_session_cache = SessionCache(size=8)
+_async_session_cache = SessionCache(size=20)
 
 
 def _get_session(endpoint_uri: URI) -> requests.Session:


### PR DESCRIPTION
### What was wrong?
With the new SessionCache, users were limited to 8 items in the cache before it hung.

Related to Issue #2446

### How was it fixed?
Bumped the cache size. This is a very quick fix solution. With this solution, if there are more than 20 items in the cache it will still hang. I'm going to leave the initial issue open to find an actual solution.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/gb7vd5zxdlf01.jpg?auto=webp&s=ca0399e1a77902ed36295ec01697a204252c5800)
