### PR TITLE
Snakecase and deprecate clientVersion

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -389,7 +389,7 @@ The easiest way to connect to a default ``geth --dev`` instance which loads the 
     >>> from web3.auto.gethdev import w3
 
     # confirm that the connection succeeded
-    >>> w3.clientVersion
+    >>> w3.client_version
     'Geth/v1.7.3-stable-4bb3c89d/linux-amd64/go1.9'
 
 This example connects to a local ``geth --dev`` instance on Linux with a
@@ -408,7 +408,7 @@ unique IPC location and loads the middleware:
     >>> w3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     # confirm that the connection succeeded
-    >>> w3.clientVersion
+    >>> w3.client_version
     'Geth/v1.7.3-stable-4bb3c89d/linux-amd64/go1.9'
 
 Why is ``geth_poa_middleware`` necessary?

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -134,10 +134,10 @@ For example, the following retrieves the client enode endpoint for both geth and
 
     connected = w3.is_connected()
 
-    if connected and w3.clientVersion.startswith('Parity'):
+    if connected and w3.client_version.startswith('Parity'):
         enode = w3.parity.enode
 
-    elif connected and w3.clientVersion.startswith('Geth'):
+    elif connected and w3.client_version.startswith('Geth'):
         enode = w3.geth.admin.nodeInfo['enode']
 
     else:

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -37,7 +37,7 @@ Attributes
        >>> web3.api
        "4.7.0"
 
-.. py:attribute:: Web3.clientVersion
+.. py:attribute:: Web3.client_version
 
     * Delegates to ``web3_clientVersion`` RPC Method
 
@@ -45,9 +45,13 @@ Attributes
 
     .. code-block:: python
 
-       >>> web3.clientVersion
+       >>> web3.client_version
        'Geth/v1.4.11-stable-fed692f6/darwin/go1.7'
 
+.. py:attribute:: Web3.clientVersion
+
+    .. warning:: Deprecated: This property is deprecated in favor of
+       :meth:`~Web3.client_version`
 
 .. _overview_type_conversions:
 

--- a/newsfragments/2869.removal.rst
+++ b/newsfragments/2869.removal.rst
@@ -1,0 +1,1 @@
+Deprecate ``clientVersion`` in favor of ``client_version``

--- a/tests/core/version-module/test_version_module.py
+++ b/tests/core/version-module/test_version_module.py
@@ -52,6 +52,12 @@ def test_legacy_version_deprecation(blocking_w3):
 async def test_async_blocking_version(async_w3, blocking_w3):
     assert async_w3.async_version.api == blocking_w3.api
 
-    assert await async_w3.async_version.node == blocking_w3.clientVersion
+    assert await async_w3.async_version.node == blocking_w3.client_version
     with pytest.warns(DeprecationWarning):
         assert await async_w3.async_version.ethereum == blocking_w3.eth.protocol_version
+
+
+@pytest.mark.asyncio
+async def test_deprecated_async_clientVersion(async_w3, blocking_w3):
+    with pytest.warns(DeprecationWarning):
+        assert await async_w3.async_version.node == blocking_w3.clientVersion

--- a/tests/core/web3-module/test_clientVersion.py
+++ b/tests/core/web3-module/test_clientVersion.py
@@ -1,2 +1,9 @@
+import pytest
+
+
 def test_web3_clientVersion(web3):
-    assert web3.clientVersion.startswith("EthereumTester/")
+    with pytest.warns(
+        DeprecationWarning,
+        match='clientVersion is deprecated in favor of client_version'
+    ):
+        assert web3.clientVersion.startswith("EthereumTester/")

--- a/tests/core/web3-module/test_client_version.py
+++ b/tests/core/web3-module/test_client_version.py
@@ -1,0 +1,2 @@
+def test_web3_client_version(web3):
+    assert web3.client_version.startswith("EthereumTester/")

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 
 class GoEthereumTest(Web3ModuleTest):
-    def _check_web3_clientVersion(self, client_version):
+    def _check_web3_client_version(self, client_version):
         assert client_version.startswith('Geth/')
 
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -212,7 +212,7 @@ def funded_account_for_raw_txn(web3):
 
 
 class TestEthereumTesterWeb3Module(Web3ModuleTest):
-    def _check_web3_clientVersion(self, client_version):
+    def _check_web3_client_version(self, client_version):
         assert client_version.startswith('EthereumTester/')
 
 

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -25,11 +25,11 @@ from web3.exceptions import (
 
 
 class Web3ModuleTest:
-    def test_web3_clientVersion(self, web3: Web3) -> None:
-        client_version = web3.clientVersion
-        self._check_web3_clientVersion(client_version)
+    def test_web3_client_version(self, web3: Web3) -> None:
+        client_version = web3.client_version
+        self._check_web3_client_version(client_version)
 
-    def _check_web3_clientVersion(self, client_version: str) -> NoReturn:
+    def _check_web3_client_version(self, client_version: str) -> NoReturn:
         raise NotImplementedError("Must be implemented by subclasses")
 
     # Contract that calculated test values can be found at
@@ -296,9 +296,20 @@ class Web3ModuleTest:
     def test_is_connected(self, web3: "Web3") -> None:
         assert web3.is_connected()
 
+    #
+    # Deprecated
+    #
     def test_isConnected(self, web3: "Web3") -> None:
         with pytest.warns(
             DeprecationWarning,
             match="isConnected is deprecated in favor of is_connected",
         ):
             assert web3.isConnected()
+
+    def test_web3_clientVersion(self, web3: Web3) -> None:
+        with pytest.warns(
+            DeprecationWarning,
+            match="clientVersion is deprecated in favor of client_version"
+        ):
+            client_version = web3.clientVersion
+        self._check_web3_client_version(client_version)

--- a/web3/main.py
+++ b/web3/main.py
@@ -275,8 +275,13 @@ class Web3:
     def provider(self, provider: BaseProvider) -> None:
         self.manager.provider = provider
 
-    @property
+    @property  # type: ignore
+    @deprecated_for("client_version")
     def clientVersion(self) -> str:
+        return self.client_version
+
+    @property
+    def client_version(self) -> str:
         return self.manager.request_blocking(RPC.web3_clientVersion, [])
 
     @property

--- a/web3/version.py
+++ b/web3/version.py
@@ -59,7 +59,7 @@ class Version(Module):
     @property
     def node(self) -> NoReturn:
         raise DeprecationWarning(
-            "This method has been deprecated ... Please use web3.clientVersion instead."
+            "This method has been deprecated ... Please use web3.client_version instead."
         )
 
     @property


### PR DESCRIPTION
### What was wrong?
clientVersion has been removed in favor of client_version in v6. Needed to deprecate in v5.

Related to Issue #2862 

### How was it fixed?
Deprecated!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRPxUl20kIXqsp0HfhSWLor1ON74CjJHWN0DRu-x6TpGmG0bSO2nEGBUBmitu2WLkr1fpw&usqp=CAU)
