### PR TITLE
Remove deprecated request async

### DIFF
--- a/newsfragments/2810.breaking.rst
+++ b/newsfragments/2810.breaking.rst
@@ -1,0 +1,1 @@
+Removed deprecated ``manager.request_async`` and associated methods.

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -12,10 +12,6 @@ from typing import (  # noqa: F401
     Union,
     cast,
 )
-import uuid
-from uuid import (
-    UUID,
-)
 
 from eth_utils.toolz import (
     pipe,
@@ -26,7 +22,6 @@ from hexbytes import (
 
 from web3._utils.threads import (  # noqa: F401
     ThreadWithReturn,
-    spawn,
 )
 from web3.datastructures import (
     NamedElementOnion,
@@ -103,7 +98,6 @@ class RequestManager:
         middlewares: Optional[Sequence[Tuple[Middleware, str]]] = None,
     ) -> None:
         self.w3 = w3
-        self.pending_requests: Dict[UUID, ThreadWithReturn[RPCResponse]] = {}
 
         if provider is None:
             self.provider = AutoProvider()
@@ -240,21 +234,3 @@ class RequestManager:
         return self.formatted_response(
             response, params, error_formatters, null_result_formatters
         )
-
-    def receive_blocking(
-        self, request_id: UUID, timeout: Optional[float] = None
-    ) -> Any:
-        try:
-            request = self.pending_requests.pop(request_id)
-        except KeyError:
-            raise KeyError(f"Request for id:{request_id} not found")
-        else:
-            response = request.get(timeout=timeout)
-
-        if "error" in response:
-            raise ValueError(response["error"])
-
-        return response["result"]
-
-    def receive_async(self, request_id: UUID, *args: Any, **kwargs: Any) -> NoReturn:
-        raise NotImplementedError("Callback pattern not implemented")

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -24,9 +24,6 @@ from hexbytes import (
     HexBytes,
 )
 
-from web3._utils.decorators import (
-    deprecated_for,
-)
 from web3._utils.threads import (  # noqa: F401
     ThreadWithReturn,
     spawn,
@@ -243,16 +240,6 @@ class RequestManager:
         return self.formatted_response(
             response, params, error_formatters, null_result_formatters
         )
-
-    @deprecated_for("coro_request")
-    def request_async(self, raw_method: str, raw_params: Any) -> UUID:
-        request_id = uuid.uuid4()
-        self.pending_requests[request_id] = spawn(
-            self.request_blocking,
-            raw_method=raw_method,
-            raw_params=raw_params,
-        )
-        return request_id
 
     def receive_blocking(
         self, request_id: UUID, timeout: Optional[float] = None


### PR DESCRIPTION
### What was wrong?
I noticed that there was a deprecated method that wasn't being used anywhere. No time like the present to remove deprecated things. 


### How was it fixed?
Removed it and associated methods.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://live.staticflickr.com/61/196051095_ca400cab2c_b.jpg)
