### PR TITLE
Ignore too slow healthcheck for test_key_generation_is_deterministic

### DIFF
--- a/newsfragments/3730.bugfix.rst
+++ b/newsfragments/3730.bugfix.rst
@@ -1,0 +1,1 @@
+Fix tests flakiness due to slow data generation from hypotesis triggering a timeout.

--- a/tests/core/caching-utils/test_generate_cache_key.py
+++ b/tests/core/caching-utils/test_generate_cache_key.py
@@ -4,7 +4,9 @@ from eth_utils import (
     to_dict,
 )
 from hypothesis import (
+    HealthCheck,
     given,
+    settings,
     strategies as st,
 )
 
@@ -42,6 +44,9 @@ def recursive_shuffle_dict(v):
         return v
 
 
+# Generating data for the `all_st` strategy can be slow, so we disable the
+# "too_slow" health check for this test.
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(value=all_st)
 def test_key_generation_is_deterministic(value):
     left = recursive_shuffle_dict(value)


### PR DESCRIPTION
### What was wrong?

Test `tests/core/caching-utils/test_generate_cache_key.py::test_key_generation_is_deterministic` is flaky (especially with py3.12) because occasionally the generation of test data from `hypothesis` takes longer than the given threshold, causing the test to fail due to an healthcheck failure.


Related to Issue https://github.com/ethereum/web3.py/issues/3730
Closes https://github.com/ethereum/web3.py/issues/3730

### How was it fixed?
The fix is to suppress the `too_slow` healthcheck from `hypothesis` for that specific test, and accept that occasionally that test will run slow.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![cute animal picture](https://i0.pickpik.com/photos/9/10/499/hedgehog-baby-cute-animal-preview.jpg)
