### PR TITLE
docs: quickstart note on eth-tester install - v6

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -39,8 +39,13 @@ Test Provider
 
 If you're just learning the ropes or doing some quick prototyping, you can use a test
 provider, `eth-tester <https://github.com/ethereum/eth-tester>`_. This provider includes
-some accounts prepopulated with test ether and automines each transaction into a block.
-Web3.py makes this test provider available via ``EthereumTesterProvider``:
+some accounts prepopulated with test ether and instantly includes each transaction into a block.
+Web3.py makes this test provider available via ``EthereumTesterProvider``.
+
+.. note::
+
+  The ``EthereumTesterProvider`` requires additional dependencies. Install them via
+  ``pip install "web3[tester]"``, then import and instantiate the provider as seen below.
 
 .. code-block:: python
 

--- a/newsfragments/2755.doc.rst
+++ b/newsfragments/2755.doc.rst
@@ -1,0 +1,1 @@
+Include eth-tester install note in quickstart


### PR DESCRIPTION
### What was wrong?

v6 port of #2754, adding an installation note, re: eth-tester, in the quickstart guide.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="497" alt="Screen Shot 2022-12-12 at 12 50 07 PM" src="https://user-images.githubusercontent.com/3621728/207146457-135c3a47-3372-4e6c-9ef2-b52711aa4ead.png">

