### PR TITLE
deprecate and snakecase toJSON in v5

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -94,7 +94,7 @@ Encoding and Decoding Helpers
 - :meth:`Web3.toBytes() <web3.Web3.toBytes>`
 - :meth:`Web3.toHex() <web3.Web3.toHex>`
 - :meth:`Web3.toInt() <web3.Web3.toInt>`
-- :meth:`Web3.toJSON() <web3.Web3.toJSON>`
+- :meth:`Web3.to_json() <web3.Web3.to_json>`
 - :meth:`Web3.toText() <web3.Web3.toText>`
 
 

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -161,17 +161,22 @@ Encoding and Decoding Helpers
         >>> Web3.toInt(hexstr='000F')
         15
 
-.. py:method:: Web3.toJSON(obj)
+.. py:method:: Web3.to_json(obj)
 
     Takes a variety of inputs and returns its JSON equivalent.
 
 
     .. code-block:: python
 
-        >>> Web3.toJSON(3)
+        >>> Web3.to_json(3)
         '3'
-        >>> Web3.toJSON({'one': 1})
+        >>> Web3.to_json({'one': 1})
         '{"one": 1}'
+    
+.. py:method:: Web3.toJSON(obj)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+       :meth:`~Web3.to_json`
 
 
 .. _overview_currency_conversions:

--- a/newsfragments/2870.removal.rst
+++ b/newsfragments/2870.removal.rst
@@ -1,0 +1,1 @@
+deprecate and snakecase toJSON

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -215,7 +215,7 @@ def test_to_hex_cleanup_only(val, expected):
     ),
 )
 def test_to_json(val, expected):
-    assert Web3.toJSON(val) == expected
+    assert Web3.to_json(val) == expected
 
 
 @pytest.mark.parametrize(
@@ -247,4 +247,12 @@ def test_to_json(val, expected):
     ),
 )
 def test_to_json_with_transaction(tx, expected):
-    assert Web3.toJSON(tx) == expected
+    assert Web3.to_json(tx) == expected
+
+
+def test_toJSON_is_deprecated():
+    with pytest.warns(
+        DeprecationWarning,
+        match="toJSON is deprecated in favor of to_json"
+    ):
+        Web3.toJSON(AttributeDict({"a": 1}))

--- a/web3/main.py
+++ b/web3/main.py
@@ -195,6 +195,12 @@ class Web3:
 
     @staticmethod
     @wraps(to_json)
+    def to_json(obj: Dict[Any, Any]) -> str:
+        return to_json(obj)
+
+    @staticmethod
+    @deprecated_for("to_json")
+    @wraps(to_json)
     def toJSON(obj: Dict[Any, Any]) -> str:
         return to_json(obj)
 


### PR DESCRIPTION
### What was wrong?

v5 needs deprecation note for toJSON -> to_json change

### How was it fixed?

deprecated and changed

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/224145837-0fa1f4c1-1b76-44a7-a00a-a209c221692f.png)
