### PR TITLE
Update how we run tox for win CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ windows_steps: &windows_steps
         command: pip install --user tox
     - run:
         name: run tox
-        command: 'C:/Users/circleci.PACKER-6400C91A/AppData/Roaming/Python/Python311/Scripts/tox.exe -r'
+        command: python -m tox -r
     - save_cache:
         paths:
           - .tox

--- a/newsfragments/2923.internal.rst
+++ b/newsfragments/2923.internal.rst
@@ -1,0 +1,1 @@
+Update win wheel CI builds to use ``python -m tox -r`` instead of specifying the ``tox`` executable directly.


### PR DESCRIPTION
### What was wrong?

Windows builds are finally working when referencing `tox` via `python -m tox -r`. Hopefully the headaches with changing PACKER names goes away for good now. Thanks to @pacrob for trying it again.

### How was it fixed?

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20230402_124811_2](https://user-images.githubusercontent.com/3532824/232855742-56fd6e1d-b276-4de5-a850-ad0b0aadb90a.jpg)

