### PR TITLE
Remove WEB3_INFURA_API_KEY environment variable in favor of WEB3_INFURA_PROJECT_ID

### DIFF
--- a/newsfragments/2634.breaking-change.rst
+++ b/newsfragments/2634.breaking-change.rst
@@ -1,1 +1,1 @@
-Remove ``WEB3_INFURA_API_KEY`` environment variable in favor of ``WEB3_INFURA_PROJECT_ID``
+Remove ``WEB3_INFURA_API_KEY`` environment variable in favor of ``WEB3_INFURA_PROJECT_ID``. Change ``InfuraKeyNotFound`` exception to ``InfuraProjectIdNotFound``

--- a/newsfragments/2634.breaking-change.rst
+++ b/newsfragments/2634.breaking-change.rst
@@ -1,0 +1,1 @@
+Remove ``WEB3_INFURA_API_KEY`` environment variable in favor of ``WEB3_INFURA_PROJECT_ID``

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -22,7 +22,7 @@ from web3.providers.ipc import (
 )
 
 # Ugly hack to import infura now that API KEY is required
-os.environ["WEB3_INFURA_API_KEY"] = "test"
+os.environ["WEB3_INFURA_PROJECT_ID"] = "test"
 from web3.auto import (  # noqa E402 isort:skip
     infura,
 )
@@ -31,7 +31,6 @@ from web3.auto import (  # noqa E402 isort:skip
 @pytest.fixture(autouse=True)
 def delete_environment_variables(monkeypatch):
     monkeypatch.delenv("WEB3_INFURA_PROJECT_ID", raising=False)
-    monkeypatch.delenv("WEB3_INFURA_API_KEY", raising=False)
     monkeypatch.delenv("WEB3_INFURA_API_SECRET", raising=False)
     monkeypatch.delenv("WEB3_INFURA_SCHEME", raising=False)
 
@@ -69,57 +68,42 @@ def test_get_dev_ipc_path(monkeypatch, tmp_path):
     assert path == uri
 
 
-@pytest.mark.parametrize(
-    "environ_name", ["WEB3_INFURA_API_KEY", "WEB3_INFURA_PROJECT_ID"]
-)
-def test_web3_auto_infura_empty_key(monkeypatch, caplog, environ_name):
+def test_web3_auto_infura_empty_key(monkeypatch):
     monkeypatch.setenv("WEB3_INFURA_SCHEME", "https")
-    monkeypatch.setenv(environ_name, "")
+    monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", "")
 
     with pytest.raises(InfuraKeyNotFound):
         importlib.reload(infura)
 
 
-@pytest.mark.parametrize(
-    "environ_name", ["WEB3_INFURA_API_KEY", "WEB3_INFURA_PROJECT_ID"]
-)
-def test_web3_auto_infura_deleted_key(monkeypatch, caplog, environ_name):
+def test_web3_auto_infura_deleted_key(monkeypatch):
     monkeypatch.setenv("WEB3_INFURA_SCHEME", "https")
 
-    monkeypatch.delenv(environ_name, raising=False)
+    monkeypatch.delenv("WEB3_INFURA_PROJECT_ID", raising=False)
 
     with pytest.raises(InfuraKeyNotFound):
         importlib.reload(infura)
 
 
-@pytest.mark.parametrize(
-    "environ_name", ["WEB3_INFURA_API_KEY", "WEB3_INFURA_PROJECT_ID"]
-)
-def test_web3_auto_infura_websocket_empty_key(monkeypatch, caplog, environ_name):
-    monkeypatch.setenv(environ_name, "")
+def test_web3_auto_infura_websocket_empty_key(monkeypatch):
+    monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", "")
 
     with pytest.raises(InfuraKeyNotFound):
         importlib.reload(infura)
 
 
-@pytest.mark.parametrize(
-    "environ_name", ["WEB3_INFURA_API_KEY", "WEB3_INFURA_PROJECT_ID"]
-)
-def test_web3_auto_infura_websocket_deleted_key(monkeypatch, caplog, environ_name):
-    monkeypatch.delenv(environ_name, raising=False)
+def test_web3_auto_infura_websocket_deleted_key(monkeypatch):
+    monkeypatch.delenv("WEB3_INFURA_PROJECT_ID", raising=False)
 
     with pytest.raises(InfuraKeyNotFound):
         importlib.reload(infura)
 
 
-@pytest.mark.parametrize(
-    "environ_name", ["WEB3_INFURA_API_KEY", "WEB3_INFURA_PROJECT_ID"]
-)
-def test_web3_auto_infura(monkeypatch, caplog, environ_name):
+def test_web3_auto_infura(monkeypatch, caplog):
     monkeypatch.setenv("WEB3_INFURA_SCHEME", "https")
     API_KEY = "aoeuhtns"
 
-    monkeypatch.setenv(environ_name, API_KEY)
+    monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", API_KEY)
 
     importlib.reload(infura)
     assert len(caplog.record_tuples) == 0
@@ -130,13 +114,10 @@ def test_web3_auto_infura(monkeypatch, caplog, environ_name):
     assert getattr(w3.provider, "endpoint_uri") == expected_url
 
 
-@pytest.mark.parametrize(
-    "environ_name", ["WEB3_INFURA_API_KEY", "WEB3_INFURA_PROJECT_ID"]
-)
-def test_web3_auto_infura_websocket_default(monkeypatch, caplog, environ_name):
+def test_web3_auto_infura_websocket_default(monkeypatch, caplog):
     monkeypatch.setenv("WEB3_INFURA_SCHEME", "wss")
     API_KEY = "aoeuhtns"
-    monkeypatch.setenv(environ_name, API_KEY)
+    monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", API_KEY)
     expected_url = f"wss://{infura.INFURA_MAINNET_DOMAIN}/ws/v3/{API_KEY}"
 
     importlib.reload(infura)
@@ -148,7 +129,7 @@ def test_web3_auto_infura_websocket_default(monkeypatch, caplog, environ_name):
 
 
 def test_web3_auto_infura_raises_error_with_nonexistent_scheme(monkeypatch):
-    monkeypatch.setenv("WEB3_INFURA_API_KEY", "test")
+    monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", "test")
     monkeypatch.setenv("WEB3_INFURA_SCHEME", "not-a-scheme")
 
     error_msg = "Cannot connect to Infura with scheme 'not-a-scheme'"
@@ -156,11 +137,8 @@ def test_web3_auto_infura_raises_error_with_nonexistent_scheme(monkeypatch):
         importlib.reload(infura)
 
 
-@pytest.mark.parametrize(
-    "environ_name", ["WEB3_INFURA_API_KEY", "WEB3_INFURA_PROJECT_ID"]
-)
-def test_web3_auto_infura_websocket_with_secret(monkeypatch, caplog, environ_name):
-    monkeypatch.setenv(environ_name, "test")
+def test_web3_auto_infura_websocket_with_secret(monkeypatch):
+    monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", "test")
     monkeypatch.setenv("WEB3_INFURA_API_SECRET", "secret")
 
     importlib.reload(infura)
@@ -171,12 +149,9 @@ def test_web3_auto_infura_websocket_with_secret(monkeypatch, caplog, environ_nam
     assert getattr(w3.provider, "endpoint_uri") == expected_url
 
 
-@pytest.mark.parametrize(
-    "environ_name", ["WEB3_INFURA_API_KEY", "WEB3_INFURA_PROJECT_ID"]
-)
-def test_web3_auto_infura_with_secret(monkeypatch, caplog, environ_name):
+def test_web3_auto_infura_with_secret(monkeypatch):
     monkeypatch.setenv("WEB3_INFURA_SCHEME", "https")
-    monkeypatch.setenv(environ_name, "test")
+    monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", "test")
     monkeypatch.setenv("WEB3_INFURA_API_SECRET", "secret")
 
     importlib.reload(infura)

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -7,7 +7,7 @@ from eth_utils import (
 )
 
 from web3.exceptions import (
-    InfuraKeyNotFound,
+    InfuraProjectIdNotFound,
 )
 from web3.providers import (
     HTTPProvider,
@@ -72,7 +72,7 @@ def test_web3_auto_infura_empty_key(monkeypatch):
     monkeypatch.setenv("WEB3_INFURA_SCHEME", "https")
     monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", "")
 
-    with pytest.raises(InfuraKeyNotFound):
+    with pytest.raises(InfuraProjectIdNotFound):
         importlib.reload(infura)
 
 
@@ -81,21 +81,21 @@ def test_web3_auto_infura_deleted_key(monkeypatch):
 
     monkeypatch.delenv("WEB3_INFURA_PROJECT_ID", raising=False)
 
-    with pytest.raises(InfuraKeyNotFound):
+    with pytest.raises(InfuraProjectIdNotFound):
         importlib.reload(infura)
 
 
 def test_web3_auto_infura_websocket_empty_key(monkeypatch):
     monkeypatch.setenv("WEB3_INFURA_PROJECT_ID", "")
 
-    with pytest.raises(InfuraKeyNotFound):
+    with pytest.raises(InfuraProjectIdNotFound):
         importlib.reload(infura)
 
 
 def test_web3_auto_infura_websocket_deleted_key(monkeypatch):
     monkeypatch.delenv("WEB3_INFURA_PROJECT_ID", raising=False)
 
-    with pytest.raises(InfuraKeyNotFound):
+    with pytest.raises(InfuraProjectIdNotFound):
         importlib.reload(infura)
 
 

--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -13,7 +13,7 @@ from eth_utils import (
 )
 
 from web3.exceptions import (
-    InfuraKeyNotFound,
+    InfuraProjectIdNotFound,
 )
 
 INFURA_MAINNET_DOMAIN = "mainnet.infura.io"
@@ -29,7 +29,7 @@ HTTP_SCHEME = "https"
 def load_project_id() -> str:
     key = os.environ.get("WEB3_INFURA_PROJECT_ID", "")
     if key == "":
-        raise InfuraKeyNotFound(
+        raise InfuraProjectIdNotFound(
             "No Infura Project ID found. Please ensure "
             "that the environment variable WEB3_INFURA_PROJECT_ID is set."
         )

--- a/web3/auto/infura/endpoints.py
+++ b/web3/auto/infura/endpoints.py
@@ -26,11 +26,8 @@ WEBSOCKET_SCHEME = "wss"
 HTTP_SCHEME = "https"
 
 
-def load_api_key() -> str:
-    # in web3py v6 remove outdated WEB3_INFURA_API_KEY
-    key = os.environ.get(
-        "WEB3_INFURA_PROJECT_ID", os.environ.get("WEB3_INFURA_API_KEY", "")
-    )
+def load_project_id() -> str:
+    key = os.environ.get("WEB3_INFURA_PROJECT_ID", "")
     if key == "":
         raise InfuraKeyNotFound(
             "No Infura Project ID found. Please ensure "
@@ -53,7 +50,7 @@ def build_http_headers() -> Optional[Dict[str, Tuple[str, str]]]:
 
 def build_infura_url(domain: str) -> URI:
     scheme = os.environ.get("WEB3_INFURA_SCHEME", WEBSOCKET_SCHEME)
-    key = load_api_key()
+    key = load_project_id()
     secret = load_secret()
 
     if scheme == WEBSOCKET_SCHEME and secret != "":

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -218,7 +218,7 @@ class BlockNotFound(Exception):
     pass
 
 
-class InfuraKeyNotFound(Exception):
+class InfuraProjectIdNotFound(Exception):
     """
     Raised when there is no Infura Project Id set.
     """


### PR DESCRIPTION
### What was wrong?

Another v6 breaking change. We had 2 environment variables that were aliases of one another for backwards compatibility.

### How was it fixed?
Standardized on WEB3_INFURA_PROJECT_ID to match up with Infura's wording.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://previews.123rf.com/images/irinavar/irinavar1807/irinavar180700034/104613565-a-cute-gopher-stands-in-the-grass-in-the-steppe.jpg)
