### PR TITLE
Add a global ccip read support flag on the provider.

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -745,7 +745,7 @@ and forwarded to the contract function when applicable.
 
 `EIP-3668 <https://eips.ethereum.org/EIPS/eip-3668>`_ introduced support for the ``OffchainLookup`` revert /
 CCIP Read support. CCIP Read is set to ``True`` for calls by default, as recommended in EIP-3668. This is done via a
-global ``ccip_read_calls_enabled`` flag on the provider. If raising the ``OffchainLookup`` revert is preferred for a
+global ``global_ccip_read_enabled`` flag on the provider. If raising the ``OffchainLookup`` revert is preferred for a
 specific call, the ``ccip_read_enabled`` flag on the call may be set to ``False``.
 
     .. code-block:: python
@@ -758,14 +758,14 @@ Disabling CCIP Read support can be useful if a transaction needs to be sent to t
 "preflighting" with an ``eth_call``, handling the ``OffchainLookup``, and sending the data via a transaction may be
 necessary. See :ref:`ccip-read-example` in the examples section for how to preflight a transaction with a contract call.
 
-Similarly, if CCIP Read is globally set to ``False`` via the ``ccip_read_calls_enabled`` flag on the provider, it may be
+Similarly, if CCIP Read is globally set to ``False`` via the ``global_ccip_read_enabled`` flag on the provider, it may be
 enabled on a per-call basis - overriding the global flag. This ensures only explicitly enabled calls will handle the
 ``OffchainLookup`` revert appropriately.
 
     .. code-block:: python
 
         >>> # global flag set to `False`
-        >>> w3.provider.ccip_read_calls_enabled = False
+        >>> w3.provider.global_ccip_read_enabled = False
 
         >>> # does not raise the revert since explicitly enabled on the call:
         >>> response = myContract.functions.revertsWithOffchainLookup(myData).call(ccip_read_enabled=True)

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -744,11 +744,13 @@ will be used to find the contract function by signature,
 and forwarded to the contract function when applicable.
 
 `EIP-3668 <https://eips.ethereum.org/EIPS/eip-3668>`_ introduced support for the ``OffchainLookup`` revert /
-CCIP Read support. The ``ccip_read_enabled`` flag is set to ``True`` for calls by default, as recommended in EIP-3668.
-If raising the ``OffchainLookup`` revert is preferred, the flag may be set to ``False`` on a per-call basis.
+CCIP Read support. CCIP Read is set to ``True`` for calls by default, as recommended in EIP-3668. This is done via a
+global ``ccip_read_calls_enabled`` flag on the provider. If raising the ``OffchainLookup`` revert is preferred for a
+specific call, the ``ccip_read_enabled`` flag on the call may be set to ``False``.
 
-.. code-block:: python
+    .. code-block:: python
 
+        >>> # raises the revert instead of handling the offchain lookup
         >>> myContract.functions.revertsWithOffchainLookup(myData).call(ccip_read_enabled=False)
         *** web3.exceptions.OffchainLookup
 
@@ -756,6 +758,17 @@ Disabling CCIP Read support can be useful if a transaction needs to be sent to t
 "preflighting" with an ``eth_call``, handling the ``OffchainLookup``, and sending the data via a transaction may be
 necessary. See :ref:`ccip-read-example` in the examples section for how to preflight a transaction with a contract call.
 
+Similarly, if CCIP Read is globally set to ``False`` via the ``ccip_read_calls_enabled`` flag on the provider, it may be
+enabled on a per-call basis - overriding the global flag. This ensures only explicitly enabled calls will handle the
+``OffchainLookup`` revert appropriately.
+
+    .. code-block:: python
+
+        >>> # global flag set to `False`
+        >>> w3.provider.ccip_read_calls_enabled = False
+
+        >>> # does not raise the revert since explicitly enabled on the call:
+        >>> response = myContract.functions.revertsWithOffchainLookup(myData).call(ccip_read_enabled=True)
 
 Methods
 ~~~~~~~~~~

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -630,7 +630,7 @@ CCIP Read support for offchain lookup
 -------------------------------------
 
 Contract calls support CCIP Read by default, via a ``ccip_read_enabled`` flag on the call and, more globally, a
-``ccip_read_calls_enabled`` flag on the provider. The following should work by default without raising an
+``global_ccip_read_enabled`` flag on the provider. The following should work by default without raising an
 ``OffchainLookup`` and instead handling it appropriately as per the specification outlined in
 `EIP-3668 <https://eips.ethereum.org/EIPS/eip-3668>`_.
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -627,11 +627,12 @@ When someone has an allowance they can transfer those tokens using the
 .. _ccip-read-example:
 
 CCIP Read support for offchain lookup
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------
 
-Contract calls support CCIP Read by default via a ``ccip_read_enabled`` flag that is set to a default value of ``True``.
-The following should work by default without raising the ``OffchainLookup`` and instead handling it appropriately as
-per the specification outlined in `EIP-3668 <https://eips.ethereum.org/EIPS/eip-3668>`_.
+Contract calls support CCIP Read by default, via a ``ccip_read_enabled`` flag on the call and, more globally, a
+``ccip_read_calls_enabled`` flag on the provider. The following should work by default without raising an
+``OffchainLookup`` and instead handling it appropriately as per the specification outlined in
+`EIP-3668 <https://eips.ethereum.org/EIPS/eip-3668>`_.
 
 .. code-block:: python
 
@@ -660,7 +661,6 @@ appropriately in the following way:
 
         # send the built transaction with `eth_sendTransaction` or sign and send with `eth_sendRawTransaction`
         tx_hash = w3.eth.send_transaction(tx)
-
 
 Contract Unit Tests in Python
 -----------------------------

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1093,11 +1093,15 @@ The following methods are available on the ``web3.eth`` namespace.
     `EIP-3668 <https://eips.ethereum.org/EIPS/eip-3668>`_ introduced support for the ``OffchainLookup`` revert / CCIP
     Read support. In order to properly handle a call to a contract function that reverts with an ``OffchainLookup``
     error for offchain data retrieval, the ``ccip_read_enabled`` flag has been added to the ``eth_call`` method.
-    ``ccip_read_enabled`` is set to ``True`` by default for calls, as recommended in EIP-3668. Therefore, calls to
-    contract functions that revert with an ``OffchainLookup`` will be handled appropriately by default. If the
-    ``ccip_read_enabled`` flag is set to ``False``, the call will raise the ``OffchainLookup`` instead of properly
-    handling the exception according to EIP-3668. This may be useful for "preflighting" a transaction call (see
-    :ref:`ccip-read-example` within the examples section).
+    ``ccip_read_enabled`` is optional, yielding the default value for CCIP Read on calls to a global
+    ``ccip_read_calls_enabled`` flag on the provider which is set to ``True`` by default. This means CCIP Read is
+    enabled by default for calls, as is recommended in EIP-3668. Therefore, calls to contract functions that revert with
+    an ``OffchainLookup`` will be handled appropriately by default.
+
+    The ``ccip_read_enabled`` flag on the call will always override the value of the global flag on the provider for
+    explicit control over specific calls. If the flag on the call is set to ``False``, the call will raise the
+    ``OffchainLookup`` instead of properly handling the exception according to EIP-3668. This may be useful for
+    "preflighting" a transaction with a call (see :ref:`ccip-read-example` within the examples section).
 
 
 .. py:method:: Eth.fee_history(block_count, newest_block, reward_percentiles=None)

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1094,7 +1094,7 @@ The following methods are available on the ``web3.eth`` namespace.
     Read support. In order to properly handle a call to a contract function that reverts with an ``OffchainLookup``
     error for offchain data retrieval, the ``ccip_read_enabled`` flag has been added to the ``eth_call`` method.
     ``ccip_read_enabled`` is optional, yielding the default value for CCIP Read on calls to a global
-    ``ccip_read_calls_enabled`` flag on the provider which is set to ``True`` by default. This means CCIP Read is
+    ``global_ccip_read_enabled`` flag on the provider which is set to ``True`` by default. This means CCIP Read is
     enabled by default for calls, as is recommended in EIP-3668. Therefore, calls to contract functions that revert with
     an ``OffchainLookup`` will be handled appropriately by default.
 

--- a/newsfragments/2499.feature.rst
+++ b/newsfragments/2499.feature.rst
@@ -1,0 +1,1 @@
+Add a global flag on the provider for enabling / disabling CCIP Read for calls: ``ccip_read_calls_enabled`` (defaults to ``True``).

--- a/newsfragments/2499.feature.rst
+++ b/newsfragments/2499.feature.rst
@@ -1,1 +1,1 @@
-Add a global flag on the provider for enabling / disabling CCIP Read for calls: ``ccip_read_calls_enabled`` (defaults to ``True``).
+Add a global flag on the provider for enabling / disabling CCIP Read for calls: ``global_ccip_read_enabled`` (defaults to ``True``).

--- a/tests/core/contracts/test_offchain_lookup.py
+++ b/tests/core/contracts/test_offchain_lookup.py
@@ -84,7 +84,7 @@ def test_eth_call_offchain_lookup_raises_when_ccip_read_is_disabled(w3, offchain
         )
 
     # test global flag on the provider
-    w3.provider.ccip_read_calls_enabled = False
+    w3.provider.global_ccip_read_enabled = False
 
     with pytest.raises(OffchainLookup):
         offchain_lookup_contract.caller.testOffchainLookup(OFFCHAIN_LOOKUP_TEST_DATA)
@@ -94,7 +94,7 @@ def test_eth_call_offchain_lookup_raises_when_ccip_read_is_disabled(w3, offchain
             OFFCHAIN_LOOKUP_TEST_DATA
         )
 
-    w3.provider.ccip_read_calls_enabled = True  # cleanup
+    w3.provider.global_ccip_read_enabled = True  # cleanup
 
 
 def test_offchain_lookup_call_flag_overrides_provider_flag(
@@ -107,14 +107,14 @@ def test_offchain_lookup_call_flag_overrides_provider_flag(
         mocked_json_data=WEB3PY_AS_HEXBYTES,
     )
 
-    w3.provider.ccip_read_calls_enabled = False
+    w3.provider.global_ccip_read_enabled = False
 
     response = offchain_lookup_contract.functions.testOffchainLookup(
         OFFCHAIN_LOOKUP_TEST_DATA
     ).call(ccip_read_enabled=True)
     assert decode_abi(['string'], response)[0] == 'web3py'
 
-    w3.provider.ccip_read_calls_enabled = True
+    w3.provider.global_ccip_read_enabled = True
 
 
 def test_offchain_lookup_raises_for_improperly_formatted_rest_request_response(

--- a/tests/core/web3-module/test_providers.py
+++ b/tests/core/web3-module/test_providers.py
@@ -26,4 +26,5 @@ def test_auto_provider_none():
 
 
 def test_provider_default_value_for_ccip_read_redirect(w3):
+    assert w3.provider.ccip_read_calls_enabled
     assert w3.provider.ccip_read_max_redirects == 4

--- a/tests/core/web3-module/test_providers.py
+++ b/tests/core/web3-module/test_providers.py
@@ -26,5 +26,5 @@ def test_auto_provider_none():
 
 
 def test_provider_default_value_for_ccip_read_redirect(w3):
-    assert w3.provider.ccip_read_calls_enabled
+    assert w3.provider.global_ccip_read_enabled
     assert w3.provider.ccip_read_max_redirects == 4

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -802,14 +802,14 @@ class AsyncEthModuleTest:
             ).call(ccip_read_enabled=False)
 
         # test global flag on the provider
-        async_w3.provider.ccip_read_calls_enabled = False
+        async_w3.provider.global_ccip_read_enabled = False
 
         with pytest.raises(OffchainLookup):
             await async_offchain_lookup_contract.functions.testOffchainLookup(  # noqa: E501 type: ignore
                 OFFCHAIN_LOOKUP_TEST_DATA
             ).call()
 
-        async_w3.provider.ccip_read_calls_enabled = True  # cleanup
+        async_w3.provider.global_ccip_read_enabled = True  # cleanup
 
     @pytest.mark.asyncio
     async def test_eth_call_offchain_lookup_call_flag_overrides_provider_flag(
@@ -829,7 +829,7 @@ class AsyncEthModuleTest:
             mocked_json_data=WEB3PY_AS_HEXBYTES,
         )
 
-        async_w3.provider.ccip_read_calls_enabled = False
+        async_w3.provider.global_ccip_read_enabled = False
 
         response = await async_offchain_lookup_contract.functions.testOffchainLookup(
             # noqa: E501 type: ignore
@@ -837,7 +837,7 @@ class AsyncEthModuleTest:
         ).call(ccip_read_enabled=True)
         assert async_w3.codec.decode_abi(['string'], response)[0] == 'web3py'
 
-        async_w3.provider.ccip_read_calls_enabled = True  # cleanup
+        async_w3.provider.global_ccip_read_enabled = True  # cleanup
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("max_redirects", range(-1, 4))
@@ -2552,12 +2552,12 @@ class EthModuleTest:
             )
 
         # test global flag on the provider
-        w3.provider.ccip_read_calls_enabled = False
+        w3.provider.global_ccip_read_enabled = False
 
         with pytest.raises(OffchainLookup):
             offchain_lookup_contract.functions.testOffchainLookup(OFFCHAIN_LOOKUP_TEST_DATA).call()
 
-        w3.provider.ccip_read_calls_enabled = True  # cleanup
+        w3.provider.global_ccip_read_enabled = True  # cleanup
 
     def test_eth_call_offchain_lookup_call_flag_overrides_provider_flag(
         self,
@@ -2573,14 +2573,14 @@ class EthModuleTest:
             mocked_json_data=WEB3PY_AS_HEXBYTES,
         )
 
-        w3.provider.ccip_read_calls_enabled = False
+        w3.provider.global_ccip_read_enabled = False
 
         response = offchain_lookup_contract.functions.testOffchainLookup(
             OFFCHAIN_LOOKUP_TEST_DATA
         ).call(ccip_read_enabled=True)
         assert w3.codec.decode_abi(['string'], response)[0] == 'web3py'
 
-        w3.provider.ccip_read_calls_enabled = True  # cleanup
+        w3.provider.global_ccip_read_enabled = True  # cleanup
 
     @pytest.mark.parametrize("max_redirects", range(-1, 4))
     def test_eth_call_offchain_lookup_raises_if_max_redirects_is_less_than_4(

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1252,7 +1252,7 @@ class ContractFunction(BaseContractFunction):
         transaction: Optional[TxParams] = None,
         block_identifier: BlockIdentifier = 'latest',
         state_override: Optional[CallOverride] = None,
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
     ) -> Any:
         """
         Execute a contract function call using the `eth_call` interface.
@@ -1364,7 +1364,7 @@ class AsyncContractFunction(BaseContractFunction):
         self, transaction: Optional[TxParams] = None,
         block_identifier: BlockIdentifier = 'latest',
         state_override: Optional[CallOverride] = None,
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
     ) -> Any:
         """
         Execute a contract function call using the `eth_call` interface.
@@ -1814,7 +1814,7 @@ class BaseContractCaller:
         address: ChecksumAddress,
         transaction: Optional[TxParams] = None,
         block_identifier: BlockIdentifier = 'latest',
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
         contract_function_class: Optional[Union[Type[ContractFunction], Type[AsyncContractFunction]]] = ContractFunction,  # noqa: E501
     ) -> None:
         self.w3 = w3
@@ -1879,7 +1879,7 @@ class BaseContractCaller:
         *args: Any,
         transaction: Optional[TxParams] = None,
         block_identifier: BlockIdentifier = 'latest',
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
         **kwargs: Any
     ) -> Any:
         if transaction is None:
@@ -1899,7 +1899,7 @@ class ContractCaller(BaseContractCaller):
         address: ChecksumAddress,
         transaction: Optional[TxParams] = None,
         block_identifier: BlockIdentifier = 'latest',
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
     ) -> None:
         super().__init__(
             abi=abi,
@@ -1916,7 +1916,7 @@ class ContractCaller(BaseContractCaller):
         transaction: Optional[TxParams] = None,
         block_identifier: BlockIdentifier = 'latest',
         state_override: Optional[CallOverride] = None,
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
     ) -> 'ContractCaller':
         if transaction is None:
             transaction = {}
@@ -1939,7 +1939,7 @@ class AsyncContractCaller(BaseContractCaller):
         address: ChecksumAddress,
         transaction: Optional[TxParams] = None,
         block_identifier: BlockIdentifier = 'latest',
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
     ) -> None:
         super().__init__(
             abi=abi,
@@ -1955,7 +1955,7 @@ class AsyncContractCaller(BaseContractCaller):
         self,
         transaction: Optional[TxParams] = None,
         block_identifier: BlockIdentifier = 'latest',
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
     ) -> 'AsyncContractCaller':
         if transaction is None:
             transaction = {}
@@ -1997,7 +1997,7 @@ def call_contract_function(
         contract_abi: Optional[ABI] = None,
         fn_abi: Optional[ABIFunction] = None,
         state_override: Optional[CallOverride] = None,
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
         *args: Any,
         **kwargs: Any) -> Any:
     """
@@ -2069,7 +2069,7 @@ async def async_call_contract_function(
         contract_abi: Optional[ABI] = None,
         fn_abi: Optional[ABIFunction] = None,
         state_override: Optional[CallOverride] = None,
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
         *args: Any,
         **kwargs: Any) -> Any:
     """

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -415,7 +415,7 @@ class AsyncEth(BaseEth):
         state_override: Optional[CallOverride] = None,
         ccip_read_enabled: Optional[bool] = None,
     ) -> Union[bytes, bytearray]:
-        ccip_read_enabled_on_provider = self.w3.provider.ccip_read_calls_enabled
+        ccip_read_enabled_on_provider = self.w3.provider.global_ccip_read_enabled
         if (
             # default conditions:
             ccip_read_enabled_on_provider and ccip_read_enabled is not False
@@ -828,7 +828,7 @@ class Eth(BaseEth):
         state_override: Optional[CallOverride] = None,
         ccip_read_enabled: Optional[bool] = None,
     ) -> Union[bytes, bytearray]:
-        ccip_read_enabled_on_provider = self.w3.provider.ccip_read_calls_enabled
+        ccip_read_enabled_on_provider = self.w3.provider.global_ccip_read_enabled
         if (
             # default conditions:
             ccip_read_enabled_on_provider and ccip_read_enabled is not False

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -413,10 +413,15 @@ class AsyncEth(BaseEth):
         transaction: TxParams,
         block_identifier: Optional[BlockIdentifier] = None,
         state_override: Optional[CallOverride] = None,
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
     ) -> Union[bytes, bytearray]:
-        if ccip_read_enabled:
-            # if ccip read is enabled, handle OffchainLookup reverts via durin call
+        ccip_read_enabled_on_provider = self.w3.provider.ccip_read_calls_enabled
+        if (
+            # default conditions:
+            ccip_read_enabled_on_provider and ccip_read_enabled is not False
+            # explicit call flag overrides provider flag, enabling ccip read for specific calls:
+            or not ccip_read_enabled_on_provider and ccip_read_enabled is True
+        ):
             return await self._durin_call(transaction, block_identifier, state_override)
 
         return await self._call(transaction, block_identifier, state_override)
@@ -821,11 +826,16 @@ class Eth(BaseEth):
         transaction: TxParams,
         block_identifier: Optional[BlockIdentifier] = None,
         state_override: Optional[CallOverride] = None,
-        ccip_read_enabled: bool = True,
+        ccip_read_enabled: Optional[bool] = None,
     ) -> Union[bytes, bytearray]:
-        if ccip_read_enabled:
-            # if ccip read is enabled, handle OffchainLookup reverts via durin call
-            self._durin_call(transaction, block_identifier, state_override)
+        ccip_read_enabled_on_provider = self.w3.provider.ccip_read_calls_enabled
+        if (
+            # default conditions:
+            ccip_read_enabled_on_provider and ccip_read_enabled is not False
+            # explicit call flag overrides provider flag, enabling ccip read for specific calls:
+            or not ccip_read_enabled_on_provider and ccip_read_enabled is True
+        ):
+            return self._durin_call(transaction, block_identifier, state_override)
 
         return self._call(transaction, block_identifier, state_override)
 

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -36,6 +36,7 @@ class AsyncBaseProvider:
     # a tuple of (all_middlewares, request_func)
     _request_func_cache: Tuple[Tuple[Middleware, ...], Callable[..., RPCResponse]] = (None, None)
 
+    ccip_read_calls_enabled: bool = True
     ccip_read_max_redirects: int = 4
 
     def __init__(self) -> None:

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -36,7 +36,7 @@ class AsyncBaseProvider:
     # a tuple of (all_middlewares, request_func)
     _request_func_cache: Tuple[Tuple[Middleware, ...], Callable[..., RPCResponse]] = (None, None)
 
-    ccip_read_calls_enabled: bool = True
+    global_ccip_read_enabled: bool = True
     ccip_read_max_redirects: int = 4
 
     def __init__(self) -> None:

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -35,7 +35,7 @@ class BaseProvider:
     # a tuple of (all_middlewares, request_func)
     _request_func_cache: Tuple[Tuple[Middleware, ...], Callable[..., RPCResponse]] = (None, None)
 
-    ccip_read_calls_enabled: bool = True
+    global_ccip_read_enabled: bool = True
     ccip_read_max_redirects: int = 4
 
     @property

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -35,6 +35,7 @@ class BaseProvider:
     # a tuple of (all_middlewares, request_func)
     _request_func_cache: Tuple[Tuple[Middleware, ...], Callable[..., RPCResponse]] = (None, None)
 
+    ccip_read_calls_enabled: bool = True
     ccip_read_max_redirects: int = 4
 
     @property


### PR DESCRIPTION
### What was wrong?

closes #2499

### How was it fixed?

- Global flag for CCIP Read support for calls added to provider: ``ccip_read_calls_enabled``
- Add relevant tests including tests making sure the ``eth.call()`` flag can override the provider flag for explicit call-specific control
- Tweak older offchain lookup tests due to timeouts after 40 calls to the contract
- Some document edits including wrong header type for CCIP Read section

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Update docs

#### Cute Animal Picture

![Image from iOS (3)](https://user-images.githubusercontent.com/3532824/172253092-b3f76365-2e79-440a-b880-8c9da3a788c4.jpg)

