### PR TITLE
Fix typing for get_ipc_path and get_dev_ipc_path

### DIFF
--- a/newsfragments/2917.bugfix.rst
+++ b/newsfragments/2917.bugfix.rst
@@ -1,0 +1,1 @@
+Typing was being ignored for the ``get_ipc_path`` and ``get_dev_ipc_path`` functions because of a missing ``None`` return. Those two methods now explicitly return ``None`` and have an ``Optional`` in their type definition.

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -14,6 +14,7 @@ from types import (
 )
 from typing import (
     Any,
+    Optional,
     Type,
     Union,
 )
@@ -85,24 +86,26 @@ class PersistantSocket:
         return self.sock
 
 
-# type ignored b/c missing return statement is by design here
-def get_default_ipc_path() -> str:  # type: ignore
+def get_default_ipc_path() -> Optional[str]:
     if sys.platform == "darwin":
         ipc_path = os.path.expanduser(
             os.path.join("~", "Library", "Ethereum", "geth.ipc")
         )
         if os.path.exists(ipc_path):
             return ipc_path
+        return None
 
     elif sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
         ipc_path = os.path.expanduser(os.path.join("~", ".ethereum", "geth.ipc"))
         if os.path.exists(ipc_path):
             return ipc_path
+        return None
 
     elif sys.platform == "win32":
         ipc_path = os.path.join("\\\\", ".", "pipe", "geth.ipc")
         if os.path.exists(ipc_path):
             return ipc_path
+        return None
 
     else:
         raise ValueError(
@@ -111,22 +114,25 @@ def get_default_ipc_path() -> str:  # type: ignore
         )
 
 
-# type ignored b/c missing return statement is by design here
-def get_dev_ipc_path() -> str:  # type: ignore
+def get_dev_ipc_path() -> Optional[str]:
     if os.environ.get("WEB3_PROVIDER_URI", ""):
         ipc_path = os.environ.get("WEB3_PROVIDER_URI")
         if os.path.exists(ipc_path):
             return ipc_path
+        return None
+
     elif sys.platform == "darwin":
         tmpdir = os.environ.get("TMPDIR", "")
         ipc_path = os.path.expanduser(os.path.join(tmpdir, "geth.ipc"))
         if os.path.exists(ipc_path):
             return ipc_path
+        return None
 
     elif sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
         ipc_path = os.path.expanduser(os.path.join("/tmp", "geth.ipc"))
         if os.path.exists(ipc_path):
             return ipc_path
+        return None
 
     elif sys.platform == "win32":
         ipc_path = os.path.join("\\\\", ".", "pipe", "geth.ipc")


### PR DESCRIPTION
### What was wrong?
The typing was incorrect on `get_ipc_path` and `get_dev_ipc_path`. 

Closes #2911 

### How was it fixed?
Added the correct typing and explicit `None` returns where needed. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wallpaperaccess.com/full/1875085.jpg)
