### PR TITLE
[fix]: link to api.md#hex-value-encoding

### DIFF
--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -208,7 +208,7 @@ Encoding and Decoding Helpers
         >>> Web3.to_hex(text='cowmö')
         '0x636f776dc3b6'
 
-.. _JSON-RPC spec: https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding
+.. _JSON-RPC spec: https://github.com/ethereum/eth-wiki/blob/master/json-rpc/api.md#hex-value-encoding
 
 .. py:method:: Web3.to_text(primitive=None, hexstr=None, text=None)
 


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/wiki/wiki/ is renamed to https://github.com/ethereum/eth-wiki/ so we need to update link because previous one is non-working

### How was it fixed?

changed https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding to https://github.com/ethereum/eth-wiki/blob/master/json-rpc/api.md#hex-value-encoding

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture


![photo_2023-05-08_14-05-51](https://github.com/user-attachments/assets/208a0a9c-736b-4ad3-a802-99bb1602e7f0)
