### PR TITLE
Add isinstance decimal to validate_abi_value

### DIFF
--- a/web3/_utils/validation.py
+++ b/web3/_utils/validation.py
@@ -1,3 +1,4 @@
+import decimal
 import itertools
 from typing import (
     Any,
@@ -126,6 +127,8 @@ def validate_abi_value(abi_type: TypeStr, value: Any) -> None:
     elif is_bool_type(abi_type) and is_boolean(value):
         return
     elif is_uint_type(abi_type) and is_integer(value) and value >= 0:
+        return
+    elif is_uint_type(abi_type) and isinstance(value, decimal.Decimal):
         return
     elif is_int_type(abi_type) and is_integer(value):
         return


### PR DESCRIPTION
### What was wrong?
Does not support Decimal type on the solidity_keccak

```
w3.solidity_keccak(['uint256'], [Decimal('1000000000000000000000000000000000000')])
```

Related to Issue #
#2620 

### How was it fixed?

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
