### PR TITLE
Add async get_block_tx_count

### DIFF
--- a/newsfragments/2687.feature.rst
+++ b/newsfragments/2687.feature.rst
@@ -1,0 +1,1 @@
+Add async ``w3.eth.get_block_transaction_count``

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1421,6 +1421,50 @@ class AsyncEthModuleTest:
         # reset to default
         async_w3.eth.default_block = "latest"
 
+    @pytest.mark.asyncio
+    async def test_eth_getBlockTransactionCountByHash_empty_block(
+        self, async_w3: "Web3", empty_block: BlockData
+    ) -> None:
+        transaction_count = await async_w3.eth.get_block_transaction_count(  # type: ignore  # noqa: E501
+            empty_block["hash"]
+        )
+
+        assert is_integer(transaction_count)
+        assert transaction_count == 0
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockTransactionCountByNumber_empty_block(
+        self, async_w3: "Web3", empty_block: BlockData
+    ) -> None:
+        transaction_count = await async_w3.eth.get_block_transaction_count(  # type: ignore  # noqa: E501
+            empty_block["number"]
+        )
+
+        assert is_integer(transaction_count)
+        assert transaction_count == 0
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockTransactionCountByHash_block_with_txn(
+        self, async_w3: "Web3", block_with_txn: BlockData
+    ) -> None:
+        transaction_count = await async_w3.eth.get_block_transaction_count(  # type: ignore  # noqa: E501
+            block_with_txn["hash"]
+        )
+
+        assert is_integer(transaction_count)
+        assert transaction_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockTransactionCountByNumber_block_with_txn(
+        self, async_w3: "Web3", block_with_txn: BlockData
+    ) -> None:
+        transaction_count = await async_w3.eth.get_block_transaction_count(  # type: ignore  # noqa: E501
+            block_with_txn["number"]
+        )
+
+        assert is_integer(transaction_count)
+        assert transaction_count >= 1
+
 
 class EthModuleTest:
     def test_eth_syncing(self, w3: "Web3") -> None:

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -310,6 +310,19 @@ class BaseEth(Module):
         RPC.eth_getTransactionReceipt, mungers=[default_root_munger]
     )
 
+    """
+    `eth_getBlockTransactionCountByHash`
+    `eth_getBlockTransactionCountByNumber`
+    """
+    get_block_transaction_count: Method[Callable[[BlockIdentifier], int]] = Method(
+        method_choice_depends_on_args=select_method_for_block_identifier(
+            if_predefined=RPC.eth_getBlockTransactionCountByNumber,
+            if_hash=RPC.eth_getBlockTransactionCountByHash,
+            if_number=RPC.eth_getBlockTransactionCountByNumber,
+        ),
+        mungers=[default_root_munger],
+    )
+
     @overload
     def contract(
         self, address: None = None, **kwargs: Any
@@ -695,19 +708,6 @@ class Eth(BaseEth):
 
     get_code: Method[Callable[..., HexBytes]] = Method(
         RPC.eth_getCode, mungers=[BaseEth.block_id_munger]
-    )
-
-    """
-    `eth_getBlockTransactionCountByHash`
-    `eth_getBlockTransactionCountByNumber`
-    """
-    get_block_transaction_count: Method[Callable[[BlockIdentifier], int]] = Method(
-        method_choice_depends_on_args=select_method_for_block_identifier(
-            if_predefined=RPC.eth_getBlockTransactionCountByNumber,
-            if_hash=RPC.eth_getBlockTransactionCountByHash,
-            if_number=RPC.eth_getBlockTransactionCountByNumber,
-        ),
-        mungers=[default_root_munger],
     )
 
     """


### PR DESCRIPTION
### What was wrong?
Missing async `w3.eth.get_block_transaction_count`

### How was it fixed?
Added it!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/6e/9f/fd/6e9ffd8d919770232894eede0ea3e295.jpg)
