### PR TITLE
Change ``eth_call``  return type to reflect pythonic formatter conver…

### DIFF
--- a/newsfragments/2842.bugfix.rst
+++ b/newsfragments/2842.bugfix.rst
@@ -1,0 +1,1 @@
+More accurately define the ``eth_call`` return type as ``HexBytes`` since the response is converted to ``HexBytes`` in the pythonic formatters and there are differences between ``HexBytes`` and ``bytes`` types.

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -225,7 +225,7 @@ class AsyncEth(BaseEth):
                 Optional[BlockIdentifier],
                 Optional[CallOverride],
             ],
-            Awaitable[Union[bytes, bytearray]],
+            Awaitable[HexBytes],
         ]
     ] = Method(RPC.eth_call, mungers=[BaseEth.call_munger])
 
@@ -235,7 +235,7 @@ class AsyncEth(BaseEth):
         block_identifier: Optional[BlockIdentifier] = None,
         state_override: Optional[CallOverride] = None,
         ccip_read_enabled: Optional[bool] = None,
-    ) -> Union[bytes, bytearray]:
+    ) -> HexBytes:
         ccip_read_enabled_on_provider = self.w3.provider.global_ccip_read_enabled
         if (
             # default conditions:
@@ -255,7 +255,7 @@ class AsyncEth(BaseEth):
         transaction: TxParams,
         block_identifier: Optional[BlockIdentifier] = None,
         state_override: Optional[CallOverride] = None,
-    ) -> Union[bytes, bytearray]:
+    ) -> HexBytes:
         max_redirects = self.w3.provider.ccip_read_max_redirects
 
         if not max_redirects or max_redirects < 4:

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -234,7 +234,7 @@ class Eth(BaseEth):
     _call: Method[
         Callable[
             [TxParams, Optional[BlockIdentifier], Optional[CallOverride]],
-            Union[bytes, bytearray],
+            HexBytes,
         ]
     ] = Method(RPC.eth_call, mungers=[BaseEth.call_munger])
 
@@ -244,7 +244,7 @@ class Eth(BaseEth):
         block_identifier: Optional[BlockIdentifier] = None,
         state_override: Optional[CallOverride] = None,
         ccip_read_enabled: Optional[bool] = None,
-    ) -> Union[bytes, bytearray]:
+    ) -> HexBytes:
         ccip_read_enabled_on_provider = self.w3.provider.global_ccip_read_enabled
         if (
             # default conditions:
@@ -264,7 +264,7 @@ class Eth(BaseEth):
         transaction: TxParams,
         block_identifier: Optional[BlockIdentifier] = None,
         state_override: Optional[CallOverride] = None,
-    ) -> Union[bytes, bytearray]:
+    ) -> HexBytes:
         max_redirects = self.w3.provider.ccip_read_max_redirects
 
         if not max_redirects or max_redirects < 4:


### PR DESCRIPTION
### What was wrong?

closes #2836

### How was it fixed?

- More accurately define the return type for ``eth_call`` as ``HexBytes``

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20230223_091940](https://user-images.githubusercontent.com/3532824/220967031-8c7ab0da-6ea4-4045-ad61-8f5cc8e73b40.jpg)

