### PR TITLE
Check for null value on TRACE_FORMATTERS.transactionHash

### DIFF
--- a/newsfragments/2965.misc.rst
+++ b/newsfragments/2965.misc.rst
@@ -1,0 +1,1 @@
+Check for null value on TRACE_FORMATTERS.transactionHash

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -582,7 +582,7 @@ TRACE_FORMATTERS = apply_formatter_if(
             "result": TRACE_RESULT_FORMATTERS,
             "blockHash": HexBytes,
             "blockNumber": to_integer_if_hex,
-            "transactionHash": HexBytes,
+            "transactionHash": apply_formatter_if(is_not_null, to_hexbytes(32)),
         }
     ),
 )


### PR DESCRIPTION
### What was wrong?

We are running a Gnosis Safe instance for Ethereum Classic chains. 
The indexer of Gnosis Safe, uses `trace_block` to fetch some info. 

This implementation works fine on Ethereum network now that is on PoS. The `trace_block` tracer returns only the traces for the block transactions. 
On the other hand, on Ethereum Classic, we include two more objects at the end of the array, which are the block and uncle rewards. Those two entries don't have a `transactionHash`, and it's being set to `null`. 
For this reason we trigger the following exception:

```
indexer_worker_mordor_1                  | 2023-05-10 11:47:08,372 [ERROR] [d14fbb79/index_internal_txs_task] Task safe_transaction_service.history.tasks.index_internal_txs_task[d14fbb79-a4a3-491b-86f1-febea2dc18f5] raised unexpected: TypeError("Could not format invalid type of None for field 'transactionHash'")
indexer_worker_mordor_1                  | Traceback (most recent call last):
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/eth_utils/applicators.py", line 84, in apply_formatters_to_dict
indexer_worker_mordor_1                  |     yield key, formatters[key](item)
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/hexbytes/main.py", line 38, in new
indexer_worker_mordor_1                  |     bytesval = to_bytes(val)
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/hexbytes/_utils.py", line 32, in to_bytes
indexer_worker_mordor_1                  |     raise TypeError(f"Cannot convert {val!r} of type {type(val)} to bytes")
indexer_worker_mordor_1                  | TypeError: Cannot convert None of type <class 'NoneType'> to bytes
indexer_worker_mordor_1                  | 
indexer_worker_mordor_1                  | The above exception was the direct cause of the following exception:
indexer_worker_mordor_1                  | 
indexer_worker_mordor_1                  | Traceback (most recent call last):
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 451, in trace_task
indexer_worker_mordor_1                  |     R = retval = fun(*args, **kwargs)
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 734, in protected_call
indexer_worker_mordor_1                  |     return self.run(*args, **kwargs)
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/celery/app/autoretry.py", line 34, in run
indexer_worker_mordor_1                  |     return task._orig_run(*args, **kwargs)
indexer_worker_mordor_1                  |   File "/app/safe_transaction_service/history/tasks.py", line 190, in index_internal_txs_task
indexer_worker_mordor_1                  |     ) = InternalTxIndexerProvider().start()
indexer_worker_mordor_1                  |   File "/app/safe_transaction_service/history/indexers/ethereum_indexer.py", line 445, in start
indexer_worker_mordor_1                  |     ) = self.process_addresses(
indexer_worker_mordor_1                  |   File "/app/safe_transaction_service/history/indexers/ethereum_indexer.py", line 390, in process_addresses
indexer_worker_mordor_1                  |     elements = self.find_relevant_elements(
indexer_worker_mordor_1                  |   File "/app/safe_transaction_service/history/indexers/internal_tx_indexer.py", line 385, in find_relevant_elements
indexer_worker_mordor_1                  |     return self._find_relevant_elements_using_trace_block(
indexer_worker_mordor_1                  |   File "/app/safe_transaction_service/history/indexers/internal_tx_indexer.py", line 152, in _find_relevant_elements_using_trace_block
indexer_worker_mordor_1                  |     blocks_traces: BlockTrace = self.ethereum_client.tracing.trace_blocks(
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/gnosis/eth/ethereum_client.py", line 1016, in trace_blocks
indexer_worker_mordor_1                  |     return [trace_list_result_formatter(block_traces) for block_traces in results]
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/gnosis/eth/ethereum_client.py", line 1016, in <listcomp>
indexer_worker_mordor_1                  |     return [trace_list_result_formatter(block_traces) for block_traces in results]
indexer_worker_mordor_1                  |   File "cytoolz/functoolz.pyx", line 253, in cytoolz.functoolz.curry.__call__
indexer_worker_mordor_1                  |   File "cytoolz/functoolz.pyx", line 249, in cytoolz.functoolz.curry.__call__
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/eth_utils/decorators.py", line 91, in wrapper
indexer_worker_mordor_1                  |     return ReturnType(result)  # type: ignore
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/eth_utils/applicators.py", line 105, in apply_formatter_to_array
indexer_worker_mordor_1                  |     yield formatter(item)
indexer_worker_mordor_1                  |   File "cytoolz/functoolz.pyx", line 253, in cytoolz.functoolz.curry.__call__
indexer_worker_mordor_1                  |   File "cytoolz/functoolz.pyx", line 249, in cytoolz.functoolz.curry.__call__
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/eth_utils/applicators.py", line 72, in apply_formatter_if
indexer_worker_mordor_1                  |     return formatter(value)
indexer_worker_mordor_1                  |   File "cytoolz/functoolz.pyx", line 253, in cytoolz.functoolz.curry.__call__
indexer_worker_mordor_1                  |   File "cytoolz/functoolz.pyx", line 249, in cytoolz.functoolz.curry.__call__
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/web3/_utils/method_formatters.py", line 163, in type_aware_apply_formatters_to_dict
indexer_worker_mordor_1                  |     formatted_dict: Dict[str, Any] = apply_formatters_to_dict(formatters, dict(value))
indexer_worker_mordor_1                  |   File "cytoolz/functoolz.pyx", line 253, in cytoolz.functoolz.curry.__call__
indexer_worker_mordor_1                  |   File "cytoolz/functoolz.pyx", line 249, in cytoolz.functoolz.curry.__call__
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/eth_utils/functional.py", line 45, in inner
indexer_worker_mordor_1                  |     return callback(fn(*args, **kwargs))
indexer_worker_mordor_1                  |   File "/usr/local/lib/python3.10/site-packages/eth_utils/applicators.py", line 95, in apply_formatters_to_dict
indexer_worker_mordor_1                  |     raise TypeError(new_error_message) from exc
indexer_worker_mordor_1                  | TypeError: Could not format invalid type of None for field 'transactionHash'
```

### How was it fixed?

By checking if trace `transactionHash` is null.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Cat](https://cdn.freecodecamp.org/curriculum/cat-photo-app/relaxing-cat.jpg)
