### PR TITLE
Block Identifier default change

### DIFF
--- a/newsfragments/2777.breaking.rst
+++ b/newsfragments/2777.breaking.rst
@@ -1,0 +1,1 @@
+When calling a contract, use ``w3.eth.default_block`` if no block_identifier is specified instead of ``latest``.

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -1021,6 +1021,20 @@ def test_call_revert_contract(revert_contract):
         revert_contract.functions.revertWithMessage().call({"gas": 100000})
 
 
+def test_changing_default_block_identifier(w3, math_contract):
+    assert math_contract.caller.counter() == 0
+    assert w3.eth.default_block == "latest"
+
+    math_contract.functions.increment(7).transact()
+    assert math_contract.caller.counter() == 7
+
+    assert math_contract.functions.counter().call(block_identifier=1) == 0
+    w3.eth.default_block = 1
+    assert math_contract.functions.counter().call(block_identifier=None) == 0
+    w3.eth.default_block = 0x2
+    assert math_contract.functions.counter().call(block_identifier=None) == 7
+
+
 @pytest.mark.asyncio
 async def test_async_invalid_address_in_deploy_arg(
     AsyncWithConstructorAddressArgumentsContract,
@@ -1885,3 +1899,22 @@ async def test_async_returns_data_from_specified_block(async_w3, async_math_cont
 
     assert output1 == 1
     assert output2 == 2
+
+
+@pytest.mark.asyncio
+async def test_async_changing_default_block_identifier(async_w3, async_math_contract):
+    assert await async_math_contract.caller.counter() == 0
+    assert async_w3.eth.default_block == "latest"
+
+    await async_math_contract.functions.increment(7).transact()
+    assert await async_math_contract.caller.counter() == 7
+
+    assert await async_math_contract.functions.counter().call(block_identifier=1) == 0
+    async_w3.eth.default_block = 1
+    assert (
+        await async_math_contract.functions.counter().call(block_identifier=None) == 0
+    )
+    async_w3.eth.default_block = 0x2
+    assert (
+        await async_math_contract.functions.counter().call(block_identifier=None) == 7
+    )


### PR DESCRIPTION
I'm not sure what happened, but I can't add to the original PR, which can be found at #2335. 

Here is the PR description from there:

Changed default block_identifier in contract.call() to None.
Changed parse_block_identifier to use web3.eth.defaultBlock if None is passed in

### What was wrong?

https://github.com/ethereum/web3.py/issues/2334

### How was it fixed?

changed block_identifier default to None in contract.call
changed parse_block_identifier to parse None to web3.eth.default_block

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://stylecaster.com/wp-content/uploads/2017/01/arthur.jpg)
