### PR TITLE
Special case for Nethermind\Gnosis revert errors

### DIFF
--- a/newsfragments/2739.feature.rst
+++ b/newsfragments/2739.feature.rst
@@ -1,0 +1,1 @@
+Add support for Nethermind/Gnosis revert reason formatting

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -123,6 +123,7 @@ SPACENETH_RESPONSE = RPCResponse(
         "test-get-revert-reason-without-msg",
         "test-get-geth-revert-reason",
         "test_get-ganache-revert-reason",
+        "test_get-spaceneth-revert-reason",
     ],
 )
 def test_get_revert_reason(response, expected) -> None:

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -113,7 +113,10 @@ SPACENETH_RESPONSE = RPCResponse(
             GANACHE_RESPONSE,
             "execution reverted: VM Exception while processing transaction: revert Custom revert message",  # noqa: 501
         ),
-        (SPACENETH_RESPONSE, "execution reverted: Marektplace::cancelMarketItem: INVALID_ITEM")
+        (
+            SPACENETH_RESPONSE,
+            "execution reverted: Marektplace::cancelMarketItem: INVALID_ITEM",
+        ),
     ),
     ids=[
         "test-get-revert-reason-with-msg",

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -91,14 +91,13 @@ GANACHE_RESPONSE = RPCResponse(
 
 SPACENETH_RESPONSE = RPCResponse(
     {
-        "name": "Error",
-        "message": "Internal JSON-RPC error.",
-        "stack": "Error: Internal JSON-RPC error",
-        "code": -32603,
-        "data": {
+        "jsonrpc": "2.0",
+        "error": {
             "code": -32015,
-            "message": "Reverted 0x4d6172656b74706c6163653a3a63616e63656c4d61726b65744974656d3a20494e56414c49445f4954454d",
+            "message": "VM execution error.",
+            "data": "Reverted 0x4f776e6572496420646f6573206e6f7420657869737420696e207265676973747279",
         },
+        "id": 3,
     }
 )
 
@@ -115,7 +114,7 @@ SPACENETH_RESPONSE = RPCResponse(
         ),
         (
             SPACENETH_RESPONSE,
-            "execution reverted: Marektplace::cancelMarketItem: INVALID_ITEM",
+            "execution reverted: OwnerId does not exist in registry",
         ),
     ),
     ids=[

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -95,7 +95,7 @@ SPACENETH_RESPONSE = RPCResponse(
         "error": {
             "code": -32015,
             "message": "VM execution error.",
-            "data": "Reverted 0x4f776e6572496420646f6573206e6f7420657869737420696e207265676973747279",
+            "data": "Reverted 0x4f776e6572496420646f6573206e6f7420657869737420696e207265676973747279",  # noqa: E501
         },
         "id": 3,
     }
@@ -110,7 +110,7 @@ SPACENETH_RESPONSE = RPCResponse(
         (GETH_RESPONSE, "execution reverted: Function has been reverted."),
         (
             GANACHE_RESPONSE,
-            "execution reverted: VM Exception while processing transaction: revert Custom revert message",  # noqa: 501
+            "execution reverted: VM Exception while processing transaction: revert Custom revert message",  # noqa: E501
         ),
         (
             SPACENETH_RESPONSE,

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -89,6 +89,20 @@ GANACHE_RESPONSE = RPCResponse(
 )
 
 
+SPACENETH_RESPONSE = RPCResponse(
+    {
+        "name": "Error",
+        "message": "Internal JSON-RPC error.",
+        "stack": "Error: Internal JSON-RPC error",
+        "code": -32603,
+        "data": {
+            "code": -32015,
+            "message": "Reverted 0x4d6172656b74706c6163653a3a63616e63656c4d61726b65744974656d3a20494e56414c49445f4954454d",
+        },
+    }
+)
+
+
 @pytest.mark.parametrize(
     "response,expected",
     (
@@ -99,6 +113,7 @@ GANACHE_RESPONSE = RPCResponse(
             GANACHE_RESPONSE,
             "execution reverted: VM Exception while processing transaction: revert Custom revert message",  # noqa: 501
         ),
+        (SPACENETH_RESPONSE, "execution reverted: Marektplace::cancelMarketItem: INVALID_ITEM")
     ),
     ids=[
         "test-get-revert-reason-with-msg",

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -610,7 +610,7 @@ def raise_contract_logic_error_on_revert(response: RPCResponse) -> RPCResponse:
         prefix = "Reverted 0x08c379a00000000000000000000000000000000000000000000000000000000000000020"  # noqa: 501
         if not data.startswith(prefix):
             if data.startswith("Reverted 0x"):
-                # Special case for this form: 'Reverted 0x4f776e6572496420646f6573206e6f7420657869737420696e207265676973747279'
+                # Special case for this form: 'Reverted 0x...'
                 receipt = data.split(" ")[1][2:]
                 revert_reason = bytes.fromhex(receipt).decode("utf-8")
                 raise ContractLogicError(f"execution reverted: {revert_reason}")

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -605,22 +605,23 @@ def raise_contract_logic_error_on_revert(response: RPCResponse) -> RPCResponse:
         raise ContractLogicError(f'execution reverted: {response["error"]["message"]}')
 
     # Parity/OpenEthereum case:
-    if data.startswith('Reverted '):
+    if data.startswith("Reverted "):
         # "Reverted", function selector and offset are always the same for revert errors
-        prefix = 'Reverted 0x08c379a00000000000000000000000000000000000000000000000000000000000000020'  # noqa: 501
+        prefix = "Reverted 0x08c379a00000000000000000000000000000000000000000000000000000000000000020"  # noqa: 501
         if not data.startswith(prefix):
             if data.startswith("Reverted 0x"):
                 # Special case for this form: 'Reverted 0x4f776e6572496420646f6573206e6f7420657869737420696e207265676973747279'
                 receipt = data.split(" ")[1][2:]
-                revert_reason = bytes.fromhex(receipt).decode('utf-8')
-                raise ContractLogicError(f'execution reverted: {revert_reason}')
-            else:       
-                raise ContractLogicError('execution reverted')
+                revert_reason = bytes.fromhex(receipt).decode("utf-8")
+                raise ContractLogicError(f"execution reverted: {revert_reason}")
+            else:
+                raise ContractLogicError("execution reverted")
 
-        reason_length = int(data[len(prefix):len(prefix) + 64], 16)
-        reason = data[len(prefix) + 64:len(prefix) + 64 + reason_length * 2]
-        raise ContractLogicError(f'execution reverted: {bytes.fromhex(reason).decode("utf8")}')
-
+        reason_length = int(data[len(prefix) : len(prefix) + 64], 16)
+        reason = data[len(prefix) + 64 : len(prefix) + 64 + reason_length * 2]
+        raise ContractLogicError(
+            f'execution reverted: {bytes.fromhex(reason).decode("utf8")}'
+        )
 
     # --- EIP-3668 | CCIP Read --- #
     # 0x556f1830 is the function selector for:


### PR DESCRIPTION
### What was wrong?

Certain forms of errors, eg. generated on Spaceneth\Nethermind setups, would fail to return revert reasons on contracts.
Of the form: 'Reverted 0x4f776e6572496420646f6573206e6f7420657869737420696e207265676973747279'

### How was it fixed?

A small edge case handling was added in the error_formatting.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
This doesn't really seem worth mentioning in release notes. Let me know if that's wanted.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1608848461950-0fe51dfc41cb?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxleHBsb3JlLWZlZWR8MTl8fHxlbnwwfHx8fA%3D%3D&w=1000&q=80)
