### PR TITLE
More flaky tests with timeouts added to loose xfail list

### DIFF
--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -19,6 +19,9 @@ from web3._utils.module_testing import (  # noqa: F401
     VersionModuleTest,
     Web3ModuleTest,
 )
+from web3.types import (
+    BlockData,
+)
 
 if TYPE_CHECKING:
     from web3 import (  # noqa: F401
@@ -81,6 +84,16 @@ class GoEthereumEthModuleTest(EthModuleTest):
         self, w3: "Web3", unlocked_account_dual_type: ChecksumAddress
     ) -> None:
         super().test_eth_wait_for_transaction_receipt_unmined(w3, unlocked_account_dual_type)
+
+    @pytest.mark.xfail(reason='Inconsistently creating timeout issues.', strict=False)
+    def test_eth_get_raw_transaction_by_block(
+        self, w3: "Web3",
+        unlocked_account_dual_type: ChecksumAddress,
+        block_with_txn: BlockData,
+    ) -> None:
+        super().test_eth_get_raw_transaction_by_block(
+            w3, unlocked_account_dual_type, block_with_txn
+        )
 
 
 class GoEthereumVersionModuleTest(VersionModuleTest):


### PR DESCRIPTION
### What was wrong?

Related to commit 69391b7651677b893f5c07b374b6c21ecb7e5aaa

### How was it fixed?

- Added ``test_eth_get_raw_transaction_by_block`` to the flaky tests with timeouts. Wack-a-mole 😅.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2F3c1703fe8d.site.internapcdn.net%2Fnewman%2Fgfx%2Fnews%2Fhires%2F2017%2F2-reintroduced.jpg&f=1&nofb=1)
