### PR TITLE
Fix bumpversion parts section key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ values = [
 	"stable",
 ]
 
-[tool.bumpversion.part.devnum]
+[tool.bumpversion.parts.devnum]
 
 [[tool.bumpversion.files]]
 filename = "setup.py"


### PR DESCRIPTION
The bumpversion config used `[tool.bumpversion.part.devnum]`, but the correct section key pattern is `parts.*`. This mismatch breaks `bumpversion --dry-run` because the `devnum` part isn't recognized.