### PR TITLE
Pin Jinja2<=3.0.3

### DIFF
--- a/newsfragments/2476.misc.rst
+++ b/newsfragments/2476.misc.rst
@@ -1,0 +1,1 @@
+Pin Jinja2<=3.0.3 to get docs to build

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ extras_require = {
         "toposort>=1.4",
         "towncrier==18.5.0",
         "urllib3",
-        "wheel"
+        "wheel",
+        "Jinja2<=3.0.3", # Jinja v3.1.0 dropped support for python 3.6
     ],
     'dev': [
         "bumpversion",


### PR DESCRIPTION
### What was wrong?
Jinja v3.1.0 started throwing errors during the release process. I think it has something to do with the fact that they dropped python 3.6 support in version 3.1.0, but I'm not sure.

### How was it fixed?
Pinned Jinja2 to the version before where they dropped python 3.6

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/168655040-52c2775f-fb4f-4840-b2f6-52bd0e75db8f.png)

