### PR TITLE
AsyncBeacon: fix AttributeError by using aiohttp.ClientTimeout throughout

### DIFF
--- a/newsfragments/3784.bugfix.rst
+++ b/newsfragments/3784.bugfix.rst
@@ -1,0 +1,1 @@
+Wrap timeout in ClientTimeout for AsyncBeacon post request

--- a/web3/beacon/async_beacon.py
+++ b/web3/beacon/async_beacon.py
@@ -85,7 +85,7 @@ class AsyncBeacon:
     ) -> dict[str, Any]:
         uri = URI(self.base_url + endpoint_uri)
         return await self._request_session_manager.async_json_make_post_request(
-            uri, json=body, timeout=self.request_timeout
+            uri, json=body, timeout=ClientTimeout(self.request_timeout)
         )
 
     # [ BEACON endpoints ]


### PR DESCRIPTION
Hello, I missed adding this. My commits were a bit out of order before so this never got added to the async post method

For reference -> https://github.com/ethereum/web3.py/pull/3503

### What was wrong?

```
AttributeError: 'float' object has no attribute 'total'
```

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)
