### PR TITLE
Increase cache size

### DIFF
--- a/newsfragments/2477.bugfix.rst
+++ b/newsfragments/2477.bugfix.rst
@@ -1,0 +1,1 @@
+Increase cache size to allow for 20 entries.

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -78,7 +78,7 @@ def _remove_session(key: str, session: requests.Session) -> None:
 
 _session_cache = lru.LRU(8, callback=_remove_session)
 _async_session_cache_lock = threading.Lock()
-_async_session_cache = SessionCache(size=8)
+_async_session_cache = SessionCache(size=20)
 
 
 def _get_session(endpoint_uri: URI) -> requests.Session:


### PR DESCRIPTION
### What was wrong?
Our async cache was limited to 8 entries and would hang after that number was reached. This is a temporary fix so that users can use more than 8. Will solve the root cause in another PR.

Related to Issue #2451

### How was it fixed?
Bumped the cache size.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/gb7vd5zxdlf01.jpg?auto=webp&s=ca0399e1a77902ed36295ec01697a204252c5800)
