### PR TITLE
Fix `is_dynamic_fee_transaction` and `TRANSACTION_DEFAULTS` when `gas_price_strategy` returns zero

### DIFF
--- a/newsfragments/2570.bugfix.rst
+++ b/newsfragments/2570.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``is_dynamic_fee_transaction`` and ``TRANSACTION_DEFAULTS`` when ``gas_price_strategy`` returns zero

--- a/tests/core/utilities/test_valid_transaction_params.py
+++ b/tests/core/utilities/test_valid_transaction_params.py
@@ -149,3 +149,20 @@ def test_fill_transaction_defaults_for_all_params(web3):
         'maxPriorityFeePerGas': web3.eth.max_priority_fee,
         'value': 0,
     }
+
+
+def test_fill_transaction_defaults_for_zero_gas_price(web3):
+    def gas_price_strategy(_w3, tx):
+        return 0
+
+    web3.eth.set_gas_price_strategy(gas_price_strategy)
+
+    default_transaction = fill_transaction_defaults(web3, {})
+
+    assert default_transaction == {
+        "chainId": web3.eth.chain_id,
+        "data": b"",
+        "gas": web3.eth.estimate_gas({}),
+        "value": 0,
+        "gasPrice": 0,
+    }

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -58,7 +58,7 @@ TRANSACTION_DEFAULTS = {
     'value': 0,
     'data': b'',
     'gas': lambda web3, tx: web3.eth.estimate_gas(tx),
-    'gasPrice': lambda web3, tx: web3.eth.generate_gas_price(tx) or web3.eth.gas_price,
+    'gasPrice': lambda web3, tx: web3.eth.generate_gas_price(tx),
     'maxFeePerGas': (
         lambda web3, tx:
         web3.eth.max_priority_fee + (2 * web3.eth.get_block('latest')['baseFeePerGas'])
@@ -91,7 +91,7 @@ def fill_transaction_defaults(web3: "Web3", transaction: TxParams) -> TxParams:
     """
     strategy_based_gas_price = web3.eth.generate_gas_price(transaction)
     is_dynamic_fee_transaction = (
-        not strategy_based_gas_price
+        strategy_based_gas_price is None
         and (
             'gasPrice' not in transaction  # default to dynamic fee transaction
             or any_in_dict(DYNAMIC_FEE_TXN_PARAMS, transaction)


### PR DESCRIPTION
Port of #2562 to v5