### PR TITLE
fix broken version selector in docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,5 @@
 version: 2
 
-build:
-  image: latest
-
 python:
-  version: 3.8
   install:
   - requirements: requirements-docs.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/newsfragments/2883.bugfix.rst
+++ b/newsfragments/2883.bugfix.rst
@@ -1,0 +1,1 @@
+fix readthedocs broken version selector 


### PR DESCRIPTION
### What was wrong?

Since v6 released, the version selector at the bottom of readthedocs hasn't worked

### How was it fixed?

`sphinx_rtd_theme` listed jquery not loading as a [known issue](https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html#known-issues). Applied their fix.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/225744352-1b743d64-a4ac-4067-92f8-6a35fb1f2db6.png)
