### PR TITLE
Declutter git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Ignore commits that added Black to the codebase
+350126eaf5d36fa0387f0a852b10735b66dbb2f3
+39f4453c2fe31be58ae187669a3f355093bf9361
+69f49ee1ffa8ca98d66d9b960976a490c846c82f

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -106,6 +106,13 @@ Code Style
 We value code consistency. To ensure your contribution conforms to the style
 being used in this project, we encourage you to read our `style guide`_.
 
+We use Black for linting. To ignore the commits that introduced Black in
+git history, you can configure your git environment like so:
+
+.. code:: sh
+
+   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
 
 Type Hints
 ~~~~~~~~~~


### PR DESCRIPTION
### What was wrong?
Git blame gets clobbered with the black updates.

### How was it fixed?
Added a .git-blame-ignore-revs file, and added docs so developers can use the file to ignore certain commits when viewing git blame locally.

More info can be found here: 
- https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
- https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html#avoiding-ruining-git-blame

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imagesvc.meredithcorp.io/v3/mm/image?q=60&c=sc&poi=%5B940%2C906%5D&w=2000&h=1000&url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F47%2F2020%2F06%2F26%2Fblack-cat-peeking-over-table-908714708-2000.jpg)
