### PR TITLE
Update eth-tester

### DIFF
--- a/newsfragments/2623.breaking-change.rst
+++ b/newsfragments/2623.breaking-change.rst
@@ -1,0 +1,1 @@
+Update eth-tester dependency to v0.7.0-beta.1; Update eth-account version to >=0.7.0,<0.8.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     "tester": [
-        "eth-tester[py-evm]==v0.6.0-beta.5",
+        "eth-tester[py-evm]==v0.7.0-beta.1",
         "py-geth>=3.9.1,<4",
     ],
     "linter": [

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     install_requires=[
         "aiohttp>=3.7.4.post0,<4",
         "eth-abi>=3.0.0,<4.0.0",
-        "eth-account>=0.6.0,<0.7.0",
+        "eth-account>=0.7.0,<0.8.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",
         "eth-typing>=3.0.0,<4.0.0",
         "eth-utils>=2.0.0,<3.0.0",


### PR DESCRIPTION
### What was wrong?
Released eth-tester v0.7.0-b.1, so pulled it in. 


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://miro.medium.com/max/1400/1*ir3MBJgZwPKAVghEbSdFIg.jpeg)
