### PR TITLE
Add get_abi_output_names utility method

### DIFF
--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -108,6 +108,13 @@ def get_abi_input_types(abi: ABIFunction) -> List[str]:
         return [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi['inputs']]
 
 
+def get_abi_input_names(abi: Union[ABIFunction, ABIEvent]) -> List[str]:
+    if 'inputs' not in abi and abi['type'] == 'fallback':
+        return []
+    else:
+        return [arg['name'] for arg in abi['inputs']]
+
+
 def get_abi_output_types(abi: ABIFunction) -> List[str]:
     if abi['type'] == 'fallback':
         return []
@@ -115,11 +122,11 @@ def get_abi_output_types(abi: ABIFunction) -> List[str]:
         return [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi['outputs']]
 
 
-def get_abi_input_names(abi: Union[ABIFunction, ABIEvent]) -> List[str]:
-    if 'inputs' not in abi and abi['type'] == 'fallback':
+def get_abi_output_names(abi: Union[ABIFunction]) -> List[str]:
+    if 'outputs' not in abi and abi['type'] == 'fallback':
         return []
     else:
-        return [arg['name'] for arg in abi['inputs']]
+        return [arg['name'] for arg in abi['outputs']]
 
 
 def get_receive_func_abi(contract_abi: ABI) -> ABIFunction:


### PR DESCRIPTION
### What was wrong?
Very simply, there isn't a utility method to get the output names from a call, and we needed that.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/540035/171408682-d508b0fb-45ba-4ab4-8c8e-447970f78b18.png)
