### PR TITLE
Snakecase address helpers

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -103,7 +103,7 @@ Address Helpers
 
 - :meth:`Web3.is_address() <web3.Web3.is_address>`
 - :meth:`Web3.is_checksum_address() <web3.Web3.is_checksum_address>`
-- :meth:`Web3.toChecksumAddress() <web3.Web3.toChecksumAddress>`
+- :meth:`Web3.to_checksum_address() <web3.Web3.to_checksum_address>`
 
 
 Currency Conversions

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -102,7 +102,7 @@ Address Helpers
 ---------------
 
 - :meth:`Web3.is_address() <web3.Web3.is_address>`
-- :meth:`Web3.isChecksumAddress() <web3.Web3.isChecksumAddress>`
+- :meth:`Web3.is_checksum_address() <web3.Web3.is_checksum_address>`
 - :meth:`Web3.toChecksumAddress() <web3.Web3.toChecksumAddress>`
 
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -101,7 +101,7 @@ Encoding and Decoding Helpers
 Address Helpers
 ---------------
 
-- :meth:`Web3.isAddress() <web3.Web3.isAddress>`
+- :meth:`Web3.is_address() <web3.Web3.is_address>`
 - :meth:`Web3.isChecksumAddress() <web3.Web3.isChecksumAddress>`
 - :meth:`Web3.toChecksumAddress() <web3.Web3.toChecksumAddress>`
 

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -208,7 +208,7 @@ Currency Conversions
 Addresses
 ~~~~~~~~~
 
-.. py:method:: Web3.isAddress(value)
+.. py:method:: Web3.is_address(value)
 
     Returns ``True`` if the value is one of the recognized address formats.
 
@@ -218,7 +218,7 @@ Addresses
 
     .. code-block:: python
 
-        >>> Web3.isAddress('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
+        >>> Web3.is_address('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
         True
 
 

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -235,14 +235,14 @@ Addresses
         False
 
 
-.. py:method:: Web3.toChecksumAddress(value)
+.. py:method:: Web3.to_checksum_address(value)
 
     Returns the given address with an `EIP55`_ checksum.
 
 
     .. code-block:: python
 
-        >>> Web3.toChecksumAddress('0xd3cda913deb6f67967b99d67acdfa1712c293601')
+        >>> Web3.to_checksum_address('0xd3cda913deb6f67967b99d67acdfa1712c293601')
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
 
 .. _EIP55: https://github.com/ethereum/EIPs/issues/55

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -222,16 +222,16 @@ Addresses
         True
 
 
-.. py:method:: Web3.isChecksumAddress(value)
+.. py:method:: Web3.is_checksum_address(value)
 
     Returns ``True`` if the value is a valid `EIP55`_ checksummed address
 
 
     .. code-block:: python
 
-        >>> Web3.isChecksumAddress('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
+        >>> Web3.is_checksum_address('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
         True
-        >>> Web3.isChecksumAddress('0xd3cda913deb6f67967b99d67acdfa1712c293601')
+        >>> Web3.is_checksum_address('0xd3cda913deb6f67967b99d67acdfa1712c293601')
         False
 
 

--- a/web3/_utils/validation.py
+++ b/web3/_utils/validation.py
@@ -186,7 +186,7 @@ def validate_address(value: Any) -> None:
                 "The software that gave you this non-checksum address should be "
                 "considered unsafe, please file it as a bug on their platform. "
                 "Try using an ENS name instead. Or, if you must accept lower safety, "
-                "use Web3.toChecksumAddress(lower_case_address).",
+                "use Web3.to_checksum_address(lower_case_address).",
                 value,
             )
         else:

--- a/web3/main.py
+++ b/web3/main.py
@@ -221,7 +221,7 @@ class Web3:
 
     @staticmethod
     @wraps(is_checksum_address)
-    def isChecksumAddress(value: Any) -> bool:
+    def is_checksum_address(value: Any) -> bool:
         return is_checksum_address(value)
 
     @staticmethod

--- a/web3/main.py
+++ b/web3/main.py
@@ -226,7 +226,7 @@ class Web3:
 
     @staticmethod
     @wraps(to_checksum_address)
-    def toChecksumAddress(value: Union[AnyAddress, str, bytes]) -> ChecksumAddress:
+    def to_checksum_address(value: Union[AnyAddress, str, bytes]) -> ChecksumAddress:
         return to_checksum_address(value)
 
     # mypy Types

--- a/web3/main.py
+++ b/web3/main.py
@@ -216,7 +216,7 @@ class Web3:
     # Address Utility
     @staticmethod
     @wraps(is_address)
-    def isAddress(value: Any) -> bool:
+    def is_address(value: Any) -> bool:
         return is_address(value)
 
     @staticmethod


### PR DESCRIPTION
### What was wrong?
Inherited javascript syntax. This PR does not include a deprecation step, intended for v6.
Related to Issue #2598 

### How was it fixed?

Changed `toAddress` to `to_address`, `isChecksumAddress` to `is_checksum_address`, and `toChecksumAddress` to `to_checksum_address`. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="620" alt="Screen Shot 2022-11-02 at 11 36 37 PM" src="https://user-images.githubusercontent.com/54052410/199653987-012e876c-041e-46b2-9d71-2026d437e4fd.png">

