### PR TITLE
removed deprecated images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ common: &common
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: python -m tox -r
     - save_cache:
         paths:
           - .tox
@@ -46,7 +46,7 @@ docs_steps: &docs_steps
         command: pip install -U web3
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: python -m tox -r
     - save_cache:
         paths:
           - .tox
@@ -90,7 +90,7 @@ geth_steps: &geth_steps
           geth makedag 0 $HOME/.ethash
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: python -m tox -r
     - save_cache:
         paths:
           - .tox
@@ -130,7 +130,7 @@ geth_custom_steps: &geth_custom_steps
           ./custom_geth makedag 0 $HOME/.ethash
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: python -m tox -r
     - save_cache:
         paths:
           - .tox
@@ -166,7 +166,7 @@ ethpm_steps: &ethpm_steps
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: python -m tox -r
     - save_cache:
         paths:
           - .tox
@@ -203,20 +203,17 @@ windows_steps: &windows_steps
 
 
 jobs:
-  #
-  # Python 3.6
-  #
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
     environment:
       TOXENV: lint
 
   docs:
     <<: *docs_steps
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
     environment:
       TOXENV: docs
 
@@ -227,21 +224,21 @@ jobs:
   py37-core:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     environment:
       TOXENV: py37-core
 
   py37-ens:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     environment:
       TOXENV: py37-ens
 
   py37-ethpm:
     <<: *ethpm_steps
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     environment:
       TOXENV: py37-ethpm
       # Please don't use this key for any shenanigans
@@ -250,7 +247,7 @@ jobs:
   py37-integration-goethereum-ipc:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     environment:
       TOXENV: py37-integration-goethereum-ipc
       GETH_VERSION: v1.10.13
@@ -258,7 +255,7 @@ jobs:
   py37-integration-goethereum-http:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     environment:
       TOXENV: py37-integration-goethereum-http
       GETH_VERSION: v1.10.13
@@ -266,7 +263,7 @@ jobs:
   py37-integration-goethereum-ws:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     environment:
       TOXENV: py37-integration-goethereum-ws
       GETH_VERSION: v1.10.13
@@ -274,7 +271,7 @@ jobs:
   py37-integration-ethtester-pyevm:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     environment:
       TOXENV: py37-integration-ethtester
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
@@ -282,7 +279,7 @@ jobs:
   py37-wheel-cli:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     environment:
       TOXENV: py37-wheel-cli
 
@@ -297,21 +294,21 @@ jobs:
   py38-core:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     environment:
       TOXENV: py38-core
 
   py38-ens:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     environment:
       TOXENV: py38-ens
 
   py38-ethpm:
     <<: *ethpm_steps
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     environment:
       TOXENV: py38-ethpm
       # Please don't use this key for any shenanigans
@@ -320,7 +317,7 @@ jobs:
   py38-integration-goethereum-ipc:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     environment:
       TOXENV: py38-integration-goethereum-ipc
       GETH_VERSION: v1.10.13
@@ -328,7 +325,7 @@ jobs:
   py38-integration-goethereum-http:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     environment:
       TOXENV: py38-integration-goethereum-http
       GETH_VERSION: v1.10.13
@@ -336,7 +333,7 @@ jobs:
   py38-integration-goethereum-ws:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     environment:
       TOXENV: py38-integration-goethereum-ws
       GETH_VERSION: v1.10.13
@@ -344,7 +341,7 @@ jobs:
   py38-integration-ethtester-pyevm:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     environment:
       TOXENV: py38-integration-ethtester
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
@@ -352,7 +349,7 @@ jobs:
   py38-wheel-cli:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
     environment:
       TOXENV: py38-wheel-cli
 
@@ -362,21 +359,21 @@ jobs:
   py39-core:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
     environment:
       TOXENV: py39-core
 
   py39-ens:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
     environment:
       TOXENV: py39-ens
 
   py39-ethpm:
     <<: *ethpm_steps
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
     environment:
       TOXENV: py39-ethpm
       # Please don't use this key for any shenanigans
@@ -385,7 +382,7 @@ jobs:
   py39-integration-goethereum-ipc:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
     environment:
       TOXENV: py39-integration-goethereum-ipc
       GETH_VERSION: v1.10.13
@@ -393,7 +390,7 @@ jobs:
   py39-integration-goethereum-http:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
     environment:
       TOXENV: py39-integration-goethereum-http
       GETH_VERSION: v1.10.13
@@ -401,7 +398,7 @@ jobs:
   py39-integration-goethereum-ws:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
     environment:
       TOXENV: py39-integration-goethereum-ws
       GETH_VERSION: v1.10.13
@@ -409,7 +406,7 @@ jobs:
   py39-integration-ethtester-pyevm:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
     environment:
       TOXENV: py39-integration-ethtester
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
@@ -417,7 +414,7 @@ jobs:
   py39-wheel-cli:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-wheel-cli
 
@@ -427,21 +424,21 @@ jobs:
   py310-core:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     environment:
       TOXENV: py310-core
 
   py310-ens:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     environment:
       TOXENV: py310-ens
 
   py310-ethpm:
     <<: *ethpm_steps
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     environment:
       TOXENV: py310-ethpm
       # Please don't use this key for any shenanigans
@@ -450,7 +447,7 @@ jobs:
   py310-integration-goethereum-ipc:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     environment:
       TOXENV: py310-integration-goethereum-ipc
       GETH_VERSION: v1.10.11
@@ -458,7 +455,7 @@ jobs:
   py310-integration-goethereum-http:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     environment:
       TOXENV: py310-integration-goethereum-http
       GETH_VERSION: v1.10.11
@@ -466,7 +463,7 @@ jobs:
   py310-integration-goethereum-ws:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     environment:
       TOXENV: py310-integration-goethereum-ws
       GETH_VERSION: v1.10.11
@@ -474,7 +471,7 @@ jobs:
   py310-integration-ethtester-pyevm:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     environment:
       TOXENV: py310-integration-ethtester
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
@@ -482,14 +479,14 @@ jobs:
   py310-wheel-cli:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
         environment:
           TOXENV: py310-wheel-cli
 
   benchmark:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
     environment:
       TOXENV: benchmark
       GETH_VERSION: v1.10.13

--- a/newsfragments/2462.misc.rst
+++ b/newsfragments/2462.misc.rst
@@ -1,0 +1,1 @@
+The circleci/ images have been deprecated for a while moving to cimg/ images.


### PR DESCRIPTION
### What was wrong?

The circleci/ images have been deprecated for a while moving to cimg/ images. Here is the [link ](https://circleci.com/docs/2.0/next-gen-migration-guide)to the circleci documentation

### How was it fixed?

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

