### PR TITLE
remove rinkeby refs and replace with goerli where appropriate

### DIFF
--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -243,8 +243,8 @@ way through the EIP process)
 -  ``chain_id``: Chain ID of the chain on which the registry lives. Defaults to Mainnet. Supported chains include...
 
   - 1: Mainnet
-  - 4: Rinkeby
   - 5: Goerli
+  - 11155111: Sepolia
 
 -  ``package-name``: Must conform to the package-name as specified in
    the

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -683,7 +683,7 @@ like so:
     :code: python
     :start-line: 1
 
-Using Infura Rinkeby Node
+Using Infura Goerli Node
 -------------------------
 Import your required libraries
 
@@ -695,7 +695,7 @@ Initialize a web3 instance with an Infura node
 
 .. code-block:: python
 
-    w3 = Web3(Web3.HTTPProvider("https://rinkeby.infura.io/v3/YOUR_INFURA_KEY"))
+    w3 = Web3(Web3.HTTPProvider("https://goerli.infura.io/v3/YOUR_INFURA_KEY"))
 
 
 Inject the middleware into the middleware onion
@@ -728,7 +728,7 @@ And finally, send the transaction
 
 Tip : afterwards you can use the value stored in ``txn_hash``, in an explorer like `etherscan`_ to view the transaction's details
 
-.. _etherscan: https://rinkeby.etherscan.io
+.. _etherscan: https://goerli.etherscan.io
 
 
 Adjusting log levels

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -373,7 +373,7 @@ Proof of Authority
     It's important to inject the middleware at the 0th layer of the middleware onion:
     `w3.middleware_onion.inject(geth_poa_middleware, layer=0)`
 
-The ``geth_poa_middleware`` is required to connect to ``geth --dev`` or the Rinkeby
+The ``geth_poa_middleware`` is required to connect to ``geth --dev`` or the Goerli 
 public network. It may also be needed for other EVM compatible blockchains like Polygon
 or BNB Chain (Binance Smart Chain).
 
@@ -421,7 +421,7 @@ Why is ``geth_poa_middleware`` necessary?
 
 There is no strong community consensus on a single Proof-of-Authority (PoA) standard yet.
 Some nodes have successful experiments running, though. One is go-ethereum (geth),
-which uses a prototype PoA for it's development mode and the Rinkeby test network.
+which uses a prototype PoA for it's development mode and the Goerli test network.
 
 Unfortunately, it does deviate from the yellow paper specification, which constrains the
 ``extraData`` field in each block to a maximum of 32-bytes. Geth's PoA uses more than

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -111,7 +111,6 @@ Faucet mechanisms tend to come and go, so if any information here is
 out of date, try the `Ethereum Stackexchange <https://ethereum.stackexchange.com/>`_.
 Here are some links to testnet ether instructions (in no particular order):
 
-- `Rinkeby <https://www.rinkeby.io/#faucet>`_
 - `Goerli <https://goerli.net>`_ (different faucet links on top menu bar)
 - `Sepolia <https://faucet.sepolia.dev>`_
 

--- a/ethpm/constants.py
+++ b/ethpm/constants.py
@@ -12,7 +12,6 @@ GITHUB_API_AUTHORITY = "api.github.com"
 
 SUPPORTED_CHAIN_IDS = {
     1: "mainnet",
-    4: "rinkeby",
     5: "goerli",
     11155111: "sepolia",
 }

--- a/ethpm/validation/uri.py
+++ b/ethpm/validation/uri.py
@@ -103,7 +103,7 @@ def validate_registry_uri_authority(auth: str) -> None:
     if not is_supported_chain_id(to_int(text=chain_id)):
         raise EthPMValidationError(
             f"Chain ID: {chain_id} is not supported. Supported chain ids include: "
-            "1 (mainnet), 4 (rinkeby), 5 (goerli), and 11155111 (sepolia)."
+            "1 (mainnet), 5 (goerli), and 11155111 (sepolia)."
             "Please try again with a valid registry URI."
         )
 

--- a/newsfragments/2815.breaking.rst
+++ b/newsfragments/2815.breaking.rst
@@ -1,0 +1,1 @@
+removed Rinkeby from list of allowed chains in EthPM

--- a/newsfragments/2815.doc.rst
+++ b/newsfragments/2815.doc.rst
@@ -1,0 +1,1 @@
+remove references to Rinkeby or replace with Goerli

--- a/tests/ethpm/_utils/test_chain_utils.py
+++ b/tests/ethpm/_utils/test_chain_utils.py
@@ -46,10 +46,10 @@ def test_parse_BIP122_uri(value, expected_resource_type):
     "chain_id,expected",
     (
         (1, True),
-        (4, True),
         (5, True),
         (11155111, True),
         (2, False),
+        (4, False),
         ("1", False),
         ({}, False),
         (None, False),


### PR DESCRIPTION
### What was wrong?

Rinkeby is [deprecated](https://twitter.com/etherscan/status/1569311894279958531?lang=en). Neither Infura nor Alchemy offer endpoints for it.

### How was it fixed?

Removed Rinkeby from lists of test chains and replaced it with Goerli if it was the only mention.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/218891459-67fc8523-b35f-43d7-baa1-057f7dc2874b.png)
