### PR TITLE
Renaming leftover references to deprecated `eth_abi.decode_abi` to `eth_abi.decode`

### DIFF
--- a/ens/base_ens.py
+++ b/ens/base_ens.py
@@ -93,7 +93,7 @@ class BaseENS:
     ) -> Any:
         func = extended_resolver.get_function_by_name(fn_name)
         output_types = get_abi_output_types(func.abi)
-        decoded = self.w3.codec.decode_abi(output_types, contract_call_result)
+        decoded = self.w3.codec.decode(output_types, contract_call_result)
 
         # if decoding a single value, return that value - else, return the tuple
         return decoded[0] if len(decoded) == 1 else decoded

--- a/newsfragments/2636.feature.rst
+++ b/newsfragments/2636.feature.rst
@@ -1,0 +1,1 @@
+update all references to deprecated `eth_abi.decode_abi` to `eth_abi.decode`

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -258,7 +258,7 @@ def test_saved_method_call_with_multiple_arguments(
 
 def test_call_get_string_value(string_contract, call):
     result = call(contract=string_contract, contract_function="getValue")
-    # eth_abi.decode_abi() does not assume implicit utf-8
+    # eth_abi.decode() does not assume implicit utf-8
     # encoding of string return values. Thus, we need to decode
     # ourselves for fair comparison.
     assert result == "Caqalai"
@@ -1073,7 +1073,7 @@ async def test_async_call_get_string_value(async_string_contract, async_call):
     result = await async_call(
         contract=async_string_contract, contract_function="getValue"
     )
-    # eth_abi.decode_abi() does not assume implicit utf-8
+    # eth_abi.decode() does not assume implicit utf-8
     # encoding of string return values. Thus, we need to decode
     # ourselves for fair comparison.
     assert result == "Caqalai"

--- a/tests/core/contracts/test_offchain_lookup.py
+++ b/tests/core/contracts/test_offchain_lookup.py
@@ -1,7 +1,7 @@
 import pytest
 
 from eth_abi import (
-    decode_abi,
+    decode,
 )
 
 from web3._utils.module_testing.module_testing_utils import (
@@ -74,7 +74,7 @@ def test_offchain_lookup_functionality(
     response = offchain_lookup_contract.caller.testOffchainLookup(
         OFFCHAIN_LOOKUP_TEST_DATA
     )
-    assert decode_abi(["string"], response)[0] == "web3py"
+    assert decode(["string"], response)[0] == "web3py"
 
 
 def test_eth_call_offchain_lookup_raises_when_ccip_read_is_disabled(
@@ -123,7 +123,7 @@ def test_offchain_lookup_call_flag_overrides_provider_flag(
     response = offchain_lookup_contract.functions.testOffchainLookup(
         OFFCHAIN_LOOKUP_TEST_DATA
     ).call(ccip_read_enabled=True)
-    assert decode_abi(["string"], response)[0] == "web3py"
+    assert decode(["string"], response)[0] == "web3py"
 
     w3.provider.global_ccip_read_enabled = True
 
@@ -176,7 +176,7 @@ def test_eth_call_offchain_lookup_tries_next_url_for_non_4xx_error_status_and_te
     response = offchain_lookup_contract.caller.testOffchainLookup(
         OFFCHAIN_LOOKUP_TEST_DATA
     )
-    assert decode_abi(["string"], response)[0] == "web3py"
+    assert decode(["string"], response)[0] == "web3py"
 
 
 @pytest.mark.parametrize("status_code_4xx_error", [400, 410, 450, 499])

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -246,7 +246,7 @@ def get_event_data(
             f"between event inputs: '{', '.join(duplicate_names)}'"
         )
 
-    decoded_log_data = abi_codec.decode_abi(log_data_types, log_data)
+    decoded_log_data = abi_codec.decode(log_data_types, log_data)
     normalized_log_data = map_abi_data(
         BASE_RETURN_NORMALIZERS, log_data_types, decoded_log_data
     )

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -267,7 +267,7 @@ def match_fn(
     """
     abi_types, all_match_values = zip(*match_values_and_abi)
 
-    decoded_values = codec.decode_abi(abi_types, HexBytes(data))
+    decoded_values = codec.decode(abi_types, HexBytes(data))
     for data_value, match_values, abi_type in zip(
         decoded_values, all_match_values, abi_types
     ):

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from eth_abi import (
-    decode_abi,
+    decode,
 )
 from eth_typing import (
     HexStr,
@@ -623,7 +623,7 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
     # OffchainLookup(address,string[],bytes,bytes4,bytes)
     if data[:10] == "0x556f1830":
         parsed_data_as_bytes = to_bytes(hexstr=data[10:])
-        abi_decoded_data = decode_abi(
+        abi_decoded_data = decode(
             OFFCHAIN_LOOKUP_FIELDS.values(), parsed_data_as_bytes
         )
         offchain_lookup_payload = dict(

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -623,9 +623,7 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
     # OffchainLookup(address,string[],bytes,bytes4,bytes)
     if data[:10] == "0x556f1830":
         parsed_data_as_bytes = to_bytes(hexstr=data[10:])
-        abi_decoded_data = decode(
-            OFFCHAIN_LOOKUP_FIELDS.values(), parsed_data_as_bytes
-        )
+        abi_decoded_data = decode(OFFCHAIN_LOOKUP_FIELDS.values(), parsed_data_as_bytes)
         offchain_lookup_payload = dict(
             zip(OFFCHAIN_LOOKUP_FIELDS.keys(), abi_decoded_data)
         )

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -829,9 +829,9 @@ class AsyncEthModuleTest:
         response_function_call = await async_offchain_lookup_contract.functions.testOffchainLookup(  # noqa: E501 type: ignore
             OFFCHAIN_LOOKUP_TEST_DATA
         ).call()
-        assert async_w3.codec.decode_abi(["string"], response_caller)[0] == "web3py"
+        assert async_w3.codec.decode(["string"], response_caller)[0] == "web3py"
         assert (
-            async_w3.codec.decode_abi(["string"], response_function_call)[0] == "web3py"
+            async_w3.codec.decode(["string"], response_function_call)[0] == "web3py"
         )
 
     @pytest.mark.asyncio
@@ -888,7 +888,7 @@ class AsyncEthModuleTest:
             # noqa: E501 type: ignore
             OFFCHAIN_LOOKUP_TEST_DATA
         ).call(ccip_read_enabled=True)
-        assert async_w3.codec.decode_abi(["string"], response)[0] == "web3py"
+        assert async_w3.codec.decode(["string"], response)[0] == "web3py"
 
         async_w3.provider.global_ccip_read_enabled = True  # cleanup
 
@@ -970,7 +970,7 @@ class AsyncEthModuleTest:
         response = await async_offchain_lookup_contract.caller().testOffchainLookup(
             OFFCHAIN_LOOKUP_TEST_DATA
         )
-        assert async_w3.codec.decode_abi(["string"], response)[0] == "web3py"
+        assert async_w3.codec.decode(["string"], response)[0] == "web3py"
 
     @pytest.mark.asyncio
     async def test_eth_call_offchain_lookup_calls_raise_for_status_for_4xx_status_code(
@@ -2644,7 +2644,7 @@ class EthModuleTest:
         response = offchain_lookup_contract.functions.testOffchainLookup(
             OFFCHAIN_LOOKUP_TEST_DATA
         ).call()
-        assert w3.codec.decode_abi(["string"], response)[0] == "web3py"
+        assert w3.codec.decode(["string"], response)[0] == "web3py"
 
     def test_eth_call_offchain_lookup_raises_when_ccip_read_is_disabled(
         self,
@@ -2694,7 +2694,7 @@ class EthModuleTest:
         response = offchain_lookup_contract.functions.testOffchainLookup(
             OFFCHAIN_LOOKUP_TEST_DATA
         ).call(ccip_read_enabled=True)
-        assert w3.codec.decode_abi(["string"], response)[0] == "web3py"
+        assert w3.codec.decode(["string"], response)[0] == "web3py"
 
         w3.provider.global_ccip_read_enabled = True  # cleanup
 
@@ -2772,7 +2772,7 @@ class EthModuleTest:
         response = offchain_lookup_contract.functions.testOffchainLookup(
             OFFCHAIN_LOOKUP_TEST_DATA
         ).call()
-        assert w3.codec.decode_abi(["string"], response)[0] == "web3py"
+        assert w3.codec.decode(["string"], response)[0] == "web3py"
 
     def test_eth_call_offchain_lookup_calls_raise_for_status_for_4xx_status_code(
         self,

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -830,9 +830,7 @@ class AsyncEthModuleTest:
             OFFCHAIN_LOOKUP_TEST_DATA
         ).call()
         assert async_w3.codec.decode(["string"], response_caller)[0] == "web3py"
-        assert (
-            async_w3.codec.decode(["string"], response_function_call)[0] == "web3py"
-        )
+        assert async_w3.codec.decode(["string"], response_function_call)[0] == "web3py"
 
     @pytest.mark.asyncio
     async def test_eth_call_offchain_lookup_raises_when_ccip_read_is_disabled(

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -476,7 +476,7 @@ class BaseContract:
         names = get_abi_input_names(func.abi)
         types = get_abi_input_types(func.abi)
 
-        decoded = self.w3.codec.decode_abi(types, cast(HexBytes, params))
+        decoded = self.w3.codec.decode(types, cast(HexBytes, params))
         normalized = map_abi_data(BASE_RETURN_NORMALIZERS, types, decoded)
 
         return func, dict(zip(names, normalized))
@@ -2007,7 +2007,7 @@ def call_contract_function(
     output_types = get_abi_output_types(fn_abi)
 
     try:
-        output_data = w3.codec.decode_abi(output_types, return_data)
+        output_data = w3.codec.decode(output_types, return_data)
     except DecodingError as e:
         # Provide a more helpful error message than the one provided by
         # eth-abi-utils
@@ -2083,7 +2083,7 @@ async def async_call_contract_function(
     output_types = get_abi_output_types(fn_abi)
 
     try:
-        output_data = async_w3.codec.decode_abi(output_types, return_data)
+        output_data = async_w3.codec.decode(output_types, return_data)
     except DecodingError as e:
         # Provide a more helpful error message than the one provided by
         # eth-abi-utils

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 from eth_abi.abi import (
-    decode_abi,
+    decode,
 )
 from eth_tester.exceptions import (
     BlockNotFound,
@@ -89,7 +89,7 @@ def call_eth_tester(
             data_payload = parsed_data_as_bytes[
                 4:
             ]  # everything but the function selector
-            abi_decoded_data = decode_abi(OFFCHAIN_LOOKUP_FIELDS.values(), data_payload)
+            abi_decoded_data = decode(OFFCHAIN_LOOKUP_FIELDS.values(), data_payload)
             offchain_lookup_payload = dict(
                 zip(OFFCHAIN_LOOKUP_FIELDS.keys(), abi_decoded_data)
             )


### PR DESCRIPTION

### What was wrong?

`eth_abi.decode_abi` was renamed to `eth_abi.decode` and the original method was deprecated. #2626 already addressed the calls to `eth_abi.encode_abi`

Related to Issue #2621

### How was it fixed?

Replaced all instances of `eth_abi.decode_abi` with `eth_abi.decode`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/iw9D6rS.jpeg)
