### PR TITLE
Remove mark on fixture

### DIFF
--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -1334,8 +1334,7 @@ async def async_mismatched_math_contract(
     return _mismatched_math_contract
 
 
-@pytest.fixture
-@pytest.mark.asyncio
+@pytest_asyncio.fixture
 async def test_async_deploy_raises_due_to_strict_byte_checking_by_default(
     async_w3, async_bytes_contract_factory, address_conversion_func
 ):


### PR DESCRIPTION
### What was wrong?
CI is failing on main when pytest is >=9.0 because a warning turned into an error. 

### How was it fixed?
pytest.mark never worked on fixtures, but it was a warning before. In pytest v9+ it is an error. Removed the mark, and added a pytest_asyncio fixture instead of a fixture + mark. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/474x/b1/ea/56/b1ea5612fd7b5988c8f6f7479d48ed51.jpg)
