### PR TITLE
Fixed typo in docs/web3.eth.rst

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1081,7 +1081,7 @@ The following methods are available on the ``web3.eth`` namespace.
         >>> myContract.functions.getVar().call()
         1
         # The above call equivalent to the raw call:
-        >>> we3.eth.call({'value': 0, 'gas': 21736, 'maxFeePerGas': 2000000000, 'maxPriorityFeePerGas': 1000000000, 'to': '0xc305c901078781C232A2a521C2aF7980f8385ee9', 'data': '0x477a5c98'})
+        >>> web3.eth.call({'value': 0, 'gas': 21736, 'maxFeePerGas': 2000000000, 'maxPriorityFeePerGas': 1000000000, 'to': '0xc305c901078781C232A2a521C2aF7980f8385ee9', 'data': '0x477a5c98'})
         HexBytes('0x0000000000000000000000000000000000000000000000000000000000000001')
 
     In most cases it is better to make contract function call through the :py:class:`web3.contract.Contract` interface.

--- a/newsfragments/2613.doc.rst
+++ b/newsfragments/2613.doc.rst
@@ -1,0 +1,1 @@
+Fix typo in eth.call docs


### PR DESCRIPTION
### What was wrong?

A reference in `web3.eth.rst` was typed out as "we3" instead of "web3", which would lead to issues while copying the code. 

### How was it fixed?

Through hours of hard work, I corrected the typo! 🔮 

### Todo:
Just accept the PR 😄 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imgs.search.brave.com/70CzDqqdkZNNt6SftPYMj0-rkD1puTY7kPK4Rs5E0b4/rs:fit:889:1200:1/g:ce/aHR0cHM6Ly9pLnBp/bmltZy5jb20vb3Jp/Z2luYWxzL2YxLzFh/LzA3L2YxMWEwN2Vi/MmUzYzcwY2ZhZjcy/NDkwMzlmYjA4NGVl/LmpwZw)
