### PR TITLE
Deprecate processLog and getLogs

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -877,7 +877,7 @@ Methods
         nodes would result in an error like:  ``ValueError: {'code': -32602, 'message': 'too many arguments, want at most 1'}``
 
 .. py:method:: ContractFunction.buildTransaction(transaction)
-  
+
     .. warning:: Deprecated: This method is deprecated in favor of :class:`~build_transaction`
 
 .. py:method:: ContractFunction.build_transaction(transaction)
@@ -1043,7 +1043,9 @@ For example:
        >>> assert processed_logs == ()
        True
 
-.. py:method:: ContractEvents.myEvent(*args, **kwargs).processLog(log)
+.. _process_log:
+
+.. py:method:: ContractEvents.myEvent(*args, **kwargs).process_log(log)
 
    Similar to processReceipt_, but only processes one log at a time, instead of a whole transaction receipt.
    Will return a single :ref:`Event Log Object <event-log-object>` if there are no errors encountered during processing. If an error is encountered during processing, it will be raised.
@@ -1053,7 +1055,7 @@ For example:
        >>> tx_hash = contract.functions.myFunction(12345).transact({'to':contract_address})
        >>> tx_receipt = w3.eth.get_transaction_receipt(tx_hash)
        >>> log_to_process = tx_receipt['logs'][0]
-       >>> processed_log = contract.events.myEvent().processLog(log_to_process)
+       >>> processed_log = contract.events.myEvent().process_log(log_to_process)
        >>> processed_log
        AttributeDict({
            'args': AttributeDict({}),
@@ -1065,6 +1067,14 @@ For example:
            'blockHash': HexBytes('0xd74c3e8bdb19337987b987aee0fa48ed43f8f2318edfc84e3a8643e009592a68'),
            'blockNumber': 3
        })
+
+
+.. py:method:: ContractEvents.myEvent(*args, **kwargs).processLog(log)
+   :noindex:
+
+   .. warning::
+     processLog has been deprecated in favor of
+     :ref:`ContractEvents.myEvent.process_log<process_log>`. It will be removed in v6.
 
 
 .. _event-log-object:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -870,7 +870,7 @@ The script can be run with: ``python ./eventscanner.py <your JSON-RPC API URL>``
             """
             :param contract: Contract
             :param events: List of web3 Event we scan
-            :param filters: Filters passed to getLogs
+            :param filters: Filters passed to get_logs
             :param max_chunk_scan_size: JSON-RPC API limit in the number of blocks we query. (Recommendation: 10,000 for mainnet, 500,000 for testnets)
             :param max_request_retries: How many times we try to reattempt a failed JSON-RPC call
             :param request_retry_seconds: Delay between failed requests to let JSON-RPC server to recover

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1185,7 +1185,7 @@ The script can be run with: ``python ./eventscanner.py <your JSON-RPC API URL>``
         all_events = []
         for log in logs:
             # Convert raw JSON-RPC log result to human readable event by using ABI data
-            # More information how processLog works here
+            # More information how process_log works here
             # https://github.com/ethereum/web3.py/blob/fbaf1ad11b0c7fac09ba34baff2c256cffe0a148/web3/_utils/events.py#L200
             evt = get_event_data(codec, abi, log)
             # Note: This was originally yield,

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -193,7 +193,7 @@ Getting events without setting up a filter
 You can query an Ethereum node for direct fetch of events, without creating a filter first.
 This works on all node types.
 
-For examples see :meth:`web3.contract.ContractEvents.getLogs`.
+For examples see :meth:`web3.contract.ContractEvents.get_logs`.
 
 Examples: Listening For Events
 ------------------------------

--- a/newsfragments/2872.removal.rst
+++ b/newsfragments/2872.removal.rst
@@ -1,0 +1,1 @@
+Deprecate and snake_case ``processLog`` and ``getLogs``

--- a/tests/core/contracts/test_contract_example.py
+++ b/tests/core/contracts/test_contract_example.py
@@ -94,7 +94,7 @@ def test_updating_greeting_emits_event(w3, foo_contract):
     receipt = w3.eth.wait_for_transaction_receipt(tx_hash, 180)
 
     # get all of the `barred` logs for the contract
-    logs = foo_contract.events.barred.getLogs()
+    logs = foo_contract.events.barred.get_logs()
     assert len(logs) == 1
 
     # verify that the log's data matches the expected value

--- a/tests/core/filtering/test_contract_get_logs.py
+++ b/tests/core/filtering/test_contract_get_logs.py
@@ -1,3 +1,4 @@
+import pytest
 
 
 def test_contract_get_available_events(
@@ -9,7 +10,7 @@ def test_contract_get_available_events(
     assert len(events) == 19
 
 
-def test_contract_getLogs_all(
+def test_contract_get_logs_all(
     web3,
     emitter,
     wait_for_transaction,
@@ -21,12 +22,12 @@ def test_contract_getLogs_all(
     txn_hash = contract.functions.logNoArgs(event_id).transact()
     wait_for_transaction(web3, txn_hash)
 
-    log_entries = list(contract.events.LogNoArguments.getLogs())
+    log_entries = list(contract.events.LogNoArguments.get_logs())
     assert len(log_entries) == 1
     assert log_entries[0]['transactionHash'] == txn_hash
 
 
-def test_contract_getLogs_range(
+def test_contract_get_logs_range(
     web3,
     emitter,
     wait_for_transaction,
@@ -41,17 +42,17 @@ def test_contract_getLogs_range(
     wait_for_transaction(web3, txn_hash)
     assert web3.eth.block_number == 3
 
-    log_entries = list(contract.events.LogNoArguments.getLogs())
+    log_entries = list(contract.events.LogNoArguments.get_logs())
     assert len(log_entries) == 1
 
-    log_entries = list(contract.events.LogNoArguments.getLogs(fromBlock=2, toBlock=3))
+    log_entries = list(contract.events.LogNoArguments.get_logs(fromBlock=2, toBlock=3))
     assert len(log_entries) == 1
 
-    log_entries = list(contract.events.LogNoArguments.getLogs(fromBlock=1, toBlock=2))
+    log_entries = list(contract.events.LogNoArguments.get_logs(fromBlock=1, toBlock=2))
     assert len(log_entries) == 0
 
 
-def test_contract_getLogs_argument_filter(
+def test_contract_get_logs_argument_filter(
         web3,
         emitter,
         wait_for_transaction,
@@ -79,19 +80,43 @@ def test_contract_getLogs_argument_filter(
     for txn_hash in txn_hashes:
         wait_for_transaction(web3, txn_hash)
 
-    all_logs = contract.events.LogTripleWithIndex.getLogs(fromBlock=1)
+    all_logs = contract.events.LogTripleWithIndex.get_logs(fromBlock=1)
     assert len(all_logs) == 4
 
     # Filter all entries where arg1 in (1, 2)
-    partial_logs = contract.events.LogTripleWithIndex.getLogs(
+    partial_logs = contract.events.LogTripleWithIndex.get_logs(
         fromBlock=1,
         argument_filters={'arg1': [1, 2]},
     )
     assert len(partial_logs) == 2
 
     # Filter all entries where arg0 == 1
-    partial_logs = contract.events.LogTripleWithIndex.getLogs(
+    partial_logs = contract.events.LogTripleWithIndex.get_logs(
         fromBlock=1,
         argument_filters={'arg0': 1},
     )
     assert len(partial_logs) == 4
+
+
+#
+# Deprecated
+#
+def test_contract_getLogs_all(
+    web3,
+    emitter,
+    wait_for_transaction,
+    emitter_event_ids,
+):
+    contract = emitter
+    event_id = emitter_event_ids.LogNoArguments
+
+    txn_hash = contract.functions.logNoArgs(event_id).transact()
+    wait_for_transaction(web3, txn_hash)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="getLogs is deprecated in favor of get_logs"
+    ):
+        log_entries = list(contract.events.LogNoArguments.getLogs())
+    assert len(log_entries) == 1
+    assert log_entries[0]['transactionHash'] == txn_hash

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1196,7 +1196,12 @@ class ContractEvent:
             yield rich_log
 
     @combomethod
+    @deprecated_for('process_log')
     def processLog(self, log: HexStr) -> EventData:
+        return self.process_log(log)
+
+    @combomethod
+    def process_log(self, log: HexStr) -> EventData:
         return get_event_data(self.web3.codec, self.abi, log)
 
     @combomethod

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1273,11 +1273,12 @@ class ContractEvent:
         return builder
 
     @combomethod
-    def getLogs(self,
-                argument_filters: Optional[Dict[str, Any]] = None,
-                fromBlock: Optional[BlockIdentifier] = None,
-                toBlock: Optional[BlockIdentifier] = None,
-                blockHash: Optional[HexBytes] = None) -> Iterable[EventData]:
+    def get_logs(self,
+                 argument_filters: Optional[Dict[str, Any]] = None,
+                 fromBlock: Optional[BlockIdentifier] = None,
+                 toBlock: Optional[BlockIdentifier] = None,
+                 blockHash: Optional[HexBytes] = None
+                 ) -> Iterable[EventData]:
         """Get events for this contract instance using eth_getLogs API.
 
         This is a stateless method, as opposed to createFilter.
@@ -1297,7 +1298,7 @@ class ContractEvent:
             from = max(mycontract.web3.eth.block_number - 10, 1)
             to = mycontract.web3.eth.block_number
 
-            events = mycontract.events.Transfer.getLogs(fromBlock=from, toBlock=to)
+            events = mycontract.events.Transfer.get_logs(fromBlock=from, toBlock=to)
 
             for e in events:
                 print(e["args"]["from"],
@@ -1371,6 +1372,15 @@ class ContractEvent:
 
         # Convert raw binary data to Python proxy objects as described by ABI
         return tuple(get_event_data(self.web3.codec, abi, entry) for entry in logs)
+
+    @combomethod
+    @deprecated_for('get_logs')
+    def getLogs(self,
+                argument_filters: Optional[Dict[str, Any]] = None,
+                fromBlock: Optional[BlockIdentifier] = None,
+                toBlock: Optional[BlockIdentifier] = None,
+                blockHash: Optional[HexBytes] = None) -> Iterable[EventData]:
+        return self.get_logs(argument_filters, fromBlock, toBlock, blockHash)
 
     @classmethod
     def factory(cls, class_name: str, **kwargs: Any) -> PropertyCheckingFactory:


### PR DESCRIPTION
### What was wrong?

Need to deprecate `processLog` and `getLogs`. 


Related to Issue #2862 

### How was it fixed?
Added warnings and aliases. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://npr.brightspotcdn.com/dims4/default/0bc2f38/2147483647/strip/true/crop/1280x960+0+0/resize/880x660!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Flegacy%2Fsites%2Fkhpr%2Ffiles%2F201701%2FHawaiian_monk_seal_at_French_Frigate_Shoals_05_WC.jpg)
