### PR TITLE
Increase default IPC timeout

### DIFF
--- a/newsfragments/2483.misc.rst
+++ b/newsfragments/2483.misc.rst
@@ -1,0 +1,1 @@
+Increase the default IPC timeout from 0.1 seconds to 2 seconds.

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -31,7 +31,7 @@ from .base import (
 )
 
 
-def get_ipc_socket(ipc_path: str, timeout: float = 0.1) -> socket.socket:
+def get_ipc_socket(ipc_path: str, timeout: float = 2.0) -> socket.socket:
     if sys.platform == 'win32':
         # On Windows named pipe is used. Simulate socket with it.
         from web3._utils.windows import NamedPipe


### PR DESCRIPTION
Was getting socket timeouts, especially on large values (>400k hex
chars).

I don't see too big of a downside to a 2s timeout. It should be
extremely rare to hit this in a real production scenario.

Port #2485 forward to v6

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://thumbs.dreamstime.com/b/dog-holding-alarm-clock-his-paws-isolated-white-71223599.jpg)