### PR TITLE
Bump and parameterize go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,11 @@ version: 2.1
 
 parameters:
   geth_version:
-    # update default when updating geth integration test fixture
+    # update default value when updating geth integration test fixture
     default: "v1.11.5"
     type: string
   pygeth_version:
-    # update default when updating geth integration test fixture
+    # update default value when updating geth integration test fixture
     default: "3.12.0"
     type: string
   go_version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,16 @@
 version: 2.1
 
 parameters:
-  # Note: update these defaults when updating the geth integration test fixture
   geth_version:
+    # update default when updating geth integration test fixture
     default: "v1.11.5"
     type: string
   pygeth_version:
+    # update default when updating geth integration test fixture
     default: "3.12.0"
+    type: string
+  go_version:
+    default: "1.20.2"
     type: string
 
 common: &common
@@ -88,8 +92,8 @@ geth_steps: &geth_steps
           echo << pipeline.parameters.geth_version >>
           export GETH_BINARY="$HOME/.py-geth/geth-<< pipeline.parameters.geth_version >>/bin/geth"
           if [ ! -e "$GETH_BINARY" ]; then
-            curl -O https://storage.googleapis.com/golang/go1.20.1.linux-amd64.tar.gz
-            tar xvf go1.20.1.linux-amd64.tar.gz
+            curl -O https://storage.googleapis.com/golang/go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
+            tar xvf go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
             sudo chown -R root:root ./go
             sudo mv go /usr/local
             sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
@@ -130,8 +134,8 @@ geth_custom_steps: &geth_custom_steps
           export GOROOT=/usr/local/go
           export GETH_BINARY="./custom_geth"
           echo 'export GETH_BINARY="./custom_geth"' >> $BASH_ENV
-          curl -O https://storage.googleapis.com/golang/go1.20.1.linux-amd64.tar.gz
-          tar xvf go1.20.1.linux-amd64.tar.gz
+          curl -O https://storage.googleapis.com/golang/go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
+          tar xvf go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
           sudo chown -R root:root ./go
           sudo mv go /usr/local
           sudo ln -s /usr/local/go/bin/go /usr/local/bin/go

--- a/newsfragments/2900.internal.rst
+++ b/newsfragments/2900.internal.rst
@@ -1,0 +1,1 @@
+Bump go version used in CI jobs that install and run go-ethereum and parameterize the version in circleci config file for ease of configuration.

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,6 @@ deps =
     .[dev]
 passenv =
     GETH_BINARY
-    GETH_VERSION
     GOROOT
     GOPATH
     WEB3_INFURA_PROJECT_ID


### PR DESCRIPTION
Bump `go` version used in geth builds to the latest and parametrize the version, much like was just done with `geth_version` and `pygeth_version` for ease of configuration.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20230328_091623](https://user-images.githubusercontent.com/3532824/228340818-a95ae8f7-8395-491a-94ed-bb521b8262b8.jpg)

