### PR TITLE
removed more depecrated methods in geth and parity

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -138,7 +138,7 @@ For example, the following retrieves the client enode endpoint for both geth and
         enode = w3.parity.enode
 
     elif connected and w3.clientVersion.startswith('Geth'):
-        enode = w3.geth.admin.nodeInfo['enode']
+        enode = w3.geth.admin.node_info['enode']
 
     else:
         enode = None
@@ -399,7 +399,7 @@ AsyncHTTPProvider
         ...              'admin' : (AsyncGethAdmin,)})
         ...         },
         ...     middlewares=[]   # See supported middleware section below for middleware options
-        ...     ) 
+        ...     )
         >>> custom_session = ClientSession()  # If you want to pass in your own session
         >>> await w3.provider.cache_async_session(custom_session) # This method is an async method so it needs to be handled accordingly
 

--- a/docs/web3.geth.rst
+++ b/docs/web3.geth.rst
@@ -54,12 +54,6 @@ The ``web3.geth.admin`` object exposes methods to interact with the RPC APIs und
         }
 
 
-.. py:method:: nodeInfo()
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.geth.admin.node_info()`
-
-
 .. py:method:: peers()
 
     * Delegates to ``admin_peers`` RPC Method
@@ -118,10 +112,6 @@ The ``web3.geth.admin`` object exposes methods to interact with the RPC APIs und
         True
 
 
-.. py:method:: addPeer(node_url)
-
-    .. warning:: Deprecated: This method is deprecated in favor of :meth:`~web3.geth.admin.add_peer()`
-
 .. py:method:: start_rpc(host='localhost', port=8545, cors="", apis="eth,net,web3")
 
     * Delegates to ``admin_startRPC`` RPC Method
@@ -135,12 +125,6 @@ The ``web3.geth.admin`` object exposes methods to interact with the RPC APIs und
 
         >>> web3.geth.admin.start_rpc()
         True
-
-
-.. py:method:: startRPC(host='localhost', port=8545, cors="", apis="eth,net,web3")
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-       :meth:`~web3.geth.admin.start_rpc()`
 
 
 .. py:method:: start_ws(host='localhost', port=8546, cors="", apis="eth,net,web3")
@@ -158,12 +142,6 @@ The ``web3.geth.admin`` object exposes methods to interact with the RPC APIs und
         True
 
 
-.. py:method:: startWS(host='localhost', port=8546, cors="", apis="eth,net,web3")
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-       :meth:`~web3.geth.admin.start_ws()`
-
-
 .. py:method:: stop_rpc()
 
     * Delegates to ``admin_stopRPC`` RPC Method
@@ -176,12 +154,6 @@ The ``web3.geth.admin`` object exposes methods to interact with the RPC APIs und
         True
 
 
-.. py:method:: stopRPC()
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-       :meth:`~web3.geth.admin.stop_rpc()`
-
-
 .. py:method:: stop_ws()
 
     * Delegates to ``admin_stopWS`` RPC Method
@@ -192,12 +164,6 @@ The ``web3.geth.admin`` object exposes methods to interact with the RPC APIs und
 
         >>> web3.geth.admin.stop_ws()
         True
-
-
-.. py:method:: stopWS()
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-       :meth:`~web3.geth.admin.stop_ws()`
 
 
 .. py:module:: web3.geth.personal
@@ -217,12 +183,6 @@ The following methods are available on the ``web3.geth.personal`` namespace.
 
         >>> web3.geth.personal.list_accounts()
         ['0xd3CdA913deB6f67967B99D67aCDFa1712C293601']
-
-
-.. py:method:: listAccounts()
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.geth.personal.list_accounts()`
 
 
 .. py:method:: list_wallets()
@@ -257,12 +217,6 @@ The following methods are available on the ``web3.geth.personal`` namespace.
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 
 
-.. py:method:: importRawKey()
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.geth.personal.import_raw_key()`
-
-
 .. py:method:: new_account(self, passphrase)
 
     * Delegates to ``personal_newAccount`` RPC Method
@@ -276,12 +230,6 @@ The following methods are available on the ``web3.geth.personal`` namespace.
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 
 
-.. py:method:: newAccount()
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.geth.personal.new_account()`
-
-
 .. py:method:: lock_account(self, account)
 
     * Delegates to ``personal_lockAccount`` RPC Method
@@ -291,12 +239,6 @@ The following methods are available on the ``web3.geth.personal`` namespace.
     .. code-block:: python
 
         >>> web3.geth.personal.lock_account('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
-
-
-.. py:method:: lockAccount()
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.geth.personal.lock_account()`
 
 
 .. py:method:: unlock_account(self, account, passphrase, duration=None)
@@ -317,23 +259,11 @@ The following methods are available on the ``web3.geth.personal`` namespace.
         True
 
 
-.. py:method:: unlockAccount()
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.geth.personal.unlock_account()`
-
-
 .. py:method:: send_transaction(self, transaction, passphrase)
 
     * Delegates to ``personal_sendTransaction`` RPC Method
 
     Sends the transaction.
-
-
-.. py:method:: sendTransaction()
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.geth.personal.send_transaction()`
 
 
 .. py:module:: web3.geth.txpool

--- a/docs/web3.net.rst
+++ b/docs/web3.net.rst
@@ -12,11 +12,6 @@ Properties
 
 The following properties are available on the ``web3.net`` namespace.
 
-.. py:method:: chainId
-  :property:
-
-    .. warning:: Deprecated: This property is deprecated as of EIP 1474.
-
 .. py:method:: listening
   :property:
 
@@ -40,12 +35,6 @@ The following properties are available on the ``web3.net`` namespace.
 
         >>> web3.net.peer_count
         1
-
-.. py:method:: peerCount
-  :property:
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.geth.admin.peer_count`
 
 .. py:method:: version
   :property:

--- a/docs/web3.parity.rst
+++ b/docs/web3.parity.rst
@@ -25,10 +25,6 @@ The following methods are available on the ``web3.parity.personal`` namespace.
         >>> web3.parity.personal.list_accounts()
         ['0xd3CdA913deB6f67967B99D67aCDFa1712C293601']
 
-.. py:method:: listAccounts
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.parity.personal.list_accounts()`
 
 .. py:method:: import_raw_key(self, private_key, passphrase)
 
@@ -42,11 +38,6 @@ The following methods are available on the ``web3.parity.personal`` namespace.
         >>> web3.parity.personal.import_raw_key(some_private_key, 'the-passphrase')
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 
-.. py:method:: importRawKey(self, private_key, passphrase)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.parity.personal.import_raw_key()`
-
 .. py:method:: new_account(self, password)
 
     * Delegates to ``personal_newAccount`` RPC Method
@@ -58,11 +49,6 @@ The following methods are available on the ``web3.parity.personal`` namespace.
 
         >>> web3.parity.personal.new_account('the-passphrase')
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
-
-.. py:method:: newAccount(self, password)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.parity.personal.new_account()`
 
 .. py:method:: unlock_account(self, account, passphrase, duration=None)
 
@@ -80,21 +66,11 @@ The following methods are available on the ``web3.parity.personal`` namespace.
         >>> web3.parity.personal.unlock_account('0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'the-passphrase')
         True
 
-.. py:method:: unlockAccount(self, account, passphrase, duration=None)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.parity.personal.unlock_account()`
-
 .. py:method:: send_transaction(self, transaction, passphrase)
 
     * Delegates to ``personal_sendTransaction`` RPC Method
 
     Sends the transaction.
-
-.. py:method:: sendTransaction(self, account, passphrase, duration=None)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.parity.personal.send_transaction()`
 
 .. py:method:: sign_typed_data(self, jsonMessage, account, passphrase)
 
@@ -104,8 +80,3 @@ The following methods are available on the ``web3.parity.personal`` namespace.
     and **NOT** the JSON String itself.
 
     Signs the ``Structured Data`` (or ``Typed Data``) with the passphrase of the given ``account``
-
-.. py:method:: signTypedData(self, jsonMessage, account, passphrase)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.parity.personal.sign_typed_data()`

--- a/newsfragments/2480.breaking-change.rst
+++ b/newsfragments/2480.breaking-change.rst
@@ -1,0 +1,1 @@
+Remove deprecated methods from Geth, Parity and Net modules

--- a/newsfragments/2480.doc.rst
+++ b/newsfragments/2480.doc.rst
@@ -1,0 +1,1 @@
+Remove deprecated methods from Geth, Parity, and Net modules

--- a/tests/core/admin-module/test_admin_addPeer.py
+++ b/tests/core/admin-module/test_admin_addPeer.py
@@ -1,16 +1,6 @@
 import pytest
 
 
-def test_admin_addPeer(w3, skip_if_testrpc):
-    skip_if_testrpc(w3)
-
-    with pytest.warns(DeprecationWarning):
-        result = w3.geth.admin.addPeer(
-            'enode://44826a5d6a55f88a18298bca4773fca5749cdc3a5c9f308aa7d810e9b31123f3e7c5fba0b1d70aac5308426f47df2a128a6747040a3815cc7dd7167d03be320d@127.0.0.1:30304',  # noqa: E501
-        )
-        assert result is True
-
-
 def test_admin_add_peer(w3, skip_if_testrpc):
     skip_if_testrpc(w3)
 

--- a/tests/core/admin-module/test_admin_addPeer.py
+++ b/tests/core/admin-module/test_admin_addPeer.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_admin_add_peer(w3, skip_if_testrpc):
     skip_if_testrpc(w3)
 

--- a/tests/core/admin-module/test_admin_nodeInfo.py
+++ b/tests/core/admin-module/test_admin_nodeInfo.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_admin_node_info(w3, skip_if_testrpc):
     skip_if_testrpc(w3)
 

--- a/tests/core/admin-module/test_admin_nodeInfo.py
+++ b/tests/core/admin-module/test_admin_nodeInfo.py
@@ -1,16 +1,6 @@
 import pytest
 
 
-def test_admin_nodeInfo(w3, skip_if_testrpc):
-    skip_if_testrpc(w3)
-
-    with pytest.warns(DeprecationWarning):
-        node_info = w3.geth.admin.nodeInfo
-
-        assert 'enode' in node_info
-        assert 'id' in node_info
-
-
 def test_admin_node_info(w3, skip_if_testrpc):
     skip_if_testrpc(w3)
 

--- a/tests/core/eth-module/conftest.py
+++ b/tests/core/eth-module/conftest.py
@@ -12,7 +12,7 @@ def extra_accounts(w3, account_password):
     num_accounts_to_create = 10 - len(w3.eth.accounts)
 
     for i in range(num_accounts_to_create):
-        w3.personal.newAccount(account_password)
+        w3.personal.new_account(account_password)
 
     return w3.eth.accounts
 

--- a/tests/core/mining-module/test_miner_setExtra.py
+++ b/tests/core/mining-module/test_miner_setExtra.py
@@ -24,7 +24,7 @@ def test_miner_set_extra(web3_empty, wait_for_block):
     # sanity
     assert initial_extra != new_extra_data
 
-    web3.geth.miner.setExtra(new_extra_data)
+    web3.geth.miner.set_extra(new_extra_data)
 
     with Timeout(60) as timeout:
         while True:
@@ -35,28 +35,4 @@ def test_miner_set_extra(web3_empty, wait_for_block):
 
     after_extra = decode_hex(web3.eth.get_block(web3.eth.block_number)['extraData'])
 
-    assert after_extra == new_extra_data
-
-
-@flaky(max_runs=3)
-def test_miner_setExtra(web3_empty, wait_for_block):
-    web3 = web3_empty
-
-    initial_extra = decode_hex(web3.eth.get_block(web3.eth.block_number)['extraData'])
-
-    new_extra_data = b'-this-is-32-bytes-of-extra-data-'
-
-    # sanity
-    assert initial_extra != new_extra_data
-
-    with pytest.warns(DeprecationWarning):
-        web3.geth.miner.setExtra(new_extra_data)
-    with Timeout(60) as timeout:
-        while True:
-            extra_data = decode_hex(web3.eth.get_block(web3.eth.block_number)['extraData'])
-            if extra_data == new_extra_data:
-                break
-            timeout.sleep(random.random())
-
-    after_extra = decode_hex(web3.eth.get_block(web3.eth.block_number)['extraData'])
     assert after_extra == new_extra_data

--- a/tests/core/mining-module/test_miner_setExtra.py
+++ b/tests/core/mining-module/test_miner_setExtra.py
@@ -1,4 +1,3 @@
-import pytest
 import random
 
 from eth_utils import (

--- a/tests/core/mining-module/test_miner_setGasPrice.py
+++ b/tests/core/mining-module/test_miner_setGasPrice.py
@@ -27,23 +27,3 @@ def test_miner_set_gas_price(web3_empty, wait_for_block):
 
     after_gas_price = web3.eth.gas_price
     assert after_gas_price < initial_gas_price
-
-
-@flaky(max_runs=3)
-def test_miner_setGasPrice(web3_empty, wait_for_block):
-    web3 = web3_empty
-
-    initial_gas_price = web3.eth.gas_price
-    assert web3.eth.gas_price > 1000
-
-    # sanity check
-
-    with pytest.warns(DeprecationWarning):
-        web3.geth.miner.setGasPrice(initial_gas_price // 2)
-
-    with Timeout(60) as timeout:
-        while web3.eth.gas_price == initial_gas_price:
-            timeout.sleep(random.random())
-
-    after_gas_price = web3.eth.gas_price
-    assert after_gas_price < initial_gas_price

--- a/tests/core/mining-module/test_miner_setGasPrice.py
+++ b/tests/core/mining-module/test_miner_setGasPrice.py
@@ -1,4 +1,3 @@
-import pytest
 import random
 
 from flaky import (

--- a/tests/core/mining-module/test_setEtherBase.py
+++ b/tests/core/mining-module/test_setEtherBase.py
@@ -7,12 +7,3 @@ def test_miner_set_etherbase(web3_empty):
     new_account = web3.personal.newAccount('this-is-a-password')
     web3.geth.miner.set_etherbase(new_account)
     assert web3.eth.coinbase == new_account
-
-
-def test_miner_setEtherbase(web3_empty):
-    web3 = web3_empty
-    assert web3.eth.coinbase == web3.eth.accounts[0]
-    new_account = web3.personal.newAccount('this-is-a-password')
-    with pytest.warns(DeprecationWarning):
-        web3.geth.miner.setEtherbase(new_account)
-    assert web3.eth.coinbase == new_account

--- a/tests/core/mining-module/test_setEtherBase.py
+++ b/tests/core/mining-module/test_setEtherBase.py
@@ -4,6 +4,6 @@ import pytest
 def test_miner_set_etherbase(web3_empty):
     web3 = web3_empty
     assert web3.eth.coinbase == web3.eth.accounts[0]
-    new_account = web3.personal.newAccount('this-is-a-password')
+    new_account = web3.personal.new_account('this-is-a-password')
     web3.geth.miner.set_etherbase(new_account)
     assert web3.eth.coinbase == new_account

--- a/tests/core/mining-module/test_setEtherBase.py
+++ b/tests/core/mining-module/test_setEtherBase.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_miner_set_etherbase(web3_empty):
     web3 = web3_empty
     assert web3.eth.coinbase == web3.eth.accounts[0]

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -373,10 +373,6 @@ class TestEthereumTesterEthModule(EthModuleTest):
         super().test_eth_get_storage_at(w3, emitter_contract_address)
 
     @pytest.mark.xfail(reason='json-rpc method is not implemented on eth-tester')
-    def test_eth_getStorageAt_deprecated(self, w3, emitter_contract_address):
-        super().test_eth_getStorageAt_deprecated(w3, emitter_contract_address)
-
-    @pytest.mark.xfail(reason='json-rpc method is not implemented on eth-tester')
     def test_eth_get_storage_at_ens_name(self, w3, emitter_contract_address):
         super().test_eth_get_storage_at_ens_name(w3, emitter_contract_address)
 
@@ -509,10 +505,6 @@ class TestEthereumTesterPersonalModule(GoEthereumPersonalModuleTest):
         GoEthereumPersonalModuleTest.test_personal_sign_and_ecrecover,
         ValueError,
     )
-    test_personal_sign_and_ecrecover_deprecated = not_implemented(
-        GoEthereumPersonalModuleTest.test_personal_sign_and_ecrecover,
-        ValueError,
-    )
 
     # Test overridden here since eth-tester returns False rather than None for failed unlock
     def test_personal_unlock_account_failure(self,
@@ -520,14 +512,6 @@ class TestEthereumTesterPersonalModule(GoEthereumPersonalModuleTest):
                                              unlockable_account_dual_type):
         result = w3.geth.personal.unlock_account(unlockable_account_dual_type, 'bad-password')
         assert result is False
-
-    def test_personal_unlockAccount_failure_deprecated(self,
-                                                       w3,
-                                                       unlockable_account_dual_type):
-        with pytest.warns(DeprecationWarning,
-                          match="unlockAccount is deprecated in favor of unlock_account"):
-            result = w3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
-            assert result is False
 
     @pytest.mark.xfail(raises=ValueError, reason="list_wallets not implemented in eth-tester")
     def test_personal_list_wallets(self, w3: "Web3") -> None:

--- a/web3/_utils/admin.py
+++ b/web3/_utils/admin.py
@@ -11,7 +11,6 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.method import (
-    DeprecatedMethod,
     Method,
     default_root_munger,
 )
@@ -85,13 +84,3 @@ stop_ws: Method[Callable[[], bool]] = Method(
     RPC.admin_stopWS,
     is_property=True,
 )
-
-#
-# Deprecated Methods
-#
-addPeer = DeprecatedMethod(add_peer, 'addPeer', 'add_peer')
-nodeInfo = DeprecatedMethod(node_info, 'nodeInfo', 'node_info')
-startRPC = DeprecatedMethod(start_rpc, 'startRPC', 'start_rpc')
-stopRPC = DeprecatedMethod(stop_rpc, 'stopRPC', 'stop_rpc')
-startWS = DeprecatedMethod(start_ws, 'startWS', 'start_ws')
-stopWS = DeprecatedMethod(stop_ws, 'stopWS', 'stop_ws')

--- a/web3/_utils/miner.py
+++ b/web3/_utils/miner.py
@@ -10,7 +10,6 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.method import (
-    DeprecatedMethod,
     Method,
     default_root_munger,
 )
@@ -65,14 +64,3 @@ stop_auto_dag: Method[Callable[[], bool]] = Method(
     RPC.miner_stopAutoDag,
     is_property=True,
 )
-
-
-#
-# Deprecated Methods
-#
-makeDag = DeprecatedMethod(make_dag, 'makeDag', 'make_dag')
-setExtra = DeprecatedMethod(set_extra, 'setExtra', 'set_extra')
-setEtherbase = DeprecatedMethod(set_etherbase, 'setEtherbase', 'set_etherbase')
-setGasPrice = DeprecatedMethod(set_gas_price, 'setGasPrice', 'set_gas_price')
-startAutoDag = DeprecatedMethod(start_auto_dag, 'startAutoDag', 'start_auto_dag')
-stopAutoDag = DeprecatedMethod(stop_auto_dag, 'stopAutoDag', 'stop_auto_dag')

--- a/web3/_utils/module_testing/go_ethereum_personal_module.py
+++ b/web3/_utils/module_testing/go_ethereum_personal_module.py
@@ -49,11 +49,6 @@ class GoEthereumPersonalModuleTest:
         actual = w3.geth.personal.import_raw_key(PRIVATE_KEY_HEX, PASSWORD)
         assert actual == ADDRESS
 
-    def test_personal_importRawKey_deprecated(self, w3: "Web3") -> None:
-        with pytest.warns(DeprecationWarning):
-            actual = w3.geth.personal.importRawKey(SECOND_PRIVATE_KEY_HEX, PASSWORD)
-            assert actual == SECOND_ADDRESS
-
     def test_personal_list_accounts(self, w3: "Web3") -> None:
         accounts = w3.geth.personal.list_accounts()
         assert is_list_like(accounts)
@@ -63,17 +58,6 @@ class GoEthereumPersonalModuleTest:
             for item
             in accounts
         ))
-
-    def test_personal_listAccounts_deprecated(self, w3: "Web3") -> None:
-        with pytest.warns(DeprecationWarning):
-            accounts = w3.geth.personal.listAccounts()
-            assert is_list_like(accounts)
-            assert len(accounts) > 0
-            assert all((
-                is_checksum_address(item)
-                for item
-                in accounts
-            ))
 
     def test_personal_list_wallets(self, w3: "Web3") -> None:
         wallets = w3.geth.personal.list_wallets()
@@ -90,13 +74,6 @@ class GoEthereumPersonalModuleTest:
         # TODO: how do we test this better?
         w3.geth.personal.lock_account(unlockable_account_dual_type)
 
-    def test_personal_lockAccount_deprecated(
-        self, w3: "Web3", unlockable_account_dual_type: ChecksumAddress
-    ) -> None:
-        with pytest.warns(DeprecationWarning):
-            # TODO: how do we test this better?
-            w3.geth.personal.lockAccount(unlockable_account_dual_type)
-
     def test_personal_unlock_account_success(
         self,
         w3: "Web3",
@@ -109,40 +86,15 @@ class GoEthereumPersonalModuleTest:
         )
         assert result is True
 
-    def test_personal_unlockAccount_success_deprecated(
-        self,
-        w3: "Web3",
-        unlockable_account_dual_type: ChecksumAddress,
-        unlockable_account_pw: str,
-    ) -> None:
-        with pytest.warns(DeprecationWarning):
-            result = w3.geth.personal.unlockAccount(
-                unlockable_account_dual_type,
-                unlockable_account_pw
-            )
-            assert result is True
-
     def test_personal_unlock_account_failure(
         self, w3: "Web3", unlockable_account_dual_type: ChecksumAddress
     ) -> None:
         with pytest.raises(ValueError):
             w3.geth.personal.unlock_account(unlockable_account_dual_type, 'bad-password')
 
-    def test_personal_unlockAccount_failure_deprecated(
-        self, w3: "Web3", unlockable_account_dual_type: ChecksumAddress
-    ) -> None:
-        with pytest.warns(DeprecationWarning):
-            with pytest.raises(ValueError):
-                w3.geth.personal.unlockAccount(unlockable_account_dual_type, 'bad-password')
-
     def test_personal_new_account(self, w3: "Web3") -> None:
         new_account = w3.geth.personal.new_account(PASSWORD)
         assert is_checksum_address(new_account)
-
-    def test_personal_newAccount_deprecated(self, w3: "Web3") -> None:
-        with pytest.warns(DeprecationWarning):
-            new_account = w3.geth.personal.newAccount(PASSWORD)
-            assert is_checksum_address(new_account)
 
     def test_personal_send_transaction(
         self,
@@ -168,32 +120,6 @@ class GoEthereumPersonalModuleTest:
         assert transaction['value'] == txn_params['value']
         assert transaction['gasPrice'] == txn_params['gasPrice']
 
-    def test_personal_sendTransaction_deprecated(
-        self,
-        w3: "Web3",
-        unlockable_account_dual_type: ChecksumAddress,
-        unlockable_account_pw: str,
-    ) -> None:
-        assert w3.eth.get_balance(unlockable_account_dual_type) > constants.WEI_PER_ETHER
-        txn_params: TxParams = {
-            'from': unlockable_account_dual_type,
-            'to': unlockable_account_dual_type,
-            'gas': 21000,
-            'value': Wei(1),
-            'gasPrice': w3.toWei(1, 'gwei'),
-        }
-        with pytest.warns(DeprecationWarning):
-            txn_hash = w3.geth.personal.sendTransaction(txn_params, unlockable_account_pw)
-        assert txn_hash
-
-        transaction = w3.eth.get_transaction(txn_hash)
-
-        assert is_same_address(transaction['from'], cast(ChecksumAddress, txn_params['from']))
-        assert is_same_address(transaction['to'], cast(ChecksumAddress, txn_params['to']))
-        assert transaction['gas'] == txn_params['gas']
-        assert transaction['value'] == txn_params['value']
-        assert transaction['gasPrice'] == txn_params['gasPrice']
-
     def test_personal_sign_and_ecrecover(
         self,
         w3: "Web3",
@@ -208,22 +134,6 @@ class GoEthereumPersonalModuleTest:
         )
         signer = w3.geth.personal.ec_recover(message, signature)
         assert is_same_address(signer, unlockable_account_dual_type)
-
-    def test_personal_sign_and_ecrecover_deprecated(
-        self,
-        w3: "Web3",
-        unlockable_account_dual_type: ChecksumAddress,
-        unlockable_account_pw: str,
-    ) -> None:
-        with pytest.warns(DeprecationWarning):
-            message = 'test-web3-geth-personal-sign'
-            signature = w3.geth.personal.sign(
-                message,
-                unlockable_account_dual_type,
-                unlockable_account_pw
-            )
-            signer = w3.geth.personal.ecRecover(message, signature)
-            assert is_same_address(signer, unlockable_account_dual_type)
 
     @pytest.mark.xfail(
         reason="personal_sign_typed_data JSON RPC call has not been released in geth"
@@ -286,67 +196,6 @@ class GoEthereumPersonalModuleTest:
         )
         assert signature == expected_signature
         assert len(signature) == 32 + 32 + 1
-
-    @pytest.mark.xfail(reason="personal_signTypedData JSON RPC call has not been released in geth")
-    def test_personal_sign_typed_data_deprecated(
-        self,
-        w3: "Web3",
-        unlockable_account_dual_type: ChecksumAddress,
-        unlockable_account_pw: str,
-    ) -> None:
-        with pytest.warns(DeprecationWarning):
-            typed_message = '''
-                {
-                    "types": {
-                        "EIP712Domain": [
-                            {"name": "name", "type": "string"},
-                            {"name": "version", "type": "string"},
-                            {"name": "chainId", "type": "uint256"},
-                            {"name": "verifyingContract", "type": "address"}
-                        ],
-                        "Person": [
-                            {"name": "name", "type": "string"},
-                            {"name": "wallet", "type": "address"}
-                        ],
-                        "Mail": [
-                            {"name": "from", "type": "Person"},
-                            {"name": "to", "type": "Person"},
-                            {"name": "contents", "type": "string"}
-                        ]
-                    },
-                    "primaryType": "Mail",
-                    "domain": {
-                        "name": "Ether Mail",
-                        "version": "1",
-                        "chainId": "0x01",
-                        "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
-                    },
-                    "message": {
-                        "from": {
-                            "name": "Cow",
-                            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
-                        },
-                        "to": {
-                            "name": "Bob",
-                            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
-                        },
-                        "contents": "Hello, Bob!"
-                    }
-                }
-            '''
-            signature = HexBytes(w3.geth.personal.sign_typed_data(
-                json.loads(typed_message),
-                unlockable_account_dual_type,
-                unlockable_account_pw
-            ))
-
-            expected_signature = HexBytes(
-                "0xc8b56aaeefd10ab4005c2455daf28d9082af661ac347cd"
-                "b612d5b5e11f339f2055be831bf57a6e6cb5f6d93448fa35"
-                "c1bd56fe1d745ffa101e74697108668c401c"
-            )
-            assert signature == expected_signature
-            assert len(signature) == 32 + 32 + 1
 
 
 class GoEthereumAsyncPersonalModuleTest:

--- a/web3/_utils/module_testing/net_module.py
+++ b/web3/_utils/module_testing/net_module.py
@@ -30,16 +30,6 @@ class NetModuleTest:
 
         assert is_integer(peer_count)
 
-    def test_net_peerCount(self, w3: "Web3") -> None:
-        with pytest.warns(DeprecationWarning):
-            peer_count = w3.net.peerCount
-
-        assert is_integer(peer_count)
-
-    def test_net_chainId_deprecation(self, w3: "Web3") -> None:
-        with pytest.raises(DeprecationWarning):
-            w3.net.chainId
-
 
 class AsyncNetModuleTest:
     @pytest.mark.asyncio

--- a/web3/_utils/personal.py
+++ b/web3/_utils/personal.py
@@ -21,7 +21,6 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.method import (
-    DeprecatedMethod,
     Method,
     default_root_munger,
 )
@@ -94,15 +93,3 @@ ec_recover: Method[Callable[[str, HexStr], ChecksumAddress]] = Method(
     RPC.personal_ecRecover,
     mungers=[default_root_munger],
 )
-
-#
-# Deprecated Methods
-#
-importRawKey = DeprecatedMethod(import_raw_key, 'importRawKey', 'import_raw_key')
-newAccount = DeprecatedMethod(new_account, 'newAccount', 'new_account')
-listAccounts = DeprecatedMethod(list_accounts, 'listAccounts', 'list_accounts')
-sendTransaction = DeprecatedMethod(send_transaction, 'sendTransaction', 'send_transaction')
-lockAccount = DeprecatedMethod(lock_account, 'lockAccount', 'lock_account')
-unlockAccount = DeprecatedMethod(unlock_account, 'unlockAccount', 'unlock_account')
-signTypedData = DeprecatedMethod(sign_typed_data, 'signTypedData', 'sign_typed_data')
-ecRecover = DeprecatedMethod(ec_recover, 'ecRecover', 'ec_recover')

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -28,39 +28,25 @@ from web3._utils.admin import (
 )
 from web3._utils.miner import (
     make_dag,
-    makeDag,
     set_etherbase,
     set_extra,
     set_gas_price,
-    setEtherbase,
-    setExtra,
-    setGasPrice,
     start,
     start_auto_dag,
-    startAutoDag,
     stop,
     stop_auto_dag,
-    stopAutoDag,
 )
 from web3._utils.personal import (
     ec_recover,
-    ecRecover,
     import_raw_key,
-    importRawKey,
     list_accounts,
     list_wallets,
-    listAccounts,
     lock_account,
-    lockAccount,
     new_account,
-    newAccount,
     send_transaction,
-    sendTransaction,
     sign,
     sign_typed_data,
-    signTypedData,
     unlock_account,
-    unlockAccount,
 )
 from web3._utils.txpool import (
     content,
@@ -96,15 +82,6 @@ class BaseGethPersonal(Module):
     _sign = sign
     _sign_typed_data = sign_typed_data
     _unlock_account = unlock_account
-    # deprecated
-    _ecRecover = ecRecover
-    _importRawKey = importRawKey
-    _listAccounts = listAccounts
-    _lockAccount = lockAccount
-    _newAccount = newAccount
-    _sendTransaction = sendTransaction
-    _signTypedData = signTypedData
-    _unlockAccount = unlockAccount
 
 
 class GethPersonal(BaseGethPersonal):
@@ -145,36 +122,6 @@ class GethPersonal(BaseGethPersonal):
                        passphrase: str,
                        duration: Optional[int] = None) -> bool:
         return self._unlock_account(account, passphrase, duration)
-
-    def ecRecover(self, message: str, signature: HexStr) -> ChecksumAddress:
-        return self._ecRecover(message, signature)
-
-    def importRawKey(self, private_key: str, passphrase: str) -> ChecksumAddress:
-        return self._importRawKey(private_key, passphrase)
-
-    def listAccounts(self) -> List[ChecksumAddress]:
-        return self._listAccounts()
-
-    def lockAccount(self, account: ChecksumAddress) -> bool:
-        return self._lockAccount(account)
-
-    def newAccount(self, passphrase: str) -> ChecksumAddress:
-        return self._newAccount(passphrase)
-
-    def sendTransaction(self, transaction: TxParams, passphrase: str) -> HexBytes:
-        return self._sendTransaction(transaction, passphrase)
-
-    def signTypedData(self,
-                      message: Dict[str, Any],
-                      account: ChecksumAddress,
-                      password: Optional[str] = None) -> HexStr:
-        return self._signTypedData(message, account, password)
-
-    def unlockAccount(self,
-                      account: ChecksumAddress,
-                      passphrase: str,
-                      duration: Optional[int] = None) -> bool:
-        return self._unlockAccount(account, passphrase, duration)
 
 
 class AsyncGethPersonal(BaseGethPersonal):
@@ -353,13 +300,6 @@ class GethMiner(Module):
     stop = stop
     start_auto_dag = start_auto_dag
     stop_auto_dag = stop_auto_dag
-    # deprecated
-    makeDag = makeDag
-    setExtra = setExtra
-    setEtherbase = setEtherbase
-    setGasPrice = setGasPrice
-    startAutoDag = startAutoDag
-    stopAutoDag = stopAutoDag
 
 
 class Geth(Module):

--- a/web3/net.py
+++ b/web3/net.py
@@ -1,14 +1,12 @@
 from typing import (
     Awaitable,
     Callable,
-    NoReturn,
 )
 
 from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.method import (
-    DeprecatedMethod,
     Method,
     default_root_munger,
 )
@@ -34,10 +32,6 @@ class Net(Module):
     )
 
     @property
-    def chainId(self) -> NoReturn:
-        raise DeprecationWarning("This method has been deprecated in EIP 1474.")
-
-    @property
     def listening(self) -> bool:
         return self._listening()
 
@@ -48,11 +42,6 @@ class Net(Module):
     @property
     def version(self) -> str:
         return self._version()
-
-    #
-    # Deprecated Methods
-    #
-    peerCount = DeprecatedMethod(peer_count, 'peerCount', 'peer_count')  # type: ignore
 
 
 class AsyncNet(Module):

--- a/web3/parity.py
+++ b/web3/parity.py
@@ -22,26 +22,18 @@ from eth_utils.toolz import (
 
 from web3._utils.personal import (
     ec_recover,
-    ecRecover,
     import_raw_key,
-    importRawKey,
     list_accounts,
-    listAccounts,
     new_account,
-    newAccount,
     send_transaction,
-    sendTransaction,
     sign,
     sign_typed_data,
-    signTypedData,
     unlock_account,
-    unlockAccount,
 )
 from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.method import (
-    DeprecatedMethod,
     Method,
     default_root_munger,
 )
@@ -75,14 +67,6 @@ class ParityPersonal(Module):
     sign = sign
     sign_typed_data = sign_typed_data
     unlock_account = unlock_account
-    # deprecated
-    ecRecover = ecRecover
-    importRawKey = importRawKey
-    listAccounts = listAccounts
-    newAccount = newAccount
-    sendTransaction = sendTransaction
-    signTypedData = signTypedData
-    unlockAccount = unlockAccount
 
 
 class Parity(Module):
@@ -219,20 +203,3 @@ class Parity(Module):
         RPC.parity_mode,
         is_property=True
     )
-
-    # Deprecated Methods
-    addReservedPeer = DeprecatedMethod(add_reserved_peer, 'addReservedPeer', 'add_reserved_peer')
-    listStorageKeys = DeprecatedMethod(list_storage_keys, 'listStorageKeys', 'list_storage_keys')
-    netPeers = DeprecatedMethod(net_peers, 'netPeers', 'net_peers')
-    setMode = DeprecatedMethod(set_mode, 'setMode', 'set_mode')
-    traceBlock = DeprecatedMethod(trace_block, 'traceBlock', 'trace_block')
-    traceCall = DeprecatedMethod(trace_call, 'traceCall', 'trace_call')
-    traceFilter = DeprecatedMethod(trace_filter, 'traceFilter', 'trace_filter')
-    traceRawTransaction = DeprecatedMethod(trace_raw_transaction, 'traceRawTransaction',
-                                           'trace_raw_transaction')
-    traceReplayTransaction = DeprecatedMethod(trace_replay_transaction, 'traceReplayTransaction',
-                                              'trace_replay_transaction')
-    traceReplayBlockTransactions = DeprecatedMethod(trace_replay_block_transactions,
-                                                    'traceReplayBlockTransactions',
-                                                    'trace_replay_block_transactions')
-    traceTransaction = DeprecatedMethod(trace_transaction, 'traceTransaction', 'trace_transaction')


### PR DESCRIPTION
### What was wrong?

Related to Issue #2432 

I missed some of the methods in the #2432 PR so here is the removal of the rest of the geth deprecated methods. Also, since some of them were also exposed in parity I had to update them there too. 