### PR TITLE
bump readme python supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Python library for interacting with Ethereum, inspired by [web3.js](https://github.com/ethereum/web3.js).
 
-* Python 3.6+ support
+* Python 3.7.2+ support
 
 ---
 


### PR DESCRIPTION
### What was wrong?

we're not supporting python 3.6 on v5 either, right?

### How was it fixed?

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
