### PR TITLE
deprecate and snakecase isAddress, isChecksumAddress, toChecksumAddress for v5

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -104,9 +104,9 @@ Encoding and Decoding Helpers
 Address Helpers
 ---------------
 
-- :meth:`Web3.isAddress() <web3.Web3.isAddress>`
-- :meth:`Web3.isChecksumAddress() <web3.Web3.isChecksumAddress>`
-- :meth:`Web3.toChecksumAddress() <web3.Web3.toChecksumAddress>`
+- :meth:`Web3.is_address() <web3.Web3.is_address>`
+- :meth:`Web3.is_checksum_address() <web3.Web3.is_checksum_address>`
+- :meth:`Web3.to_checksum_address() <web3.Web3.to_checksum_address>`
 
 
 Currency Conversions

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -233,7 +233,7 @@ Currency Conversions
 Addresses
 ~~~~~~~~~
 
-.. py:method:: Web3.isAddress(value)
+.. py:method:: Web3.is_address(value)
 
     Returns ``True`` if the value is one of the recognized address formats.
 
@@ -243,32 +243,51 @@ Addresses
 
     .. code-block:: python
 
-        >>> Web3.isAddress('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
+        >>> Web3.is_address('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
         True
 
 
-.. py:method:: Web3.isChecksumAddress(value)
+.. py:method:: Web3.isAddress(value)
+   
+    .. warning:: Deprecated: This method is deprecated in favor of
+       :meth:`~Web3.is_address`
+   
+
+.. py:method:: Web3.is_checksum_address(value)
 
     Returns ``True`` if the value is a valid `EIP55`_ checksummed address
 
 
     .. code-block:: python
 
-        >>> Web3.isChecksumAddress('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
+        >>> Web3.is_checksum_address('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
         True
-        >>> Web3.isChecksumAddress('0xd3cda913deb6f67967b99d67acdfa1712c293601')
+        >>> Web3.is_checksum_address('0xd3cda913deb6f67967b99d67acdfa1712c293601')
         False
 
 
-.. py:method:: Web3.toChecksumAddress(value)
+.. py:method:: Web3.isChecksumAddress(value)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+       :meth:`~Web3.is_checksum_address`
+
+
+.. py:method:: Web3.to_checksum_address(value)
 
     Returns the given address with an `EIP55`_ checksum.
 
 
     .. code-block:: python
 
-        >>> Web3.toChecksumAddress('0xd3cda913deb6f67967b99d67acdfa1712c293601')
+        >>> Web3.to_checksum_address('0xd3cda913deb6f67967b99d67acdfa1712c293601')
         '0xd3CdA913deB6f67967B99D67aCDFa1712C293601'
+
+
+.. py:method:: Web3.toChecksumAddress(value)
+
+    .. warning:: Deprecated: This method is deprecated in favor of
+       :meth:`~Web3.to_checksum_address`
+
 
 .. _EIP55: https://github.com/ethereum/EIPs/issues/55
 

--- a/newsfragments/2874.removal.rst
+++ b/newsfragments/2874.removal.rst
@@ -1,0 +1,1 @@
+deprecate and snakecase isAddress, isChecksumAddress, toChecksumAddress

--- a/tests/core/contracts/test_contract_estimate_gas.py
+++ b/tests/core/contracts/test_contract_estimate_gas.py
@@ -27,7 +27,7 @@ def math_contract(web3,
 
     assert deploy_receipt is not None
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
-    web3.isAddress(contract_address)
+    web3.is_address(contract_address)
 
     _math_contract = MathContract(address=contract_address)
     assert _math_contract.address == contract_address
@@ -51,7 +51,7 @@ def fallback_function_contract(web3,
 
     assert deploy_receipt is not None
     contract_address = address_conversion_func(deploy_receipt['contractAddress'])
-    web3.isAddress(contract_address)
+    web3.is_address(contract_address)
 
     _fallback_function_contract = fallback_contract(address=contract_address)
     assert _fallback_function_contract.address == contract_address

--- a/tests/core/web3-module/test_conversions.py
+++ b/tests/core/web3-module/test_conversions.py
@@ -280,3 +280,27 @@ def test_toJSON_is_deprecated():
         match="toJSON is deprecated in favor of to_json"
     ):
         Web3.toJSON(AttributeDict({"a": 1}))
+
+
+def test_isAddress_is_deprecated():
+    with pytest.warns(
+        DeprecationWarning,
+        match="isAddress is deprecated in favor of is_address"
+    ):
+        Web3.isAddress("snek")
+
+
+def test_isChecksumAddress_is_deprecated():
+    with pytest.warns(
+        DeprecationWarning,
+        match="isChecksumAddress is deprecated in favor of is_checksum_address"
+    ):
+        Web3.isChecksumAddress("snek")
+
+
+def test_toChecksumAddress_is_deprecated():
+    with pytest.warns(
+        DeprecationWarning,
+        match="toChecksumAddress is deprecated in favor of to_checksum_address"
+    ):
+        Web3.toChecksumAddress("0xffffffffffffffffffffffffffffffffffffffff")

--- a/web3/_utils/validation.py
+++ b/web3/_utils/validation.py
@@ -184,7 +184,7 @@ def validate_address(value: Any) -> None:
                 "The software that gave you this non-checksum address should be considered unsafe, "
                 "please file it as a bug on their platform. "
                 "Try using an ENS name instead. Or, if you must accept lower safety, "
-                "use Web3.toChecksumAddress(lower_case_address).",
+                "use Web3.to_checksum_address(lower_case_address).",
                 value,
             )
         else:

--- a/web3/main.py
+++ b/web3/main.py
@@ -248,15 +248,33 @@ class Web3:
     # Address Utility
     @staticmethod
     @wraps(is_address)
+    def is_address(value: Any) -> bool:
+        return is_address(value)
+
+    @staticmethod
+    @wraps(is_checksum_address)
+    def is_checksum_address(value: Any) -> bool:
+        return is_checksum_address(value)
+
+    @staticmethod
+    @wraps(to_checksum_address)
+    def to_checksum_address(value: Union[AnyAddress, str, bytes]) -> ChecksumAddress:
+        return to_checksum_address(value)
+
+    @staticmethod
+    @deprecated_for("is_address")
+    @wraps(is_address)
     def isAddress(value: Any) -> bool:
         return is_address(value)
 
     @staticmethod
+    @deprecated_for("is_checksum_address")
     @wraps(is_checksum_address)
     def isChecksumAddress(value: Any) -> bool:
         return is_checksum_address(value)
 
     @staticmethod
+    @deprecated_for("to_checksum_address")
     @wraps(to_checksum_address)
     def toChecksumAddress(value: Union[AnyAddress, str, bytes]) -> ChecksumAddress:
         return to_checksum_address(value)


### PR DESCRIPTION
### What was wrong?

v5 needs deprecation and snakecasing for  isAddress, isChecksumAddress, and toChecksumAddress

### How was it fixed?

deprecated and snakecased

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/224185571-d484e814-e4bc-4139-ac89-dc5102cb836f.png)
