### PR TITLE
Refactor geth steps to use correct py-geth version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,14 @@ geth_steps: &geth_steps
           - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
-        command: pip install --user tox
+        command: |
+          pip install --upgrade pip
+          pip install --user tox
     - run:
         name: build geth if missing
         command: |
           mkdir -p $HOME/.ethash
-          pip install --user py-geth>=<< pipeline.parameters.pygeth_version >>
+          pip install --user "py-geth>=<< pipeline.parameters.pygeth_version >>"
           export GOROOT=/usr/local/go
           echo << pipeline.parameters.geth_version >>
           export GETH_BINARY="$HOME/.py-geth/geth-<< pipeline.parameters.geth_version >>/bin/geth"

--- a/newsfragments/2898.internal.rst
+++ b/newsfragments/2898.internal.rst
@@ -1,0 +1,1 @@
+Update ``geth_steps`` in CircleCI builds to pip install the proper version of ``py-geth``.


### PR DESCRIPTION
### What was wrong?

- pip install with [minimum requirements](https://pip.pypa.io/en/stable/cli/pip_install/#examples) must use quotes around the library and minimum version.

### How was it fixed?

- Make sure pip is up to date and use quotes around minimum version for pip installing py-geth.

Alternative:

Just use `pip install --user py-geth=={version}`

---
**Note:**

The windows wheel build just started failing on this PR. I'm going to address that in a separate PR, so please ignore that failing CI build and it should still fail on `master` until we get the fix in.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20230328_091602](https://user-images.githubusercontent.com/3532824/228322207-335f8c78-ce86-4ded-b62e-6126a164327d.jpg)

