### PR TITLE
Update pip and virtualenv for CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,9 @@ windows_steps: &windows_steps
         command: git submodule update --init --recursive
     - run:
         name: install dependencies
-        command: pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: run tox
         command: python -m tox -r

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,9 @@ common: &common
         command: git submodule update --init --recursive
     - run:
         name: install dependencies
-        command: pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: run tox
         command: python -m tox -r
@@ -52,7 +54,9 @@ docs_steps: &docs_steps
         command: git submodule update --init --recursive
     - run:
         name: install dependencies
-        command: pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: install web3
         command: pip install -U web3
@@ -81,8 +85,8 @@ geth_steps: &geth_steps
     - run:
         name: install dependencies
         command: |
-          pip install --upgrade pip
-          pip install --user tox
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: build geth if missing
         command: |
@@ -126,7 +130,9 @@ geth_custom_steps: &geth_custom_steps
           - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
-        command: pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: use a pre-built geth binary
         command: |
@@ -179,7 +185,9 @@ ethpm_steps: &ethpm_steps
         command: git submodule update --init --recursive
     - run:
         name: install dependencies
-        command: pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: run tox
         command: python -m tox -r

--- a/newsfragments/2927.internal.rst
+++ b/newsfragments/2927.internal.rst
@@ -1,0 +1,1 @@
+update pip and tox install on CI containers


### PR DESCRIPTION
### What was wrong?

- circleci image tox versions were clashing with the new virtualenv release. Make sure to `--upgrade` the tox version sitting in the image before running `tox`.
- Also, `--upgrade` the pip version sitting in the image python install before any of the above steps.

### How was it fixed?

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![images](https://user-images.githubusercontent.com/3950603/233856737-5c777937-28fb-45b6-ad9e-84dfd411d9b5.jpeg)
