### PR TITLE
fix: replace generic Exception with specific RequestException in exce…

### DIFF
--- a/web3/utils/exception_handling.py
+++ b/web3/utils/exception_handling.py
@@ -57,7 +57,7 @@ def handle_offchain_lookup(
                     json={"data": formatted_data, "sender": formatted_sender},
                     timeout=DEFAULT_HTTP_TIMEOUT,
                 )
-        except Exception:
+        except requests.RequestException:
             continue  # try next url if timeout or issues making the request
 
         if (


### PR DESCRIPTION

### What was wrong?
Replace the overly broad `except Exception` with the more specific `except requests.RequestException` in the handle_offchain_lookup function. This change improves error handling by only catching expected network-related exceptions while allowing other unexpected errors to propagate properly, making the code more robust and easier to debug


### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="440" height="586" alt="image" src="https://github.com/user-attachments/assets/0717b75d-5509-4e3d-b268-206188889c0c" />