### PR TITLE
fix: improve code quality and documentation

### DIFF
--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -271,9 +271,9 @@ class AsyncContractFunction(BaseContractFunction):
             addr = contract.functions.owner().call()
 
         :param transaction: Dictionary of transaction info for web3 interface
-        :param block_identifier TODO
-        :param state_override TODO
-        :param ccip_read_enabled TODO
+        :param block_identifier: Block number or string "latest", "pending", "earliest"
+        :param state_override: Dictionary of state override values
+        :param ccip_read_enabled: Enable CCIP read operations for the call
         :return: ``Caller`` object that has contract public functions
             and variables exposed as Python methods
         """

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -99,7 +99,12 @@ class MutableAttributeDict(
 
 class AttributeDict(ReadableAttributeDict[TKey, TValue], Hashable):
     """
-    Provides superficial immutability, someone could hack around it
+    Provides superficial immutability.
+
+    Note: This class prevents direct attribute modification through normal
+    means, but advanced users could still modify the underlying dictionary
+    through direct access to ``__dict__``. For true immutability, consider
+    using ``frozenmap`` or similar immutable data structures.
     """
 
     def __setattr__(self, attr: str, val: TValue) -> None:

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -24,7 +24,7 @@ class Web3Exception(Exception):
             some_call()
         except Web3Exception:
             # deal with web3 exception
-        except:
+        except Exception:
             # deal with other exceptions
     """
 


### PR DESCRIPTION
```
Fix code quality issues and improve documentation:

- Replace bare except clause with except Exception in Web3Exception docstring
- Complete missing docstring parameters in AsyncContractFunction.call()
- Improve AttributeDict immutability documentation with clearer explanation

These changes improve code quality, documentation completeness, and follow Python best practices for exception handling and documentation.
```