### PR TITLE
Change validate_payable to allow zero hexadecimal transaction["value"]

### DIFF
--- a/newsfragments/2602.bugfix.rst
+++ b/newsfragments/2602.bugfix.rst
@@ -1,0 +1,1 @@
+Allow hex for ``value`` field when validating via ``validate_payable()`` contracts method

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -352,10 +352,10 @@ def get_function_info(
 
 def validate_payable(transaction: TxParams, abi: ABIFunction) -> None:
     """Raise ValidationError if non-zero ether
-    is sent to a non payable function.
+    is sent to a non-payable function.
     """
     if "value" in transaction:
-        if transaction["value"] != 0:
+        if transaction["value"] not in [0, "0x0"]:
             if "payable" in abi and not abi["payable"]:
                 raise ValidationError(
                     "Sending non-zero ether to a contract function "

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -55,6 +55,9 @@ from web3._utils.function_identifiers import (
     FallbackFn,
     ReceiveFn,
 )
+from web3._utils.method_formatters import (
+    to_integer_if_hex,
+)
 from web3._utils.normalizers import (
     abi_address_to_hex,
     abi_bytes_to_bytes,
@@ -355,7 +358,7 @@ def validate_payable(transaction: TxParams, abi: ABIFunction) -> None:
     is sent to a non-payable function.
     """
     if "value" in transaction:
-        if transaction["value"] not in [0, "0x0"]:
+        if to_integer_if_hex(transaction["value"]) != 0:
             if "payable" in abi and not abi["payable"]:
                 raise ValidationError(
                     "Sending non-zero ether to a contract function "


### PR DESCRIPTION
### What was wrong?

validate_payable was raising ValidationError exception on passing a transaction["value"] of zero in hexadecimal format.

### How was it fixed?

Changed if statement to check if transaction["value"] is not in [0, "0x0] instead of checking for inequality with zero.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://s3.amazonaws.com/petcentral.com/wp-content/uploads/2016/09/01160419/black-cat-1.jpg)
