### PR TITLE
Add build to towncrier commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ docs: build-docs validate-docs
 
 validate-docs: build-docs
 	python newsfragments/validate_files.py
-	towncrier --draft
+	towncrier build --draft
 
 linux-docs: build-docs
 	readlink -f docs/_build/html/index.html
@@ -57,7 +57,7 @@ notes:
 	# Let UPCOMING_VERSION be the version that is used for the current bump
 	$(eval UPCOMING_VERSION=$(shell bumpversion $(bump) --dry-run --list | grep new_version= | sed 's/new_version=//g'))
 	# Now generate the release notes to have them included in the release commit
-	towncrier --yes --version $(UPCOMING_VERSION)
+	towncrier build --yes --version $(UPCOMING_VERSION)
 	# Before we bump the version, make sure that the towncrier-generated docs will build
 	make build-docs
 	git commit -m "Compile release notes"

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -465,7 +465,7 @@ Preview The Release Notes
 
 .. code:: sh
 
-   $ towncrier --draft
+   $ towncrier build --draft
 
 
 Compile The Release Notes

--- a/newsfragments/2915.internal.rst
+++ b/newsfragments/2915.internal.rst
@@ -1,0 +1,1 @@
+Added ``build`` to towncrier commands in Makefile


### PR DESCRIPTION
### What was wrong?

The towncrier version dependency got updated which included a change in their commands. Needed to update throughout the Makefile.


### How was it fixed?

Added `build` to towncrier commands.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://drscdn.500px.org/photo/143867467/m%3D900/v2?sig=b9c52522ea1c7768602c736213afe351f30c66fb2fba8cb5a13e24a2933b3659)
