### PR TITLE
Increase eth-utils dep to 5.3.0+

### DIFF
--- a/newsfragments/3790.breaking.rst
+++ b/newsfragments/3790.breaking.rst
@@ -1,0 +1,1 @@
+Bump eth-utils dependency to require >=5.3.0

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "eth-account>=0.13.6",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=5.0.0",
-        "eth-utils>=5.0.0",
+        "eth-utils>=5.3.0",
         "hexbytes>=1.2.0",
         "aiohttp>=3.7.4.post0",
         "pydantic>=2.4.0",


### PR DESCRIPTION
### What was wrong?
We want to be able to use the handy CamelModel introduced in eth-utils 5.3.0, but couldn't until we hit a breaking cycle.

### How was it fixed?
Bumped eth-utils to require v5.3.0+.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/N-UZc3Ur6k0/hq720.jpg?sqp=-oaymwEhCK4FEIIDSFryq4qpAxMIARUAAAAAGAElAADIQj0AgKJD&rs=AOn4CLCihF1J96kNNKEFOHBQSfxJFirXqQ)
