### PR TITLE
Snakecase fromWeb3

### DIFF
--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -35,7 +35,7 @@ Create an :class:`~ens.ENS` object (named ``ns`` below) in one of three ways:
     # Note: This inherits the w3 middlewares from the w3 instance and adds a stalecheck middleware to the middleware onion
     from ens import ENS
     w3 = Web3(...)
-    ns = ENS.fromWeb3(w3)
+    ns = ENS.from_web3(w3)
 
 
 Asynchronous support is available via the ``AsyncENS`` module:
@@ -49,7 +49,7 @@ Asynchronous support is available via the ``AsyncENS`` module:
 
 Note that an ``ens`` module instance is also avaliable on the ``w3`` instance.
 The first time it's used, Web3.py will create the  ``ens`` instance using
-``ENS.fromWeb3(w3)`` or ``AsyncENS.fromWeb3(w3)`` as appropriate.
+``ENS.from_web3(w3)`` or ``AsyncENS.from_web3(w3)`` as appropriate.
 
 .. code-block:: python
 

--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -108,7 +108,7 @@ class AsyncENS(BaseENS):
         )
 
     @classmethod
-    def fromWeb3(cls, w3: "Web3", addr: ChecksumAddress = None) -> "AsyncENS":
+    def from_web3(cls, w3: "Web3", addr: ChecksumAddress = None) -> "AsyncENS":
         """
         Generate an AsyncENS instance with web3
 

--- a/ens/ens.py
+++ b/ens/ens.py
@@ -108,7 +108,7 @@ class ENS(BaseENS):
         )
 
     @classmethod
-    def fromWeb3(cls, w3: "Web3", addr: ChecksumAddress = None) -> "ENS":
+    def from_web3(cls, w3: "Web3", addr: ChecksumAddress = None) -> "ENS":
         """
         Generate an ENS instance with web3
 

--- a/ethpm/backends/registry.py
+++ b/ethpm/backends/registry.py
@@ -96,7 +96,7 @@ def parse_registry_uri(uri: str) -> RegistryURI:
         address_or_ens, chain_id = parsed_uri.netloc.split(":")
     else:
         address_or_ens, chain_id = parsed_uri.netloc, "1"
-    ns = ENS.fromWeb3(w3)
+    ns = ENS.from_web3(w3)
     if is_address(address_or_ens):
         address = address_or_ens
         ens = None

--- a/newsfragments/2703.breaking.rst
+++ b/newsfragments/2703.breaking.rst
@@ -1,0 +1,1 @@
+Snakecase the fromWeb3 method

--- a/tests/core/pm-module/test_ens_integration.py
+++ b/tests/core/pm-module/test_ens_integration.py
@@ -104,7 +104,7 @@ def ens_setup(deployer):
     ens_contract.functions.setSubnodeOwner(
         b"\0" * 32, eth_labelhash, eth_registrar.address
     ).transact({"from": ens_key})
-    return ENS.fromWeb3(w3, ens_contract.address)
+    return ENS.from_web3(w3, ens_contract.address)
 
 
 @pytest.fixture
@@ -124,7 +124,7 @@ def test_ens_must_be_set_before_ens_methods_can_be_used(ens):
 @pytest.mark.xfail(reason="Need to properly add authorization as of 8/10/2022")
 def test_web3_ens(ens):
     w3 = ens.w3
-    ns = ENS.fromWeb3(w3, ens.ens.address)
+    ns = ENS.from_web3(w3, ens.ens.address)
     w3.ens = ns
     registry = SimpleRegistry.deploy_new_instance(w3)
     w3.ens.setup_address("tester.eth", registry.address)

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -343,7 +343,7 @@ def ens_setup():
         reverse_tld_namehash, w3.keccak(text="addr"), reverse_registrar.address
     ).transact({"from": ens_key})
 
-    return ENS.fromWeb3(w3, ens_contract.address)
+    return ENS.from_web3(w3, ens_contract.address)
 
 
 @pytest.fixture()
@@ -645,7 +645,7 @@ async def async_ens_setup(async_w3):
         reverse_tld_namehash, async_w3.keccak(text="addr"), reverse_registrar.address
     ).transact({"from": ens_key})
 
-    return AsyncENS.fromWeb3(async_w3, ens_contract.address)
+    return AsyncENS.from_web3(async_w3, ens_contract.address)
 
 
 @pytest_asyncio.fixture

--- a/tests/ens/test_ens.py
+++ b/tests/ens/test_ens.py
@@ -10,11 +10,11 @@ from web3.middleware import (
 )
 
 
-def test_fromWeb3_inherits_web3_middlewares(w3):
+def test_from_web3_inherits_web3_middlewares(w3):
     test_middleware = pythonic_middleware
     w3.middleware_onion.add(test_middleware, "test_middleware")
 
-    ns = ENS.fromWeb3(w3)
+    ns = ENS.from_web3(w3)
     assert ns.w3.middleware_onion.get("test_middleware") == test_middleware
 
 
@@ -22,9 +22,9 @@ def test_fromWeb3_inherits_web3_middlewares(w3):
 
 
 @pytest.mark.asyncio
-async def test_async_fromWeb3_inherits_web3_middlewares(async_w3):
+async def test_async_from_web3_inherits_web3_middlewares(async_w3):
     test_middleware = async_validation_middleware
     async_w3.middleware_onion.add(test_middleware, "test_middleware")
 
-    ns = AsyncENS.fromWeb3(async_w3)
+    ns = AsyncENS.from_web3(async_w3)
     assert ns.w3.middleware_onion.get("test_middleware") == test_middleware

--- a/web3/main.py
+++ b/web3/main.py
@@ -347,7 +347,9 @@ class Web3:
     @property
     def ens(self) -> Union[ENS, AsyncENS, "Empty"]:
         if self._ens is empty:
-            return AsyncENS.from_web3(self) if self.eth.is_async else ENS.from_web3(self)
+            return (
+                AsyncENS.from_web3(self) if self.eth.is_async else ENS.from_web3(self)
+            )  # noqa: E501
 
         return self._ens
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -347,7 +347,7 @@ class Web3:
     @property
     def ens(self) -> Union[ENS, AsyncENS, "Empty"]:
         if self._ens is empty:
-            return AsyncENS.fromWeb3(self) if self.eth.is_async else ENS.fromWeb3(self)
+            return AsyncENS.from_web3(self) if self.eth.is_async else ENS.from_web3(self)
 
         return self._ens
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -349,7 +349,7 @@ class Web3:
         if self._ens is empty:
             return (
                 AsyncENS.from_web3(self) if self.eth.is_async else ENS.from_web3(self)
-            )  # noqa: E501
+            )
 
         return self._ens
 


### PR DESCRIPTION
### What was wrong?
Inherited javascript syntax. This PR does not include a deprecation step, intended for v6.
Related to Issue #2598 

### How was it fixed?
Changed fromWeb3 to from_web3 where needed

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![cute-red-panda](https://user-images.githubusercontent.com/54052410/199152381-5943ab6a-2520-414e-b502-cdef60aef2a9.jpeg)


