### PR TITLE
Unused import cleanup

### DIFF
--- a/ethpm/contract.py
+++ b/ethpm/contract.py
@@ -1,4 +1,4 @@
-from typing import (  # noqa: F401
+from typing import (
     TYPE_CHECKING,
     Any,
     Dict,

--- a/newsfragments/2838.internal.rst
+++ b/newsfragments/2838.internal.rst
@@ -1,0 +1,1 @@
+clean up ignored unused imports

--- a/tests/core/middleware/test_latest_block_based_cache_middleware.py
+++ b/tests/core/middleware/test_latest_block_based_cache_middleware.py
@@ -19,7 +19,7 @@ from web3._utils.caching import (
 from web3._utils.formatters import (
     hex_to_integer,
 )
-from web3.middleware import (  # noqa: F401
+from web3.middleware import (
     construct_error_generator_middleware,
     construct_latest_block_based_cache_middleware,
     construct_result_generator_middleware,

--- a/tests/core/middleware/test_time_based_cache_middleware.py
+++ b/tests/core/middleware/test_time_based_cache_middleware.py
@@ -9,7 +9,7 @@ from web3 import (
 from web3._utils.caching import (
     generate_cache_key,
 )
-from web3.middleware import (  # noqa: F401
+from web3.middleware import (
     construct_error_generator_middleware,
     construct_result_generator_middleware,
     construct_time_based_cache_middleware,

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -61,7 +61,6 @@ from web3.types import (
 )
 
 if TYPE_CHECKING:
-    from web3 import Web3  # noqa: F401
     from web3.eth import AsyncEth  # noqa: F401
     from web3.eth import Eth  # noqa: F401
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -107,7 +107,6 @@ from web3.types import (
 )
 
 if TYPE_CHECKING:
-    from web3 import Web3  # noqa: F401
     from web3.eth import AsyncEth  # noqa: F401
     from web3.eth import Eth  # noqa: F401
     from web3.module import Module  # noqa: F401

--- a/web3/_utils/module_testing/go_ethereum_personal_module.py
+++ b/web3/_utils/module_testing/go_ethereum_personal_module.py
@@ -24,7 +24,7 @@ from web3 import (
 from web3.datastructures import (
     AttributeDict,
 )
-from web3.types import (  # noqa: F401
+from web3.types import (
     TxParams,
     Wei,
 )

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -62,10 +62,8 @@ from web3._utils.validation import (
 from web3.exceptions import (
     InvalidAddress,
 )
-from web3.types import (  # noqa: F401
+from web3.types import (
     ABI,
-    ABIEvent,
-    ABIFunction,
 )
 
 if TYPE_CHECKING:

--- a/web3/_utils/validation.py
+++ b/web3/_utils/validation.py
@@ -54,9 +54,8 @@ from web3._utils.abi import (
 from web3.exceptions import (
     InvalidAddress,
 )
-from web3.types import (  # noqa: F401
+from web3.types import (
     ABI,
-    ABIEvent,
     ABIFunction,
 )
 

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -60,7 +60,7 @@ from web3.contract.utils import (
     find_functions_by_identifier,
     get_function_by_identifier,
 )
-from web3.types import (  # noqa: F401
+from web3.types import (
     ABI,
     BlockIdentifier,
     CallOverride,

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -106,7 +106,7 @@ from web3.logs import (
     WARN,
     EventLogErrorFlags,
 )
-from web3.types import (  # noqa: F401
+from web3.types import (
     ABI,
     ABIEvent,
     ABIFunction,

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -60,7 +60,7 @@ from web3.contract.utils import (
     get_function_by_identifier,
     transact_with_contract_function,
 )
-from web3.types import (  # noqa: F401
+from web3.types import (
     ABI,
     BlockIdentifier,
     CallOverride,

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -46,7 +46,7 @@ from web3.contract.base_contract import (
 from web3.exceptions import (
     BadFunctionCallOutput,
 )
-from web3.types import (  # noqa: F401
+from web3.types import (
     ABI,
     ABIFunction,
     BlockIdentifier,

--- a/web3/main.py
+++ b/web3/main.py
@@ -119,8 +119,7 @@ from web3.providers.websocket import (
 from web3.testing import (
     Testing,
 )
-from web3.types import (  # noqa: F401
-    Middleware,
+from web3.types import (
     MiddlewareOnion,
     Wei,
 )

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -1,11 +1,9 @@
 import logging
-from typing import (  # noqa: F401
+from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     List,
-    NoReturn,
     Optional,
     Sequence,
     Tuple,
@@ -20,9 +18,6 @@ from hexbytes import (
     HexBytes,
 )
 
-from web3._utils.threads import (  # noqa: F401
-    ThreadWithReturn,
-)
 from web3.datastructures import (
     NamedElementOnion,
 )
@@ -47,8 +42,7 @@ from web3.middleware import (
 from web3.providers import (
     AutoProvider,
 )
-from web3.types import (  # noqa: F401
-    AsyncMiddleware,
+from web3.types import (
     Middleware,
     MiddlewareOnion,
     RPCEndpoint,

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -23,7 +23,7 @@ from web3._utils.compat import (
     Literal,
     TypedDict,
 )
-from web3.types import (  # noqa: F401
+from web3.types import (
     BlockData,
     BlockNumber,
     Middleware,

--- a/web3/middleware/filter.py
+++ b/web3/middleware/filter.py
@@ -43,7 +43,7 @@ from web3._utils.formatters import (
 from web3._utils.rpc_abi import (
     RPC,
 )
-from web3.types import (  # noqa: F401
+from web3.types import (
     Coroutine,
     FilterParams,
     LatestBlockParam,

--- a/web3/tools/pytest_ethereum/deployer.py
+++ b/web3/tools/pytest_ethereum/deployer.py
@@ -1,8 +1,7 @@
-from typing import (  # noqa: F401
+from typing import (
     Any,
     Callable,
     Dict,
-    Tuple,
 )
 
 from eth_typing import (


### PR DESCRIPTION
### What was wrong?

There were a number of `# noqa: F401` comments either hiding unnecessary unused imports, or that were just unnecessary themselves. 

### How was it fixed?

Removed them.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/220689937-c8eb2eaf-9177-4215-8939-5d7738df01d9.png)
