### PR TITLE
Adds async version of eth_getUncleCount methods

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -295,6 +295,7 @@ Eth
 - :meth:`web3.eth.sign() <web3.eth.Eth.sign>`
 - :meth:`web3.eth.sign_transaction() <web3.eth.Eth.sign_transaction>`
 - :meth:`web3.eth.replace_transaction() <web3.eth.Eth.replace_transaction>`
+- :meth:`web3.eth.get_uncle_count() <web3.eth.Eth.get_uncle_count>`
 
 Net
 ***

--- a/newsfragments/2822.feature.rst
+++ b/newsfragments/2822.feature.rst
@@ -1,0 +1,1 @@
+Adds async version of `eth_getUncleCount` methods

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1590,6 +1590,24 @@ class AsyncEthModuleTest:
         assert transaction_count >= 1
 
     @pytest.mark.asyncio
+    async def test_eth_getUncleCountByBlockHash(
+        self, async_w3: "AsyncWeb3", empty_block: BlockData
+    ) -> None:
+        uncle_count = await async_w3.eth.get_uncle_count(empty_block["hash"])
+
+        assert is_integer(uncle_count)
+        assert uncle_count == 0
+
+    @pytest.mark.asyncio
+    async def test_eth_getUncleCountByBlockNumber(
+        self, async_w3: "AsyncWeb3", empty_block: BlockData
+    ) -> None:
+        uncle_count = await async_w3.eth.get_uncle_count(empty_block["number"])
+
+        assert is_integer(uncle_count)
+        assert uncle_count == 0
+
+    @pytest.mark.asyncio
     async def test_eth_getBlockTransactionCountByNumber_block_with_txn(
         self, async_w3: "AsyncWeb3", block_with_txn: BlockData
     ) -> None:

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -558,6 +558,21 @@ class AsyncEth(BaseEth):
     async def sign_transaction(self, transaction: TxParams) -> SignedTx:
         return await self._sign_transaction(transaction)
 
+    # eth_getUncleCountByBlockHash
+    # eth_getUncleCountByBlockNumber
+
+    _get_uncle_count: Method[Callable[[BlockIdentifier], Awaitable[int]]] = Method(
+        method_choice_depends_on_args=select_method_for_block_identifier(
+            if_predefined=RPC.eth_getUncleCountByBlockNumber,
+            if_hash=RPC.eth_getUncleCountByBlockHash,
+            if_number=RPC.eth_getUncleCountByBlockNumber,
+        ),
+        mungers=[default_root_munger],
+    )
+
+    async def get_uncle_count(self, block_identifier: BlockIdentifier) -> int:
+        return await self._get_uncle_count(block_identifier)
+
     # eth_newFilter, eth_newBlockFilter, eth_newPendingTransactionFilter
 
     filter: Method[


### PR DESCRIPTION
### What was wrong?

Related to Issue #2822. Missing async version of `eth_getUncleCount` JSON-RPC methods.

### How was it fixed?

Add `get_uncle_count` to `AsyncEth` class, and add corresponding tests. 
Also updated the docs to include the new method.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/8c/b2/af/8cb2af25c3fe160f1b2bfeb3b9d94788.jpg)
