### PR TITLE
Deprecate isConnected

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -374,7 +374,7 @@ virtualenv for smoke testing:
     $ pip install ipython
     $ ipython
     >>> from web3.auto import w3
-    >>> w3.isConnected()
+    >>> w3.is_connected()
     >>> ...
 
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -101,7 +101,7 @@ setting the middlewares the provider should use.
       the JSON-RPC method being called.
 
 
-.. py:method:: BaseProvider.isConnected()
+.. py:method:: BaseProvider.is_connected()
 
     This function should return ``True`` or ``False`` depending on whether the
     provider should be considered *connected*.  For example, an IPC socket

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -40,8 +40,11 @@ following built-in providers:
    # WebsocketProvider:
    >>> w3 = Web3(Web3.WebsocketProvider('ws://127.0.0.1:8546'))
 
-   >>> w3.isConnected()
+   >>> w3.is_connected()
    True
+
+.. note::
+   ``w3.isConnected`` has been deprecated in favor of ``w3.is_connected``
 
 For more information, (e.g., connecting to remote nodes, provider auto-detection,
 using a test provider) see the :ref:`Providers <providers>` documentation.

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -132,7 +132,7 @@ For example, the following retrieves the client enode endpoint for both geth and
 
     from web3.auto import w3
 
-    connected = w3.isConnected()
+    connected = w3.is_connected()
 
     if connected and w3.clientVersion.startswith('Parity'):
         enode = w3.parity.enode
@@ -186,7 +186,7 @@ an optional secret key, set the environment variable ``WEB3_INFURA_API_SECRET``:
     >>> from web3.auto.infura import w3
 
     # confirm that the connection succeeded
-    >>> w3.isConnected()
+    >>> w3.is_connected()
     True
 
 Geth dev Proof of Authority
@@ -199,7 +199,7 @@ To connect to a ``geth --dev`` Proof of Authority instance with defaults:
     >>> from web3.auto.gethdev import w3
 
     # confirm that the connection succeeded
-    >>> w3.isConnected()
+    >>> w3.is_connected()
     True
 
 Built In Providers
@@ -399,7 +399,7 @@ AsyncHTTPProvider
         ...              'admin' : (AsyncGethAdmin,)})
         ...         },
         ...     middlewares=[]   # See supported middleware section below for middleware options
-        ...     ) 
+        ...     )
         >>> custom_session = ClientSession()  # If you want to pass in your own session
         >>> await w3.provider.cache_async_session(custom_session) # This method is an async method so it needs to be handled accordingly
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -51,7 +51,7 @@ Web3.py makes this test provider available via ``EthereumTesterProvider``.
 
    >>> from web3 import Web3, EthereumTesterProvider
    >>> w3 = Web3(EthereumTesterProvider())
-   >>> w3.isConnected()
+   >>> w3.is_connected()
    True
 
 
@@ -59,7 +59,7 @@ Local Providers
 ***************
 
 The hardware requirements are `steep <https://ethereum.org/en/developers/docs/nodes-and-clients/run-a-node/#top>`_,
-but the safest way to interact with Ethereum is to run an Ethereum client on your own hardware. 
+but the safest way to interact with Ethereum is to run an Ethereum client on your own hardware.
 For locally run nodes, an IPC connection is the most secure option, but HTTP and
 websocket configurations are also available. By default, the popular `Geth client <https://geth.ethereum.org/>`_
 exposes port ``8545`` to serve HTTP requests and ``8546`` for websocket requests. Connecting
@@ -78,7 +78,7 @@ to this local node can be done as follows:
    # WebsocketProvider:
    >>> w3 = Web3(Web3.WebsocketProvider('wss://127.0.0.1:8546'))
 
-   >>> w3.isConnected()
+   >>> w3.is_connected()
    True
 
 If you stick to the default ports or IPC file locations, you can utilize a
@@ -88,7 +88,7 @@ and save a few keystrokes:
 .. code-block:: python
 
    >>> from web3.auto import w3
-   >>> w3.isConnected()
+   >>> w3.is_connected()
    True
 
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -55,7 +55,7 @@ Ethereum network. An example configuration, if you're connecting to a locally ru
     >>> w3 = Web3(Web3.HTTPProvider('http://localhost:8545'))
 
     # now `w3` is available to use:
-    >>> w3.isConnected()
+    >>> w3.is_connected()
     True
     >>> w3.eth.send_transaction(...)
 
@@ -66,11 +66,11 @@ Refer to the :ref:`providers` documentation for further help with configuration.
 
 Why isn't my web3 instance connecting to the network?
 -----------------------------------------------------
-You can check that your instance is connected via the ``isConnected`` method:
+You can check that your instance is connected via the ``is_connected`` method:
 
 .. code-block:: python
 
-    >>> w3.isConnected()
+    >>> w3.is_connected()
     False
 
 There's a variety of explanations for why you may see ``False`` here. If you're
@@ -177,7 +177,7 @@ Your Ethereum node JSON-RPC API might be slow when fetching multiple and large r
         multiple and large responses.
         """
         provider.decode_rpc_response = _fast_decode_rpc_response
-        
+
 Why am I getting Visual C++ or Cython not installed error?
 ----------------------------------------------------------
 
@@ -187,13 +187,13 @@ when installing Web3.py as shown below:
 .. code-block:: shell
 
     error: Microsoft Visual C++ 14.0 or greater is required. Get it with "Microsoft C++ Build Tools": https://visualstudio.microsoft.com/visual-cpp-build-tools/
-    
 
-To fix this error, download and install Microsoft Visual C++ from here : 
+
+To fix this error, download and install Microsoft Visual C++ from here :
 
 `Microsoft Visual C++ Redistributable for Visual Studio <https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2019>`_
 
-- `x64 Visual C++ <https://aka.ms/vs/16/release/VC_redist.x64.exe>`_  
+- `x64 Visual C++ <https://aka.ms/vs/16/release/VC_redist.x64.exe>`_
 
 - `x86 Visual C++ <https://aka.ms/vs/16/release/VC_redist.x86.exe>`_
 

--- a/newsfragments/2866.removal.rst
+++ b/newsfragments/2866.removal.rst
@@ -1,0 +1,1 @@
+Deprecate ``isConnected`` in favor of ``is_connected``.

--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -23,7 +23,7 @@ from web3.providers.ipc import (
 @pytest.fixture
 def jsonrpc_ipc_pipe_path():
     with tempfile.TemporaryDirectory() as temp_dir:
-        ipc_path = os.path.join(temp_dir, '{0}.ipc'.format(uuid.uuid4()))
+        ipc_path = os.path.join(temp_dir, "{0}.ipc".format(uuid.uuid4()))
         try:
             yield ipc_path
         finally:
@@ -33,16 +33,16 @@ def jsonrpc_ipc_pipe_path():
 
 def test_ipc_no_path():
     """
-    IPCProvider.isConnected() returns False when no path is supplied
+    IPCProvider.is_connected() returns False when no path is supplied
     """
     ipc = IPCProvider(None)
-    assert ipc.isConnected() is False
+    assert ipc.is_connected() is False
 
 
 def test_ipc_tilda_in_path():
-    expectedPath = str(pathlib.Path.home()) + '/foo'
-    assert IPCProvider('~/foo').ipc_path == expectedPath
-    assert IPCProvider(pathlib.Path('~/foo')).ipc_path == expectedPath
+    expectedPath = str(pathlib.Path.home()) + "/foo"
+    assert IPCProvider("~/foo").ipc_path == expectedPath
+    assert IPCProvider(pathlib.Path("~/foo")).ipc_path == expectedPath
 
 
 @pytest.fixture
@@ -64,7 +64,7 @@ def serve_empty_result(simple_ipc_server):
             connection.recv(1024)
             connection.sendall(b'{"id":1, "result": {}')
             time.sleep(0.1)
-            connection.sendall(b'}')
+            connection.sendall(b"}")
         finally:
             # Clean up the connection
             connection.close()
@@ -82,16 +82,18 @@ def serve_empty_result(simple_ipc_server):
 def test_sync_waits_for_full_result(jsonrpc_ipc_pipe_path, serve_empty_result):
     provider = IPCProvider(pathlib.Path(jsonrpc_ipc_pipe_path), timeout=3)
     result = provider.make_request("method", [])
-    assert result == {'id': 1, 'result': {}}
+    assert result == {"id": 1, "result": {}}
     provider._socket.sock.close()
 
 
 def test_web3_auto_gethdev():
     assert isinstance(w3.provider, IPCProvider)
-    return_block_with_long_extra_data = construct_fixture_middleware({
-        'eth_getBlockByNumber': {'extraData': '0x' + 'ff' * 33},
-    })
+    return_block_with_long_extra_data = construct_fixture_middleware(
+        {
+            "eth_getBlockByNumber": {"extraData": "0x" + "ff" * 33},
+        }
+    )
     w3.middleware_onion.inject(return_block_with_long_extra_data, layer=0)
-    block = w3.eth.get_block('latest')
-    assert 'extraData' not in block
-    assert block.proofOfAuthorityData == b'\xff' * 33
+    block = w3.eth.get_block("latest")
+    assert "extraData" not in block
+    assert block.proofOfAuthorityData == b"\xff" * 33

--- a/tests/core/providers/test_provider.py
+++ b/tests/core/providers/test_provider.py
@@ -6,30 +6,30 @@ from web3.providers import (
 
 
 class ConnectedProvider(BaseProvider):
-    def isConnected(self):
+    def is_connected(self):
         return True
 
 
 class DisconnectedProvider(BaseProvider):
-    def isConnected(self):
+    def is_connected(self):
         return False
 
 
-def test_isConnected_connected():
+def test_is_connected_connected():
     """
-    Web3.isConnected() returns True when connected to a node.
+    Web3.is_connected() returns True when connected to a node.
     """
     web3 = Web3(ConnectedProvider())
-    assert web3.isConnected() is True
+    assert web3.is_connected() is True
 
 
-def test_isConnected_disconnected():
+def test_is_connected_disconnected():
     """
-    Web3.isConnected() returns False when configured with a provider
+    Web3.is_connected() returns False when configured with a provider
     that's not connected to a node.
     """
     web3 = Web3(DisconnectedProvider())
-    assert web3.isConnected() is False
+    assert web3.is_connected() is False
 
 
 def test_autoprovider_detection():
@@ -39,15 +39,17 @@ def test_autoprovider_detection():
     def must_not_call():
         assert False
 
-    auto = AutoProvider([
-        no_provider,
-        DisconnectedProvider,
-        ConnectedProvider,
-        must_not_call,
-    ])
+    auto = AutoProvider(
+        [
+            no_provider,
+            DisconnectedProvider,
+            ConnectedProvider,
+            must_not_call,
+        ]
+    )
 
     w3 = Web3(auto)
 
-    assert w3.isConnected()
+    assert w3.is_connected()
 
     assert isinstance(auto._active_provider, ConnectedProvider)

--- a/tests/core/utilities/test_attach_modules.py
+++ b/tests/core/utilities/test_attach_modules.py
@@ -43,10 +43,13 @@ class MockGethPersonal(Module):
 
 def test_attach_modules():
     mods = {
-        "geth": (MockGeth, {
-            "personal": MockGethPersonal,
-            "admin": MockGethAdmin,
-        }),
+        "geth": (
+            MockGeth,
+            {
+                "personal": MockGethPersonal,
+                "admin": MockGethAdmin,
+            },
+        ),
         "eth": MockEth,
     }
     w3 = Web3(EthereumTesterProvider(), modules={})
@@ -57,18 +60,24 @@ def test_attach_modules():
 
 
 def test_attach_single_module_as_tuple():
-    w3 = Web3(EthereumTesterProvider(), modules={'eth': (MockEth,)})
+    w3 = Web3(EthereumTesterProvider(), modules={"eth": (MockEth,)})
     assert w3.eth.block_number() == 42
 
 
 def test_attach_modules_multiple_levels_deep():
     mods = {
         "eth": MockEth,
-        "geth": (MockGeth, {
-            "personal": (MockGethPersonal, {
-                "admin": MockGethAdmin,
-            }),
-        }),
+        "geth": (
+            MockGeth,
+            {
+                "personal": (
+                    MockGethPersonal,
+                    {
+                        "admin": MockGethAdmin,
+                    },
+                ),
+            },
+        ),
     }
     w3 = Web3(EthereumTesterProvider(), modules={})
     attach_modules(w3, mods)
@@ -78,11 +87,11 @@ def test_attach_modules_multiple_levels_deep():
 
 
 def test_attach_modules_with_wrong_module_format():
-    mods = {
-        "eth": (MockEth, MockGeth, MockGethPersonal)
-    }
+    mods = {"eth": (MockEth, MockGeth, MockGethPersonal)}
     w3 = Web3(EthereumTesterProvider, modules={})
-    with pytest.raises(ValidationError, match="Module definitions can only have 1 or 2 elements"):
+    with pytest.raises(
+        ValidationError, match="Module definitions can only have 1 or 2 elements"
+    ):
         attach_modules(w3, mods)
 
 
@@ -91,93 +100,113 @@ def test_attach_modules_with_existing_modules():
         "eth": MockEth,
     }
     w3 = Web3(EthereumTesterProvider, modules=mods)
-    with pytest.raises(AttributeError,
-                       match="The web3 object already has an attribute with that name"):
+    with pytest.raises(
+        AttributeError, match="The web3 object already has an attribute with that name"
+    ):
         attach_modules(w3, mods)
 
 
-def test_attach_external_modules_multiple_levels_deep(module1, module2, module3, module4):
-    w3 = Web3(
-        EthereumTesterProvider(),
-        external_modules={
-            'module1': module1,
-            'module2': (module2, {
-                'submodule1': (module3, {
-                    'submodule2': module4,
-                }),
-            })
-        }
-    )
-
-    assert w3.isConnected()
-
-    # assert instantiated with default modules
-    assert hasattr(w3, 'geth')
-    assert hasattr(w3, 'eth')
-    assert is_integer(w3.eth.chain_id)
-
-    # assert instantiated with module1
-    assert hasattr(w3, 'module1')
-    assert w3.module1.a == 'a'
-    assert w3.module1.b == 'b'
-
-    # assert instantiated with module2 + submodules
-    assert hasattr(w3, 'module2')
-    assert w3.module2.c == 'c'
-    assert w3.module2.d() == 'd'
-
-    assert hasattr(w3.module2, 'submodule1')
-    assert w3.module2.submodule1.e == 'e'
-    assert hasattr(w3.module2.submodule1, 'submodule2')
-    assert w3.module2.submodule1.submodule2.f == 'f'
-
-
-def test_attach_external_modules_that_do_not_inherit_from_module_class(
-    module1_unique, module2_unique, module3_unique, module4_unique,
+def test_attach_external_modules_multiple_levels_deep(
+    module1, module2, module3, module4
 ):
     w3 = Web3(
         EthereumTesterProvider(),
         external_modules={
-            'module1': module1_unique,
-            'module2': (module2_unique, {
-                'submodule1': (module3_unique, {
-                    'submodule2': module4_unique,
-                }),
-            })
-        }
+            "module1": module1,
+            "module2": (
+                module2,
+                {
+                    "submodule1": (
+                        module3,
+                        {
+                            "submodule2": module4,
+                        },
+                    ),
+                },
+            ),
+        },
+    )
+
+    assert w3.is_connected()
+
+    # assert instantiated with default modules
+    assert hasattr(w3, "geth")
+    assert hasattr(w3, "eth")
+    assert is_integer(w3.eth.chain_id)
+
+    # assert instantiated with module1
+    assert hasattr(w3, "module1")
+    assert w3.module1.a == "a"
+    assert w3.module1.b == "b"
+
+    # assert instantiated with module2 + submodules
+    assert hasattr(w3, "module2")
+    assert w3.module2.c == "c"
+    assert w3.module2.d() == "d"
+
+    assert hasattr(w3.module2, "submodule1")
+    assert w3.module2.submodule1.e == "e"
+    assert hasattr(w3.module2.submodule1, "submodule2")
+    assert w3.module2.submodule1.submodule2.f == "f"
+
+
+def test_attach_external_modules_that_do_not_inherit_from_module_class(
+    module1_unique,
+    module2_unique,
+    module3_unique,
+    module4_unique,
+):
+    w3 = Web3(
+        EthereumTesterProvider(),
+        external_modules={
+            "module1": module1_unique,
+            "module2": (
+                module2_unique,
+                {
+                    "submodule1": (
+                        module3_unique,
+                        {
+                            "submodule2": module4_unique,
+                        },
+                    ),
+                },
+            ),
+        },
     )
 
     # assert module1 attached
-    assert hasattr(w3, 'module1')
-    assert w3.module1.a == 'a'
-    assert w3.module1.b() == 'b'
+    assert hasattr(w3, "module1")
+    assert w3.module1.a == "a"
+    assert w3.module1.b() == "b"
     assert w3.module1.return_eth_chain_id == w3.eth.chain_id
 
     # assert module2 + submodules attached
-    assert hasattr(w3, 'module2')
-    assert w3.module2.c == 'c'
-    assert w3.module2.d() == 'd'
+    assert hasattr(w3, "module2")
+    assert w3.module2.c == "c"
+    assert w3.module2.d() == "d"
 
-    assert hasattr(w3.module2, 'submodule1')
-    assert w3.module2.submodule1.e == 'e'
-    assert hasattr(w3.module2.submodule1, 'submodule2')
-    assert w3.module2.submodule1.submodule2.f == 'f'
+    assert hasattr(w3.module2, "submodule1")
+    assert w3.module2.submodule1.e == "e"
+    assert hasattr(w3.module2.submodule1, "submodule2")
+    assert w3.module2.submodule1.submodule2.f == "f"
 
     # assert default modules intact
-    assert hasattr(w3, 'geth')
-    assert hasattr(w3, 'eth')
+    assert hasattr(w3, "geth")
+    assert hasattr(w3, "eth")
     assert is_integer(w3.eth.chain_id)
 
 
-def test_attach_modules_for_module_with_more_than_one_init_argument(web3, module_many_init_args):
+def test_attach_modules_for_module_with_more_than_one_init_argument(
+    web3, module_many_init_args
+):
     with pytest.raises(
         UnsupportedOperation,
         match=(
             "A module class may accept a single `Web3` instance as the first argument of its "
             "__init__\\(\\) method. More than one argument found for ModuleManyArgs: \\['a', 'b']"
-        )
+        ),
     ):
         Web3(
             EthereumTesterProvider(),
-            external_modules={'module_should_fail': module_many_init_args}
+            external_modules={"module_should_fail": module_many_init_args},
         )

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -114,8 +114,8 @@ class AsyncEthModuleTest:
         assert gas_price > 0
 
     @pytest.mark.asyncio
-    async def test_isConnected(self, async_w3: "Web3") -> None:
-        is_connected = await async_w3.isConnected()  # type: ignore
+    async def test_is_connected(self, async_w3: "Web3") -> None:
+        is_connected = await async_w3.is_connected()  # type: ignore
         assert is_connected is True
 
     @pytest.mark.asyncio
@@ -1152,6 +1152,18 @@ class AsyncEthModuleTest:
 
         # reset to default
         async_w3.eth.default_block = 'latest'
+
+    #
+    # Deprecated Methods
+    #
+    @pytest.mark.asyncio
+    async def test_isConnected(self, async_w3: "Web3") -> None:
+        with pytest.warns(
+            DeprecationWarning,
+            match="isConnected is deprecated in favor of is_connected",
+        ):
+            is_connected = await async_w3.isConnected()
+        assert is_connected is True
 
 
 class EthModuleTest:

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -35,148 +35,196 @@ class Web3ModuleTest:
     # Contract that calculated test values can be found at
     # https://kovan.etherscan.io/address/0xb9be06f5b99372cf9afbccadbbb9954ccaf7f4bb#code
     @pytest.mark.parametrize(
-        'types,values,expected',
+        "types,values,expected",
         (
             (
-                ['bool'],
+                ["bool"],
                 [True],
-                HexBytes("0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2"),
+                HexBytes(
+                    "0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2"
+                ),
             ),
             (
-                ['uint8', 'uint8', 'uint8'],
+                ["uint8", "uint8", "uint8"],
                 [97, 98, 99],
-                HexBytes("0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"),
+                HexBytes(
+                    "0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"
+                ),
             ),
             (
-                ['uint248'],
+                ["uint248"],
                 [30],
-                HexBytes("0x30f95d210785601eb33ae4d53d405b26f920e765dff87cca8e9a4aec99f82671"),
+                HexBytes(
+                    "0x30f95d210785601eb33ae4d53d405b26f920e765dff87cca8e9a4aec99f82671"
+                ),
             ),
             (
-                ['bool', 'uint16'],
+                ["bool", "uint16"],
                 [True, 299],
-                HexBytes("0xed18599ccd80ee9fae9a28b0e34a5573c3233d7468f808fd659bc171cf0b43bd"),
+                HexBytes(
+                    "0xed18599ccd80ee9fae9a28b0e34a5573c3233d7468f808fd659bc171cf0b43bd"
+                ),
             ),
             (
-                ['int256'],
+                ["int256"],
                 [-10],
-                HexBytes("0xd6fb717f7e270a360f5093ce6a7a3752183e89c9a9afe5c0cb54b458a304d3d5"),
+                HexBytes(
+                    "0xd6fb717f7e270a360f5093ce6a7a3752183e89c9a9afe5c0cb54b458a304d3d5"
+                ),
             ),
             (
-                ['int256'],
+                ["int256"],
                 [10],
-                HexBytes("0xc65a7bb8d6351c1cf70c95a316cc6a92839c986682d98bc35f958f4883f9d2a8"),
+                HexBytes(
+                    "0xc65a7bb8d6351c1cf70c95a316cc6a92839c986682d98bc35f958f4883f9d2a8"
+                ),
             ),
             (
-                ['int8', 'uint8'],
+                ["int8", "uint8"],
                 [-10, 18],
-                HexBytes("0x5c6ab1e634c08d9c0f4df4d789e8727943ef010dd7ca8e3c89de197a26d148be"),
+                HexBytes(
+                    "0x5c6ab1e634c08d9c0f4df4d789e8727943ef010dd7ca8e3c89de197a26d148be"
+                ),
             ),
             (
-                ['address'],
+                ["address"],
                 ["0x49eddd3769c0712032808d86597b84ac5c2f5614"],
                 InvalidAddress,
             ),
             (
-                ['address'],
+                ["address"],
                 ["0x49EdDD3769c0712032808D86597B84ac5c2F5614"],
-                HexBytes("0x2ff37b5607484cd4eecf6d13292e22bd6e5401eaffcc07e279583bc742c68882"),
+                HexBytes(
+                    "0x2ff37b5607484cd4eecf6d13292e22bd6e5401eaffcc07e279583bc742c68882"
+                ),
             ),
             (
-                ['bytes2'],
-                ['0x5402'],
-                HexBytes("0x4ed9171bda52fca71ab28e7f452bd6eacc3e5a568a47e0fa53b503159a9b8910"),
+                ["bytes2"],
+                ["0x5402"],
+                HexBytes(
+                    "0x4ed9171bda52fca71ab28e7f452bd6eacc3e5a568a47e0fa53b503159a9b8910"
+                ),
             ),
             (
-                ['bytes3'],
-                ['0x5402'],
-                HexBytes("0x4ed9171bda52fca71ab28e7f452bd6eacc3e5a568a47e0fa53b503159a9b8910"),
+                ["bytes3"],
+                ["0x5402"],
+                HexBytes(
+                    "0x4ed9171bda52fca71ab28e7f452bd6eacc3e5a568a47e0fa53b503159a9b8910"
+                ),
             ),
             (
-                ['bytes'],
+                ["bytes"],
                 [
-                    '0x636865636b6c6f6e6762797465737472696e676167'
-                    '61696e7374736f6c6964697479736861336861736866756e6374696f6e'
+                    "0x636865636b6c6f6e6762797465737472696e676167"
+                    "61696e7374736f6c6964697479736861336861736866756e6374696f6e"
                 ],
-                HexBytes("0xd78a84d65721b67e4011b10c99dafdedcdcd7cb30153064f773e210b4762e22f"),
+                HexBytes(
+                    "0xd78a84d65721b67e4011b10c99dafdedcdcd7cb30153064f773e210b4762e22f"
+                ),
             ),
             (
-                ['string'],
-                ['testing a string!'],
-                HexBytes("0xe8c275c0b4070a5ec6cfcb83f0ba394b30ddd283de785d43f2eabfb04bd96747"),
+                ["string"],
+                ["testing a string!"],
+                HexBytes(
+                    "0xe8c275c0b4070a5ec6cfcb83f0ba394b30ddd283de785d43f2eabfb04bd96747"
+                ),
             ),
             (
-                ['string', 'bool', 'uint16', 'bytes2', 'address'],
+                ["string", "bool", "uint16", "bytes2", "address"],
                 [
-                    'testing a string!',
+                    "testing a string!",
                     False,
                     299,
-                    '0x5402',
+                    "0x5402",
                     "0x49eddd3769c0712032808d86597b84ac5c2f5614",
                 ],
                 InvalidAddress,
             ),
             (
-                ['string', 'bool', 'uint16', 'bytes2', 'address'],
+                ["string", "bool", "uint16", "bytes2", "address"],
                 [
-                    'testing a string!',
+                    "testing a string!",
                     False,
                     299,
-                    '0x5402',
+                    "0x5402",
                     "0x49EdDD3769c0712032808D86597B84ac5c2F5614",
                 ],
-                HexBytes("0x8cc6eabb25b842715e8ca39e2524ed946759aa37bfb7d4b81829cf5a7e266103"),
+                HexBytes(
+                    "0x8cc6eabb25b842715e8ca39e2524ed946759aa37bfb7d4b81829cf5a7e266103"
+                ),
             ),
             (
-                ['bool[2][]'],
+                ["bool[2][]"],
                 [[[True, False], [False, True]]],
-                HexBytes("0x1eef261f2eb51a8c736d52be3f91ff79e78a9ec5df2b7f50d0c6f98ed1e2bc06"),
+                HexBytes(
+                    "0x1eef261f2eb51a8c736d52be3f91ff79e78a9ec5df2b7f50d0c6f98ed1e2bc06"
+                ),
             ),
             (
-                ['bool[]'],
+                ["bool[]"],
                 [[True, False, True]],
-                HexBytes("0x5c6090c0461491a2941743bda5c3658bf1ea53bbd3edcde54e16205e18b45792"),
+                HexBytes(
+                    "0x5c6090c0461491a2941743bda5c3658bf1ea53bbd3edcde54e16205e18b45792"
+                ),
             ),
             (
-                ['uint24[]'],
+                ["uint24[]"],
                 [[1, 0, 1]],
-                HexBytes("0x5c6090c0461491a2941743bda5c3658bf1ea53bbd3edcde54e16205e18b45792"),
+                HexBytes(
+                    "0x5c6090c0461491a2941743bda5c3658bf1ea53bbd3edcde54e16205e18b45792"
+                ),
             ),
             (
-                ['uint8[2]'],
+                ["uint8[2]"],
                 [[8, 9]],
-                HexBytes("0xc7694af312c4f286114180fd0ba6a52461fcee8a381636770b19a343af92538a"),
+                HexBytes(
+                    "0xc7694af312c4f286114180fd0ba6a52461fcee8a381636770b19a343af92538a"
+                ),
             ),
             (
-                ['uint256[2]'],
+                ["uint256[2]"],
                 [[8, 9]],
-                HexBytes("0xc7694af312c4f286114180fd0ba6a52461fcee8a381636770b19a343af92538a"),
+                HexBytes(
+                    "0xc7694af312c4f286114180fd0ba6a52461fcee8a381636770b19a343af92538a"
+                ),
             ),
             (
-                ['uint8[]'],
+                ["uint8[]"],
                 [[8]],
-                HexBytes("0xf3f7a9fe364faab93b216da50a3214154f22a0a2b415b23a84c8169e8b636ee3"),
+                HexBytes(
+                    "0xf3f7a9fe364faab93b216da50a3214154f22a0a2b415b23a84c8169e8b636ee3"
+                ),
             ),
             (
-                ['address[]'],
-                [[
-                    "0x49EdDD3769c0712032808D86597B84ac5c2F5614",
-                    "0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5",
-                ]],
-                HexBytes("0xb98565c0c26a962fd54d93b0ed6fb9296e03e9da29d2281ed3e3473109ef7dde"),
+                ["address[]"],
+                [
+                    [
+                        "0x49EdDD3769c0712032808D86597B84ac5c2F5614",
+                        "0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5",
+                    ]
+                ],
+                HexBytes(
+                    "0xb98565c0c26a962fd54d93b0ed6fb9296e03e9da29d2281ed3e3473109ef7dde"
+                ),
             ),
             (
-                ['address[]'],
-                [[
-                    "0x49EdDD3769c0712032808D86597B84ac5c2F5614",
-                    "0xa6b759bbbf4b59d24acf7e06e79f3a5d104fdce5",
-                ]],
+                ["address[]"],
+                [
+                    [
+                        "0x49EdDD3769c0712032808D86597B84ac5c2F5614",
+                        "0xa6b759bbbf4b59d24acf7e06e79f3a5d104fdce5",
+                    ]
+                ],
                 InvalidAddress,
             ),
         ),
     )
     def test_solidityKeccak(
-        self, web3: "Web3", types: Sequence[TypeStr], values: Sequence[Any], expected: HexBytes
+        self,
+        web3: "Web3",
+        types: Sequence[TypeStr],
+        values: Sequence[Any],
+        expected: HexBytes,
     ) -> None:
         if isinstance(expected, type) and issubclass(expected, Exception):
             with pytest.raises(expected):
@@ -187,31 +235,42 @@ class Web3ModuleTest:
         assert actual == expected
 
     @pytest.mark.parametrize(
-        'types, values, expected',
+        "types, values, expected",
         (
             (
-                ['address'],
-                ['one.eth'],
-                HexBytes("0x2ff37b5607484cd4eecf6d13292e22bd6e5401eaffcc07e279583bc742c68882"),
+                ["address"],
+                ["one.eth"],
+                HexBytes(
+                    "0x2ff37b5607484cd4eecf6d13292e22bd6e5401eaffcc07e279583bc742c68882"
+                ),
             ),
             (
-                ['address[]'],
-                [['one.eth', 'two.eth']],
-                HexBytes("0xb98565c0c26a962fd54d93b0ed6fb9296e03e9da29d2281ed3e3473109ef7dde"),
+                ["address[]"],
+                [["one.eth", "two.eth"]],
+                HexBytes(
+                    "0xb98565c0c26a962fd54d93b0ed6fb9296e03e9da29d2281ed3e3473109ef7dde"
+                ),
             ),
         ),
     )
     def test_solidityKeccak_ens(
-        self, web3: "Web3", types: Sequence[TypeStr], values: Sequence[str], expected: HexBytes
+        self,
+        web3: "Web3",
+        types: Sequence[TypeStr],
+        values: Sequence[str],
+        expected: HexBytes,
     ) -> None:
-        with ens_addresses(web3, {
-            'one.eth': ChecksumAddress(
-                HexAddress(HexStr("0x49EdDD3769c0712032808D86597B84ac5c2F5614"))
-            ),
-            'two.eth': ChecksumAddress(
-                HexAddress(HexStr("0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5"))
-            ),
-        }):
+        with ens_addresses(
+            web3,
+            {
+                "one.eth": ChecksumAddress(
+                    HexAddress(HexStr("0x49EdDD3769c0712032808D86597B84ac5c2F5614"))
+                ),
+                "two.eth": ChecksumAddress(
+                    HexAddress(HexStr("0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5"))
+                ),
+            },
+        ):
             # when called as class method, any name lookup attempt will fail
             with pytest.raises(InvalidAddress):
                 Web3.solidityKeccak(types, values)
@@ -221,12 +280,12 @@ class Web3ModuleTest:
             assert actual == expected
 
     @pytest.mark.parametrize(
-        'types,values',
+        "types,values",
         (
-            (['address'], ['0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5', True]),
-            (['address', 'bool'], ['0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5']),
-            ([], ['0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5']),
-        )
+            (["address"], ["0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5", True]),
+            (["address", "bool"], ["0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5"]),
+            ([], ["0xA6b759bBbf4B59D24acf7E06e79f3a5D104fdCE5"]),
+        ),
     )
     def test_solidityKeccak_same_number_of_types_and_values(
         self, web3: "Web3", types: Sequence[TypeStr], values: Sequence[Any]
@@ -235,4 +294,11 @@ class Web3ModuleTest:
             web3.solidityKeccak(types, values)
 
     def test_is_connected(self, web3: "Web3") -> None:
-        assert web3.isConnected()
+        assert web3.is_connected()
+
+    def test_isConnected(self, web3: "Web3") -> None:
+        with pytest.warns(
+            DeprecationWarning,
+            match="isConnected is deprecated in favor of is_connected",
+        ):
+            assert web3.isConnected()

--- a/web3/main.py
+++ b/web3/main.py
@@ -137,15 +137,21 @@ def get_default_modules() -> Dict[str, Union[Type[Module], Sequence[Any]]]:
         "eth": Eth,
         "net": Net,
         "version": Version,
-        "parity": (Parity, {
-            "personal": ParityPersonal,
-        }),
-        "geth": (Geth, {
-            "admin": GethAdmin,
-            "miner": GethMiner,
-            "personal": GethPersonal,
-            "txpool": GethTxPool,
-        }),
+        "parity": (
+            Parity,
+            {
+                "personal": ParityPersonal,
+            },
+        ),
+        "geth": (
+            Geth,
+            {
+                "admin": GethAdmin,
+                "miner": GethMiner,
+                "personal": GethPersonal,
+                "txpool": GethTxPool,
+            },
+        ),
         "testing": Testing,
     }
 
@@ -237,8 +243,10 @@ class Web3:
         provider: Optional[BaseProvider] = None,
         middlewares: Optional[Sequence[Any]] = None,
         modules: Optional[Dict[str, Union[Type[Module], Sequence[Any]]]] = None,
-        external_modules: Optional[Dict[str, Union[Type[Module], Sequence[Any]]]] = None,
-        ens: ENS = cast(ENS, empty)
+        external_modules: Optional[
+            Dict[str, Union[Type[Module], Sequence[Any]]]
+        ] = None,
+        ens: ENS = cast(ENS, empty),
     ) -> None:
         self.manager = self.RequestManager(self, provider, middlewares)
         # this codec gets used in the module initialization,
@@ -274,19 +282,26 @@ class Web3:
     @property
     def api(self) -> str:
         from web3 import __version__
+
         return __version__
 
     @staticmethod
     @deprecated_for("keccak")
     @apply_to_return_value(HexBytes)
-    def sha3(primitive: Optional[Primitives] = None, text: Optional[str] = None,
-             hexstr: Optional[HexStr] = None) -> bytes:
+    def sha3(
+        primitive: Optional[Primitives] = None,
+        text: Optional[str] = None,
+        hexstr: Optional[HexStr] = None,
+    ) -> bytes:
         return Web3.keccak(primitive, text, hexstr)
 
     @staticmethod
     @apply_to_return_value(HexBytes)
-    def keccak(primitive: Optional[Primitives] = None, text: Optional[str] = None,
-               hexstr: Optional[HexStr] = None) -> bytes:
+    def keccak(
+        primitive: Optional[Primitives] = None,
+        text: Optional[str] = None,
+        hexstr: Optional[HexStr] = None,
+    ) -> bytes:
         if isinstance(primitive, (bytes, int, type(None))):
             input_bytes = to_bytes(primitive, hexstr=hexstr, text=text)
             return eth_utils_keccak(input_bytes)
@@ -294,10 +309,8 @@ class Web3:
         raise TypeError(
             "You called keccak with first arg %r and keywords %r. You must call it with one of "
             "these approaches: keccak(text='txt'), keccak(hexstr='0x747874'), "
-            "keccak(b'\\x74\\x78\\x74'), or keccak(0x747874)." % (
-                primitive,
-                {'text': text, 'hexstr': hexstr}
-            )
+            "keccak(b'\\x74\\x78\\x74'), or keccak(0x747874)."
+            % (primitive, {"text": text, "hexstr": hexstr})
         )
 
     @combomethod
@@ -324,11 +337,14 @@ class Web3:
             w3 = cls
         normalized_values = map_abi_data([abi_ens_resolver(w3)], abi_types, values)
 
-        hex_string = add_0x_prefix(HexStr(''.join(
-            remove_0x_prefix(hex_encode_abi_type(abi_type, value))
-            for abi_type, value
-            in zip(abi_types, normalized_values)
-        )))
+        hex_string = add_0x_prefix(
+            HexStr(
+                "".join(
+                    remove_0x_prefix(hex_encode_abi_type(abi_type, value))
+                    for abi_type, value in zip(abi_types, normalized_values)
+                )
+            )
+        )
         return cls.keccak(hexstr=hex_string)
 
     def attach_modules(
@@ -339,8 +355,12 @@ class Web3:
         """
         _attach_modules(self, modules)
 
+    @deprecated_for("is_connected")
     def isConnected(self) -> bool:
-        return self.provider.isConnected()
+        return self.is_connected()
+
+    def is_connected(self) -> bool:
+        return self.provider.is_connected()
 
     def is_encodable(self, _type: TypeStr, value: Any) -> bool:
         return self.codec.is_encodable(_type, value)
@@ -358,7 +378,7 @@ class Web3:
 
     @property
     def pm(self) -> "PM":
-        if hasattr(self, '_pm'):
+        if hasattr(self, "_pm"):
             # ignored b/c property is dynamically set via enable_unstable_package_management_api
             return self._pm  # type: ignore
         else:
@@ -370,8 +390,9 @@ class Web3:
 
     def enable_unstable_package_management_api(self) -> None:
         from web3.pm import PM  # noqa: F811
-        if not hasattr(self, '_pm'):
-            self.attach_modules({'_pm': PM})
+
+        if not hasattr(self, "_pm"):
+            self.attach_modules({"_pm": PM})
 
     def enable_strict_bytes_type_checking(self) -> None:
         self.codec = ABICodec(build_strict_registry())

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -14,6 +14,9 @@ from eth_utils import (
     to_text,
 )
 
+from web3._utils.decorators import (
+    deprecated_for,
+)
 from web3._utils.encoding import (
     FriendlyJsonSerde,
 )
@@ -34,21 +37,23 @@ if TYPE_CHECKING:
 class AsyncBaseProvider:
     _middlewares: Tuple[Middleware, ...] = ()
     # a tuple of (all_middlewares, request_func)
-    _request_func_cache: Tuple[Tuple[Middleware, ...], Callable[..., RPCResponse]] = (None, None)
+    _request_func_cache: Tuple[Tuple[Middleware, ...], Callable[..., RPCResponse]] = (
+        None,
+        None,
+    )
 
     def __init__(self) -> None:
         warnings.warn(
             "Async providers are still being developed and refined. "
-            "Expect breaking changes in minor releases.")
+            "Expect breaking changes in minor releases."
+        )
 
     @property
     def middlewares(self) -> Tuple[Middleware, ...]:
         return self._middlewares
 
     @middlewares.setter
-    def middlewares(
-        self, values: MiddlewareOnion
-    ) -> None:
+    def middlewares(self, values: MiddlewareOnion) -> None:
         # tuple(values) converts to MiddlewareOnion -> Tuple[Middleware, ...]
         self._middlewares = tuple(values)  # type: ignore
 
@@ -61,7 +66,7 @@ class AsyncBaseProvider:
         if cache_key is None or cache_key != all_middlewares:
             self._request_func_cache = (
                 all_middlewares,
-                await self._generate_request_func(web3, all_middlewares)
+                await self._generate_request_func(web3, all_middlewares),
             )
         return self._request_func_cache[-1]
 
@@ -77,7 +82,11 @@ class AsyncBaseProvider:
     async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         raise NotImplementedError("Providers must implement this method")
 
+    @deprecated_for("is_connected")
     async def isConnected(self) -> bool:
+        raise NotImplementedError("Providers must implement this method")
+
+    async def is_connected(self) -> bool:
         raise NotImplementedError("Providers must implement this method")
 
 
@@ -99,13 +108,16 @@ class AsyncJSONBaseProvider(AsyncBaseProvider):
         text_response = to_text(raw_response)
         return cast(RPCResponse, FriendlyJsonSerde().json_decode(text_response))
 
-    async def isConnected(self) -> bool:
+    async def is_connected(self) -> bool:
         try:
-            response = await self.make_request(RPCEndpoint('web3_clientVersion'), [])
+            response = await self.make_request(RPCEndpoint("web3_clientVersion"), [])
         except IOError:
             return False
 
-        assert response['jsonrpc'] == '2.0'
-        assert 'error' not in response
+        assert response["jsonrpc"] == "2.0"
+        assert "error" not in response
 
         return True
+
+    async def isConnected(self) -> bool:
+        return await self.is_connected()

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -17,6 +17,9 @@ from eth_typing import (
     URI,
 )
 
+from web3._utils.decorators import (
+    deprecated_for,
+)
 from web3.exceptions import (
     CannotHandleRequest,
 )
@@ -31,12 +34,12 @@ from web3.types import (
     RPCResponse,
 )
 
-HTTP_SCHEMES = {'http', 'https'}
-WS_SCHEMES = {'ws', 'wss'}
+HTTP_SCHEMES = {"http", "https"}
+WS_SCHEMES = {"ws", "wss"}
 
 
 def load_provider_from_environment() -> BaseProvider:
-    uri_string = URI(os.environ.get('WEB3_PROVIDER_URI', ''))
+    uri_string = URI(os.environ.get("WEB3_PROVIDER_URI", ""))
     if not uri_string:
         return None
 
@@ -47,7 +50,7 @@ def load_provider_from_uri(
     uri_string: URI, headers: Optional[Dict[str, Tuple[str, str]]] = None
 ) -> BaseProvider:
     uri = urlparse(uri_string)
-    if uri.scheme == 'file':
+    if uri.scheme == "file":
         return IPCProvider(uri.path)
     elif uri.scheme in HTTP_SCHEMES:
         return HTTPProvider(uri_string, headers)
@@ -55,7 +58,8 @@ def load_provider_from_uri(
         return WebsocketProvider(uri_string)
     else:
         raise NotImplementedError(
-            'Web3 does not know how to connect to scheme %r in %r' % (
+            "Web3 does not know how to connect to scheme %r in %r"
+            % (
                 uri.scheme,
                 uri_string,
             )
@@ -74,8 +78,9 @@ class AutoProvider(BaseProvider):
 
     def __init__(
         self,
-        potential_providers: Optional[Sequence[Union[Callable[..., BaseProvider],
-                                      Type[BaseProvider]]]] = None
+        potential_providers: Optional[
+            Sequence[Union[Callable[..., BaseProvider], Type[BaseProvider]]]
+        ] = None,
     ) -> None:
         """
         :param iterable potential_providers: ordered series of provider classes to attempt with
@@ -95,20 +100,24 @@ class AutoProvider(BaseProvider):
         except IOError:
             return self._proxy_request(method, params, use_cache=False)
 
+    @deprecated_for("is_connected")
     def isConnected(self) -> bool:
-        provider = self._get_active_provider(use_cache=True)
-        return provider is not None and provider.isConnected()
+        return self.is_connected()
 
-    def _proxy_request(self, method: RPCEndpoint, params: Any,
-                       use_cache: bool = True) -> RPCResponse:
+    def is_connected(self) -> bool:
+        provider = self._get_active_provider(use_cache=True)
+        return provider is not None and provider.is_connected()
+
+    def _proxy_request(
+        self, method: RPCEndpoint, params: Any, use_cache: bool = True
+    ) -> RPCResponse:
         provider = self._get_active_provider(use_cache)
         if provider is None:
             raise CannotHandleRequest(
                 "Could not discover provider while making request: "
                 "method:{0}\n"
-                "params:{1}\n".format(
-                    method,
-                    params))
+                "params:{1}\n".format(method, params)
+            )
 
         return provider.make_request(method, params)
 
@@ -118,7 +127,7 @@ class AutoProvider(BaseProvider):
 
         for Provider in self._potential_providers:
             provider = Provider()
-            if provider is not None and provider.isConnected():
+            if provider is not None and provider.is_connected():
                 self._active_provider = provider
                 return provider
 


### PR DESCRIPTION
### What was wrong?
We removed isConnected in v6, but haven't yet issued a warning in v5 that it will be removed. This PR aims to fix that.  

Related to Issue #2862 

### How was it fixed?
Added tests and deprecation warnings. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn1.tedsby.com/tb/medium/storage/8/0/2/802971/stuffed-animal-other-belek-baby-seal.jpg)
