### PR TITLE
update beacon api to 2.3.0

### DIFF
--- a/docs/web3.beacon.rst
+++ b/docs/web3.beacon.rst
@@ -1,5 +1,5 @@
-Eth 2.0 Beacon API
-=======================
+Beacon API
+==========
 
 .. warning:: This API Is experimental. Client support is incomplete and the API itself is still evolving.
 

--- a/newsfragments/2616.bugfix.rst
+++ b/newsfragments/2616.bugfix.rst
@@ -1,0 +1,1 @@
+Update Beacon API to v2.3.0

--- a/tests/beacon/test_beacon.py
+++ b/tests/beacon/test_beacon.py
@@ -15,88 +15,88 @@ def beacon():
 # Beacon endpoint tests:
 
 
-def test_eth2_beacon_get_genesis(beacon):
+def test_cl_beacon_get_genesis(beacon):
     response = beacon.get_genesis()
     assert response is not None
 
 
-def test_eth2_beacon_get_hash_root(beacon):
+def test_cl_beacon_get_hash_root(beacon):
     response = beacon.get_hash_root()
     assert response is not None
 
 
-def test_eth2_beacon_get_fork_data(beacon):
+def test_cl_beacon_get_fork_data(beacon):
     response = beacon.get_fork_data()
     assert response is not None
 
 
-def test_eth2_beacon_get_finality_checkpoint(beacon):
+def test_cl_beacon_get_finality_checkpoint(beacon):
     response = beacon.get_finality_checkpoint()
     assert response is not None
 
 
-def test_eth2_beacon_get_validators(beacon):
+def test_cl_beacon_get_validators(beacon):
     response = beacon.get_validators()
     assert response is not None
 
 
-def test_eth2_beacon_get_validator(beacon):
-    pyrmont_validator_pub_key = "0xa09c261fc2b44badc0059b6eeb8e6935f2b795f15dad32449afeec3bc635ef0ae92fe0bab5edba31aebfde1947e2acf5"  # noqa: E501
-    response = beacon.get_validator(pyrmont_validator_pub_key)
+def test_cl_beacon_get_validator(beacon):
+    sepolia_validator_pub_key = "0xa9f6b6b04e36850d2dbbc390a9614013da239375f105b0f3738138431f0a3a8c685445f6c518e0b0e72fb3244ddc0d9e"  # noqa: E501
+    response = beacon.get_validator(sepolia_validator_pub_key)
     assert response is not None
 
 
-def test_eth2_beacon_get_validator_balances(beacon):
+def test_cl_beacon_get_validator_balances(beacon):
     response = beacon.get_validator_balances()
     assert response is not None
 
 
-def test_eth2_beacon_get_epoch_committees(beacon):
+def test_cl_beacon_get_epoch_committees(beacon):
     response = beacon.get_epoch_committees()
     assert response is not None
 
 
-def test_eth2_beacon_get_block_headers(beacon):
+def test_cl_beacon_get_block_headers(beacon):
     response = beacon.get_block_headers()
     assert response is not None
 
 
-def test_eth2_beacon_get_block_header(beacon):
-    response = beacon.get_block_header("123")
+def test_cl_beacon_get_block_header(beacon):
+    response = beacon.get_block_header("head")
     assert response is not None
 
 
-def test_eth2_beacon_get_block(beacon):
-    response = beacon.get_block("123")
+def test_cl_beacon_get_block(beacon):
+    response = beacon.get_block("head")
     assert response is not None
 
 
-def test_eth2_beacon_get_block_root(beacon):
-    response = beacon.get_block_root("123")
+def test_cl_beacon_get_block_root(beacon):
+    response = beacon.get_block_root("head")
     assert response is not None
 
 
-def test_eth2_beacon_get_block_attestations(beacon):
-    response = beacon.get_block_attestations("123")
+def test_cl_beacon_get_block_attestations(beacon):
+    response = beacon.get_block_attestations("head")
     assert response is not None
 
 
-def test_eth2_beacon_get_attestations(beacon):
+def test_cl_beacon_get_attestations(beacon):
     response = beacon.get_attestations()
     assert response is not None
 
 
-def test_eth2_beacon_get_attester_slashings(beacon):
+def test_cl_beacon_get_attester_slashings(beacon):
     response = beacon.get_attester_slashings()
     assert response is not None
 
 
-def test_eth2_beacon_get_proposer_slashings(beacon):
+def test_cl_beacon_get_proposer_slashings(beacon):
     response = beacon.get_proposer_slashings()
     assert response is not None
 
 
-def test_eth2_beacon_get_voluntary_exits(beacon):
+def test_cl_beacon_get_voluntary_exits(beacon):
     response = beacon.get_voluntary_exits()
     assert response is not None
 
@@ -104,17 +104,17 @@ def test_eth2_beacon_get_voluntary_exits(beacon):
 # Config endpoint tests:
 
 
-def test_eth2_config_get_fork_schedule(beacon):
+def test_cl_config_get_fork_schedule(beacon):
     response = beacon.get_fork_schedule()
     assert response is not None
 
 
-def test_eth2_config_get_spec(beacon):
+def test_cl_config_get_spec(beacon):
     response = beacon.get_spec()
     assert response is not None
 
 
-def test_eth2_config_get_deposit_contract(beacon):
+def test_cl_config_get_deposit_contract(beacon):
     response = beacon.get_deposit_contract()
     assert response is not None
 
@@ -122,12 +122,12 @@ def test_eth2_config_get_deposit_contract(beacon):
 # Debug endpoint tests:
 
 
-def test_eth2_debug_get_beacon_state(beacon):
+def test_cl_debug_get_beacon_state(beacon):
     response = beacon.get_beacon_state()
     assert response is not None
 
 
-def test_eth2_debug_get_beacon_heads(beacon):
+def test_cl_debug_get_beacon_heads(beacon):
     response = beacon.get_beacon_heads()
     assert response is not None
 
@@ -135,31 +135,31 @@ def test_eth2_debug_get_beacon_heads(beacon):
 # Node endpoint tests:
 
 
-def test_eth2_node_get_node_identity(beacon):
+def test_cl_node_get_node_identity(beacon):
     response = beacon.get_node_identity()
     assert response is not None
 
 
-def test_eth2_node_get_peers(beacon):
+def test_cl_node_get_peers(beacon):
     response = beacon.get_peers()
     assert response is not None
 
 
-def test_eth2_node_get_peer(beacon):
+def test_cl_node_get_peer(beacon):
     response = beacon.get_peer("")
     assert response is not None
 
 
-def test_eth2_node_get_health(beacon):
+def test_cl_node_get_health(beacon):
     response = beacon.get_health()
     assert response <= 206
 
 
-def test_eth2_node_get_version(beacon):
+def test_cl_node_get_version(beacon):
     response = beacon.get_version()
     assert response is not None
 
 
-def test_eth2_node_get_syncing(beacon):
+def test_cl_node_get_syncing(beacon):
     response = beacon.get_syncing()
     assert response is not None

--- a/web3/beacon/__init__.py
+++ b/web3/beacon/__init__.py
@@ -1,7 +1,1 @@
-import warnings
 from .main import Beacon  # noqa: F401
-
-warnings.warn(
-    "Beacon node APIs are experimental and may not be "
-    "implemented consistently by all clients.",
-)

--- a/web3/beacon/main.py
+++ b/web3/beacon/main.py
@@ -70,7 +70,7 @@ class Beacon(Module):
         return self._make_get_request(endpoint)
 
     def get_block(self, block_id: str) -> Dict[str, Any]:
-        endpoint = f"/eth/v1/beacon/blocks/{block_id}"
+        endpoint = f"/eth/v2/beacon/blocks/{block_id}"
         return self._make_get_request(endpoint)
 
     def get_block_root(self, block_id: str) -> Dict[str, Any]:


### PR DESCRIPTION
### What was wrong?

Web3.py's Beacon API is lagging behind the latest spec.

### How was it fixed?

- Smol fixes: a `v1`->`v2` bump and testing always-in-range values.
- These smoke/sanity tests are still not integrated into CI. Separate effort required to first decide how we'd want to introduce a Beacon node into the test infrastructure. Local testing performed with a lighthouse node on the `sepolia` network, e.g. by running `lighthouse b --http --http-port 5051 --network sepolia`, then executing the tests.
- Removed some `eth2` references and replaced with consensus layer (`cl`)
- Removed the 'experimental' warning.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQaqoh8pT0q0f5gOJC8DfbqYXGkCa9f_0o5RxoXZ7urBzIoTZUDBgpxVB-gnxEnmCxLfas&usqp=CAU)
