### PR TITLE
Snake case and deprecate ``ENS.fromWeb3()``

### DIFF
--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -17,9 +17,9 @@ Create an :class:`~ens.main.ENS` object (named ``ns`` below) in one of three way
 
 1. Automatic detection
 2. Specify an instance or list of :ref:`providers`
-3. From an existing :class:`web3.Web3` object
+3. From an existing :class:`web3.Web3` object via :meth:`ens.main.ENS.from_web3`
 
-::
+.. code-block:: python
 
     # automatic detection
     from ens.auto import ns
@@ -38,7 +38,7 @@ Create an :class:`~ens.main.ENS` object (named ``ns`` below) in one of three way
     from ens import ENS
 
     w3 = Web3(...)
-    ns = ENS.fromWeb3(w3)
+    ns = ENS.from_web3(w3)
 
 
 Usage
@@ -52,7 +52,7 @@ Name info
 Look up the address for an ENS name
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-::
+.. code-block:: python
 
     from ens.auto import ns
 
@@ -71,24 +71,21 @@ but will not infer a TLD if it is not provided with the name.
 Get name from address
 ^^^^^^^^^^^^^^^^^^^^^
 
-::
+.. code-block:: python
 
     domain = ns.name('0x5B2063246F2191f18F2675ceDB8b28102e957458')
 
-
     # name() also accepts the bytes version of the address
-
     assert ns.name(b'[ c$o!\x91\xf1\x8f&u\xce\xdb\x8b(\x10.\x95tX') == domain
 
 
     # confirm that the name resolves back to the address that you looked up:
-
     assert ns.address(domain) == '0x5B2063246F2191f18F2675ceDB8b28102e957458'
 
 Get owner of name
 ^^^^^^^^^^^^^^^^^
 
-::
+.. code-block:: python
 
     eth_address = ns.owner('exchange.eth')
 
@@ -101,7 +98,7 @@ Point your name to your address
 Do you want to set up your name so that :meth:`~ens.main.ENS.address` will show the
 address it points to?
 
-::
+.. code-block:: python
 
     ns.setup_address('jasoncarver.eth', '0x5B2063246F2191f18F2675ceDB8b28102e957458')
 
@@ -110,20 +107,20 @@ You must already be the owner of the domain (or its parent).
 In the common case where you want to point the name to the owning
 address, you can skip the address
 
-::
+.. code-block:: python
 
     ns.setup_address('jasoncarver.eth')
 
 You can claim arbitrarily deep subdomains. *Gas costs scale up with the
 number of subdomains!*
 
-::
+.. code-block:: python
 
     ns.setup_address('supreme.executive.power.derives.from.a.mandate.from.the.masses.jasoncarver.eth')
 
 Wait for the transaction to be mined, then:
 
-::
+.. code-block:: python
 
     assert ns.address('supreme.executive.power.derives.from.a.mandate.from.the.masses.jasoncarver.eth') == \
         '0x5B2063246F2191f18F2675ceDB8b28102e957458'
@@ -138,7 +135,7 @@ This is like Caller ID. It enables you and others to take an account and
 determine what name points to it. Sometimes this is referred to as
 "reverse" resolution.
 
-::
+.. code-block:: python
 
     ns.setup_name('jasoncarver.eth', '0x5B2063246F2191f18F2675ceDB8b28102e957458')
 
@@ -150,7 +147,7 @@ determine what name points to it. Sometimes this is referred to as
 If you don't supply the address, :meth:`~ens.main.ENS.setup_name` will assume you want the
 address returned by :meth:`~ens.main.ENS.address`.
 
-::
+.. code-block:: python
 
     ns.setup_name('jasoncarver.eth')
 
@@ -159,7 +156,7 @@ call :meth:`~ens.main.ENS.setup_address` for you.
 
 Wait for the transaction to be mined, then:
 
-::
+.. code-block:: python
 
     assert ns.name('0x5B2063246F2191f18F2675ceDB8b28102e957458') == 'jasoncarver.eth'
 
@@ -171,14 +168,14 @@ A list of supported fields can be found in the
 `ENS documentation <https://docs.ens.domains/contract-api-reference/publicresolver#get-text-data>`_.
 You'll need to setup the address first, and then the text can be set:
 
-::
+.. code-block:: python
 
     ns.setup_address('jasoncarver.eth', 0x5B2063246F2191f18F2675ceDB8b28102e957458)
     ns.set_text('jasoncarver.eth', 'url', 'https://example.com')
 
 A transaction dictionary can be passed as the last argument if desired:
 
-::
+.. code-block:: python
 
     transaction_dict = {'from': '0x123...'}
     ns.set_text('jasoncarver.eth', 'url', 'https://example.com', transaction_dict)
@@ -192,7 +189,7 @@ Read Text Metadata for an ENS Record
 
 Anyone can read the data from an ENS Record:
 
-::
+.. code-block:: python
 
     url = ns.get_text('jasoncarver.eth', 'url')
     assert url == 'https://example.com'

--- a/ens/main.py
+++ b/ens/main.py
@@ -123,7 +123,7 @@ class ENS:
         self._resolverContract = self.web3.eth.contract(abi=abis.RESOLVER)
 
     @classmethod
-    def fromWeb3(cls, web3: 'Web3', addr: ChecksumAddress = None) -> 'ENS':
+    def from_web3(cls, web3: 'Web3', addr: ChecksumAddress = None) -> 'ENS':
         """
         Generate an ENS instance with web3
 
@@ -134,6 +134,14 @@ class ENS:
         provider = web3.manager.provider
         middlewares = web3.middleware_onion.middlewares
         return cls(provider, addr=addr, middlewares=middlewares)
+
+    @classmethod
+    def fromWeb3(cls, web3: 'Web3', addr: ChecksumAddress = None) -> 'ENS':
+        warnings.warn(
+            category=DeprecationWarning,
+            message="ENS.fromWeb3 is deprecated in favor of ENS.from_web3",
+        )
+        return cls.from_web3(web3, addr=addr)
 
     def address(self, name: str) -> Optional[ChecksumAddress]:
         """

--- a/ethpm/backends/registry.py
+++ b/ethpm/backends/registry.py
@@ -96,7 +96,7 @@ def parse_registry_uri(uri: str) -> RegistryURI:
         address_or_ens, chain_id = parsed_uri.netloc.split(":")
     else:
         address_or_ens, chain_id = parsed_uri.netloc, "1"
-    ns = ENS.fromWeb3(w3)
+    ns = ENS.from_web3(w3)
     if is_address(address_or_ens):
         address = address_or_ens
         ens = None

--- a/newsfragments/2877.removal.rst
+++ b/newsfragments/2877.removal.rst
@@ -1,0 +1,1 @@
+Snake case and deprecate ``ENS.fromWeb3()`` method.

--- a/tests/core/pm-module/test_ens_integration.py
+++ b/tests/core/pm-module/test_ens_integration.py
@@ -110,7 +110,7 @@ def ens_setup(deployer):
         eth_labelhash,
         eth_registrar.address
     ).transact({'from': ens_key})
-    return ENS.fromWeb3(w3, ens_contract.address)
+    return ENS.from_web3(w3, ens_contract.address)
 
 
 @pytest.fixture
@@ -130,7 +130,7 @@ def test_ens_must_be_set_before_ens_methods_can_be_used(ens):
 @pytest.mark.xfail(reason="Need to properly add authorization as of 8/10/2022")
 def test_web3_ens(ens):
     w3 = ens.web3
-    ns = ENS.fromWeb3(w3, ens.ens.address)
+    ns = ENS.from_web3(w3, ens.ens.address)
     w3.ens = ns
     registry = SimpleRegistry.deploy_new_instance(w3)
     w3.ens.setup_address('tester.eth', registry.address)

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -214,7 +214,7 @@ def ens_setup():
         reverse_registrar.address
     ).transact({'from': ens_key})
 
-    return ENS.fromWeb3(w3, ens_contract.address)
+    return ENS.from_web3(w3, ens_contract.address)
 
 
 @pytest.fixture

--- a/tests/ens/test_ens.py
+++ b/tests/ens/test_ens.py
@@ -1,12 +1,27 @@
+import pytest
+from unittest.mock import (
+    patch,
+)
+
 from ens import ENS
 from web3.middleware import (
     pythonic_middleware,
 )
 
 
-def test_fromWeb3_inherits_web3_middlewares(web3):
+def test_from_web3_inherits_web3_middlewares(web3):
     test_middleware = pythonic_middleware
     web3.middleware_onion.add(test_middleware, 'test_middleware')
 
-    ns = ENS.fromWeb3(web3)
+    ns = ENS.from_web3(web3)
     assert ns.web3.middleware_onion.get('test_middleware') == test_middleware
+
+
+@patch('ens.ENS.from_web3', lambda *args, **kwargs: (args, kwargs))
+def test_fromWeb3_delegates_to_from_web3_and_issues_deprecation_warning(web3):
+    with pytest.warns(
+        DeprecationWarning,
+        match="ENS.fromWeb3 is deprecated in favor of ENS.from_web3",
+    ):
+        passed_on_args, _ = ENS.fromWeb3(web3)
+        assert passed_on_args == (web3,)

--- a/web3/main.py
+++ b/web3/main.py
@@ -426,7 +426,7 @@ class Web3:
     @property
     def ens(self) -> ENS:
         if self._ens is cast(ENS, empty):
-            return ENS.fromWeb3(self)
+            return ENS.from_web3(self)
         else:
             return self._ens
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #2862

### How was it fixed?

- Snake case and deprecate `ENS.fromWeb3()`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![craiyon_133253_a_snake_turning_into_a_camel](https://user-images.githubusercontent.com/3532824/224422914-e2c454d2-228d-48bc-beb3-98eccaae0a24.png)

