### PR TITLE
Adding <meta description> tag to HTML

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: Python Web3 SDK for Ethereum and EVM blockchains
+
 Introduction
 ============
 


### PR DESCRIPTION
### What was wrong?

Added `<meta name="description">` tag for web3.py documentation landing page.
Without this, when searching in Google, you get somewhat random text snippets from the Introduction page in the results. Tthis might be confusing for the person looking for web3.py library.

### How was it fixed?

Added a description that should describe more carefully what people in Google are likely to search:

```
Python Web3 SDK for Ethereum and EVM blockchains
```

#### Cute Animal Picture

```
\|/          (__)    
     `\------(oo)
       ||    (__)
       ||w--||     \|/
   \|/

```
