### PR TITLE
find missing readthedocs bulletpoints

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,2 +1,9 @@
+version: 2
+
 build:
   image: latest
+
+python:
+  version: 3.8
+  install:
+  - requirements: requirements-docs.txt

--- a/newsfragments/2688.bugfix.rst
+++ b/newsfragments/2688.bugfix.rst
@@ -1,0 +1,1 @@
+bump `sphinx_rtd_theme` version to fix missing unordered list bullets

--- a/newsfragments/2688.internal.rst
+++ b/newsfragments/2688.internal.rst
@@ -1,0 +1,1 @@
+move definition of RTD install requirements file from their dashboard into `.readthedocs.yml`, and remove unused `sphinx-better-theme` from requirements

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
         "py-solc>=0.4.0",
         "pytest>=6.2.5,<7",
         "sphinx>=4.2.0,<5",
-        "sphinx_rtd_theme>=0.1.9",
+        "sphinx_rtd_theme>=0.5.2",
         "toposort>=1.4",
         "towncrier==18.5.0",
         "urllib3",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ extras_require = {
     ],
     "docs": [
         "mock",
-        "sphinx-better-theme>=0.1.4",
         "click>=5.1",
         "configparser==3.5.0",
         "contextlib2>=0.5.4",


### PR DESCRIPTION
### What was wrong?

Unordered list bulletpoints were missing in RTD.

### How was it fixed?

A CSS fix was issued in `sphinx_rtd_theme` v0.5.2. Bumped our version.

Also:
 - Removed unneeded `sphinx-better-theme` docs dependency
 - Moved notation of `requirements-docs.txt` as build deps for RTD from their dashboard into `.readthedocs.yml`



### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/197058276-a2e8fe9d-1601-4e2e-b62b-a74d1f7e63b8.png)
