### PR TITLE
Update link  wiki

### DIFF
--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -312,7 +312,7 @@ Each Contract Factory exposes the following methods.
     - ``to_block`` optional. Defaults to 'latest'. Defines the ending block (inclusive) in the filter block range.  Special values 'latest' and 'pending' set a dynamic range that always includes the 'latest' or 'pending' blocks for the filter's upper block range.
     - ``address`` optional. Defaults to the contract address. The filter matches the event logs emanating from ``address``.
     - ``argument_filters``, optional. Expects a dictionary of argument names and values. When provided event logs are filtered for the event argument values. Event arguments can be both indexed or unindexed. Indexed values will be translated to their corresponding topic arguments. Unindexed arguments will be filtered using a regular expression.
-    - ``topics`` optional, accepts the standard JSON-RPC topics argument.  See the JSON-RPC documentation for `eth_newFilter <https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter>`_ more information on the ``topics`` parameters.
+    - ``topics`` optional, accepts the standard JSON-RPC topics argument.  See the JSON-RPC documentation for `eth_newFilter <https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newfilter>`_ more information on the ``topics`` parameters.
 
     .. doctest:: contractmethods
 

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -208,7 +208,7 @@ Encoding and Decoding Helpers
         >>> Web3.to_hex(text='cowmö')
         '0x636f776dc3b6'
 
-.. _JSON-RPC spec: https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding
+.. _JSON-RPC spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#hex-encoding
 
 .. py:method:: Web3.to_text(primitive=None, hexstr=None, text=None)
 

--- a/newsfragments/3746.docs.rst
+++ b/newsfragments/3746.docs.rst
@@ -1,0 +1,1 @@
+Update a few broken links


### PR DESCRIPTION
### What was wrong?


[Update link web3.main.rst](https://github.com/ethereum/web3.py/pull/3746/commits/8fbd39fc1747189866efb5b240da2df73f16360f):  
https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding --> https://ethereum.org/en/developers/docs/apis/json-rpc/#hex-encoding

[Update web3.contract.rst](https://github.com/ethereum/web3.py/pull/3746/commits/aaa990184ad82b21193596f8a6926597e6bfb8a4)
https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter --> https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newfilter


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/1154370446/ru/%D1%84%D0%BE%D1%82%D0%BE/%D0%B7%D0%B0%D0%B1%D0%B0%D0%B2%D0%BD%D1%8B%D0%B9-%D0%B5%D0%BD%D0%BE%D1%82-%D0%B2-%D0%B7%D0%B5%D0%BB%D0%B5%D0%BD%D1%8B%D1%85-%D1%81%D0%BE%D0%BB%D0%BD%D1%86%D0%B5%D0%B7%D0%B0%D1%89%D0%B8%D1%82%D0%BD%D1%8B%D1%85-%D0%BE%D1%87%D0%BA%D0%B0%D1%85-%D0%BF%D0%BE%D0%BA%D0%B0%D0%B7%D1%8B%D0%B2%D0%B0%D1%8E%D1%89%D0%B8%D0%B9-%D1%80%D0%BE%D0%BA-%D0%B6%D0%B5%D1%81%D1%82-%D0%B8%D0%B7%D0%BE%D0%BB%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%BD%D1%8B%D0%B9-%D0%BD%D0%B0-%D0%B1%D0%B5%D0%BB%D0%BE%D0%BC-%D1%84%D0%BE%D0%BD%D0%B5.jpg?s=612x612&w=0&k=20&c=xFOLPvc4qmaab3aRROpRzN5OXc2bkQT14eD1Js2BnTU=)
