### PR TITLE
fix link formatting in contract docs

### DIFF
--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -151,12 +151,12 @@ Each Contract Factory exposes the following properties.
 
     If a Tuple/Struct is returned by a contract function, this flag defines whether
     to apply the field names from the ABI to the returned data.
-    If False, the returned value will be a normal Python `Tuple`. If True, the returned
-    value will be a Python `NamedTuple` of the class `ABIDecodedNamedTuple`.
+    If False, the returned value will be a normal Python ``Tuple``. If True, the returned
+    value will be a Python ``NamedTuple`` of the class ``ABIDecodedNamedTuple``.
     
     NamedTuples have some restrictions regarding field names.
-    web3.py sets `NamedTuple`'s `rename=True`, so disallowed field names may be 
-    different than expected. See the [Python docs](https://docs.python.org/3/library/collections.html#collections.namedtuple)
+    web3.py sets ``NamedTuple``'s ``rename=True``, so disallowed field names may be 
+    different than expected. See the `Python docs <https://docs.python.org/3/library/collections.html#collections.namedtuple>`_
     for more information.
     
     Defaults to ``False`` if not provided during factory creation.

--- a/newsfragments/2897.doc.rst
+++ b/newsfragments/2897.doc.rst
@@ -1,0 +1,1 @@
+fix styling and external link formatting


### PR DESCRIPTION
### What was wrong?

the `decode_tuples` portion of the contract docs had some incorrect formatting.

### How was it fixed?.

Formatted correctly.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/228070768-fc342772-e6cc-4010-bb2c-bb16900d613c.png)
