### PR TITLE
migration guide updates

### DIFF
--- a/docs/v6_migration.rst
+++ b/docs/v6_migration.rst
@@ -106,7 +106,7 @@ The `Web3` class previously contained both sync and async methods. We've separat
 `Eth` module data returned as key-value pairs was previously automatically converted to
 an `AttributeDict` by result formatters, which could cause problems with typing. This
 conversion has been moved to a default `attrdict_middleware` where it can be easily
-removed if necessary.
+removed if necessary. See the `Eth module <web3.eth.html#web3.eth.Eth>`_ docs for more detail.
 
 Other Misc Changes
 ------------------

--- a/docs/v6_migration.rst
+++ b/docs/v6_migration.rst
@@ -99,6 +99,14 @@ The `Web3` class previously contained both sync and async methods. We've separat
 
     w3 = Web3(Web3.HTTPProvider(<provider.url>))
     async_w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(<provider.url>))
+    
+`dict` to `AttributeDict` conversion moved to middleware
+--------------------------------------------------------
+
+`Eth` module data returned as key-value pairs was previously automatically converted to
+an `AttributeDict` by result formatters, which could cause problems with typing. This
+conversion has been moved to a default `attrdict_middleware` where it can be easily
+removed if necessary.
 
 Other Misc Changes
 ------------------

--- a/docs/v6_migration.rst
+++ b/docs/v6_migration.rst
@@ -87,6 +87,19 @@ by a particular module. So we now have a ``Web3ValidationError``, ``EthPMValidat
 and an ``ENSValidationError`` that all inherit from the generic
 ``eth_utils.exceptions.ValidationError``.
 
+Web3 class split into Web3 and AsyncWeb3
+-----------------------------------------
+
+The `Web3` class previously contained both sync and async methods. We've separated
+`Web3` and `AsyncWeb3` functionality to tighten up typing. For example:
+
+.. code-block:: python
+
+    from web3 import Web3, AsyncWeb3
+
+    w3 = Web3(Web3.HTTPProvider(<provider.url>))
+    async_w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(<provider.url>))
+
 Other Misc Changes
 ------------------
 


### PR DESCRIPTION
### What was wrong?

v6 migration guide needs a few things:
- [x] Web3 is now Web3 and AsyncWeb3
- [x] removal of `dict -> AttributeDict` conversion from the result formatters and leaving that logic to the middleware

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/223583348-67458f58-9963-43ca-b673-00cc0c48964f.png)
