### PR TITLE
Remove python_paths pytest option

### DIFF
--- a/newsfragments/2887.misc.rst
+++ b/newsfragments/2887.misc.rst
@@ -1,0 +1,1 @@
+Fix failing tests from eth-tester, and deprecated ``python_paths`` config option

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 addopts= -v --showlocals --durations 10
-python_paths= .
 xfail_strict=true
 asyncio_mode=strict
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -586,6 +586,16 @@ class TestEthereumTesterEthModule(EthModuleTest):
     ) -> None:
         super().test_eth_getBlockByNumber_finalized(w3, empty_block)
 
+    def test_eth_get_balance_with_block_identifier(self, w3: "Web3") -> None:
+        w3.testing.mine()
+        miner_address = w3.eth.get_block(1)["miner"]
+        genesis_balance = w3.eth.get_balance(miner_address, 0)
+        later_balance = w3.eth.get_balance(miner_address, 1)
+
+        assert is_integer(genesis_balance)
+        assert is_integer(later_balance)
+        assert later_balance > genesis_balance
+
 
 class TestEthereumTesterNetModule(NetModuleTest):
     pass


### PR DESCRIPTION
### What was wrong?
Tests on master are failing. 
- The `python_paths` option is deprecated.
- eth-tester was failing because it couldn't find block 1

### How was it fixed?

- Removed the `python_paths` option. 
- Added a `w3.testing.mine()` to the failing `eth-tester` test. @fselmo: I didn't know if this was the right approach. I couldn't see anything immediately obvious about what might have changed with `eth-tester` to cause this failure.  

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/236x/c5/09/43/c509436a9ef14a0bed6cb54a95e1fa26--crazy-costumes-pet-halloween-costumes.jpg)
