### PR TITLE
Fix indentation in the docs

### DIFF
--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -23,19 +23,19 @@ When you subscribe to an event – new block headers, for example – you'll rec
         # connect to a node:
         async with AsyncWeb3(WebSocketProvider("wss://...")) as w3:
 
-        # subscribe to new block headers:
-        subscription_id = await w3.eth.subscribe("newHeads")
-        print(subscription_id)
+            # subscribe to new block headers:
+            subscription_id = await w3.eth.subscribe("newHeads")
+            print(subscription_id)
 
-        # listen for events as they occur:
-        async for response in w3.socket.process_subscriptions():
-            # handle each event:
-            print(response)
+            # listen for events as they occur:
+            async for response in w3.socket.process_subscriptions():
+                # handle each event:
+                print(response)
 
-            # unsubscribe:
-            if response["number"] > 42012345:
-                await w3.eth.unsubscribe(subscription_id)
-                break
+                # unsubscribe:
+                if response["number"] > 42012345:
+                    await w3.eth.unsubscribe(subscription_id)
+                    break
 
     asyncio.run(example())
 

--- a/newsfragments/3752.docs.rst
+++ b/newsfragments/3752.docs.rst
@@ -1,0 +1,1 @@
+Fix indentation in the code block in "An introduction to subscriptions"


### PR DESCRIPTION
### What was wrong?
The code snippet at https://web3py.readthedocs.io/en/stable/subscriptions.html#an-introduction-to-subscriptions had a wrong indentation.

### How was it fixed?
Indented where needed.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![cute animal](https://images.pexels.com/photos/7893866/pexels-photo-7893866.jpeg)
