### PR TITLE
Fix get cached latest block (#2346)

### DIFF
--- a/newsfragments/2185.bugfix.rst
+++ b/newsfragments/2185.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in _is_latest_block_number_request in cache middleware

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -12,6 +12,9 @@ from typing import (
     cast,
 )
 
+from eth_utils import (
+    is_list_like,
+)
 import lru
 
 from web3._utils.caching import (
@@ -318,7 +321,7 @@ AVG_BLOCK_TIME_UPDATED_AT_KEY: Literal['avg_block_time_updated_at'] = 'avg_block
 def _is_latest_block_number_request(method: RPCEndpoint, params: Any) -> bool:
     if method != 'eth_getBlockByNumber':
         return False
-    elif params[:1] == ['latest']:
+    elif is_list_like(params) and tuple(params[:1]) == ('latest',):
         return True
     return False
 


### PR DESCRIPTION
### What was wrong?

latest block cache bug fix, for v5

Related to PR #2346

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/168644766-31204d0c-acf9-45de-9379-0391a4e92b15.png)
