### PR TITLE
Add async eth.sign

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -294,6 +294,7 @@ Eth
 - :meth:`web3.eth.send_transaction() <web3.eth.Eth.send_transaction>`
 - :meth:`web3.eth.send_raw_transaction() <web3.eth.Eth.send_raw_transaction>`
 - :meth:`web3.eth.wait_for_transaction_receipt() <web3.eth.Eth.wait_for_transaction_receipt>`
+- :meth:`web3.eth.sign() <web3.eth.Eth.sign>`
 
 Net
 ***

--- a/newsfragments/2833.feature.rst
+++ b/newsfragments/2833.feature.rst
@@ -1,0 +1,1 @@
+Add the ``sign`` method to the ``AsyncEth`` class

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1454,6 +1454,54 @@ class AsyncEthModuleTest:
         assert is_integer(transaction_count)
         assert transaction_count >= 1
 
+    async def test_async_eth_sign(
+        self, async_w3: "AsyncWeb3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        signature = await async_w3.eth.sign(
+            unlocked_account_dual_type, text="Message tö sign. Longer than hash!"
+        )
+        assert is_bytes(signature)
+        assert len(signature) == 32 + 32 + 1
+
+        # test other formats
+        hexsign = await async_w3.eth.sign(
+            unlocked_account_dual_type,
+            hexstr=HexStr(
+                "0x4d6573736167652074c3b6207369676e2e204c6f6e676572207468616e206861736821"  # noqa: E501
+            ),
+        )
+        assert hexsign == signature
+
+        intsign = await async_w3.eth.sign(
+            unlocked_account_dual_type,
+            0x4D6573736167652074C3B6207369676E2E204C6F6E676572207468616E206861736821,
+        )
+        assert intsign == signature
+
+        bytessign = await async_w3.eth.sign(
+            unlocked_account_dual_type, b"Message t\xc3\xb6 sign. Longer than hash!"
+        )
+        assert bytessign == signature
+
+        new_signature = await async_w3.eth.sign(
+            unlocked_account_dual_type, text="different message is different"
+        )
+        assert new_signature != signature
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(
+        reason="Async middleware to convert ENS names to addresses is missing"
+    )
+    async def test_async_eth_sign_ens_names(
+        self, async_w3: "AsyncWeb3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        with ens_addresses(async_w3, {"unlocked-acct.eth": unlocked_account_dual_type}):
+            signature = await async_w3.eth.sign(
+                ENS("unlocked-acct.eth"), text="Message tö sign. Longer than hash!"
+            )
+            assert is_bytes(signature)
+            assert len(signature) == 32 + 32 + 1
+
     @pytest.mark.asyncio
     async def test_async_eth_new_filter(self, async_w3: "AsyncWeb3") -> None:
         filter = await async_w3.eth.filter({})

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -518,6 +518,21 @@ class AsyncEth(BaseEth):
     ) -> HexBytes:
         return await self._get_storage_at(account, position, block_identifier)
 
+    # eth_sign
+
+    _sign: Method[Callable[..., Awaitable[HexStr]]] = Method(
+        RPC.eth_sign, mungers=[BaseEth.sign_munger]
+    )
+
+    async def sign(
+        self,
+        account: Union[Address, ChecksumAddress, ENS],
+        data: Union[int, bytes] = None,
+        hexstr: HexStr = None,
+        text: str = None,
+    ) -> HexStr:
+        return await self._sign(account, data, hexstr, text)
+
     # eth_newFilter, eth_newBlockFilter, eth_newPendingTransactionFilter
 
     filter: Method[

--- a/web3/eth/base_eth.py
+++ b/web3/eth/base_eth.py
@@ -28,6 +28,9 @@ from web3._utils.empty import (
     Empty,
     empty,
 )
+from web3._utils.encoding import (
+    to_hex,
+)
 from web3.module import (
     Module,
 )
@@ -148,6 +151,16 @@ class BaseEth(Module):
             return (transaction, block_identifier)
         else:
             return (transaction, block_identifier, state_override)
+
+    def sign_munger(
+        self,
+        account: Union[Address, ChecksumAddress, ENS],
+        data: Union[int, bytes] = None,
+        hexstr: HexStr = None,
+        text: str = None,
+    ) -> Tuple[Union[Address, ChecksumAddress, ENS], HexStr]:
+        message_hex = to_hex(data, hexstr=hexstr, text=text)
+        return (account, message_hex)
 
     def filter_munger(
         self,

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -29,9 +29,6 @@ from hexbytes import (
 from web3._utils.blocks import (
     select_method_for_block_identifier,
 )
-from web3._utils.encoding import (
-    to_hex,
-)
 from web3._utils.fee_utils import (
     fee_history_priority_fee,
 )
@@ -566,17 +563,9 @@ class Eth(BaseEth):
 
     # eth_sign
 
-    def sign_munger(
-        self,
-        account: Union[Address, ChecksumAddress, ENS],
-        data: Union[int, bytes] = None,
-        hexstr: HexStr = None,
-        text: str = None,
-    ) -> Tuple[Union[Address, ChecksumAddress, ENS], HexStr]:
-        message_hex = to_hex(data, hexstr=hexstr, text=text)
-        return (account, message_hex)
-
-    sign: Method[Callable[..., HexStr]] = Method(RPC.eth_sign, mungers=[sign_munger])
+    sign: Method[Callable[..., HexStr]] = Method(
+        RPC.eth_sign, mungers=[BaseEth.sign_munger]
+    )
 
     # eth_signTransaction
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #2826. The `sign` method is unavailable on the `AsyncEth` class.

### How was it fixed?

Add the `sign` method to the `AsyncEth` class, and add corresponding tests.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://ipetgroup.com/photo/50232_0_620.png)
