### PR TITLE
Update link resources.rst

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -73,7 +73,7 @@ Libraries
 ---------
 
 - `Web3 Ethereum DeFi <https://github.com/tradingstrategy-ai/web3-ethereum-defi>`__ - Library for DeFi trading and protocols (Uniswap, PancakeSwap, Sushi, Aave, Chainlink)
-- `lighter-v1-python <https://github.com/elliottech/lighter-v1-python>`__ - Lighter.xyz DEX client for Python
+- `lighter-python <https://github.com/elliottech/lighter-python>`__ - Lighter.xyz DEX client for Python
 - `uniswap-python <https://uniswap-python.com/>`__ - Library lets you easily retrieve prices and make trades on all Uniswap versions.
 - `pyWalletConnect <https://github.com/bitlogik/pyWalletConnect>`__ - WalletConnect implementation for wallets in Python
 - `dydx-v3-python <https://github.com/dydxprotocol/dydx-v3-python>`__ - Python client for dYdX v3


### PR DESCRIPTION
### What was wrong?

The documentation was referencing an outdated repository link:
- `lighter-v1-python` → this repo no longer exists and returned 404.

### How was it fixed?

Updated the reference to point to the correct and maintained repo:
- `lighter-python <https://github.com/elliottech/lighter-python>` — Lighter.xyz DEX client for Python.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture
<img width="251" height="201" alt="image" src="https://github.com/user-attachments/assets/10c2310e-e557-4860-a7dc-3c68785cc300" />
