### PR TITLE
add formatter breaking changes to v6 migration guide

### DIFF
--- a/docs/v6_migration.rst
+++ b/docs/v6_migration.rst
@@ -116,6 +116,8 @@ Other Misc Changes
 - When a method is unavailable from a node provider (i.e. a response error
   code of -32601 is returned), a ``MethodUnavailable`` error is
   now raised instead of ``ValueError``
+- Logs' `data` field was previously formatted with `to_ascii_if_bytes`, now formatted to `HexBytes`
+- Receipts' `type` field was previously not formatted, now formatted with `to_integer_if_hex`
 
 Removals
 ~~~~~~~~

--- a/newsfragments/2907.doc.rst
+++ b/newsfragments/2907.doc.rst
@@ -1,0 +1,1 @@
+Added breaking changes from pr2448 to v6 migration guide


### PR DESCRIPTION
### What was wrong?

PR #2488 introduced breaking changes that were not mentioned in the v6 migration guide.

### How was it fixed?

Mentioned them.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/230639926-d2947a44-553b-4c8f-9001-0c1acd6a98f1.png)

