### PR TITLE
Add v6 warnings to ENS changes from pr #2411

### DIFF
--- a/ens/main.py
+++ b/ens/main.py
@@ -12,6 +12,7 @@ from typing import (
     Union,
     cast,
 )
+import warnings
 
 from eth_typing import (
     Address,
@@ -259,6 +260,12 @@ class ENS:
             return self._setup_reverse(name, address, transact=transact)
 
     def resolve(self, name: str, get: str = 'addr') -> Optional[Union[ChecksumAddress, str]]:
+        warnings.warn(
+            "In v6, the resolve() method will be made internal and renamed to _resolve(). The "
+            "'get' param name will also change to 'fn_name'.",
+            category=DeprecationWarning,
+        )
+
         normal_name = normalize_name(name)
         resolver = self.resolver(normal_name)
         if resolver:
@@ -272,6 +279,12 @@ class ENS:
             return None
 
     def resolver(self, normal_name: str) -> Optional['Contract']:
+        warnings.warn(
+            "The function signature for resolver() will change in v6 to accept 'name' as a param, "
+            "over 'normalized_name', and the method will normalize the name internally.",
+            category=FutureWarning,
+        )
+
         resolver_addr = self.ens.caller.resolver(normal_name_to_hash(normal_name))
         if is_none_or_zero_address(resolver_addr):
             return None

--- a/ens/main.py
+++ b/ens/main.py
@@ -261,8 +261,10 @@ class ENS:
 
     def resolve(self, name: str, get: str = 'addr') -> Optional[Union[ChecksumAddress, str]]:
         warnings.warn(
-            "In v6, the resolve() method will be made internal and renamed to _resolve(). The "
-            "'get' param name will also change to 'fn_name'.",
+            "In v6, the `ENS.resolve()` method will be made internal and renamed to "
+            "`_resolve()`. It is recommended to use the abstracted resolve functionality of "
+            "`ENS.address()` for forward resolution, and `ENS.name()` for reverse resolution "
+            "instead.",
             category=DeprecationWarning,
         )
 
@@ -278,12 +280,15 @@ class ENS:
         else:
             return None
 
-    def resolver(self, normal_name: str) -> Optional['Contract']:
-        warnings.warn(
-            "The function signature for resolver() will change in v6 to accept 'name' as a param, "
-            "over 'normalized_name', and the method will normalize the name internally.",
-            category=FutureWarning,
-        )
+    def resolver(self, normal_name: str, name: str = None) -> Optional['Contract']:
+        if not name:
+            warnings.warn(
+                "The function signature for resolver() will change in v6 to accept `name` as a "
+                "the positional argument, over `normal_name`, and the method will instead "
+                "normalize the name internally. To suppress warnings for now, `name` may be passed "
+                "in as a keyword argument.",
+                category=FutureWarning,
+            )
 
         resolver_addr = self.ens.caller.resolver(normal_name_to_hash(normal_name))
         if is_none_or_zero_address(resolver_addr):

--- a/ens/main.py
+++ b/ens/main.py
@@ -280,15 +280,22 @@ class ENS:
         else:
             return None
 
-    def resolver(self, normal_name: str, name: str = None) -> Optional['Contract']:
+    def resolver(self, normal_name: str = None, name: str = None) -> Optional['Contract']:
         if not name:
             warnings.warn(
                 "The function signature for resolver() will change in v6 to accept `name` as a "
                 "the positional argument, over `normal_name`, and the method will instead "
-                "normalize the name internally. To suppress warnings for now, `name` may be passed "
-                "in as a keyword argument.",
+                "normalize the name internally. You may migrate to using `name` by passing it in "
+                "as a keyword, e.g. resolver(name=\"ensname.eth\").",
                 category=FutureWarning,
             )
+        else:
+            if normal_name:
+                raise TypeError(
+                    "Only supply one positional argument or the `name` keyword, e.g. "
+                    "resolver(\"ensname.eth\") or resolver(name=\"ensname.eth\")."
+                )
+            normal_name = normalize_name(name)
 
         resolver_addr = self.ens.caller.resolver(normal_name_to_hash(normal_name))
         if is_none_or_zero_address(resolver_addr):

--- a/newsfragments/2452.misc.rst
+++ b/newsfragments/2452.misc.rst
@@ -1,0 +1,1 @@
+Add deprecation and future warnings for ENS changes in v6

--- a/tests/ens/test_v6_warnings.py
+++ b/tests/ens/test_v6_warnings.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def test_resolve_deprecation_warning(ens):
+    with pytest.warns(
+        DeprecationWarning,
+        match="In v6, the resolve\\(\\) method will be made internal and renamed to "
+              "_resolve\\(\\). The 'get' param name will also change to 'fn_name'.",
+    ):
+        ens.resolve('tester.eth')
+
+
+def test_resolver_future_warning(ens):
+    with pytest.warns(
+        FutureWarning,
+        match="The function signature for resolver\\(\\) will change in v6 to accept 'name' as a "
+              "param, over 'normalized_name', and the method will normalize the name internally.",
+    ):
+        ens.resolver('tester.eth')

--- a/tests/ens/test_v6_warnings.py
+++ b/tests/ens/test_v6_warnings.py
@@ -10,20 +10,28 @@ def test_resolve_deprecation_warning(ens):
             "`ENS.address\\(\\)` for forward resolution, and `ENS.name\\(\\)` for reverse "
             "resolution instead."
     ):
-        ens.resolve('tester.eth')
+        ens.resolve("tester.eth")
 
 
-def test_resolver_future_warning(ens):
+def test_resolver_future_warning_when_name_is_missing(ens):
     with pytest.warns(
         FutureWarning,
         match="The function signature for resolver\\(\\) will change in v6 to accept `name` as a "
             "the positional argument, over `normal_name`, and the method will instead "
-            "normalize the name internally. To suppress warnings for now, `name` may be passed "
-            "in as a keyword argument.",
+            "normalize the name internally. You may migrate to using `name` by passing it in "
+            "as a keyword, e.g. resolver\\(name=\"ensname.eth\"\\).",
     ):
-        ens.resolver('tester.eth')
+        assert ens.resolver("eth")
 
-    # assert no warning when `name` kwarg is passed in
+    # assert no warning when `name` is passed in as a kwarg
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # turn all warnings to errors
-        ens.resolver('tester.eth', name='tester.eth')
+        assert ens.resolver(name="EtH")
+
+    # assert TypeError if both arguments passed in
+    with pytest.raises(
+        TypeError,
+        match="Only supply one positional argument or the `name` keyword, e.g. resolver\\("
+        "\"ensname.eth\"\\) or resolver\\(name=\"ensname.eth\"\\).",
+    ):
+        ens.resolver("eth", name="EtH")

--- a/tests/ens/test_v6_warnings.py
+++ b/tests/ens/test_v6_warnings.py
@@ -1,11 +1,14 @@
 import pytest
+import warnings
 
 
 def test_resolve_deprecation_warning(ens):
     with pytest.warns(
         DeprecationWarning,
-        match="In v6, the resolve\\(\\) method will be made internal and renamed to "
-              "_resolve\\(\\). The 'get' param name will also change to 'fn_name'.",
+        match="In v6, the `ENS.resolve\\(\\)` method will be made internal and renamed to "
+            "`_resolve\\(\\)`. It is recommended to use the abstracted resolve functionality of "
+            "`ENS.address\\(\\)` for forward resolution, and `ENS.name\\(\\)` for reverse "
+            "resolution instead."
     ):
         ens.resolve('tester.eth')
 
@@ -13,7 +16,14 @@ def test_resolve_deprecation_warning(ens):
 def test_resolver_future_warning(ens):
     with pytest.warns(
         FutureWarning,
-        match="The function signature for resolver\\(\\) will change in v6 to accept 'name' as a "
-              "param, over 'normalized_name', and the method will normalize the name internally.",
+        match="The function signature for resolver\\(\\) will change in v6 to accept `name` as a "
+            "the positional argument, over `normal_name`, and the method will instead "
+            "normalize the name internally. To suppress warnings for now, `name` may be passed "
+            "in as a keyword argument.",
     ):
         ens.resolver('tester.eth')
+
+    # assert no warning when `name` kwarg is passed in
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # turn all warnings to errors
+        ens.resolver('tester.eth', name='tester.eth')


### PR DESCRIPTION
### What was wrong?

Method signature changes and method deprecation for some ENS methods in `v6`.

Related to Issue #2411 

### How was it fixed?

Add warnings for method deprecation and method signature changes for ENS methods in `v6`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.thesprucepets.com/thmb/W3k_DWdDZWY7GRSBmpUpN1-G-HM=/2125x1411/filters:fill(auto,1)/wallaby-GettyImages-590486136-58e667df5f9b58ef7ec76598.jpg)
