### PR TITLE
Move flaky option to top level

### DIFF
--- a/newsfragments/2642.bugfix.rst
+++ b/newsfragments/2642.bugfix.rst
@@ -1,0 +1,1 @@
+Move ``flaky`` option to top-level conftest.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,3 +20,7 @@ def address_conversion_func(request):
 @pytest.fixture()
 def open_port():
     return get_open_port()
+
+
+def pytest_addoption(parser):
+    parser.addoption("--flaky", action="store_true")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,10 +21,6 @@ from web3._utils.module_testing.revert_contract import (
 # --- integration test configurations --- #
 
 
-def pytest_addoption(parser):
-    parser.addoption("--flaky", action="store_true")
-
-
 def pytest_collection_modifyitems(items, config):
     """
     It is ideal to keep this configuration as simple as possible so that we don't


### PR DESCRIPTION
### What was wrong?
Running `pytest tests/` was throwing an `AttributeError` because there was no `flaky` on the top level. 


### How was it fixed?

Moved `pytest_addoption` from `tests/integration/conftest.py` to `tests/conftest.py`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.freepik.com/premium-photo/portrait-arctic-ground-squirrel-cute-curious-wild-animal-genus-medium-sized-rodents-squirrel-family-eurasia-russian-far-east-kamchatka-peninsula_494000-562.jpg?w=2000)
