### PR TITLE
Remove SolidityError in favor of ContractLogicError

### DIFF
--- a/newsfragments/2697.breaking.rst
+++ b/newsfragments/2697.breaking.rst
@@ -1,0 +1,1 @@
+Remove ``SolidityError`` in favor of ``ContractLogicError``

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -2,7 +2,7 @@ import pytest
 
 from web3._utils.method_formatters import (
     get_error_formatters,
-    raise_solidity_error_on_revert,
+    raise_contract_logic_error_on_revert,
 )
 from web3._utils.rpc_abi import (
     RPC,
@@ -109,11 +109,11 @@ GANACHE_RESPONSE = RPCResponse(
 )
 def test_get_revert_reason(response, expected) -> None:
     with pytest.raises(ContractLogicError, match=expected):
-        raise_solidity_error_on_revert(response)
+        raise_contract_logic_error_on_revert(response)
 
 
 def test_get_revert_reason_other_error() -> None:
-    assert raise_solidity_error_on_revert(OTHER_ERROR) is OTHER_ERROR
+    assert raise_contract_logic_error_on_revert(OTHER_ERROR) is OTHER_ERROR
 
 
 def test_get_error_formatters() -> None:

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -585,7 +585,7 @@ OFFCHAIN_LOOKUP_FIELDS = {
 }
 
 
-def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
+def raise_contract_logic_error_on_revert(response: RPCResponse) -> RPCResponse:
     """
     Reverts contain a `data` attribute with the following layout:
         "Reverted "
@@ -649,8 +649,8 @@ def raise_invalid_parity_mode(response: RPCResponse) -> NoReturn:
 
 
 ERROR_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
-    RPC.eth_estimateGas: raise_solidity_error_on_revert,
-    RPC.eth_call: raise_solidity_error_on_revert,
+    RPC.eth_estimateGas: raise_contract_logic_error_on_revert,
+    RPC.eth_call: raise_contract_logic_error_on_revert,
     RPC.parity_setMode: raise_invalid_parity_mode,
 }
 

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -242,17 +242,8 @@ class InvalidEventABI(ValueError):
     pass
 
 
-class SolidityError(ValueError):
+class ContractLogicError(ValueError):
     # Inherits from ValueError for backwards compatibility
-    """
-    Raised on a contract revert error
-    """
-    pass
-
-
-class ContractLogicError(SolidityError, ValueError):
-    # Inherits from ValueError for backwards compatibility
-    # TODO: Remove SolidityError inheritance in v6
     """
     Raised on a contract revert error
     """


### PR DESCRIPTION
### What was wrong?
`SolidityError` wasn't an accurate name for the exception class. The better name is `ContractLogicError`. 

Related to Issue #1901 

### How was it fixed?
Removed `SolidityError` in favor of `ContractLogicError`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://s3.envato.com/files/269913671/DSC_3610.jpg)
