### PR TITLE
Add other async middlewares to supported list

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -470,9 +470,9 @@ Geth
 
 Contract
 ^^^^^^^^
-Contract is fully implemented for the Async provider. The only documented exception to this at 
+Contract is fully implemented for the Async provider. The only documented exception to this at
 the moment is where :class:`ENS` is needed for address lookup. All addresses that are passed to Async
-contract should not be :class:`ENS` addresses. 
+contract should not be :class:`ENS` addresses.
 
 ENS
 ^^^^^^^^
@@ -483,3 +483,5 @@ Supported Middleware
 - :meth:`Gas Price Strategy <web3.middleware.gas_price_strategy_middleware>`
 - :meth:`Buffered Gas Estimate Middleware <web3.middleware.buffered_gas_estimate_middleware>`
 - :meth:`Stalecheck Middleware <web3.middleware.make_stalecheck_middleware>`
+- :meth:`Validation middleware <web3.middleware.validation>`
+- :ref:`Geth POA Middleware <geth-poa>`

--- a/newsfragments/2574.doc.rst
+++ b/newsfragments/2574.doc.rst
@@ -1,0 +1,1 @@
+Add some missing supported async middlewares to docs.


### PR DESCRIPTION
### What was wrong?

I noticed that there are a few middlewares that weren't on the list. 

### How was it fixed?

Added them!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/photos/funny-raccoon-in-green-sunglasses-showing-a-rock-gesture-isolated-on-picture-id1154370446?k=20&m=1154370446&s=612x612&w=0&h=2AWvof66ovB87P3b7C_cu0pCZlZhDDFYUFr2KQ2UnwQ=)
