### PR TITLE
fix docs for eth.get_transaction returns

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -236,8 +236,8 @@ You can look up transactions using the ``web3.eth.get_transaction`` function.
         'value': 31337,
     }
 
-If no transaction for the given hash can be found, then this function will
-instead return ``None``.
+If no transaction for the given hash can be found, this method will
+throw :class:`web3.exceptions.TransactionNotFound`.
 
 
 Looking up receipts
@@ -263,7 +263,8 @@ Transaction receipts can be retrieved using the ``web3.eth.get_transaction_recei
     }
 
 
-If the transaction has not yet been mined then this method will raise a ``TransactionNotFound`` error.
+If no transaction for the given hash can be found, this method will
+throw :class:`web3.exceptions.TransactionNotFound`.
 
 
 Working with Contracts

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -580,7 +580,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
     * Delegates to ``eth_getTransactionByHash`` RPC Method
 
-    Returns the transaction specified by ``transaction_hash``. If the transaction has not yet been mined throws :class:`web3.exceptions.TransactionNotFound`.
+    Returns the transaction specified by ``transaction_hash``. If the transaction cannot be found throws :class:`web3.exceptions.TransactionNotFound`.
 
     .. code-block:: python
 
@@ -742,7 +742,7 @@ The following methods are available on the ``web3.eth`` namespace.
 
     * Delegates to ``eth_getTransactionReceipt`` RPC Method
 
-    Returns the transaction receipt specified by ``transaction_hash``.  If the transaction has not yet been mined throws :class:`web3.exceptions.TransactionNotFound`.
+    Returns the transaction receipt specified by ``transaction_hash``.  If the transaction cannot be found throws :class:`web3.exceptions.TransactionNotFound`.
 
     If ``status`` in response equals 1 the transaction was successful. If it is equals 0 the transaction was reverted by EVM.
 

--- a/newsfragments/2617.doc.rst
+++ b/newsfragments/2617.doc.rst
@@ -1,0 +1,1 @@
+examples docs gave incorrect return type for `eth.get_transaction`, fixed


### PR DESCRIPTION
### What was wrong?

Examples docs had the wrong return noted for when `eth.get_transaction` doesn't find anything. 

Related to Issue #2617
Closes #2617

### How was it fixed?

Corrected it, plus a little related cleanup.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/186487391-03d4c666-cfe9-4972-b7c4-02862a08f01c.png)
