### PR TITLE
removed deprecate sha3 methods

### DIFF
--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -304,54 +304,6 @@ Cryptographic Hashing
         assert(data2 == hex"4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45");
 
 
-.. py:classmethod:: Web3.sha3(primitive=None, hexstr=None, text=None)
-
-    .. WARNING::
-      This method has been deprecated for :meth:`~Web3.keccak`
-
-    Returns the Keccak SHA256 of the given value. Text is encoded to UTF-8 before
-    computing the hash, just like Solidity. Any of the following are
-    valid and equivalent:
-
-    .. code-block:: python
-
-        >>> Web3.sha3(0x747874)
-        >>> Web3.sha3(b'\x74\x78\x74')
-        >>> Web3.sha3(hexstr='0x747874')
-        >>> Web3.sha3(hexstr='747874')
-        >>> Web3.sha3(text='txt')
-        HexBytes('0xd7278090a36507640ea6b7a0034b69b0d240766fa3f98e3722be93c613b29d2e')
-
-.. py:classmethod:: Web3.soliditySha3(abi_types, value)
-
-    .. WARNING::
-      This method has been deprecated for :meth:`~Web3.solidityKeccak`
-
-
-    Returns the sha3 as it would be computed by the solidity ``sha3`` function
-    on the provided ``value`` and ``abi_types``.  The ``abi_types`` value
-    should be a list of solidity type strings which correspond to each of the
-    provided values.
-
-
-    .. code-block:: python
-
-        >>> Web3.soliditySha3(['bool'], [True])
-        HexBytes("0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2")
-
-        >>> Web3.soliditySha3(['uint8', 'uint8', 'uint8'], [97, 98, 99])
-        HexBytes("0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45")
-
-        >>> Web3.soliditySha3(['uint8[]'], [[97, 98, 99]])
-        HexBytes("0x233002c671295529bcc50b76a2ef2b0de2dac2d93945fca745255de1a9e4017e")
-
-        >>> Web3.soliditySha3(['address'], ["0x49EdDD3769c0712032808D86597B84ac5c2F5614"])
-        HexBytes("0x2ff37b5607484cd4eecf6d13292e22bd6e5401eaffcc07e279583bc742c68882")
-
-        >>> Web3.soliditySha3(['address'], ["ethereumfoundation.eth"])
-        HexBytes("0x913c99ea930c78868f1535d34cd705ab85929b2eaaf70fcd09677ecd6e5d75e9")
-
-
 Check Encodability
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/newsfragments/2479.breaking-change.rst
+++ b/newsfragments/2479.breaking-change.rst
@@ -1,0 +1,1 @@
+sha3 and soliditySha3 were previously deprecated and now removed

--- a/tests/core/web3-module/test_keccak.py
+++ b/tests/core/web3-module/test_keccak.py
@@ -97,10 +97,3 @@ def test_keccak_raise_if_hexstr_and_text():
 def test_keccak_raise_if_no_args():
     with pytest.raises(TypeError):
         Web3.keccak()
-
-
-def test_deprecated_bound_method():
-    w3 = Web3()
-    h = HexBytes('0x0f355f04c0a06eebac1d219b34c598f85a1169badee164be8a30345944885fe8')
-    with pytest.warns(DeprecationWarning, match='sha3 is deprecated in favor of keccak'):
-        assert w3.sha3(text='cowmö') == h

--- a/web3/main.py
+++ b/web3/main.py
@@ -51,9 +51,6 @@ from web3._utils.abi import (
     build_strict_registry,
     map_abi_data,
 )
-from web3._utils.decorators import (
-    deprecated_for,
-)
 from web3._utils.empty import (
     empty,
 )
@@ -277,13 +274,6 @@ class Web3:
         return __version__
 
     @staticmethod
-    @deprecated_for("keccak")
-    @apply_to_return_value(HexBytes)
-    def sha3(primitive: Optional[Primitives] = None, text: Optional[str] = None,
-             hexstr: Optional[HexStr] = None) -> bytes:
-        return Web3.keccak(primitive, text, hexstr)
-
-    @staticmethod
     @apply_to_return_value(HexBytes)
     def keccak(primitive: Optional[Primitives] = None, text: Optional[str] = None,
                hexstr: Optional[HexStr] = None) -> bytes:
@@ -299,11 +289,6 @@ class Web3:
                 {'text': text, 'hexstr': hexstr}
             )
         )
-
-    @combomethod
-    @deprecated_for("solidityKeccak")
-    def soliditySha3(cls, abi_types: List[TypeStr], values: List[Any]) -> bytes:
-        return cls.solidityKeccak(abi_types, values)
 
     @combomethod
     def solidityKeccak(cls, abi_types: List[TypeStr], values: List[Any]) -> bytes:


### PR DESCRIPTION
The sha3 methods have been deprecated in main.py for some time now. Since the v6 branch is now on main it probably makes sense to remove these.