### PR TITLE
test(accounts): add assertion for expected_bytes in test_eth_account_…

### DIFF
--- a/newsfragments/3698.misc.rst
+++ b/newsfragments/3698.misc.rst
@@ -1,0 +1,1 @@
+Add a check against previously unused ``expected_bytes`` parametrized variable when testing ``eth_account`` sign.

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -264,6 +264,7 @@ def test_eth_account_sign(
     acct, message_text, key, expected_bytes, expected_hash, v, r, s, signature
 ):
     message = encode_defunct(text=message_text)
+    assert message.body == expected_bytes
     signed_message = Web3.keccak(
         b"\x19Ethereum Signed Message:\n"
         + bytes(f"{len(message.body)}", encoding="utf-8")
@@ -357,9 +358,9 @@ def test_eth_account_sign(
         ),
         (
             {
-                "gas": 100000,
-                "maxFeePerGas": 2000000000,
-                "maxPriorityFeePerGas": 2000000000,
+                "gas": "0x186a0",
+                "maxFeePerGas": "0x77359400",
+                "maxPriorityFeePerGas": "0x77359400",
                 "data": "0x5544",
                 "nonce": "0x2",
                 "to": "0x96216849c49358B10257cb55b28eA603c874b05E",


### PR DESCRIPTION
### What was wrong?

The expected_bytes parameter in the test_eth_account_sign test was defined and provided via parametrization, but was not actually used in the test body. This resulted in a linter warning for an unused variable and missed an opportunity to verify the correctness of the message's byte representation.

### How was it fixed?

Added an assertion to check that message.body matches the expected_bytes parameter. This ensures the test validates the correct byte encoding of the message and eliminates the unused variable warning.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<https://static.independent.co.uk/s3fs-public/thumbnails/image/2013/01/24/12/v2-cute-cat-picture.jpg?quality=75&width=1250&crop=3%3A2%2Csmart&auto=webp>)
