### PR TITLE
Fixing Issue #2646

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -338,7 +338,7 @@ The following example demonstrates a few things:
        with open(file_path, 'r') as f:
           source = f.read()
 
-       return compile_source(source)
+       return compile_source(source,output_values=['abi','bin'])
 
 
     def deploy_contract(w3, contract_interface):

--- a/newsfragments/2646.doc.rst
+++ b/newsfragments/2646.doc.rst
@@ -1,0 +1,1 @@
+fix bug in `Deploying new contracts` example


### PR DESCRIPTION
### What was wrong?
The Solidity compiler gets a return code 0 and prints "solcx.exceptions.SolcError: An error occurred during execution"
and then a list of command line options.
Related to Issue #2646
Closes #2646 

### How was it fixed?
Making the required code changes as specified by @mathstream

