### PR TITLE
feat: optimize passing data thru formatters

### DIFF
--- a/tests/core/utilities/test_abi.py
+++ b/tests/core/utilities/test_abi.py
@@ -262,7 +262,7 @@ def test_get_tuple_type_str_parts(
 def test_abi_data_tree(
     types: List[str], data: Tuple[List[bool], bytes], expected: List[Any]
 ) -> None:
-    assert abi_data_tree(types, data) == expected
+    assert list(abi_data_tree(types, data)) == expected
 
 
 @pytest.mark.parametrize(

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -623,9 +623,7 @@ def map_abi_data(
 
 
 @curry
-def abi_data_tree(
-    types: Iterable[TypeStr], data: Iterable[Any]
-) -> "map[ABITypedData]":
+def abi_data_tree(types: Iterable[TypeStr], data: Iterable[Any]) -> "map[ABITypedData]":
     """
     Decorate the data tree with pairs of (type, data). The pair tuple is actually an
     ABITypedData, but can be accessed as a tuple.

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -618,6 +618,7 @@ def map_abi_data(
         *map(data_tree_map, normalizers),
         # 3. Stripping the types back out of the tree
         strip_abi_types,
+        list,
     )
 
 

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -624,7 +624,7 @@ def map_abi_data(
 @curry
 def abi_data_tree(
     types: Iterable[TypeStr], data: Iterable[Any]
-) -> List["ABITypedData"]:
+) -> "map[ABITypedData]":
     """
     Decorate the data tree with pairs of (type, data). The pair tuple is actually an
     ABITypedData, but can be accessed as a tuple.
@@ -634,7 +634,7 @@ def abi_data_tree(
     >>> abi_data_tree(types=["bool[2]", "uint"], data=[[True, False], 0])
     [("bool[2]", [("bool", True), ("bool", False)]), ("uint256", 0)]
     """
-    return list(map(abi_sub_tree, types, data))
+    return map(abi_sub_tree, types, data)
 
 
 @curry
@@ -929,6 +929,8 @@ async def async_map_if_collection(
     If the value is not a collection, return it unmodified.
     """
     datatype = type(value)
+    if datatype is map:
+        return [await func(item) for item in value]
     if isinstance(value, Mapping):
         return datatype({key: await func(val) for key, val in value.values()})
     if is_string(value):

--- a/web3/_utils/formatters.py
+++ b/web3/_utils/formatters.py
@@ -65,6 +65,8 @@ def map_collection(func: Callable[..., TReturn], collection: Any) -> Any:
     If the value is not a collection, return it unmodified
     """
     datatype = type(collection)
+    if datatype is map:
+        return map(func, collection)
     if isinstance(collection, Mapping):
         return datatype((key, func(val)) for key, val in collection.items())
     if is_string(collection):


### PR DESCRIPTION
### What was wrong?

In the current code, data_tree_map is called multiple times in rapid succession. This occurs for every call that is formatted.

data_tree_map creates and populates a new list each time its called, which is quite wasteful and not necessary for our use case, especially when we're calling it recursively

This PR changes the codebase so, instead of creating and populating a new list object at each and every stage of formatting, now we pass `map` objects thru the formatters and only create and populate one list when the formatting is complete. 


The only api that changed was in an internal module, and the codebase was adapted accordingly. This small change makes a much bigger difference than the past few PRs did, so I'm hoping this API change doesn't block us from merging. 

@kclowes you can use the same benchmark script you used for the last PR, you will see a tangible difference on that benchmark and you should also in the overall testing times

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
