### PR TITLE
bump v5 tox version

### DIFF
--- a/newsfragments/2756.misc.rst
+++ b/newsfragments/2756.misc.rst
@@ -1,0 +1,1 @@
+Upgrade tox version to >=3.18.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     "tester": [
-        "eth-tester[py-evm]==v0.6.0-beta.7",
+        "eth-tester[py-evm]==v0.6.0-b.7",
         "py-geth>=3.9.1,<4",
     ],
     "linter": [
@@ -46,7 +46,7 @@ extras_require = {
         "pytest-watch>=4.2,<5",
         "pytest-xdist>=1.29,<2",
         "setuptools>=38.6.0",
-        "tox>=1.8.0",
+        "tox>=3.18.0",
         "tqdm>4.32,<5",
         "twine>=1.13,<2",
         "pluggy==0.13.1",

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ max-line-length= 100
 exclude= venv*,.tox,docs,build
 ignore=W503
 [testenv]
-whitelist_externals=/usr/bin/make
+allowlist_externals=/usr/bin/make
 install_command=python -m pip install --no-use-pep517 {opts} {packages}
 usedevelop=True
 commands=
@@ -71,7 +71,7 @@ commands=
 
 [common-wheel-cli]
 deps=wheel
-whitelist_externals=
+allowlist_externals=
     /bin/rm
     /bin/bash
 commands=
@@ -82,31 +82,31 @@ commands=
 
 [testenv:py36-wheel-cli]
 deps={[common-wheel-cli]deps}
-whitelist_externals={[common-wheel-cli]whitelist_externals}
+allowlist_externals={[common-wheel-cli]allowlist_externals}
 commands={[common-wheel-cli]commands}
 skip_install=true
 
 [testenv:py37-wheel-cli]
 deps={[common-wheel-cli]deps}
-whitelist_externals={[common-wheel-cli]whitelist_externals}
+allowlist_externals={[common-wheel-cli]allowlist_externals}
 commands={[common-wheel-cli]commands}
 skip_install=true
 
 [testenv:py38-wheel-cli]
 deps={[common-wheel-cli]deps}
-whitelist_externals={[common-wheel-cli]whitelist_externals}
+allowlist_externals={[common-wheel-cli]allowlist_externals}
 commands={[common-wheel-cli]commands}
 skip_install=true
 
 [testenv:py39-wheel-cli]
 deps={[common-wheel-cli]deps}
-whitelist_externals={[common-wheel-cli]whitelist_externals}
+allowlist_externals={[common-wheel-cli]allowlist_externals}
 commands={[common-wheel-cli]commands}
 skip_install=true
 
 [common-wheel-cli-windows]
 deps=wheel
-whitelist_externals=
+allowlist_externals=
     bash.exe
 commands=
     bash.exe -c "rm -rf build dist"
@@ -116,6 +116,6 @@ commands=
 
 [testenv:py37-wheel-cli-windows]
 deps={[common-wheel-cli]deps}
-whitelist_externals={[common-wheel-cli-windows]whitelist_externals}
+allowlist_externals={[common-wheel-cli-windows]allowlist_externals}
 commands={[common-wheel-cli-windows]commands}
 skip_install=true


### PR DESCRIPTION
### What was wrong?

v5 deps got grumpy following v6's upgrade of tox. backporting #2751.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/6e/a8/bc/6ea8bc3ffb40da7bfdb35cc869d61049.jpg)
