### PR TITLE
Only lock cache thread if method is whitelisted

### DIFF
--- a/newsfragments/2493.bugfix.rst
+++ b/newsfragments/2493.bugfix.rst
@@ -1,0 +1,1 @@
+Only thread lock methods attempting to access the cache for the caching middleware.

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -35,6 +35,7 @@ from web3.types import (  # noqa: F401
 if TYPE_CHECKING:
     from web3 import Web3  # noqa: F401
 
+
 SIMPLE_CACHE_RPC_WHITELIST = cast(Set[RPCEndpoint], {
     'web3_clientVersion',
     'web3_sha3',
@@ -109,7 +110,7 @@ def construct_simple_cache_middleware(
     Constructs a middleware which caches responses based on the request
     ``method`` and ``params``
 
-    :param cache: Any dictionary-like object
+    :param cache_class: Any dictionary-like object
     :param rpc_whitelist: A set of RPC methods which may have their responses cached.
     :param should_cache_fn: A callable which accepts ``method`` ``params`` and
         ``response`` and returns a boolean as to whether the response should be
@@ -124,7 +125,7 @@ def construct_simple_cache_middleware(
         def middleware(
             method: RPCEndpoint, params: Any
         ) -> RPCResponse:
-            lock_acquired = lock.acquire(blocking=False)
+            lock_acquired = lock.acquire(blocking=False) if method in rpc_whitelist else False
 
             try:
                 if lock_acquired and method in rpc_whitelist:
@@ -211,7 +212,7 @@ def construct_time_based_cache_middleware(
     Constructs a middleware which caches responses based on the request
     ``method`` and ``params`` for a maximum amount of time as specified
 
-    :param cache: Any dictionary-like object
+    :param cache_class: Any dictionary-like object
     :param cache_expire_seconds: The number of seconds an item may be cached
         before it should expire.
     :param rpc_whitelist: A set of RPC methods which may have their responses cached.
@@ -226,7 +227,7 @@ def construct_time_based_cache_middleware(
         lock = threading.Lock()
 
         def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
-            lock_acquired = lock.acquire(blocking=False)
+            lock_acquired = lock.acquire(blocking=False) if method in rpc_whitelist else False
 
             try:
                 if lock_acquired and method in rpc_whitelist:
@@ -345,9 +346,7 @@ def construct_latest_block_based_cache_middleware(
     Constructs a middleware which caches responses based on the request
     ``method``, ``params``, and the current latest block hash.
 
-    :param cache: Any dictionary-like object
-    :param cache_expire_seconds: The number of seconds an item may be cached
-        before it should expire.
+    :param cache_class: Any dictionary-like object
     :param rpc_whitelist: A set of RPC methods which may have their responses cached.
     :param should_cache_fn: A callable which accepts ``method`` ``params`` and
         ``response`` and returns a boolean as to whether the response should be
@@ -414,7 +413,7 @@ def construct_latest_block_based_cache_middleware(
         lock = threading.Lock()
 
         def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
-            lock_acquired = lock.acquire(blocking=False)
+            lock_acquired = lock.acquire(blocking=False) if method in rpc_whitelist else False
 
             try:
                 should_try_cache = (


### PR DESCRIPTION
### What was wrong?

We thread lock within the caching middleware for methods that are not attempting to access the cache. This means that a `eth_call` with a transaction that doesn't include a `chainId` needs to call `eth_chainId` but can't access the cache because the original `eth_call` has locked the thread. I think this might make sense to some extent so we should probably discuss some options here.

I think it's probably safe to only lock access to the cache when the method is whitelisted but I'm curious if I'm missing something with this thought.

Related to Issue #2493

### How was it fixed?

- Lock thread for caching middleware only when the method in question might read or write to the cache (only whitelisted methods).

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20220531_133808](https://user-images.githubusercontent.com/3532824/171271136-621daef9-7367-4b7e-a37c-8b808b59a620.jpg)

