### PR TITLE
Doc fixup

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -278,9 +278,6 @@ AsyncHTTPProvider
 
         >>> from aiohttp import ClientSession
         >>> from web3 import Web3, AsyncHTTPProvider
-        >>> from web3.eth import AsyncEth
-        >>> from web3.net import AsyncNet
-        >>> from web3.geth import Geth, AsyncGethTxPool
 
         >>> w3 = Web3(AsyncHTTPProvider(endpoint_uri))
 

--- a/newsfragments/2789.doc.rst
+++ b/newsfragments/2789.doc.rst
@@ -1,0 +1,1 @@
+Remove unused module lines to instantiate the AsyncHTTPProvider


### PR DESCRIPTION
Cherry-picked from #2789 

### What was wrong?

AsyncHTTPProvider docs needed an update. 

Related to Issue #2789. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
