### PR TITLE
Added Chainstack to provider list

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -91,7 +91,7 @@ Remote Providers
 ****************
 
 The quickest way to interact with the Ethereum blockchain is to use a remote node provider,
-like `Infura <https://infura.io/>`_, `Alchemy <https://www.alchemy.com/>`_, or `QuickNode <https://www.quicknode.com/>`_.
+like `Infura <https://infura.io/>`_, `Alchemy <https://www.alchemy.com/>`_, `QuickNode <https://www.quicknode.com/>`_, or `Chainstack <https://www.chainstack.com/>`_.
 You can connect to a remote node by specifying the endpoint, just like the previous local node example:
 
 .. code-block:: python

--- a/newsfragments/2677.doc.rst
+++ b/newsfragments/2677.doc.rst
@@ -1,0 +1,1 @@
+Added Chainstack link to quickstart docs.


### PR DESCRIPTION
### What was wrong?

Provider list previously only included three providers: Alchemy, Quicknode, and Infura.

### How was it fixed?

A fourth option (Chainstack) has been included to this section of the Quickstart page for visibility of an additional option.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/7ytrufurt4n81.jpg?width=640&crop=smart&auto=webp&s=5d995fa60e1e1ebf3d814ace76d28da465baf7cb)
