### PR TITLE
Add black to the auto directory

### DIFF
--- a/newsfragments/2514.misc.rst
+++ b/newsfragments/2514.misc.rst
@@ -1,0 +1,1 @@
+Add black checks to ``web3/auto``

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ basepython=python
 extras=linter
 commands=
     flake8 {toxinidir}/web3 {toxinidir}/ens {toxinidir}/ethpm {toxinidir}/tests --exclude {toxinidir}/ethpm/ethpm-spec
-    black {toxinidir}/ethpm {toxinidir}/web3/utils --exclude {toxinidir}/ethpm/ethpm-spec --check
+    black {toxinidir}/ethpm {toxinidir}/web3/auto {toxinidir}/web3/utils --exclude {toxinidir}/ethpm/ethpm-spec --check
     isort --recursive --check-only --diff {toxinidir}/web3/ {toxinidir}/ens/ {toxinidir}/ethpm/ {toxinidir}/tests/
     mypy -p web3 -p ethpm -p ens --config-file {toxinidir}/mypy.ini
 

--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -16,21 +16,22 @@ from web3.exceptions import (
     InfuraKeyNotFound,
 )
 
-INFURA_MAINNET_DOMAIN = 'mainnet.infura.io'
-INFURA_ROPSTEN_DOMAIN = 'ropsten.infura.io'
-INFURA_GOERLI_DOMAIN = 'goerli.infura.io'
-INFURA_RINKEBY_DOMAIN = 'rinkeby.infura.io'
-INFURA_KOVAN_DOMAIN = 'kovan.infura.io'
+INFURA_MAINNET_DOMAIN = "mainnet.infura.io"
+INFURA_ROPSTEN_DOMAIN = "ropsten.infura.io"
+INFURA_GOERLI_DOMAIN = "goerli.infura.io"
+INFURA_RINKEBY_DOMAIN = "rinkeby.infura.io"
+INFURA_KOVAN_DOMAIN = "kovan.infura.io"
 
-WEBSOCKET_SCHEME = 'wss'
-HTTP_SCHEME = 'https'
+WEBSOCKET_SCHEME = "wss"
+HTTP_SCHEME = "https"
 
 
 def load_api_key() -> str:
     # in web3py v6 remove outdated WEB3_INFURA_API_KEY
-    key = os.environ.get('WEB3_INFURA_PROJECT_ID',
-                         os.environ.get('WEB3_INFURA_API_KEY', ''))
-    if key == '':
+    key = os.environ.get(
+        "WEB3_INFURA_PROJECT_ID", os.environ.get("WEB3_INFURA_API_KEY", "")
+    )
+    if key == "":
         raise InfuraKeyNotFound(
             "No Infura Project ID found. Please ensure "
             "that the environment variable WEB3_INFURA_PROJECT_ID is set."
@@ -39,25 +40,25 @@ def load_api_key() -> str:
 
 
 def load_secret() -> str:
-    return os.environ.get('WEB3_INFURA_API_SECRET', '')
+    return os.environ.get("WEB3_INFURA_API_SECRET", "")
 
 
 def build_http_headers() -> Optional[Dict[str, Tuple[str, str]]]:
     secret = load_secret()
     if secret:
-        headers = {'auth': ('', secret)}
+        headers = {"auth": ("", secret)}
         return headers
     return None
 
 
 def build_infura_url(domain: str) -> URI:
-    scheme = os.environ.get('WEB3_INFURA_SCHEME', WEBSOCKET_SCHEME)
+    scheme = os.environ.get("WEB3_INFURA_SCHEME", WEBSOCKET_SCHEME)
     key = load_api_key()
     secret = load_secret()
 
-    if scheme == WEBSOCKET_SCHEME and secret != '':
+    if scheme == WEBSOCKET_SCHEME and secret != "":
         return URI(f"{scheme}://:{secret}@{domain}/ws/v3/{key}")
-    elif scheme == WEBSOCKET_SCHEME and secret == '':
+    elif scheme == WEBSOCKET_SCHEME and secret == "":
         return URI(f"{scheme}://{domain}/ws/v3/{key}")
     elif scheme == HTTP_SCHEME:
         return URI(f"{scheme}://{domain}/v3/{key}")


### PR DESCRIPTION
### What was wrong?
More black!

Related to Issue #1416 

### How was it fixed?
Added `web3/auto` to the list of directories that black runs against in `tox.ini` and ran `black web3/auto`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1609627176341-ba129d30c869?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8YmxhY2slMjBraXR0ZW58ZW58MHx8MHx8&w=1000&q=80)
