### PR TITLE
Remove Duplicate ENS Test Case and Unused RequestProcessor Re-export

### DIFF
--- a/tests/ens/test_utils.py
+++ b/tests/ens/test_utils.py
@@ -61,7 +61,6 @@ def test_init_web3_adds_expected_middleware():
             b"\x011\x012\x013\x014\x015\x016\x017\x018\x019\x0210\x00",
         ),
         ("abc.123.def-456.eth", b"\x03abc\x03123\x07def-456\x03eth\x00"),
-        ("abc.123.def-456.eth", b"\x03abc\x03123\x07def-456\x03eth\x00"),
         (
             "nhéééééé.eth",
             b"\x0enh\xc3\xa9\xc3\xa9\xc3\xa9\xc3\xa9\xc3\xa9\xc3\xa9\x03eth\x00",

--- a/web3/providers/persistent/__init__.py
+++ b/web3/providers/persistent/__init__.py
@@ -4,9 +4,6 @@ from .persistent import (
 from .persistent_connection import (
     PersistentConnection,
 )
-from .request_processor import (
-    RequestProcessor,
-)
 from .async_ipc import (
     AsyncIPCProvider,
 )


### PR DESCRIPTION
Drop the redundant ("abc.123.def-456.eth", …) entry so the ENS DNS encoding parametrized test no longer executes the same check twice stop re-exporting RequestProcessor from web3.providers.persistent.__init__, keeping the public surface limited to the supported provider APIs
