### PR TITLE
docs: quickstart note on eth-tester install

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -39,8 +39,13 @@ Test Provider
 
 If you're just learning the ropes or doing some quick prototyping, you can use a test
 provider, `eth-tester <https://github.com/ethereum/eth-tester>`_. This provider includes
-some accounts prepopulated with test ether and automines each transaction into a block.
-Web3.py makes this test provider available via ``EthereumTesterProvider``:
+some accounts prepopulated with test ether and instantly includes each transaction into a block.
+Web3.py makes this test provider available via ``EthereumTesterProvider``.
+
+.. note::
+
+  The ``EthereumTesterProvider`` requires additional dependencies. Install them via
+  ``pip install "web3[tester]"``, then import and instantiate the provider as seen below.
 
 .. code-block:: python
 

--- a/newsfragments/2754.doc.rst
+++ b/newsfragments/2754.doc.rst
@@ -1,0 +1,1 @@
+Include eth-tester installation note in quickstart


### PR DESCRIPTION
### What was wrong?

- quick start docs omit a note about eth-tester being a separate dependency. addresses #2745.
- "mining" verbiage

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="497" alt="Screen Shot 2022-12-12 at 12 50 07 PM" src="https://user-images.githubusercontent.com/3621728/207140639-691dac71-eb47-4653-bd8a-9cb4c9478574.png">
