### PR TITLE
Raise new MethodUnavailable error for methods that are unavailable

### DIFF
--- a/docs/v6_migration.rst
+++ b/docs/v6_migration.rst
@@ -76,6 +76,9 @@ Other Misc Changes
 
 - ``InfuraKeyNotFound`` exception has been changed to ``InfuraProjectIdNotFound``
 - ``SolidityError`` has been removed in favor of ``ContractLogicError``
+- When a method is unavailable from a node provider (i.e. a response error
+  code of -32601 is returned), a ``MethodUnavailable`` error is
+  now raised instead of ``ValueError``
 
 Removals
 ~~~~~~~~

--- a/newsfragments/2796.breaking.rst
+++ b/newsfragments/2796.breaking.rst
@@ -1,0 +1,1 @@
+When a method is not supported by a node provider, raise a MethodUnavailable error instead of the generic ValueError.

--- a/tests/core/manager/test_response_formatters.py
+++ b/tests/core/manager/test_response_formatters.py
@@ -41,6 +41,9 @@ METHOD_NOT_FOUND_RESP_FORMAT = {
         "available",
     },
 }
+ETH_TESTER_METHOD_NOT_FOUND_RESP_FORMAT = {
+    "error": "the method eth_getTransactionByHash does not exist/is not available",
+}
 
 
 def raise_contract_logic_error(response):
@@ -120,6 +123,13 @@ def raise_contract_logic_error(response):
             identity,
             identity,
             MethodUnavailable,
+        ),
+        (
+            ETH_TESTER_METHOD_NOT_FOUND_RESP_FORMAT,
+            (),
+            identity,
+            identity,
+            ValueError,
         ),
     ],
 )

--- a/tests/core/manager/test_response_formatters.py
+++ b/tests/core/manager/test_response_formatters.py
@@ -13,6 +13,7 @@ from web3.exceptions import (
     BadResponseFormat,
     BlockNotFound,
     ContractLogicError,
+    MethodUnavailable,
     TransactionNotFound,
 )
 
@@ -31,6 +32,14 @@ ANOTHER_UNEXPECTED_RESP_FORMAT = {
     "name": "LimitError",
     "message": "You cannot query logs for more than 10000 blocks at once.",
     "method": "eth_getLogs",
+}
+METHOD_NOT_FOUND_RESP_FORMAT = {
+    "jsonrpc": "2.0",
+    "error": {
+        "code": -32601,
+        "message": "the method eth_getTransactionByHash does not exist/is not "
+        "available",
+    },
 }
 
 
@@ -104,6 +113,13 @@ def raise_contract_logic_error(response):
             identity,
             raise_transaction_not_found,
             TransactionNotFound,
+        ),
+        (
+            METHOD_NOT_FOUND_RESP_FORMAT,
+            (),
+            identity,
+            identity,
+            MethodUnavailable,
         ),
     ],
 )

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -287,3 +287,11 @@ class BadResponseFormat(Web3Exception):
     """
 
     pass
+
+
+class MethodUnavailable(Web3Exception):
+    """
+    Raised when the method is not available on the node
+    """
+
+    pass

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -34,6 +34,7 @@ from web3.datastructures import (
 )
 from web3.exceptions import (
     BadResponseFormat,
+    MethodUnavailable,
 )
 from web3.middleware import (
     abi_middleware,
@@ -188,6 +189,8 @@ class RequestManager:
     ) -> Any:
         if "error" in response:
             apply_error_formatters(error_formatters, response)
+            if response["error"].get("code") == -32601:
+                raise MethodUnavailable(response["error"])
             raise ValueError(response["error"])
         # NULL_RESPONSES includes None, so return False here as the default
         # so we don't apply the null_result_formatters if there is no 'result' key

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -189,8 +189,13 @@ class RequestManager:
     ) -> Any:
         if "error" in response:
             apply_error_formatters(error_formatters, response)
-            if response["error"].get("code") == -32601:
-                raise MethodUnavailable(response["error"])
+
+            # guard against eth-tester case - eth-tester returns a string
+            # with no code, so can't parse what the error is.
+            if isinstance(response["error"], dict):
+                resp_code = response["error"].get("code")
+                if resp_code == -32601:
+                    raise MethodUnavailable(response["error"])
             raise ValueError(response["error"])
         # NULL_RESPONSES includes None, so return False here as the default
         # so we don't apply the null_result_formatters if there is no 'result' key


### PR DESCRIPTION
### What was wrong?
When methods are not supported by the node, we were raising a generic ValueError. It would be good to raise a custom error and maybe add more details to the error message.

Closes #2448 

### How was it fixed?
Now if a method is unsupported, we raise `MethodUnavailable`, which inherits from `Web3Exception`.

@fselmo / @pacrob - This is one of the error messages that we get asked about most in the Discord channel. Does anyone have thoughts on adding a custom "hint" here or something? Maybe something along the lines of "The provider you're using does not support this method. Check the provider docs for more info."?

The response comes back like:
```py
response = { 
    "jsonrpc": "2.0",
    "error": {
        "code": -32601,
        "message": "the method eth_getTransactionByHash does not exist/is not "
        "available",
    },
}
```
and we return `response["error"]`  to the user. But maybe we should add something like: 

```py
 {
    "code": -32601,
    "message": "the method eth_getTransactionByHash does not exist/is not available",
    "hint": "Check your node provider's API docs to see what methods are supported",
}
```
Open to other ideas too or just leaving it as-is!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F47%2F2021%2F09%2F30%2Ffrisco-front-walking-granny-cat-costume.jpg)
