### PR TITLE
Remove v5 docs survey banner

### DIFF
--- a/docs/_templates/searchbox.html
+++ b/docs/_templates/searchbox.html
@@ -7,11 +7,4 @@
   </form>
 </div>
 
-{# Include banner under the search box #}
-<div class="search-banner-wrapper">
-  <a href="https://forms.gle/Nt56JVeWgpXtJi5F6">
-    <img src="{{ pathto('_static/banner/user-survey.png', 1) }}" alt="Web3.py User Survey">
-  </a>
-</div>
-
 {%- endif %}

--- a/newsfragments/2839.doc.rst
+++ b/newsfragments/2839.doc.rst
@@ -1,0 +1,1 @@
+Remove survey banner image from docs after close of survey


### PR DESCRIPTION
### What was wrong?

Removed the survey banner in v5 of the documentation. (Cherry-picked @AlaiY95's commit pointed at v6: #2835)

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://squeaksandnibbles.com/wp-content/uploads/2019/06/Cute-hamster-names-SN-long.jpg)
