### PR TITLE
Resolve datetime.datetime.utcnow() deprecation

### DIFF
--- a/newsfragments/3751.internal.rst
+++ b/newsfragments/3751.internal.rst
@@ -1,0 +1,1 @@
+Resolve the DeprecationWarning for the usage of `datetime.datetime.utcnow()`

--- a/tests/core/utilities/test_encoding.py
+++ b/tests/core/utilities/test_encoding.py
@@ -144,8 +144,11 @@ def test_text_if_str_on_text(val):
         ),
         (
             {
-                "date": [datetime.datetime.utcnow(), datetime.datetime.now()],
-                "other_date": datetime.datetime.utcnow().date(),
+                "date": [
+                    datetime.datetime.now(datetime.timezone.utc),
+                    datetime.datetime.now(),
+                ],
+                "other_date": datetime.datetime.now(datetime.timezone.utc).date(),
             },
             TypeError,
             "Could not encode to JSON: .*'other_date'.*is not JSON serializable",


### PR DESCRIPTION
### What was wrong?
Since python3.12 `datetime.datetime.utcnow` is deprecated, this raises a warning.

### How was it fixed?
Using the `.now()` method passing the UTC timezone explicitly.
I used `datetime.timezone.utc` instead of `datetime.UTC` due to compatibility issues, i.e. py38 doesn't have the `datetime.UTC` shortcut to `datetime.timezone.utc`.

- [CI before](https://app.circleci.com/pipelines/github/ethereum/web3.py/8830/workflows/cceb01d2-e261-4bde-8a61-d414108ae9f2/jobs/667999)
- [CI after](https://app.circleci.com/pipelines/github/ethereum/web3.py/8832/workflows/139761d1-c18e-417e-a563-2a67b5b5bf64/jobs/668196) 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Cute animal picture](https://images.pexels.com/photos/735423/pexels-photo-735423.jpeg)
