### PR TITLE
update all references to deprecated eth_abi.encode_abi to eth_abi.encode

### DIFF
--- a/newsfragments/2621.feature.rst
+++ b/newsfragments/2621.feature.rst
@@ -1,0 +1,2 @@
+update all references to deprecated `eth_abi.encode_abi` to `eth_abi.encode`
+

--- a/tests/core/contracts/test_contract_constructor_encoding.py
+++ b/tests/core/contracts/test_contract_constructor_encoding.py
@@ -67,7 +67,7 @@ def test_contract_constructor_encoding_encoding(
     )
     encoded_args = "0x00000000000000000000000000000000000000000000000000000000000004d26162636400000000000000000000000000000000000000000000000000000000"  # noqa: E501
     expected_ending = encode_hex(
-        w3.codec.encode_abi(["uint256", "bytes32"], [1234, b"abcd"])
+        w3.codec.encode(["uint256", "bytes32"], [1234, b"abcd"])
     )
     assert expected_ending == encoded_args
     assert deploy_data.endswith(remove_0x_prefix(expected_ending))
@@ -86,7 +86,7 @@ def test_contract_constructor_encoding_encoding_warning(
         encoded_args = "0x00000000000000000000000000000000000000000000000000000000000004d26162636400000000000000000000000000000000000000000000000000000000"  # noqa: E501
 
         expected_ending = encode_hex(
-            w3.codec.encode_abi(["uint256", "bytes32"], [1234, b"abcd"])
+            w3.codec.encode(["uint256", "bytes32"], [1234, b"abcd"])
         )
         assert expected_ending == encoded_args
         assert deploy_data.endswith(remove_0x_prefix(expected_ending))
@@ -114,7 +114,7 @@ def test_contract_constructor_encoding_encoding_strict(
     )
 
     expected_ending = encode_hex(
-        w3_strict_abi.codec.encode_abi(["uint256", "bytes32"], [1234, bytes_arg])
+        w3_strict_abi.codec.encode(["uint256", "bytes32"], [1234, bytes_arg])
     )
     assert expected_ending == encoded_args
     assert deploy_data.endswith(remove_0x_prefix(expected_ending))

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -337,7 +337,7 @@ def test_argument_extraction_strict_bytes_types(
     event_topic = emitter_log_topics.LogListArgs
     assert event_topic in log_entry["topics"]
 
-    encoded_arg_0 = w3_strict_abi.codec.encode_abi(["bytes2"], arg_0)
+    encoded_arg_0 = w3_strict_abi.codec.encode(["bytes2"], arg_0)
     padded_arg_0 = encoded_arg_0.ljust(32, b"\x00")
     arg_0_topic = w3_strict_abi.keccak(padded_arg_0)
     assert arg_0_topic in log_entry["topics"]

--- a/tests/core/filtering/test_utils_functions.py
+++ b/tests/core/filtering/test_utils_functions.py
@@ -125,7 +125,7 @@ from web3._utils.filters import (
 )
 def test_match_fn_with_various_data_types(w3, data, expected, match_data_and_abi):
     abi_types, match_data = zip(*match_data_and_abi)
-    encoded_data = w3.codec.encode_abi(abi_types, data)
+    encoded_data = w3.codec.encode(abi_types, data)
     assert match_fn(w3.codec, match_data_and_abi, encoded_data) == expected
 
 
@@ -189,7 +189,7 @@ def test_match_fn_with_various_data_types_strict(
     w3_strict_abi, data, expected, match_data_and_abi
 ):
     abi_types, match_data = zip(*match_data_and_abi)
-    encoded_data = w3_strict_abi.codec.encode_abi(abi_types, data)
+    encoded_data = w3_strict_abi.codec.encode(abi_types, data)
     assert match_fn(w3_strict_abi.codec, match_data_and_abi, encoded_data) == expected
 
 
@@ -203,9 +203,9 @@ def test_match_fn_with_various_data_types_strict(
         ),
     ),
 )
-def test_encode_abi_with_wrong_types_strict(w3_strict_abi, data, abi_type):
+def test_encode_with_wrong_types_strict(w3_strict_abi, data, abi_type):
     with pytest.raises(ValueOutOfBounds):
-        w3_strict_abi.codec.encode_abi(abi_type, data)
+        w3_strict_abi.codec.encode(abi_type, data)
 
 
 def test_wrong_type_match_data(w3):
@@ -215,6 +215,6 @@ def test_wrong_type_match_data(w3):
         ("string", (50505050,)),
     )
     abi_types, match_data = zip(*match_data_and_abi)
-    encoded_data = w3.codec.encode_abi(abi_types, data)
+    encoded_data = w3.codec.encode(abi_types, data)
     with pytest.raises(ValueError):
         match_fn(w3.codec, match_data_and_abi, encoded_data)

--- a/web3/_utils/async_transactions.py
+++ b/web3/_utils/async_transactions.py
@@ -8,7 +8,7 @@ from typing import (
 )
 
 from eth_abi import (
-    encode_abi,
+    encode,
 )
 from eth_typing import (
     URI,
@@ -199,7 +199,7 @@ async def async_handle_offchain_lookup(
                 # 4-byte callback function selector
                 to_bytes_if_hex(offchain_lookup_payload["callbackFunction"]),
                 # encode the `data` from the result and the `extraData` as bytes
-                encode_abi(
+                encode(
                     ["bytes", "bytes"],
                     [
                         to_bytes_if_hex(result["data"]),

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -218,7 +218,7 @@ def encode_abi(
         argument_types,
         arguments,
     )
-    encoded_arguments = w3.codec.encode_abi(
+    encoded_arguments = w3.codec.encode(
         argument_types,
         normalized_arguments,
     )

--- a/web3/utils/async_exception_handling.py
+++ b/web3/utils/async_exception_handling.py
@@ -4,7 +4,7 @@ from typing import (
 )
 
 from eth_abi import (
-    encode_abi,
+    encode,
 )
 from eth_typing import (
     URI,
@@ -81,7 +81,7 @@ async def async_handle_offchain_lookup(
                 # 4-byte callback function selector
                 to_bytes_if_hex(offchain_lookup_payload["callbackFunction"]),
                 # encode the `data` from the result and the `extraData` as bytes
-                encode_abi(
+                encode(
                     ["bytes", "bytes"],
                     [
                         to_bytes_if_hex(result["data"]),

--- a/web3/utils/exception_handling.py
+++ b/web3/utils/exception_handling.py
@@ -4,7 +4,7 @@ from typing import (
 )
 
 from eth_abi import (
-    encode_abi,
+    encode,
 )
 from eth_typing import (
     URI,
@@ -83,7 +83,7 @@ def handle_offchain_lookup(
                 # 4-byte callback function selector
                 to_bytes_if_hex(offchain_lookup_payload["callbackFunction"]),
                 # encode the `data` from the result and the `extraData` as bytes
-                encode_abi(
+                encode(
                     ["bytes", "bytes"],
                     [
                         to_bytes_if_hex(result["data"]),


### PR DESCRIPTION
### What was wrong?

We were still calling the deprecated method `eth_abi.encode_abi`.

Related to Issue #2621 
Closes #2621

### How was it fixed?

 Changed all calls to the new `eth_abi.encode`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/187738382-8ff7b0f0-7622-494d-8301-f0d1385dfe00.png)
