### PR TITLE
Pin importlib-metadata<5 on Python 3.7

### DIFF
--- a/newsfragments/2671.misc.rst
+++ b/newsfragments/2671.misc.rst
@@ -1,0 +1,1 @@
+Pin importlib-metadata dependency to <5 to allow Python 3.7 builds to run

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ extras_require = {
         "bumpversion",
         "flaky>=3.7.0,<4",
         "hypothesis>=3.31.2,<6",
+        "importlib-metadata<5.0;python_version<'3.8'",
         "pytest>=6.2.5,<7",
         "pytest-asyncio>=0.18.1,<0.19",
         "pytest-mock>=1.10,<2",


### PR DESCRIPTION
### What was wrong?
PRs started failing on python 3.7 builds. 

Related to Issue #

### How was it fixed?
Pin importlib-metadata<5 on versions of python less than 3.7.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://hips.hearstapps.com/ell.h-cdn.co/assets/17/22/1024x512/landscape-1496072343-fiona-hippo2.jpg?resize=1200:*)
