### PR TITLE
Make eth_chainId retryable

### DIFF
--- a/newsfragments/2892.feature.rst
+++ b/newsfragments/2892.feature.rst
@@ -1,0 +1,1 @@
+add eth_chainId to exception_retry_middleware whitelist

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -33,6 +33,7 @@ whitelist = [
     "eth_coinbase",
     "eth_mining",
     "eth_hashrate",
+    "eth_chainId",
     "eth_gasPrice",
     "eth_accounts",
     "eth_blockNumber",


### PR DESCRIPTION
eth_chainId not whitelisted

### What was wrong?

eth_chainId was not marked as a retryable method.

### How was it fixed?

Added `eth_chainId` to the whitelist.

#### Cute Animal Picture

```
                                       /;    ;\
                                   __  \\____//
                                  /{_\_/   `'\____
                                  \___   (o)  (o  }
       _____________________________/          :--'
   ,-,'`@@@@@@@@       @@@@@@         \_    `__\
  ;:(  @@@@@@@@@        @@@             \___(o'o)
  :: )  @@@@          @@@@@@        ,'@@(  `===='
  :: : @@@@@:          @@@@         `@@@:
  :: \  @@@@@:       @@@@@@@)    (  '@@@'
  ;; /\      /`,    @@@@@@@@@\   :@@@@@)
  ::/  )    {_----------------:  :~`,~~;
 ;;'`; :   )                  :  / `; ;   
;;;; : :   ;                  :  ;  ; :
`'`' / :  :                   :  :  : :
    )_ \__;      ";"          :_ ;  \_\       `,','
    :__\  \    * `,'*         \  \  :  \   *  8`;'*  *
        `^'     \ :/           `^'  `-^-'   \v/ :  \/
----------  Targon (Ed Wisniewski)



```