### PR TITLE
removed verison check in __init__

### DIFF
--- a/newsfragments/2478.misc.rst
+++ b/newsfragments/2478.misc.rst
@@ -1,0 +1,1 @@
+Removed version check in `__init__`

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -1,5 +1,3 @@
-import sys
-import warnings
 
 import pkg_resources
 
@@ -24,18 +22,6 @@ from web3.providers.async_rpc import (  # noqa: E402
 from web3.providers.websocket import (  # noqa: E402
     WebsocketProvider,
 )
-
-if (3, 5) <= sys.version_info < (3, 6):
-    warnings.warn(
-        "Support for Python 3.5 will be removed in web3.py v5",
-        category=DeprecationWarning,
-        stacklevel=2)
-
-if sys.version_info < (3, 5):
-    raise EnvironmentError(
-        "Python 3.5 or above is required. "
-        "Note that support for Python 3.5 will be removed in web3.py v5")
-
 
 __version__ = pkg_resources.get_distribution("web3").version
 


### PR DESCRIPTION
These version checks are out of data and probably not needed since the setup.py restricts the ability to install in any python version that is not supported. 
