### PR TITLE
allow dict_to_namedtuple to handle empty dict

### DIFF
--- a/newsfragments/2867.bugfix.rst
+++ b/newsfragments/2867.bugfix.rst
@@ -1,0 +1,1 @@
+fix dict_to_namedtuple unable to handle empty dict as input

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -957,7 +957,7 @@ def recursive_dict_to_namedtuple(data: Dict[str, Any]) -> Tuple[Any, ...]:
         if not isinstance(value, dict):
             return value
 
-        keys, values = zip(*value.items())
+        keys, values = zip(*value.items()) if value else ((), ())
         return abi_decoded_namedtuple_factory(keys)(values)
 
     return recursive_map(_dict_to_namedtuple, data)


### PR DESCRIPTION
### What was wrong?

`dict_to_namedtuple` failed when trying to unpack an empty `dict`
Closes #2865

### How was it fixed?

It now checks for empty values and passes empty tuples to `abi_decoded_namedtuple_factory if found.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/223861237-a5816e93-b852-40af-a767-7d161dab3c95.png)

