### PR TITLE
Use the correct type for `trace_filter`

### DIFF
--- a/newsfragments/2913.bugfix.rst
+++ b/newsfragments/2913.bugfix.rst
@@ -1,0 +1,1 @@
+Use ``TraceFilterParams`` instead of ``FilterParams`` for ``trace_filter`` typing

--- a/web3/tracing.py
+++ b/web3/tracing.py
@@ -29,7 +29,7 @@ from web3.module import (
 from web3.types import (
     BlockIdentifier,
     BlockTrace,
-    FilterParams,
+    TraceFilterParams,
     FilterTrace,
     TraceMode,
     TxParams,
@@ -73,7 +73,7 @@ class Tracing(Module):
         mungers=[default_root_munger],
     )
 
-    trace_filter: Method[Callable[[FilterParams], List[FilterTrace]]] = Method(
+    trace_filter: Method[Callable[[TraceFilterParams], List[FilterTrace]]] = Method(
         RPC.trace_filter,
         mungers=[default_root_munger],
     )

--- a/web3/tracing.py
+++ b/web3/tracing.py
@@ -29,8 +29,8 @@ from web3.module import (
 from web3.types import (
     BlockIdentifier,
     BlockTrace,
-    TraceFilterParams,
     FilterTrace,
+    TraceFilterParams,
     TraceMode,
     TxParams,
     _Hash32,


### PR DESCRIPTION
- Use `TraceFilterParams` for `trace_filter` instead of `FilterParams` (for events)