### PR TITLE
docs: add developer setup instructions for Windows

### DIFF
--- a/docs/README-windows.md
+++ b/docs/README-windows.md
@@ -1,7 +1,59 @@
+
 # web3.py on Windows
 
 ## Developer Setup
 
-1. Install all of the package dependencies (TODO)
+### Option 1: Native Windows setup
 
-1. Install `leveldb` (TODO)
+1. **Install Python 3.9+**  
+   Download from [python.org](https://www.python.org/downloads/windows/).  
+   Make sure to check **"Add Python to PATH"** during installation.
+
+2. **Clone the repository and create a virtual environment**:
+
+```powershell
+cd %USERPROFILE%
+````
+```powershell
+git clone https://github.com/ethereum/web3.py.git
+````
+```powershell
+cd web3.py
+````
+```powershell
+python -m venv venv
+````
+```powershell
+venv\Scripts\activate
+````
+
+3. **Upgrade pip and install development dependencies**:
+
+```powershell
+pip install --upgrade pip
+```
+```powershell
+pip install -e ".[dev]"
+```
+
+4. **(Optional) Install `leveldb` binaries if needed**:
+
+```powershell
+pip install plyvel-binary
+```
+
+> ⚠️ Note: `leveldb` is not required for most users.
+> If installation fails, you can safely skip this step.
+
+---
+
+### Option 2: Recommended (via WSL)
+
+Many Ethereum developers prefer using
+[WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install)
+to avoid dependency issues.
+
+With WSL you can run a Linux distribution (Ubuntu/Debian/Fedora, etc.) directly on Windows.
+After installing WSL, follow the Linux setup guide: [README-linux.md](./README-linux.md).
+
+---


### PR DESCRIPTION
### What was wrong?

Windows developer setup instructions were missing in the documentation (`TODO` placeholder only).

Related to Issue #
N/A

### How was it fixed?

Added step-by-step setup guide for Windows in `docs/README-windows.md`.

### Todo:

- [ ] Clean up commit history ✅ (squash if needed)
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md) (not required for small docs changes)

#### Cute Animal Picture

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/e56e6e28-e85e-4c2b-8e6a-7f05ea7704f0" />

