### PR TITLE
Fix spelling errors in release notes documentation

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3700,7 +3700,7 @@ Released January 23rd, 2019
 
 - Features
 
-  - Stablize the ``PM`` module
+  - Stabilize the ``PM`` module
     - `#1125 <https://github.com/ethereum/web3.py/pull/1125>`_
   - Implement async ``Version`` module
     - `#1166 <https://github.com/ethereum/web3.py/pull/1166>`_
@@ -4404,7 +4404,7 @@ v4.0.0-beta.1
 3.13.1
 ------
 
-* Fix mispelled ``attrdict_middleware`` (was spelled ``attrdict_middlware``).
+* Fix misspelled ``attrdict_middleware`` (was spelled ``attrdict_middlware``).
 
 
 3.13.0
@@ -4571,7 +4571,7 @@ v4.0.0-beta.1
 3.0.1
 -----
 
-* Better RPC compliance to be compatable with the Parity JSON-RPC server.
+* Better RPC compliance to be compatible with the Parity JSON-RPC server.
 
 3.0.0
 -----


### PR DESCRIPTION


## **Description:**
- "Stablize" → "Stabilize" 
- "mispelled" → "misspelled" 
- "compatable" → "compatible" 

