### PR TITLE
dependencies: upgrade websockets, drop py3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,9 @@ setup(
         "requests>=2.16.0,<3.0.0",
         # remove typing_extensions after python_requires>=3.8, see web3._utils.compat
         "typing-extensions>=3.7.4.1,<5;python_version<'3.8'",
-        "websockets>=9.1,<10",
+        "websockets>=10,<11",
     ],
-    python_requires=">=3.6,<4",
+    python_requires=">=3.7,<4",
     extras_require=extras_require,
     py_modules=["web3", "ens", "ethpm"],
     entry_points={"pytest11": ["pytest_ethereum = web3.tools.pytest_ethereum.plugins"]},


### PR DESCRIPTION
### What was wrong?

`web3.py` depends on a pretty old version of `websockets` and has dependency collisions with many other packages that also depend on `websockets`.

### How was it fixed?
I upgraded `websockets` to `>=10,<11`. Because `websockets>=10,<11` drops support for python3.6, I did that here as well.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
