### PR TITLE
Remove deprecated ``start_rpc`` and ``stop_rpc`` from ``w3.geth.admin`` module

### DIFF
--- a/docs/web3.geth.rst
+++ b/docs/web3.geth.rst
@@ -125,12 +125,6 @@ The ``web3.geth.admin`` object exposes methods to interact with the RPC APIs und
 
         >>> web3.geth.admin.start_http()
         True
-        
-
-.. py:method:: start_rpc()
-
-  .. warning:: Deprecated: This method is deprecated in favor of
-    :meth:`~web3.geth.admin.start_http()`
 
 
 .. py:method:: start_ws(host='localhost', port=8546, cors="", apis="eth,net,web3")
@@ -158,12 +152,6 @@ The ``web3.geth.admin`` object exposes methods to interact with the RPC APIs und
 
         >>> web3.geth.admin.stop_http()
         True
-
-
-.. py:method:: stop_rpc()
-
-  .. warning:: Deprecated: This method is deprecated in favor of
-    :meth:`~web3.geth.admin.stop_http()`
 
 
 .. py:method:: stop_ws()

--- a/newsfragments/2731.removal.rst
+++ b/newsfragments/2731.removal.rst
@@ -1,0 +1,1 @@
+Remove already-deprecated ``start_rpc`` and ``stop_rpc`` from the ``w3.geth.admin`` module.

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -114,11 +114,6 @@ class TestGoEthereumAdminModuleTest(GoEthereumAdminModuleTest):
         pytest.xfail(reason="Only one WS endpoint is allowed to be active at any time")
         super().test_admin_start_stop_ws(w3)
 
-    def test_admin_start_stop_rpc(self, w3: "Web3") -> None:
-        # This test causes all tests after it to fail on CI if it's allowed to run
-        pytest.xfail(reason="Only one RPC endpoint is allowed to be active at any time")
-        super().test_admin_start_stop_rpc(w3)
-
 
 class TestGoEthereumEthModuleTest(GoEthereumEthModuleTest):
     pass
@@ -186,12 +181,6 @@ class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):
         # This test causes all tests after it to fail on CI if it's allowed to run
         pytest.xfail(reason="Only one WS endpoint is allowed to be active at any time")
         await super().test_admin_start_stop_ws(w3)
-
-    @pytest.mark.asyncio
-    async def test_admin_start_stop_rpc(self, w3: "Web3") -> None:
-        # This test causes all tests after it to fail on CI if it's allowed to run
-        pytest.xfail(reason="Only one RPC endpoint is allowed to be active at any time")
-        await super().test_admin_start_stop_rpc(w3)
 
 
 class TestGoEthereumAsyncNetModuleTest(GoEthereumAsyncNetModuleTest):

--- a/tests/integration/go_ethereum/test_goethereum_ipc.py
+++ b/tests/integration/go_ethereum/test_goethereum_ipc.py
@@ -77,11 +77,6 @@ class TestGoEthereumAdminModuleTest(GoEthereumAdminModuleTest):
         pytest.xfail(reason="Only one WS endpoint is allowed to be active at any time")
         super().test_admin_start_stop_ws(w3)
 
-    def test_admin_start_stop_rpc(self, w3: "Web3") -> None:
-        # This test causes all tests after it to fail on CI if it's allowed to run
-        pytest.xfail(reason="Only one RPC endpoint is allowed to be active at any time")
-        super().test_admin_start_stop_rpc(w3)
-
 
 class TestGoEthereumEthModuleTest(GoEthereumEthModuleTest):
     pass

--- a/tests/integration/go_ethereum/test_goethereum_ws.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws.py
@@ -93,12 +93,6 @@ class TestGoEthereumAdminModuleTest(GoEthereumAdminModuleTest):
         )
         super().test_admin_start_stop_ws(w3)
 
-    def test_admin_start_stop_rpc(self, w3: "Web3") -> None:
-        pytest.xfail(
-            reason="This test inconsistently causes all tests after it on CI to fail if it's allowed to run"  # noqa: E501
-        )
-        super().test_admin_start_stop_rpc(w3)
-
 
 class TestGoEthereumEthModuleTest(GoEthereumEthModuleTest):
     pass

--- a/web3/_utils/admin.py
+++ b/web3/_utils/admin.py
@@ -11,7 +11,6 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.method import (
-    DeprecatedMethod,
     Method,
     default_root_munger,
 )
@@ -26,7 +25,7 @@ from web3.types import (
 
 
 def admin_start_params_munger(
-    module: Module,
+    _module: Module,
     host: str = "localhost",
     port: int = 8546,
     cors: str = "",
@@ -92,9 +91,3 @@ stop_ws: Method[Callable[[], bool]] = Method(
     RPC.admin_stopWS,
     is_property=True,
 )
-
-#
-# Deprecated Methods
-#
-start_rpc = DeprecatedMethod(start_http, "start_rpc", "start_http")
-stop_rpc = DeprecatedMethod(stop_http, "stop_rpc", "stop_http")

--- a/web3/_utils/module_testing/go_ethereum_admin_module.py
+++ b/web3/_utils/module_testing/go_ethereum_admin_module.py
@@ -57,17 +57,6 @@ class GoEthereumAdminModuleTest:
         start = w3.geth.admin.start_http()
         assert start is True
 
-    def test_admin_start_stop_rpc(self, w3: "Web3") -> None:
-        with pytest.warns(DeprecationWarning, match="deprecated in favor of stop_http"):
-            stop = w3.geth.admin.stop_rpc()
-            assert stop is True
-
-        with pytest.warns(
-            DeprecationWarning, match="deprecated in favor of start_http"
-        ):
-            start = w3.geth.admin.start_rpc()
-            assert start is True
-
     def test_admin_start_stop_ws(self, w3: "Web3") -> None:
         stop = w3.geth.admin.stop_ws()
         assert stop is True
@@ -106,18 +95,6 @@ class GoEthereumAsyncAdminModuleTest:
 
         start = await w3.geth.admin.start_http()  # type: ignore
         assert start is True
-
-    @pytest.mark.asyncio
-    async def test_admin_start_stop_rpc(self, w3: "Web3") -> None:
-        with pytest.warns(DeprecationWarning, match="deprecated in favor of stop_http"):
-            stop = await w3.geth.admin.stop_rpc()
-            assert stop is True
-
-        with pytest.warns(
-            DeprecationWarning, match="deprecated in favor of start_http"
-        ):
-            start = await w3.geth.admin.start_rpc()
-            assert start is True
 
     @pytest.mark.asyncio
     async def test_admin_start_stop_ws(self, w3: "Web3") -> None:

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -22,14 +22,9 @@ from web3._utils.admin import (
     node_info,
     peers,
     start_http,
-    start_rpc,
     start_ws,
     stop_http,
-    stop_rpc,
     stop_ws,
-)
-from web3._utils.decorators import (
-    deprecated_for,
 )
 from web3._utils.miner import (
     make_dag,
@@ -223,9 +218,6 @@ class BaseGethAdmin(Module):
     _start_ws = start_ws
     _stop_http = stop_http
     _stop_ws = stop_ws
-    # deprecated
-    _start_rpc = start_rpc
-    _stop_rpc = stop_rpc
 
 
 class GethAdmin(BaseGethAdmin):
@@ -262,24 +254,10 @@ class GethAdmin(BaseGethAdmin):
         return self._start_ws(host, port, cors, apis)
 
     def stop_http(self) -> bool:
-        return self._stop_rpc()
+        return self._stop_http()
 
     def stop_ws(self) -> bool:
         return self._stop_ws()
-
-    @deprecated_for("start_http")
-    def start_rpc(
-        self,
-        host: str = "localhost",
-        port: int = 8546,
-        cors: str = "",
-        apis: str = "eth,net,web3",
-    ) -> bool:
-        return self._start_rpc(host, port, cors, apis)
-
-    @deprecated_for("stop_http")
-    def stop_rpc(self) -> bool:
-        return self._stop_rpc()
 
 
 class AsyncGethAdmin(BaseGethAdmin):
@@ -320,20 +298,6 @@ class AsyncGethAdmin(BaseGethAdmin):
 
     async def stop_ws(self) -> Awaitable[bool]:
         return await self._stop_ws()  # type: ignore
-
-    @deprecated_for("start_http")
-    async def start_rpc(
-        self,
-        host: str = "localhost",
-        port: int = 8546,
-        cors: str = "",
-        apis: str = "eth,net,web3",
-    ) -> Awaitable[bool]:
-        return await self._start_rpc(host, port, cors, apis)
-
-    @deprecated_for("stop_http")
-    async def stop_rpc(self) -> Awaitable[bool]:
-        return await self._stop_rpc()
 
 
 class GethMiner(Module):

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -354,9 +354,6 @@ API_ENDPOINTS = {
         "start_ws": not_implemented,
         "stop_http": not_implemented,
         "stop_ws": not_implemented,
-        # deprecated
-        "start_rpc": not_implemented,
-        "stop_rpc": not_implemented,
     },
     "debug": {
         "backtraceAt": not_implemented,


### PR DESCRIPTION
### What was wrong?

Related to Issue #1416

- Removed deprecated `start_rpc` and `stop_rpc` from `w3.geth.admin` module

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![45394_463634591059_729511059_6399634_879711_n](https://user-images.githubusercontent.com/3532824/203428274-2ff7a76f-c42f-48b7-a869-0ad6aa118e3d.jpg)

