### PR TITLE
removed camel deprecation notices from web3.eth docs

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -59,22 +59,10 @@ The following properties are available on the ``web3.eth`` namespace.
     all transactions. Defaults to empty.
 
 
-.. py:attribute:: Eth.defaultAccount
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.eth.Eth.default_account`
-
-
 .. py:attribute:: Eth.default_block
 
     The default block number that will be used for any RPC methods that accept
     a block identifier. Defaults to ``'latest'``.
-
-
-.. py:attribute:: Eth.defaultBlock
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.eth.Eth.default_block`
 
 
 .. py:attribute:: Eth.syncing
@@ -156,12 +144,6 @@ The following properties are available on the ``web3.eth`` namespace.
         20000000000
 
 
-.. py:attribute:: Eth.gasPrice
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.eth.Eth.gas_price`
-
-
 .. py:attribute:: Eth.accounts
 
     * Delegates to ``eth_accounts`` RPC Method
@@ -188,12 +170,6 @@ The following properties are available on the ``web3.eth`` namespace.
         2206939
 
 
-.. py:attribute:: Eth.blockNumber
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.eth.Eth.block_number`
-
-
 .. py:attribute:: Eth.protocol_version
 
     * Delegates to ``eth_protocolVersion`` RPC Method
@@ -204,12 +180,6 @@ The following properties are available on the ``web3.eth`` namespace.
 
        >>> web3.eth.protocol_version
        '63'
-
-
-.. py:attribute:: Eth.protocolVersion
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.eth.Eth.protocol_version`
 
 
 .. py:attribute:: Eth.chain_id
@@ -236,12 +206,6 @@ The following properties are available on the ``web3.eth`` namespace.
           >>> w3.middleware_onion.add(simple_cache_middleware)
 
 
-.. py:attribute:: Eth.chainId
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.eth.chain_id`
-
-
 
 Methods
 -------
@@ -262,12 +226,6 @@ The following methods are available on the ``web3.eth`` namespace.
 
         >>> web3.eth.get_balance('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
         77320681768999138915
-
-
-.. py:method:: Eth.getBalance(account, block_identifier=eth.default_block)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.get_balance()`
 
 
 .. py:method:: Eth.get_block_number()
@@ -295,12 +253,6 @@ The following methods are available on the ``web3.eth`` namespace.
 
         >>> web3.eth.get_storage_at('0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B', 0)
         '0x00000000000000000000000000000000000000000000000000120a0b063499d4'
-
-
-.. py:method:: Eth.getStorageAt(account, position, block_identifier=eth.default_block)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.get_storage_at`
 
 
 .. py:method:: Eth.get_proof(account, positions, block_identifier=eth.default_block)
@@ -405,11 +357,6 @@ The following methods are available on the ``web3.eth`` namespace.
         assert verify_eth_get_proof(proof, block.stateRoot)
 
 
-.. py:method:: Eth.getProof(account, positions, block_identifier=eth.default_block)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.get_proof`
-
 .. py:method:: Eth.get_code(account, block_identifier=eth.default_block)
 
     * Delegates to ``eth_getCode`` RPC Method
@@ -428,11 +375,6 @@ The following methods are available on the ``web3.eth`` namespace.
         >>> web3.eth.get_code('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
         '0x'
 
-
-.. py:method:: Eth.getCode(account, block_identifier=eth.default_block)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.get_code`
 
 .. py:method:: Eth.get_block(block_identifier=eth.default_block, full_transactions=False)
 
@@ -473,10 +415,6 @@ The following methods are available on the ``web3.eth`` namespace.
             'uncles': [],
         })
 
-.. py:method:: Eth.getBlock(block_identifier=eth.default_block, full_transactions=False)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.get_block`
 
 .. py:method:: Eth.get_block_transaction_count(block_identifier)
 
@@ -497,19 +435,6 @@ The following methods are available on the ``web3.eth`` namespace.
         1
         >>> web3.eth.get_block_transaction_count('0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd')  # block 46147
         1
-
-
-.. py:method:: Eth.getBlockTransactionCount(block_identifier)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.get_block_transaction_count`
-
-
-
-.. py:method:: Eth.getUncle(block_identifier)
-
-    .. note:: Method to get an Uncle from its hash is not available through
-      RPC, a possible substitute is the method ``Eth.get_uncle_by_block``
 
 
 .. py:method:: Eth.get_uncle_by_block(block_identifier, uncle_index)
@@ -557,10 +482,6 @@ The following methods are available on the ``web3.eth`` namespace.
             ...
         })
 
-.. py:method:: Eth.getUncleByBlock(block_identifier, uncle_index)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.get_uncle_by_block()`
 
 .. py:method:: Eth.get_uncle_count(block_identifier)
 
@@ -582,10 +503,6 @@ The following methods are available on the ``web3.eth`` namespace.
         >>> web3.eth.get_uncle_count('0x685b2226cbf6e1f890211010aa192bf16f0a0cba9534264a033b023d7367b845')
         1
 
-.. py:method:: Eth.getUncleCount(block_identifier)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :attr:`~web3.eth.Eth.get_uncle_count()`
 
 .. py:method:: Eth.get_transaction(transaction_hash)
 
@@ -613,12 +530,6 @@ The following methods are available on the ``web3.eth`` namespace.
         })
 
 
-.. py:method:: Eth.getTransaction(transaction_hash)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :attr:`~web3.eth.Eth.get_transaction`
-
-
 .. py:method:: Eth.get_raw_transaction(transaction_hash)
 
     * Delegates to ``eth_getRawTransactionByHash`` RPC Method
@@ -631,11 +542,6 @@ The following methods are available on the ``web3.eth`` namespace.
 
         >>> web3.eth.get_raw_transaction('0x86fbfe56cce542ff0a2a2716c31675a0c9c43701725c4a751d20ee2ddf8a733d')
         HexBytes('0xf86907843b9aca0082520894dc544d1aa88ff8bbd2f2aec754b1f1e99e1812fd018086eecac466e115a0f9db4e25484b28f486b247a372708d4cd0643fc63e604133afac577f4cc1eab8a044841d84e799d4dc18ba146816a937e8a0be8bc296bd8bb8aea126de5e627e06')
-
-
-.. py:method:: Eth.getTransactionFromBlock(block_identifier, transaction_index)
-
-   .. note:: This method is deprecated in EIP 1474.
 
 
 .. py:method:: Eth.get_transaction_by_block(block_identifier, transaction_index)
@@ -686,10 +592,6 @@ The following methods are available on the ``web3.eth`` namespace.
             'value': 31337,
         })
 
-.. py:method:: Eth.getTransactionByBlock(block_identifier, transaction_index)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :attr:`~web3.eth.Eth.get_transaction_by_block`
 
 .. py:method:: Eth.get_raw_transaction_by_block(block_identifier, transaction_index)
 
@@ -744,11 +646,6 @@ The following methods are available on the ``web3.eth`` namespace.
         })
 
 
-.. py:method:: Eth.waitForTransactionReceipt(transaction_hash, timeout=120, poll_latency=0.1)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.wait_for_transaction_receipt()`
-
 .. py:method:: Eth.get_transaction_receipt(transaction_hash)
 
     * Delegates to ``eth_getTransactionReceipt`` RPC Method
@@ -780,10 +677,6 @@ The following methods are available on the ``web3.eth`` namespace.
             'transactionIndex': 0,
         })
 
-.. py:method:: Eth.getTransactionReceipt(transaction_hash)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.get_transaction_receipt()`
 
 .. py:method:: Eth.get_transaction_count(account, block_identifier=web3.eth.default_block)
 
@@ -798,12 +691,6 @@ The following methods are available on the ``web3.eth`` namespace.
 
         >>> web3.eth.get_transaction_count('0xd3CdA913deB6f67967B99D67aCDFa1712C293601')
         340
-
-
-.. py:method:: Eth.getTransactionCount(account, block_identifier=web3.eth.default_block)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.get_transaction_count()`
 
 
 .. py:method:: Eth.send_transaction(transaction)
@@ -877,10 +764,6 @@ The following methods are available on the ``web3.eth`` namespace.
         })
         HexBytes('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
 
-.. py:method:: Eth.sendTransaction(transaction)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :attr:`~web3.eth.Eth.send_transaction()`
 
 .. py:method:: Eth.sign_transaction(transaction)
 
@@ -903,11 +786,6 @@ The following methods are available on the ``web3.eth`` namespace.
         )
         b"\xf8d\x80\x85\x040\xe24\x00\x82R\x08\x94\xdcTM\x1a\xa8\x8f\xf8\xbb\xd2\xf2\xae\xc7T\xb1\xf1\xe9\x9e\x18\x12\xfd\x01\x80\x1b\xa0\x11\r\x8f\xee\x1d\xe5=\xf0\x87\x0en\xb5\x99\xed;\xf6\x8f\xb3\xf1\xe6,\x82\xdf\xe5\x97lF|\x97%;\x15\xa04P\xb7=*\xef \t\xf0&\xbc\xbf\tz%z\xe7\xa3~\xb5\xd3\xb7=\xc0v\n\xef\xad+\x98\xe3'"  # noqa: E501
 
-
-.. py:method:: Eth.signTransaction(transaction)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :attr:`~web3.eth.Eth.sign_transaction()`
 
 .. py:method:: Eth.send_raw_transaction(raw_transaction)
 
@@ -933,10 +811,6 @@ The following methods are available on the ``web3.eth`` namespace.
         >>> w3.eth.send_raw_transaction(signed_txn.rawTransaction)
         HexBytes('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
 
-.. py:method:: Eth.sendRawTransaction(raw_transaction)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.send_raw_transaction()`
 
 .. py:method:: Eth.replace_transaction(transaction_hash, new_transaction)
 
@@ -993,10 +867,6 @@ The following methods are available on the ``web3.eth`` namespace.
             })
         HexBytes('0x4177e670ec6431606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1528989')
 
-.. py:method:: Eth.replaceTransaction(transaction_hash, new_transaction)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.replace_transaction()`
 
 .. py:method:: Eth.modify_transaction(transaction_hash, **transaction_params)
 
@@ -1024,10 +894,6 @@ The following methods are available on the ``web3.eth`` namespace.
         >>> web3.eth.modify_transaction('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331', value=2000)
         HexBytes('0xec6434e6701771606e55d6b4ca35a1a6b75ee3d73315145a921026d15299d05')
 
-.. py:method:: Eth.modifyTransaction(transaction_hash, **transaction_params)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.modify_transaction()`
 
 .. py:method:: Eth.sign(account, data=None, hexstr=None, text=None)
 
@@ -1070,10 +936,6 @@ The following methods are available on the ``web3.eth`` namespace.
 
     ``account`` may be a checksum address or an ENS name
 
-.. py:method:: Eth.signTypedData(account, jsonMessage)
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :meth:`~web3.eth.Eth.sign_typed_data()`
 
 .. py:method:: Eth.call(transaction, block_identifier=web3.eth.default_block, state_override=None, ccip_read_enabled=True)
 
@@ -1169,10 +1031,6 @@ The following methods are available on the ``web3.eth`` namespace.
         >>> web3.eth.estimate_gas({'to': '0xd3CdA913deB6f67967B99D67aCDFa1712C293601', 'from':web3.eth.coinbase, 'value': 12345})
         21000
 
-.. py:method:: Eth.estimateGas(transaction, block_identifier=None)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.estimate_gas()`
 
 .. py:method:: Eth.generate_gas_price(transaction_params=None)
 
@@ -1191,20 +1049,12 @@ The following methods are available on the ``web3.eth`` namespace.
         For information about how gas price can be customized in web3 see
         :ref:`Gas_Price`.
 
-.. py:method:: Eth.generateGasPrice(transaction_params=None)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.generate_gas_price()`
 
 .. py:method:: Eth.set_gas_price_strategy(gas_price_strategy)
 
     Set the selected gas price strategy. It must be a method of the signature
     ``(web3, transaction_params)`` and return a gas price denominated in wei.
 
-.. py:method:: Eth.setGasPriceStrategy(gas_price_strategy)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.set_gas_price_strategy()`
 
 Filters
 -------
@@ -1299,12 +1149,6 @@ with the filtering API.
         ]
 
 
-.. py:method:: Eth.getFilterChanges(self, filter_id)
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :meth:`~web3.eth.Eth.get_filter_changes()`
-
-
 .. py:method:: Eth.get_filter_logs(self, filter_id)
 
     * Delegates to ``eth_getFilterLogs`` RPC Method.
@@ -1332,12 +1176,6 @@ with the filtering API.
         ]
 
 
-.. py:method:: Eth.getFilterLogs(self, filter_id)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.get_filter_logs`
-
-
 .. py:method:: Eth.uninstall_filter(self, filter_id)
 
     * Delegates to ``eth_uninstallFilter`` RPC Method.
@@ -1352,11 +1190,6 @@ with the filtering API.
         True
         >>> web3.eth.uninstall_filter(filter.filter_id)
         False  # already uninstalled.
-
-.. py:method:: Eth.uninstallFilter(self, filter_id)
-
-    .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~web3.eth.Eth.uninstall_filter`
 
 
 .. py:method:: Eth.get_logs(filter_params)
@@ -1375,10 +1208,6 @@ with the filtering API.
        >>> web3.eth.submit_hashrate(5000, node_id)
        True
 
-.. py:method:: Eth.submitHashrate(hashrate, nodeid)
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.eth.Eth.submit_hashrate()`
 
 .. py:method:: Eth.submit_work(nonce, pow_hash, mix_digest)
 
@@ -1393,10 +1222,6 @@ with the filtering API.
            )
        True
 
-.. py:method:: Eth.submitWork(nonce, pow_hash, mix_digest)
-
-    .. warning:: Deprecated: This property is deprecated in favor of
-      :attr:`~web3.eth.Eth.submit_work()`
 
 Contracts
 ---------

--- a/newsfragments/2882.doc.rst
+++ b/newsfragments/2882.doc.rst
@@ -1,0 +1,1 @@
+remove camelCased method deprecation notices from web3.eth docs


### PR DESCRIPTION
### What was wrong?

Camel-cased methods were removed, but their deprecation notices were still in the docs.

I also removed:
 - `Eth.getUncle`, as it was just a note saying such a method never existed.
 - `Eth.getTransactionFromBlock`, which was deprecated going into v5.

### How was it fixed?

Removed from web3.eth docs. I left them in geth.miner as those will be coming in another PR.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/225709370-4e4846c7-87d2-41dc-af35-28dddbfe234d.png)
