### PR TITLE
fixed typo in bugfix description

### DIFF
--- a/newsfragments/3730.bugfix.rst
+++ b/newsfragments/3730.bugfix.rst
@@ -1,1 +1,1 @@
-Fix tests flakiness due to slow data generation from hypotesis triggering a timeout.
+Fix tests flakiness due to slow data generation from hypothesis triggering a timeout.


### PR DESCRIPTION
Corrected spelling from `hypotesis` to `hypothesis`

