### PR TITLE
format receipt.type to int and log.data to HexBytes

### DIFF
--- a/newsfragments/2482.bugfix.rst
+++ b/newsfragments/2482.bugfix.rst
@@ -1,0 +1,1 @@
+format receipt.type to int and log.data to HexBytes

--- a/tests/core/middleware/test_filter_middleware.py
+++ b/tests/core/middleware/test_filter_middleware.py
@@ -27,7 +27,7 @@ class DummyProvider(BaseProvider):
 
 
 BLOCK_HASH = '0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553'
-FILTER_LOG = [AttributeDict({'address': '0xDc3A9Db694BCdd55EBaE4A89B22aC6D12b3F0c24', 'blockHash': HexBytes('0xb72256286ca528e09022ffd408856a73ef90e7216ac560187c6e43b4c4efd2f0'), 'blockNumber': 2217196, 'data': '0x0000000000000000000000000000000000000000000000000000000000000001', 'logIndex': 0, 'topics': [HexBytes('0xe65b00b698ba37c614af350761c735c5f4a82b4ab365a1f1022d49d9dfc8e930'), HexBytes('0x000000000000000000000000754c50465885f1ed1fa1a55b95ee8ecf3f1f4324'), HexBytes('0x296c7fb6ccafa3e689950b947c2895b07357c95b066d5cdccd58c301f41359a3')], 'transactionHash': HexBytes('0xfe1289fd3915794b99702202f65eea2e424b2f083a12749d29b4dd51f6dce40d'), 'transactionIndex': 1})]  # noqa: E501
+FILTER_LOG = [AttributeDict({'address': '0xDc3A9Db694BCdd55EBaE4A89B22aC6D12b3F0c24', 'blockHash': HexBytes('0xb72256286ca528e09022ffd408856a73ef90e7216ac560187c6e43b4c4efd2f0'), 'blockNumber': 2217196, 'data': HexBytes('0x0000000000000000000000000000000000000000000000000000000000000001'), 'logIndex': 0, 'topics': [HexBytes('0xe65b00b698ba37c614af350761c735c5f4a82b4ab365a1f1022d49d9dfc8e930'), HexBytes('0x000000000000000000000000754c50465885f1ed1fa1a55b95ee8ecf3f1f4324'), HexBytes('0x296c7fb6ccafa3e689950b947c2895b07357c95b066d5cdccd58c301f41359a3')], 'transactionHash': HexBytes('0xfe1289fd3915794b99702202f65eea2e424b2f083a12749d29b4dd51f6dce40d'), 'transactionIndex': 1})]  # noqa: E501
 
 
 @pytest.fixture(scope='function')

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -180,7 +180,7 @@ LOG_ENTRY_FORMATTERS = {
     'logIndex': to_integer_if_hex,
     'address': to_checksum_address,
     'topics': apply_list_to_array_formatter(to_hexbytes(32)),
-    'data': to_ascii_if_bytes,
+    'data': HexBytes,
 }
 
 
@@ -201,6 +201,7 @@ RECEIPT_FORMATTERS = {
     'from': apply_formatter_if(is_not_null, to_checksum_address),
     'to': apply_formatter_if(is_address, to_checksum_address),
     'effectiveGasPrice': to_integer_if_hex,
+    'type': to_integer_if_hex,
 }
 
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #2482

### How was it fixed?

Added/updated formatters for log entries and receipts

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/170546383-044680f1-c822-4167-8227-6d45b5bc7e12.png)
