### PR TITLE
Snakecase encoding decoding helpers

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -91,7 +91,7 @@ Encoding and Decoding Helpers
 -----------------------------
 
 - :meth:`Web3.is_encodable() <web3.w3.is_encodable>`
-- :meth:`Web3.toBytes() <web3.Web3.toBytes>`
+- :meth:`Web3.to_bytes() <web3.Web3.to_bytes>`
 - :meth:`Web3.toHex() <web3.Web3.toHex>`
 - :meth:`Web3.toInt() <web3.Web3.toInt>`
 - :meth:`Web3.toJSON() <web3.Web3.toJSON>`

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -94,8 +94,8 @@ Encoding and Decoding Helpers
 - :meth:`Web3.to_bytes() <web3.Web3.to_bytes>`
 - :meth:`Web3.to_hex() <web3.Web3.to_hex>`
 - :meth:`Web3.to_int() <web3.Web3.to_int>`
-- :meth:`Web3.toJSON() <web3.Web3.toJSON>`
-- :meth:`Web3.toText() <web3.Web3.toText>`
+- :meth:`Web3.to_json() <web3.Web3.to_json>`
+- :meth:`Web3.to_text() <web3.Web3.to_text>`
 
 
 Address Helpers

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -93,7 +93,7 @@ Encoding and Decoding Helpers
 - :meth:`Web3.is_encodable() <web3.w3.is_encodable>`
 - :meth:`Web3.to_bytes() <web3.Web3.to_bytes>`
 - :meth:`Web3.to_hex() <web3.Web3.to_hex>`
-- :meth:`Web3.toInt() <web3.Web3.toInt>`
+- :meth:`Web3.to_int() <web3.Web3.to_int>`
 - :meth:`Web3.toJSON() <web3.Web3.toJSON>`
 - :meth:`Web3.toText() <web3.Web3.toText>`
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -92,7 +92,7 @@ Encoding and Decoding Helpers
 
 - :meth:`Web3.is_encodable() <web3.w3.is_encodable>`
 - :meth:`Web3.to_bytes() <web3.Web3.to_bytes>`
-- :meth:`Web3.toHex() <web3.Web3.toHex>`
+- :meth:`Web3.to_hex() <web3.Web3.to_hex>`
 - :meth:`Web3.toInt() <web3.Web3.toInt>`
 - :meth:`Web3.toJSON() <web3.Web3.toJSON>`
 - :meth:`Web3.toText() <web3.Web3.toText>`

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -226,7 +226,7 @@ this will prepare it for Solidity:
     #   and r, s as a bytes32
     # Remix / web3.js expect r and s to be encoded to hex
     >>> sig = Web3.to_bytes(hexstr=hex_signature)
-    >>> v, hex_r, hex_s = Web3.toInt(sig[-1]), Web3.to_hex(sig[:32]), Web3.to_hex(sig[32:64])
+    >>> v, hex_r, hex_s = Web3.to_int(sig[-1]), Web3.to_hex(sig[:32]), Web3.to_hex(sig[32:64])
 
     # ecrecover in Solidity takes the arguments in order = (msghash, v, r, s)
     >>> ec_recover_args = (hex_message_hash, v, hex_r, hex_s)

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -75,44 +75,44 @@ Example ``account_test_script.py``
 
 .. code-block:: python
 
-    import os 
+    import os
     from eth_account import Account
     from eth_account.signers.local import LocalAccount
     from web3.auto import w3
     from web3.middleware import construct_sign_and_send_raw_middleware
-    
+
     private_key = os.environ.get("PRIVATE_KEY")
     assert private_key is not None, "You must set PRIVATE_KEY environment variable"
     assert private_key.startswith("0x"), "Private key must start with 0x hex prefix"
-    
+
     account: LocalAccount = Account.from_key(private_key)
     w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
-    
+
     print(f"Your hot wallet address is {account.address}")
-    
-    # Now you can use web3.eth.send_transaction(), Contract.functions.xxx.transact() functions 
-    # with your local private key through middleware and you no longer get the error 
+
+    # Now you can use web3.eth.send_transaction(), Contract.functions.xxx.transact() functions
+    # with your local private key through middleware and you no longer get the error
     # "ValueError: The method eth_sendTransaction does not exist/is not available
-    
+
 Example how to run this in UNIX shell:
 
 .. code-block:: shell
- 
+
     # Generate a new 256-bit random integer using openssl UNIX command that acts as a private key.
     # You can also do:
-    # python -c "from web3 import Web3; w3 = Web3(); acc = w3.eth.account.create(); print(f'private key={w3.toHex(acc.key)}, account={acc.address}')"
+    # python -c "from web3 import Web3; w3 = Web3(); acc = w3.eth.account.create(); print(f'private key={w3.to_hex(acc.key)}, account={acc.address}')"
     # Store this in a safe place, like in your password manager.
-    export PRIVATE_KEY=0x`openssl rand -hex 32` 
-    
+    export PRIVATE_KEY=0x`openssl rand -hex 32`
+
     # Run our script
     python account_test_script.py
-    
-    
+
+
 This will print::
 
     Your hot wallet address is 0x27C8F899bb69E1501BBB96d09d7477a2a7518918
 
-  
+
 .. _extract_geth_pk:
 
 Extract private key from geth keyfile
@@ -186,10 +186,10 @@ You might have produced the signed_message locally, as in
     # Remix / web3.js expect r and s to be encoded to hex
     # This convenience method will do the pad & hex for us:
     >>> def to_32byte_hex(val):
-    ...   return Web3.toHex(Web3.to_bytes(val).rjust(32, b'\0'))
+    ...   return Web3.to_hex(Web3.to_bytes(val).rjust(32, b'\0'))
 
     >>> ec_recover_args = (msghash, v, r, s) = (
-    ...   Web3.toHex(signed_message.messageHash),
+    ...   Web3.to_hex(signed_message.messageHash),
     ...   signed_message.v,
     ...   to_32byte_hex(signed_message.r),
     ...   to_32byte_hex(signed_message.s),
@@ -220,13 +220,13 @@ this will prepare it for Solidity:
     >>> message_hash = _hash_eip191_message(message)
 
     # Remix / web3.js expect the message hash to be encoded to a hex string
-    >>> hex_message_hash = Web3.toHex(message_hash)
+    >>> hex_message_hash = Web3.to_hex(message_hash)
 
     # ecrecover in Solidity expects the signature to be split into v as a uint8,
     #   and r, s as a bytes32
     # Remix / web3.js expect r and s to be encoded to hex
     >>> sig = Web3.to_bytes(hexstr=hex_signature)
-    >>> v, hex_r, hex_s = Web3.toInt(sig[-1]), Web3.toHex(sig[:32]), Web3.toHex(sig[32:64])
+    >>> v, hex_r, hex_s = Web3.toInt(sig[-1]), Web3.to_hex(sig[:32]), Web3.to_hex(sig[32:64])
 
     # ecrecover in Solidity takes the arguments in order = (msghash, v, r, s)
     >>> ec_recover_args = (hex_message_hash, v, hex_r, hex_s)
@@ -378,5 +378,5 @@ To sign a transaction locally that will invoke a smart contract:
     >>> w3.eth.send_raw_transaction(signed_txn.rawTransaction)  # doctest: +SKIP
 
     # When you run send_raw_transaction, you get the same result as the hash of the transaction:
-    >>> w3.toHex(w3.keccak(signed_txn.rawTransaction))
+    >>> w3.to_hex(w3.keccak(signed_txn.rawTransaction))
     '0x748db062639a45e519dba934fce09c367c92043867409160c9989673439dc817'

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -186,7 +186,7 @@ You might have produced the signed_message locally, as in
     # Remix / web3.js expect r and s to be encoded to hex
     # This convenience method will do the pad & hex for us:
     >>> def to_32byte_hex(val):
-    ...   return Web3.toHex(Web3.toBytes(val).rjust(32, b'\0'))
+    ...   return Web3.toHex(Web3.to_bytes(val).rjust(32, b'\0'))
 
     >>> ec_recover_args = (msghash, v, r, s) = (
     ...   Web3.toHex(signed_message.messageHash),
@@ -225,7 +225,7 @@ this will prepare it for Solidity:
     # ecrecover in Solidity expects the signature to be split into v as a uint8,
     #   and r, s as a bytes32
     # Remix / web3.js expect r and s to be encoded to hex
-    >>> sig = Web3.toBytes(hexstr=hex_signature)
+    >>> sig = Web3.to_bytes(hexstr=hex_signature)
     >>> v, hex_r, hex_s = Web3.toInt(sig[-1]), Web3.toHex(sig[:32]), Web3.toHex(sig[32:64])
 
     # ecrecover in Solidity takes the arguments in order = (msghash, v, r, s)

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -109,7 +109,7 @@ Encoding and Decoding Helpers
         'cowmö'
 
 
-.. py:method:: Web3.toBytes(primitive=None, hexstr=None, text=None)
+.. py:method:: Web3.to_bytes(primitive=None, hexstr=None, text=None)
 
     Takes a variety of inputs and returns its bytes equivalent.
     Text gets encoded as UTF-8.
@@ -117,25 +117,25 @@ Encoding and Decoding Helpers
 
     .. code-block:: python
 
-        >>> Web3.toBytes(0)
+        >>> Web3.to_bytes(0)
         b'\x00'
-        >>> Web3.toBytes(0x000F)
+        >>> Web3.to_bytes(0x000F)
         b'\x0f'
-        >>> Web3.toBytes(b'')
+        >>> Web3.to_bytes(b'')
         b''
-        >>> Web3.toBytes(b'\x00\x0F')
+        >>> Web3.to_bytes(b'\x00\x0F')
         b'\x00\x0f'
-        >>> Web3.toBytes(False)
+        >>> Web3.to_bytes(False)
         b'\x00'
-        >>> Web3.toBytes(True)
+        >>> Web3.to_bytes(True)
         b'\x01'
-        >>> Web3.toBytes(hexstr='0x000F')
+        >>> Web3.to_bytes(hexstr='0x000F')
         b'\x00\x0f'
-        >>> Web3.toBytes(hexstr='000F')
+        >>> Web3.to_bytes(hexstr='000F')
         b'\x00\x0f'
-        >>> Web3.toBytes(text='')
+        >>> Web3.to_bytes(text='')
         b''
-        >>> Web3.toBytes(text='cowmö')
+        >>> Web3.to_bytes(text='cowmö')
         b'cowm\xc3\xb6'
 
 

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -89,7 +89,7 @@ Encoding and Decoding Helpers
 
 .. _JSON-RPC spec: https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding
 
-.. py:method:: Web3.toText(primitive=None, hexstr=None, text=None)
+.. py:method:: Web3.to_text(primitive=None, hexstr=None, text=None)
 
     Takes a variety of inputs and returns its string equivalent.
     Text gets decoded as UTF-8.
@@ -97,15 +97,15 @@ Encoding and Decoding Helpers
 
     .. code-block:: python
 
-        >>> Web3.toText(0x636f776dc3b6)
+        >>> Web3.to_text(0x636f776dc3b6)
         'cowmö'
-        >>> Web3.toText(b'cowm\xc3\xb6')
+        >>> Web3.to_text(b'cowm\xc3\xb6')
         'cowmö'
-        >>> Web3.toText(hexstr='0x636f776dc3b6')
+        >>> Web3.to_text(hexstr='0x636f776dc3b6')
         'cowmö'
-        >>> Web3.toText(hexstr='636f776dc3b6')
+        >>> Web3.to_text(hexstr='636f776dc3b6')
         'cowmö'
-        >>> Web3.toText(text='cowmö')
+        >>> Web3.to_text(text='cowmö')
         'cowmö'
 
 
@@ -161,16 +161,16 @@ Encoding and Decoding Helpers
         >>> Web3.to_int(hexstr='000F')
         15
 
-.. py:method:: Web3.toJSON(obj)
+.. py:method:: Web3.to_json(obj)
 
     Takes a variety of inputs and returns its JSON equivalent.
 
 
     .. code-block:: python
 
-        >>> Web3.toJSON(3)
+        >>> Web3.to_json(3)
         '3'
-        >>> Web3.toJSON({'one': 1})
+        >>> Web3.to_json({'one': 1})
         '{"one": 1}'
 
 

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -54,7 +54,7 @@ Attributes
 Encoding and Decoding Helpers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. py:method:: Web3.toHex(primitive=None, hexstr=None, text=None)
+.. py:method:: Web3.to_hex(primitive=None, hexstr=None, text=None)
 
     Takes a variety of inputs and returns it in its hexadecimal representation.
     It follows the rules for converting to hex in the
@@ -62,29 +62,29 @@ Encoding and Decoding Helpers
 
     .. code-block:: python
 
-        >>> Web3.toHex(0)
+        >>> Web3.to_hex(0)
         '0x0'
-        >>> Web3.toHex(1)
+        >>> Web3.to_hex(1)
         '0x1'
-        >>> Web3.toHex(0x0)
+        >>> Web3.to_hex(0x0)
         '0x0'
-        >>> Web3.toHex(0x000F)
+        >>> Web3.to_hex(0x000F)
         '0xf'
-        >>> Web3.toHex(b'')
+        >>> Web3.to_hex(b'')
         '0x'
-        >>> Web3.toHex(b'\x00\x0F')
+        >>> Web3.to_hex(b'\x00\x0F')
         '0x000f'
-        >>> Web3.toHex(False)
+        >>> Web3.to_hex(False)
         '0x0'
-        >>> Web3.toHex(True)
+        >>> Web3.to_hex(True)
         '0x1'
-        >>> Web3.toHex(hexstr='0x000F')
+        >>> Web3.to_hex(hexstr='0x000F')
         '0x000f'
-        >>> Web3.toHex(hexstr='000F')
+        >>> Web3.to_hex(hexstr='000F')
         '0x000f'
-        >>> Web3.toHex(text='')
+        >>> Web3.to_hex(text='')
         '0x'
-        >>> Web3.toHex(text='cowmö')
+        >>> Web3.to_hex(text='cowmö')
         '0x636f776dc3b6'
 
 .. _JSON-RPC spec: https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -139,26 +139,26 @@ Encoding and Decoding Helpers
         b'cowm\xc3\xb6'
 
 
-.. py:method:: Web3.toInt(primitive=None, hexstr=None, text=None)
+.. py:method:: Web3.to_int(primitive=None, hexstr=None, text=None)
 
     Takes a variety of inputs and returns its integer equivalent.
 
 
     .. code-block:: python
 
-        >>> Web3.toInt(0)
+        >>> Web3.to_int(0)
         0
-        >>> Web3.toInt(0x000F)
+        >>> Web3.to_int(0x000F)
         15
-        >>> Web3.toInt(b'\x00\x0F')
+        >>> Web3.to_int(b'\x00\x0F')
         15
-        >>> Web3.toInt(False)
+        >>> Web3.to_int(False)
         0
-        >>> Web3.toInt(True)
+        >>> Web3.to_int(True)
         1
-        >>> Web3.toInt(hexstr='0x000F')
+        >>> Web3.to_int(hexstr='0x000F')
         15
-        >>> Web3.toInt(hexstr='000F')
+        >>> Web3.to_int(hexstr='000F')
         15
 
 .. py:method:: Web3.toJSON(obj)

--- a/newsfragments/2707.breaking.rst
+++ b/newsfragments/2707.breaking.rst
@@ -1,0 +1,1 @@
+Snakecase the toBytes, toHex, toInt, toJSON, and toText methods

--- a/tests/core/contracts/test_contract_util_functions.py
+++ b/tests/core/contracts/test_contract_util_functions.py
@@ -38,7 +38,7 @@ def test_parse_block_identifier_bytes_and_hex(w3):
     block_id_by_hash = parse_block_identifier(w3, block_0_hash)
     assert block_id_by_hash == 0
     # test retrieve by hexstring
-    block_0_hexstring = w3.toHex(block_0_hash)
+    block_0_hexstring = w3.to_hex(block_0_hash)
     block_id_by_hex = parse_block_identifier(w3, block_0_hexstring)
     assert block_id_by_hex == 0
 
@@ -104,7 +104,7 @@ async def test_async_parse_block_identifier_bytes_and_hex(async_w3):
     block_id_by_hash = await async_parse_block_identifier(async_w3, block_0_hash)
     assert block_id_by_hash == 0
     # test retrieve by hexstring
-    block_0_hexstring = async_w3.toHex(block_0_hash)
+    block_0_hexstring = async_w3.to_hex(block_0_hash)
     block_id_by_hex = await async_parse_block_identifier(async_w3, block_0_hexstring)
     assert block_id_by_hex == 0
 

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -447,7 +447,7 @@ def test_eth_account_sign_transaction_from_eth_test(acct, transaction_info):
     # seem to agree, so far.
     # See ecdsa_raw_sign() in /eth_keys/backends/native/ecdsa.py
     signed = acct.sign_transaction(transaction, key)
-    assert signed.r == Web3.toInt(hexstr=expected_raw_txn[-130:-66])
+    assert signed.r == Web3.to_int(hexstr=expected_raw_txn[-130:-66])
 
     # confirm that signed transaction can be recovered to the sender
     expected_sender = acct.from_key(key).address

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -28,7 +28,7 @@ from web3.datastructures import (
     ),
 )
 def test_to_bytes_primitive(val, expected):
-    assert Web3.toBytes(val) == expected
+    assert Web3.to_bytes(val) == expected
 
 
 @pytest.mark.parametrize(
@@ -46,7 +46,7 @@ def test_to_bytes_primitive(val, expected):
     ),
 )
 def test_to_bytes_hexstr(val, expected):
-    assert Web3.toBytes(hexstr=val) == expected
+    assert Web3.to_bytes(hexstr=val) == expected
 
 
 @pytest.mark.parametrize(
@@ -57,7 +57,7 @@ def test_to_bytes_hexstr(val, expected):
     ),
 )
 def test_to_bytes_text(val, expected):
-    assert Web3.toBytes(text=val) == expected
+    assert Web3.to_bytes(text=val) == expected
 
 
 def test_to_text_identity():

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -61,7 +61,7 @@ def test_to_bytes_text(val, expected):
 
 
 def test_to_text_identity():
-    assert Web3.toText(text="pass-through") == "pass-through"
+    assert Web3.to_text(text="pass-through") == "pass-through"
 
 
 @pytest.mark.parametrize(
@@ -76,7 +76,7 @@ def test_to_text_identity():
     ),
 )
 def test_to_text(val, expected):
-    assert Web3.toText(val) == expected
+    assert Web3.to_text(val) == expected
 
 
 @pytest.mark.parametrize(
@@ -89,7 +89,7 @@ def test_to_text(val, expected):
     ),
 )
 def test_to_text_hexstr(val, expected):
-    assert Web3.toText(hexstr=val) == expected
+    assert Web3.to_text(hexstr=val) == expected
 
 
 @pytest.mark.parametrize(
@@ -214,7 +214,7 @@ def test_to_hex_cleanup_only(val, expected):
     ),
 )
 def test_to_json(val, expected):
-    assert Web3.toJSON(val) == expected
+    assert Web3.to_json(val) == expected
 
 
 @pytest.mark.parametrize(
@@ -252,4 +252,4 @@ def test_to_json(val, expected):
     ),
 )
 def test_to_json_with_transaction(tx, expected):
-    assert Web3.toJSON(tx) == expected
+    assert Web3.to_json(tx) == expected

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -110,9 +110,9 @@ def test_to_text_hexstr(val, expected):
 def test_to_int(val, expected):
     if isinstance(expected, type):
         with pytest.raises(expected):
-            Web3.toInt(val)
+            Web3.to_int(val)
     else:
-        assert Web3.toInt(val) == expected
+        assert Web3.to_int(val) == expected
 
 
 @pytest.mark.parametrize(
@@ -130,9 +130,9 @@ def test_to_int(val, expected):
 def test_to_int_text(val, expected):
     if isinstance(expected, type):
         with pytest.raises(expected):
-            Web3.toInt(text=val)
+            Web3.to_int(text=val)
     else:
-        assert Web3.toInt(text=val) == expected
+        assert Web3.to_int(text=val) == expected
 
 
 @pytest.mark.parametrize(
@@ -149,7 +149,7 @@ def test_to_int_text(val, expected):
     ),
 )
 def test_to_int_hexstr(val, expected):
-    assert Web3.toInt(hexstr=val) == expected
+    assert Web3.to_int(hexstr=val) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -172,7 +172,7 @@ def test_to_int_hexstr(val, expected):
     ),
 )
 def test_to_hex(val, expected):
-    assert Web3.toHex(val) == expected
+    assert Web3.to_hex(val) == expected
 
 
 @pytest.mark.parametrize(
@@ -183,7 +183,7 @@ def test_to_hex(val, expected):
     ),
 )
 def test_to_hex_text(val, expected):
-    assert Web3.toHex(text=val) == expected
+    assert Web3.to_hex(text=val) == expected
 
 
 @pytest.mark.parametrize(
@@ -198,7 +198,7 @@ def test_to_hex_text(val, expected):
     ),
 )
 def test_to_hex_cleanup_only(val, expected):
-    assert Web3.toHex(hexstr=val) == expected
+    assert Web3.to_hex(hexstr=val) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/core/web3-module/test_providers.py
+++ b/tests/core/web3-module/test_providers.py
@@ -20,7 +20,7 @@ def test_auto_provider_none():
     w3 = Web3()
 
     # non-node requests succeed
-    w3.toHex(0) == "0x0"
+    w3.to_hex(0) == "0x0"
 
     type(w3.provider) == AutoProvider
 

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -53,7 +53,7 @@ from web3.providers.eth_tester import (
 
 def bytes32(val):
     if isinstance(val, int):
-        result = Web3.toBytes(val)
+        result = Web3.to_bytes(val)
     else:
         raise TypeError(f"{val!r} could not be converted to bytes")
     if len(result) < 32:

--- a/tests/ens/test_get_registry.py
+++ b/tests/ens/test_get_registry.py
@@ -45,5 +45,5 @@ def test_labelhash(ens, label, expected_hash):
     else:
         labelhash = ens.labelhash(label)
         assert isinstance(labelhash, bytes)
-        hash_hex = Web3.toHex(labelhash)
+        hash_hex = Web3.to_hex(labelhash)
         assert hash_hex == expected_hash

--- a/tests/ens/test_setup_address.py
+++ b/tests/ens/test_setup_address.py
@@ -75,7 +75,7 @@ def test_setup_address(ens, name, namehash_hex, TEST_ADDRESS):
     ens.setup_address(name, TEST_ADDRESS)
     assert is_same_address(ens.address(name), TEST_ADDRESS)
 
-    namehash = Web3.toBytes(hexstr=HexStr(namehash_hex))
+    namehash = Web3.to_bytes(hexstr=HexStr(namehash_hex))
     normal_name = ens.nameprep(name)
     # check that the correct namehash is set:
     assert is_same_address(
@@ -178,7 +178,7 @@ async def test_async_setup_address(async_ens, name, namehash_hex, TEST_ADDRESS):
     await async_ens.setup_address(name, TEST_ADDRESS)
     assert is_same_address(await async_ens.address(name), TEST_ADDRESS)
 
-    namehash = Web3.toBytes(hexstr=HexStr(namehash_hex))
+    namehash = Web3.to_bytes(hexstr=HexStr(namehash_hex))
     normal_name = async_ens.nameprep(name)
 
     # check that the correct namehash is set:

--- a/tests/ens/test_setup_name.py
+++ b/tests/ens/test_setup_name.py
@@ -65,7 +65,7 @@ def test_setup_name(ens, name, normalized_name, namehash_hex):
     assert ens.name(address) == normalized_name
 
     # check that the correct namehash is set:
-    node = Web3.toBytes(hexstr=HexStr(namehash_hex))
+    node = Web3.to_bytes(hexstr=HexStr(namehash_hex))
     assert ens.resolver(normalized_name).caller.addr(node) == address
 
     # check that the correct owner is set:
@@ -166,7 +166,7 @@ async def test_async_setup_name(async_ens, name, normalized_name, namehash_hex):
     assert await async_ens.name(address) == normalized_name
 
     # check that the correct namehash is set:
-    node = Web3.toBytes(hexstr=HexStr(namehash_hex))
+    node = Web3.to_bytes(hexstr=HexStr(namehash_hex))
     resolver = await async_ens.resolver(normalized_name)
     assert await resolver.caller.addr(node) == address
 

--- a/tests/ethpm/conftest.py
+++ b/tests/ethpm/conftest.py
@@ -210,7 +210,7 @@ def manifest_with_no_matching_deployments(w3, tmpdir, safe_math_manifest):
     w3.testing.mine(5)
     incorrect_genesis_hash = b"\x00" * 31 + b"\x01"
     block = w3.eth.get_block("earliest")
-    block_uri = create_block_uri(w3.toHex(incorrect_genesis_hash), w3.toHex(block.hash))
+    block_uri = create_block_uri(w3.to_hex(incorrect_genesis_hash), w3.to_hex(block.hash))
     manifest = copy.deepcopy(safe_math_manifest)
     manifest["deployments"][block_uri] = {
         "SafeMathLib": {

--- a/tests/ethpm/conftest.py
+++ b/tests/ethpm/conftest.py
@@ -210,7 +210,9 @@ def manifest_with_no_matching_deployments(w3, tmpdir, safe_math_manifest):
     w3.testing.mine(5)
     incorrect_genesis_hash = b"\x00" * 31 + b"\x01"
     block = w3.eth.get_block("earliest")
-    block_uri = create_block_uri(w3.to_hex(incorrect_genesis_hash), w3.to_hex(block.hash))
+    block_uri = create_block_uri(
+        w3.to_hex(incorrect_genesis_hash), w3.to_hex(block.hash)
+    )
     manifest = copy.deepcopy(safe_math_manifest)
     manifest["deployments"][block_uri] = {
         "SafeMathLib": {

--- a/web3/_utils/decorators.py
+++ b/web3/_utils/decorators.py
@@ -39,7 +39,7 @@ def deprecated_for(replace_message: str) -> Callable[..., Any]:
     """
     Decorate a deprecated function, with info about what to use instead, like:
 
-    @deprecated_for("toBytes()")
+    @deprecated_for("to_bytes()")
     def toAscii(arg):
         ...
     """

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -352,7 +352,7 @@ class AsyncEthModuleTest:
             "0x52b0ff9cb472f25872fa8ec6a62fa59454fc2ae7901cfcc6cc89d096f49b8fc1"
         )
         txn_hash = await async_w3.eth.send_raw_transaction(raw_txn)  # type: ignore
-        assert txn_hash == async_w3.toBytes(hexstr=expected_hash)
+        assert txn_hash == async_w3.to_bytes(hexstr=expected_hash)
 
     @pytest.mark.asyncio
     async def test_gas_price_strategy_middleware(

--- a/web3/main.py
+++ b/web3/main.py
@@ -178,7 +178,7 @@ class Web3:
 
     @staticmethod
     @wraps(to_int)
-    def toInt(
+    def to_int(
         primitive: Primitives = None, hexstr: HexStr = None, text: str = None
     ) -> int:
         return to_int(primitive, hexstr, text)

--- a/web3/main.py
+++ b/web3/main.py
@@ -192,14 +192,14 @@ class Web3:
 
     @staticmethod
     @wraps(to_text)
-    def toText(
+    def to_text(
         primitive: Primitives = None, hexstr: HexStr = None, text: str = None
     ) -> str:
         return to_text(primitive, hexstr, text)
 
     @staticmethod
     @wraps(to_json)
-    def toJSON(obj: Dict[Any, Any]) -> str:
+    def to_json(obj: Dict[Any, Any]) -> str:
         return to_json(obj)
 
     # Currency Utility

--- a/web3/main.py
+++ b/web3/main.py
@@ -171,7 +171,7 @@ class Web3:
     # Encoding and Decoding
     @staticmethod
     @wraps(to_bytes)
-    def toBytes(
+    def to_bytes(
         primitive: Primitives = None, hexstr: HexStr = None, text: str = None
     ) -> bytes:
         return to_bytes(primitive, hexstr, text)

--- a/web3/main.py
+++ b/web3/main.py
@@ -185,7 +185,7 @@ class Web3:
 
     @staticmethod
     @wraps(to_hex)
-    def toHex(
+    def to_hex(
         primitive: Primitives = None, hexstr: HexStr = None, text: str = None
     ) -> HexStr:
         return to_hex(primitive, hexstr, text)


### PR DESCRIPTION
### What was wrong?
Inherited javascript syntax. This PR does not include a deprecation step, intended for v6.
Related to Issue #2598 

### How was it fixed?
Changed `toBytes` to `to_bytes`, `toHex` to `to_hex`, `toInt` to `to_int`, `toJSON` to `to_json`, and `toText` to `to_text`. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![hedgehog](https://user-images.githubusercontent.com/54052410/199651025-9c96a67c-3330-48d8-808b-959085dcde87.jpeg)
