### PR TITLE
Chore: address test timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,36 +248,28 @@ jobs:
       # Please don't use this key for any shenanigans
       WEB3_INFURA_PROJECT_ID: 7707850c2fb7465ebe6f150d67182e22
 
-  py37-integration-goethereum-ipc_eth:
+  py37-integration-goethereum-ipc:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.7
     environment:
-      TOXENV: py37-integration-goethereum-ipc_eth
+      TOXENV: py37-integration-goethereum-ipc
       GETH_VERSION: v1.10.23
 
-  py37-integration-goethereum-ipc_non_eth:
+  py37-integration-goethereum-ipc_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.7
     environment:
-      TOXENV: py37-integration-goethereum-ipc_non_eth
+      TOXENV: py37-integration-goethereum-ipc_flaky
       GETH_VERSION: v1.10.23
 
-  py37-integration-goethereum-http_eth:
+  py37-integration-goethereum-http:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.7
     environment:
-      TOXENV: py37-integration-goethereum-http_eth
-      GETH_VERSION: v1.10.23
-
-  py37-integration-goethereum-http_non_eth:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.7
-    environment:
-      TOXENV: py37-integration-goethereum-http_non_eth
+      TOXENV: py37-integration-goethereum-http
       GETH_VERSION: v1.10.23
 
   py37-integration-goethereum-http_async:
@@ -288,20 +280,28 @@ jobs:
       TOXENV: py37-integration-goethereum-http_async
       GETH_VERSION: v1.10.23
 
-  py37-integration-goethereum-ws_eth:
+  py37-integration-goethereum-http_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.7
     environment:
-      TOXENV: py37-integration-goethereum-ws_eth
+      TOXENV: py37-integration-goethereum-http_flaky
       GETH_VERSION: v1.10.23
 
-  py37-integration-goethereum-ws_non_eth:
+  py37-integration-goethereum-ws:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.7
     environment:
-      TOXENV: py37-integration-goethereum-ws_non_eth
+      TOXENV: py37-integration-goethereum-ws
+      GETH_VERSION: v1.10.23
+
+  py37-integration-goethereum-ws_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.7
+    environment:
+      TOXENV: py37-integration-goethereum-ws_flaky
       GETH_VERSION: v1.10.23
 
   py37-integration-ethtester-pyevm:
@@ -350,36 +350,28 @@ jobs:
       # Please don't use this key for any shenanigans
       WEB3_INFURA_PROJECT_ID: 7707850c2fb7465ebe6f150d67182e22
 
-  py38-integration-goethereum-ipc_eth:
+  py38-integration-goethereum-ipc:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.8
     environment:
-      TOXENV: py38-integration-goethereum-ipc_eth
+      TOXENV: py38-integration-goethereum-ipc
       GETH_VERSION: v1.10.23
 
-  py38-integration-goethereum-ipc_non_eth:
+  py38-integration-goethereum-ipc_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.8
     environment:
-      TOXENV: py38-integration-goethereum-ipc_non_eth
+      TOXENV: py38-integration-goethereum-ipc_flaky
       GETH_VERSION: v1.10.23
 
-  py38-integration-goethereum-http_eth:
+  py38-integration-goethereum-http:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.8
     environment:
-      TOXENV: py38-integration-goethereum-http_eth
-      GETH_VERSION: v1.10.23
-
-  py38-integration-goethereum-http_non_eth:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-integration-goethereum-http_non_eth
+      TOXENV: py38-integration-goethereum-http
       GETH_VERSION: v1.10.23
 
   py38-integration-goethereum-http_async:
@@ -390,20 +382,28 @@ jobs:
       TOXENV: py38-integration-goethereum-http_async
       GETH_VERSION: v1.10.23
 
-  py38-integration-goethereum-ws_eth:
+  py38-integration-goethereum-http_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.8
     environment:
-      TOXENV: py38-integration-goethereum-ws_eth
+      TOXENV: py38-integration-goethereum-http_flaky
       GETH_VERSION: v1.10.23
 
-  py38-integration-goethereum-ws_non_eth:
+  py38-integration-goethereum-ws:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.8
     environment:
-      TOXENV: py38-integration-goethereum-ws_non_eth
+      TOXENV: py38-integration-goethereum-ws
+      GETH_VERSION: v1.10.23
+
+  py38-integration-goethereum-ws_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.8
+    environment:
+      TOXENV: py38-integration-goethereum-ws_flaky
       GETH_VERSION: v1.10.23
 
   py38-integration-ethtester-pyevm:
@@ -447,36 +447,28 @@ jobs:
       # Please don't use this key for any shenanigans
       WEB3_INFURA_PROJECT_ID: 7707850c2fb7465ebe6f150d67182e22
 
-  py39-integration-goethereum-ipc_eth:
+  py39-integration-goethereum-ipc:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.9
     environment:
-      TOXENV: py39-integration-goethereum-ipc_eth
+      TOXENV: py39-integration-goethereum-ipc
       GETH_VERSION: v1.10.23
 
-  py39-integration-goethereum-ipc_non_eth:
+  py39-integration-goethereum-ipc_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.9
     environment:
-      TOXENV: py39-integration-goethereum-ipc_non_eth
+      TOXENV: py39-integration-goethereum-ipc_flaky
       GETH_VERSION: v1.10.23
 
-  py39-integration-goethereum-http_eth:
+  py39-integration-goethereum-http:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.9
     environment:
-      TOXENV: py39-integration-goethereum-http_eth
-      GETH_VERSION: v1.10.23
-
-  py39-integration-goethereum-http_non_eth:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-integration-goethereum-http_non_eth
+      TOXENV: py39-integration-goethereum-http
       GETH_VERSION: v1.10.23
 
   py39-integration-goethereum-http_async:
@@ -487,20 +479,28 @@ jobs:
       TOXENV: py39-integration-goethereum-http_async
       GETH_VERSION: v1.10.23
 
-  py39-integration-goethereum-ws_eth:
+  py39-integration-goethereum-http_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.9
     environment:
-      TOXENV: py39-integration-goethereum-ws_eth
+      TOXENV: py39-integration-goethereum-http_flaky
       GETH_VERSION: v1.10.23
 
-  py39-integration-goethereum-ws_non_eth:
+  py39-integration-goethereum-ws:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.9
     environment:
-      TOXENV: py39-integration-goethereum-ws_non_eth
+      TOXENV: py39-integration-goethereum-ws
+      GETH_VERSION: v1.10.23
+
+  py39-integration-goethereum-ws_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.9
+    environment:
+      TOXENV: py39-integration-goethereum-ws_flaky
       GETH_VERSION: v1.10.23
 
   py39-integration-ethtester-pyevm:
@@ -544,36 +544,28 @@ jobs:
       # Please don't use this key for any shenanigans
       WEB3_INFURA_PROJECT_ID: 7707850c2fb7465ebe6f150d67182e22
 
-  py310-integration-goethereum-ipc_eth:
+  py310-integration-goethereum-ipc:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.10
     environment:
-      TOXENV: py310-integration-goethereum-ipc_eth
+      TOXENV: py310-integration-goethereum-ipc
       GETH_VERSION: v1.10.23
 
-  py310-integration-goethereum-ipc_non_eth:
+  py310-integration-goethereum-ipc_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.10
     environment:
-      TOXENV: py310-integration-goethereum-ipc_non_eth
+      TOXENV: py310-integration-goethereum-ipc_flaky
       GETH_VERSION: v1.10.23
 
-  py310-integration-goethereum-http_eth:
+  py310-integration-goethereum-http:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.10
     environment:
-      TOXENV: py310-integration-goethereum-http_eth
-      GETH_VERSION: v1.10.23
-
-  py310-integration-goethereum-http_non_eth:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-integration-goethereum-http_non_eth
+      TOXENV: py310-integration-goethereum-http
       GETH_VERSION: v1.10.23
 
   py310-integration-goethereum-http_async:
@@ -584,20 +576,28 @@ jobs:
       TOXENV: py310-integration-goethereum-http_async
       GETH_VERSION: v1.10.23
 
-  py310-integration-goethereum-ws_eth:
+  py310-integration-goethereum-http_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.10
     environment:
-      TOXENV: py310-integration-goethereum-ws_eth
+      TOXENV: py310-integration-goethereum-http_flaky
       GETH_VERSION: v1.10.23
 
-  py310-integration-goethereum-ws_non_eth:
+  py310-integration-goethereum-ws:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.10
     environment:
-      TOXENV: py310-integration-goethereum-ws_non_eth
+      TOXENV: py310-integration-goethereum-ws
+      GETH_VERSION: v1.10.23
+
+  py310-integration-goethereum-ws_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.10
+    environment:
+      TOXENV: py310-integration-goethereum-ws_flaky
       GETH_VERSION: v1.10.23
 
   py310-integration-ethtester-pyevm:
@@ -637,46 +637,46 @@ workflows:
       - benchmark
       - py37-ens
       - py37-ethpm
-      - py37-integration-goethereum-ipc_eth
-      - py37-integration-goethereum-ipc_non_eth
-      - py37-integration-goethereum-http_eth
-      - py37-integration-goethereum-http_non_eth
+      - py37-integration-goethereum-ipc
+      - py37-integration-goethereum-ipc_flaky
+      - py37-integration-goethereum-http
       - py37-integration-goethereum-http_async
-      - py37-integration-goethereum-ws_eth
-      - py37-integration-goethereum-ws_non_eth
+      - py37-integration-goethereum-http_flaky
+      - py37-integration-goethereum-ws
+      - py37-integration-goethereum-ws_flaky
       - py37-integration-ethtester-pyevm
       - py37-wheel-cli
       - py37-wheel-cli-windows
       - py38-ens
       - py38-ethpm
-      - py38-integration-goethereum-ipc_eth
-      - py38-integration-goethereum-ipc_non_eth
-      - py38-integration-goethereum-http_eth
-      - py38-integration-goethereum-http_non_eth
+      - py38-integration-goethereum-ipc
+      - py38-integration-goethereum-ipc_flaky
+      - py38-integration-goethereum-http
       - py38-integration-goethereum-http_async
-      - py38-integration-goethereum-ws_eth
-      - py38-integration-goethereum-ws_non_eth
+      - py38-integration-goethereum-http_flaky
+      - py38-integration-goethereum-ws
+      - py38-integration-goethereum-ws_flaky
       - py38-integration-ethtester-pyevm
       - py38-wheel-cli
       - py39-ens
       - py39-ethpm
-      - py39-integration-goethereum-ipc_eth
-      - py39-integration-goethereum-ipc_non_eth
-      - py39-integration-goethereum-http_eth
-      - py39-integration-goethereum-http_non_eth
+      - py39-integration-goethereum-ipc
+      - py39-integration-goethereum-ipc_flaky
+      - py39-integration-goethereum-http
       - py39-integration-goethereum-http_async
-      - py39-integration-goethereum-ws_eth
-      - py39-integration-goethereum-ws_non_eth
+      - py39-integration-goethereum-http_flaky
+      - py39-integration-goethereum-ws
+      - py39-integration-goethereum-ws_flaky
       - py39-integration-ethtester-pyevm
       - py39-wheel-cli
       - py310-ens
       - py310-ethpm
-      - py310-integration-goethereum-ipc_eth
-      - py310-integration-goethereum-ipc_non_eth
-      - py310-integration-goethereum-http_eth
-      - py310-integration-goethereum-http_non_eth
+      - py310-integration-goethereum-ipc
+      - py310-integration-goethereum-ipc_flaky
+      - py310-integration-goethereum-http
       - py310-integration-goethereum-http_async
-      - py310-integration-goethereum-ws_eth
-      - py310-integration-goethereum-ws_non_eth
+      - py310-integration-goethereum-http_flaky
+      - py310-integration-goethereum-ws
+      - py310-integration-goethereum-ws_flaky
       - py310-integration-ethtester-pyevm
       - py310-wheel-cli

--- a/newsfragments/2638.misc.rst
+++ b/newsfragments/2638.misc.rst
@@ -1,0 +1,1 @@
+Run some flaky tests related to unlocked account fixtures as a separate test run in the CI builds.

--- a/tox.ini
+++ b/tox.ini
@@ -34,13 +34,13 @@ commands=
     core: pytest {posargs:tests/core}
     ens: pytest {posargs:tests/ens}
     ethpm: pytest {posargs:tests/ethpm}
-    integration-goethereum-ipc_eth: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py -k EthModule}
-    integration-goethereum-ipc_non_eth: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py -k "not EthModule"}
-    integration-goethereum-http_eth: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py -k "EthModule and not Async"}
-    integration-goethereum-http_non_eth: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py -k "not EthModule and not Async"}
+    integration-goethereum-ipc: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py}
+    integration-goethereum-ipc_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py --flaky}
+    integration-goethereum-http: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py -k "not Async"}
     integration-goethereum-http_async: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py -k Async}
-    integration-goethereum-ws_eth: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py -k EthModule}
-    integration-goethereum-ws_non_eth: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py -k "not EthModule"}
+    integration-goethereum-http_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py --flaky}
+    integration-goethereum-ws: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py}
+    integration-goethereum-ws_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py --flaky}
     integration-ethtester: pytest {posargs:tests/integration/test_ethereum_tester.py}
     docs: make -C {toxinidir} validate-docs
 deps =


### PR DESCRIPTION
### What was wrong?

- We have inconsistent test timeouts that are leading to many failed test runs. Tests using `unlock_account` and `unlock_account_dual_type` pytest fixtures are a known source of timeout issues.

### How was it fixed?

- Split flaky tests, starting with `unlocked_account` and `unlocked_account_dual_type` fixture tests into their own test run / shorter CI job. It does seem to have many continuous successful runs.
- Add some notes around integration test config so we don't start to clutter those conditionals and risk skipping some tests.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20220908_143048](https://user-images.githubusercontent.com/3532824/189220107-c9db8077-f969-401e-b98a-647aebee198a.jpg)
