### PR TITLE
bugfix: Use correct types and formatters for call overrides

### DIFF
--- a/newsfragments/2843.breaking.rst
+++ b/newsfragments/2843.breaking.rst
@@ -1,0 +1,1 @@
+Fix typing for ``CallOverrideParams`` and add proper request formatters for call state overrides.

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -457,8 +457,14 @@ class TestEthereumTesterEthModule(EthModuleTest):
     @pytest.mark.xfail(
         raises=TypeError, reason="call override param not implemented on eth-tester"
     )
-    def test_eth_call_with_override(self, w3, revert_contract):
-        super().test_eth_call_with_override(w3, revert_contract)
+    def test_eth_call_with_override_code(self, w3, revert_contract):
+        super().test_eth_call_with_override_code(w3, revert_contract)
+
+    @pytest.mark.xfail(
+        raises=TypeError, reason="call override param not implemented on eth-tester"
+    )
+    def test_eth_call_with_override_param_type_check(self, w3, math_contract):
+        super().test_eth_call_with_override_param_type_check(w3, math_contract)
 
     def test_eth_call_revert_with_msg(self, w3, revert_contract, unlocked_account):
         with pytest.raises(

--- a/web3/_utils/type_conversion.py
+++ b/web3/_utils/type_conversion.py
@@ -16,6 +16,9 @@ def to_hex_if_bytes(val: Union[HexStr, str, bytes, bytearray]) -> HexStr:
     Note: This method does not validate against all cases and is only
     meant to work with bytes and hex strings.
     """
+    if isinstance(val, str) and not val.startswith("0x"):
+        raise ValueError(f"Expected a hex string. Got: {val!r}")
+
     return to_hex(val) if isinstance(val, (bytes, bytearray)) else to_hex(hexstr=val)
 
 

--- a/web3/types.py
+++ b/web3/types.py
@@ -245,8 +245,8 @@ CallOverrideParams = TypedDict(
         "balance": Optional[Wei],
         "nonce": Optional[int],
         "code": Optional[Union[bytes, HexStr]],
-        "state": Optional[Dict[str, Any]],
-        "stateDiff": Optional[Dict[Address, Dict[str, Any]]],
+        "state": Optional[Dict[HexStr, HexStr]],
+        "stateDiff": Optional[Dict[HexStr, HexStr]],
     },
     total=False,
 )


### PR DESCRIPTION
### What was wrong?

closes #2832

### How was it fixed?

- Fix typing for `CallOverrideParams` based on the [expected types](https://github.com/ethereum/go-ethereum/blob/master/ethclient/gethclient/gethclient.go#L224-L244).
- Use proper formatters for call override params
- Add testing

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20230223_131751 (1)](https://user-images.githubusercontent.com/3532824/221020708-775588e4-af77-4dfe-8dcf-7e33ef45251a.jpg)

