### PR TITLE
Moved account to BaseEth

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -411,6 +411,7 @@ Supported Methods
 
 Eth
 ***
+- :class:`web3.eth.account <eth_account.account.Account>`
 - :meth:`web3.eth.accounts <web3.eth.Eth.accounts>`
 - :meth:`web3.eth.block_number <web3.eth.Eth.block_number>`
 - :meth:`web3.eth.chain_id <web3.eth.Eth.chain_id>`

--- a/newsfragments/2580.feature.rst
+++ b/newsfragments/2580.feature.rst
@@ -1,1 +1,1 @@
-Moved `Eth.account` to BaseEth.account so that it could be use in `AsyncEth`
+Moved `Eth.account` to `BaseEth.account` so that it could be use in `AsyncEth`

--- a/newsfragments/2580.feature.rst
+++ b/newsfragments/2580.feature.rst
@@ -1,0 +1,1 @@
+Moved `Eth.account` to BaseEth.account so that it could be use in `AsyncEth`

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -102,21 +102,6 @@ def w3():
     return Web3(EthereumTesterProvider())
 
 
-@pytest.fixture()
-def async_w3():
-    return Web3(AsyncEthereumTesterProvider(), modules={"eth": [AsyncEth]})
-
-
-def test_blocking_eth_account(w3):
-    account = w3.eth.account.create()
-    assert account is not None
-
-
-def test_async_eth_account(async_w3):
-    account = async_w3.eth.account.create()
-    assert account is not None
-
-
 def test_eth_account_create_variation(acct):
     account1 = acct.create()
     account2 = acct.create()
@@ -565,6 +550,14 @@ def test_eth_account_sign_and_send_EIP155_transaction_to_eth_tester(
     assert actual_txn.r == r
     assert actual_txn.s == s
     assert actual_txn.v == v
+
+
+# -- async -- #
+
+
+@pytest.fixture()
+def async_w3():
+    return Web3(AsyncEthereumTesterProvider(), modules={"eth": [AsyncEth]})
 
 
 @patch("web3.eth.BaseEth.account", "wired via BaseEth")

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -115,6 +115,7 @@ class BaseEth(Module):
     _default_account: Union[ChecksumAddress, Empty] = empty
     _default_block: BlockIdentifier = "latest"
     gasPriceStrategy = None
+    account = Account()
     defaultContractFactory: Any = None
 
     _gas_price: Method[Callable[[], Wei]] = Method(
@@ -598,7 +599,6 @@ class AsyncEth(BaseEth):
 
 
 class Eth(BaseEth):
-    account = Account()
     defaultContractFactory: Type[Union[Contract, ContractCaller]] = Contract
 
     def namereg(self) -> NoReturn:


### PR DESCRIPTION
### What was wrong?

Make account accessible in AsyncEth

closes #2580 

### How was it fixed?

Move Eth.account to BaseEth so that it can be used in AsyncEth.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)