### PR TITLE
CircleCI orb ``windows@5.0.0`` is now using Python311

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ windows_steps: &windows_steps
         command: pip install --user tox
     - run:
         name: run tox
-        command: 'C:/Users/circleci.PACKER-633B1A5A/AppData/Roaming/Python/Python310/Scripts/tox.exe -r'
+        command: 'C:/Users/circleci.PACKER-6400C91A/AppData/Roaming/Python/Python311/Scripts/tox.exe -r'
     - save_cache:
         paths:
           - .tox
@@ -602,10 +602,10 @@ jobs:
         environment:
           TOXENV: py310-wheel-cli
 
-  py310-wheel-cli-windows:
+  py311-wheel-cli-windows:
     <<: *windows_steps
     environment:
-      TOXENV: py310-wheel-cli-windows
+      TOXENV: py311-wheel-cli-windows
 
   #
   # Python 3.11
@@ -770,7 +770,6 @@ workflows:
       - py310-integration-goethereum-ws_flaky
       - py310-integration-ethtester-pyevm
       - py310-wheel-cli
-      - py310-wheel-cli-windows
       - py311-lint
       - py311-ens
       - py311-ethpm
@@ -783,3 +782,4 @@ workflows:
       - py311-integration-goethereum-ws_flaky
       - py311-integration-ethtester-pyevm
       - py311-wheel-cli
+      - py311-wheel-cli-windows

--- a/newsfragments/2899.internal.rst
+++ b/newsfragments/2899.internal.rst
@@ -1,0 +1,1 @@
+Update CircleCI windows orb path since it now uses python 3.11.

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ commands=
     python -c "from web3 import Web3"
 skip_install=true
 
-[testenv:py310-wheel-cli-windows]
+[testenv:py311-wheel-cli-windows]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
### What was wrong?

CircleCI orb windows@5.0.0 is now using Python311

### How was it fixed?

- Update the path and `tox` job + description to match the new path to Python311

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQBFzCGV2fkL_G-m0mC9va55vtfDFqfaPvJsxvvDdoFGhdE9TrCrA2n0p8vjSPG5tWWSvs&usqp=CAU)
