### PR TITLE
Fix websockets deprecation warning

### DIFF
--- a/newsfragments/3749.internal.rst
+++ b/newsfragments/3749.internal.rst
@@ -1,0 +1,1 @@
+Remove websockets deprecation warning by using the asyncio websocket provider

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ import time
 from websockets import (
     WebSocketException,
 )
-from websockets.legacy.client import (
+from websockets import (
     connect,
 )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,8 +4,6 @@ import time
 
 from websockets import (
     WebSocketException,
-)
-from websockets import (
     connect,
 )
 

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -54,10 +54,6 @@ from web3.utils import (
 )
 
 if TYPE_CHECKING:
-    from websockets.legacy.client import (
-        WebSocketClientProtocol,
-    )
-
     from web3 import (  # noqa: F401
         AsyncWeb3,
         WebSocketProvider,

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -174,9 +174,6 @@ class AsyncBaseProvider:
             "Persistent connection providers must implement this method"
         )
 
-    # WebSocket typing
-    _ws: "WebSocketClientProtocol"
-
     # IPC typing
     _reader: Optional[asyncio.StreamReader]
     _writer: Optional[asyncio.StreamWriter]

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
 import asyncio
 import json
 import logging
 import os
+import typing
 from threading import (
     Thread,
 )
@@ -21,10 +23,6 @@ from typing import (
 from eth_typing import (
     URI,
 )
-from websockets.legacy.client import (
-    WebSocketClientProtocol,
-    connect,
-)
 
 from web3._utils.batching import (
     sort_batch_response_by_response_ids,
@@ -42,6 +40,11 @@ from web3.types import (
     RPCEndpoint,
     RPCResponse,
 )
+
+if typing.TYPE_CHECKING:
+    from websockets.legacy.client import (
+        WebSocketClientProtocol,
+    )
 
 RESTRICTED_WEBSOCKET_KWARGS = {"uri", "loop"}
 DEFAULT_WEBSOCKET_TIMEOUT = 30
@@ -72,6 +75,7 @@ class PersistentWebSocket:
 
     async def __aenter__(self) -> WebSocketClientProtocol:
         if self.ws is None:
+            from websockets.legacy.client import connect
             self.ws = await connect(uri=self.endpoint_uri, **self.websocket_kwargs)
         return self.ws
 

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -12,8 +12,8 @@ from threading import (
 from types import (
     TracebackType,
 )
-import typing
 from typing import (
+    TYPE_CHECKING,
     Any,
     List,
     cast,
@@ -40,7 +40,7 @@ from web3.types import (
     RPCResponse,
 )
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from websockets.legacy.client import (
         WebSocketClientProtocol,
     )

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -1,22 +1,21 @@
-from __future__ import annotations
+from __future__ import (
+    annotations,
+)
+
 import asyncio
 import json
 import logging
 import os
-import typing
 from threading import (
     Thread,
 )
 from types import (
     TracebackType,
 )
+import typing
 from typing import (
     Any,
     List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
     cast,
 )
 
@@ -69,19 +68,22 @@ def get_default_endpoint() -> URI:
 
 class PersistentWebSocket:
     def __init__(self, endpoint_uri: URI, websocket_kwargs: Any) -> None:
-        self.ws: Optional[WebSocketClientProtocol] = None
+        self.ws: WebSocketClientProtocol | None = None
         self.endpoint_uri = endpoint_uri
         self.websocket_kwargs = websocket_kwargs
 
     async def __aenter__(self) -> WebSocketClientProtocol:
         if self.ws is None:
-            from websockets.legacy.client import connect
+            from websockets.legacy.client import (
+                connect,
+            )
+
             self.ws = await connect(uri=self.endpoint_uri, **self.websocket_kwargs)
         return self.ws
 
     async def __aexit__(
         self,
-        exc_type: Type[BaseException],
+        exc_type: type[BaseException],
         exc_val: BaseException,
         exc_tb: TracebackType,
     ) -> None:
@@ -99,8 +101,8 @@ class LegacyWebSocketProvider(JSONBaseProvider):
 
     def __init__(
         self,
-        endpoint_uri: Optional[Union[URI, str]] = None,
-        websocket_kwargs: Optional[Any] = None,
+        endpoint_uri: URI | str | None = None,
+        websocket_kwargs: Any | None = None,
         websocket_timeout: int = DEFAULT_WEBSOCKET_TIMEOUT,
         **kwargs: Any,
     ) -> None:
@@ -148,8 +150,8 @@ class LegacyWebSocketProvider(JSONBaseProvider):
         return future.result()
 
     def make_batch_request(
-        self, requests: List[Tuple[RPCEndpoint, Any]]
-    ) -> List[RPCResponse]:
+        self, requests: list[tuple[RPCEndpoint, Any]]
+    ) -> list[RPCResponse]:
         self.logger.debug(
             "Making batch request WebSocket. URI: %s, Methods: %s",
             self.endpoint_uri,

--- a/web3/providers/persistent/websocket.py
+++ b/web3/providers/persistent/websocket.py
@@ -142,7 +142,7 @@ class WebSocketProvider(PersistentConnectionProvider):
 
     async def _provider_specific_disconnect(self) -> None:
         # this should remain idempotent
-        if self._ws is not None and not self._ws.closed:
+        if self._ws is not None:
             await self._ws.close()
             self._ws = None
 

--- a/web3/providers/persistent/websocket.py
+++ b/web3/providers/persistent/websocket.py
@@ -1,4 +1,7 @@
-from __future__ import annotations
+from __future__ import (
+    annotations,
+)
+
 import asyncio
 import json
 import logging
@@ -6,9 +9,6 @@ import os
 import typing
 from typing import (
     Any,
-    Dict,
-    Optional,
-    Union,
 )
 
 from eth_typing import (
@@ -17,12 +17,12 @@ from eth_typing import (
 from toolz import (
     merge,
 )
+from websockets import (
+    connect,
+)
 from websockets.exceptions import (
     ConnectionClosedOK,
     WebSocketException,
-)
-from websockets import (
-    connect,
 )
 
 from web3.exceptions import (
@@ -38,7 +38,9 @@ from web3.types import (
 )
 
 if typing.TYPE_CHECKING:
-    from websockets import ClientConnection
+    from websockets import (
+        ClientConnection,
+    )
 
 DEFAULT_PING_INTERVAL = 30  # 30 seconds
 DEFAULT_PING_TIMEOUT = 300  # 5 minutes

--- a/web3/providers/persistent/websocket.py
+++ b/web3/providers/persistent/websocket.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import logging
 import os
-import typing
 from typing import (
     Any,
 )
@@ -17,7 +16,15 @@ from eth_typing import (
 from toolz import (
     merge,
 )
-from websockets import (
+
+# python3.8 supports up to version 13,
+# which does not default to the asyncio implementation yet.
+# For this reason connect and ClientConnection need to be imported
+# from asyncio.client explicitly.
+# When web3.py stops supporting python3.8,
+# it'll be possible to use `from websockets import connect, ClientConnection`.
+from websockets.asyncio.client import (
+    ClientConnection,
     connect,
 )
 from websockets.exceptions import (
@@ -36,11 +43,6 @@ from web3.providers.persistent import (
 from web3.types import (
     RPCResponse,
 )
-
-if typing.TYPE_CHECKING:
-    from websockets import (
-        ClientConnection,
-    )
 
 DEFAULT_PING_INTERVAL = 30  # 30 seconds
 DEFAULT_PING_TIMEOUT = 300  # 5 minutes


### PR DESCRIPTION
### What was wrong?
Importing `from web3 import Web3` was causing a DeprecationWarning to be raised.
This can be easily replicated by doing:
```shell
$ pytest tests/core/providers/test_legacy_websocket_provider.py -W error::DeprecationWarning
ImportError while loading conftest '/Users/mdalp/coding/web3.py/conftest.py'.
conftest.py:7: in <module>
    from tests.utils import (
tests/utils.py:8: in <module>
    from websockets.legacy.client import (
.venv/lib/python3.13/site-packages/websockets/legacy/__init__.py:6: in <module>
    warnings.warn(  # deprecated in 14.0 - 2024-11-09
E   DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
```
This PR aims at resolving that once for all.

### How was it fixed?
1. lazy loading `websockets.legacy` in the legacy provider
2. using the recommended implementation from the `websockets` package
3. running tests to ensure they still pass

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)


### Notes:
The pre-commit hook changed quite a lot the file, I ended up committing those changes in a separate commit so that the relevant changes can be seen in isolation.

#### Cute Animal Picture
<img width="1024" height="1024" alt="Cute baby xenomorph" src="https://github.com/user-attachments/assets/c8521874-9050-4340-ad2f-3ab59a2cbdbb" />

