### PR TITLE
Pin eth-rlp<0.3

### DIFF
--- a/newsfragments/2502.misc.rst
+++ b/newsfragments/2502.misc.rst
@@ -1,0 +1,1 @@
+Pin eth-rlp to <0.3 so that dependencies will resolve with older versions of pip.

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         "eth-abi>=2.0.0b6,<3.0.0",
         "eth-account>=0.5.7,<0.6.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
+        "eth-rlp<0.3",
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.9.5,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,8 @@ setup(
         "eth-abi>=2.0.0b6,<3.0.0",
         "eth-account>=0.5.7,<0.6.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
+        # eth-account allows too broad of an eth-rlp dependency.
+        # This eth-rlp pin can be removed once it gets tightened up in eth-account
         "eth-rlp<0.3",
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.9.5,<2.0.0",


### PR DESCRIPTION
### What was wrong?
`eth-account` has a typo (I believe) [here](https://github.com/ethereum/eth-account/blob/v0.5.x/setup.py#L67), which causes dependency resolution errors for us on older versions of pip, before they changed their dependency resolution.

I could be convinced that this change belongs in `eth-account` if someone feels strongly, but I think it belongs here because it's breaking here.

Closes #2424 

### How was it fixed?
Pinned `eth-rlp` to `<0.3` to support older versions of pip.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.whatspaper.com/wp-content/uploads/2021/10/cute-puppy-wallpaper-whatspaper-5.jpg)
