### PR TITLE
Upgrade eth-abi requirement to v4 stable

### DIFF
--- a/newsfragments/2886.internal.rst
+++ b/newsfragments/2886.internal.rst
@@ -1,0 +1,1 @@
+Require eth-abi v4 stable

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "aiohttp>=3.7.4.post0",
-        "eth-abi>=4.0.0-b.2",
-        "parsimonious==0.9.0",  # TODO - fix in eth-abi
+        "eth-abi>=4.0.0",
         "eth-account>=0.8.0",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=3.0.0",


### PR DESCRIPTION
### What was wrong?
`eth-abi` v4.0.0 is out, so we no longer need to require beta. 


### How was it fixed?

Require `eth-abi >=4.0.0` in setup.py

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://assets3.thrillist.com/v1/image/2624261/792x456/scale;webp=auto;jpeg_quality=60;progressive.jpg)
