### PR TITLE
fix minor wording in docs for quickstart, migration, and providers

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -357,7 +357,7 @@ encodable as a bytes type with length of 4. This means only 0x-prefixed hex stri
 a length of 4 and bytes types with a length of 4 will be considered valid. This removes
 doubt that comes from inferring values and assuming they should be padded.
 
-This behavior was previously available in via the ``w3.enable_strict_bytes_checking()``
+This behavior was previously available via the ``w3.enable_strict_bytes_checking()``
 method. This is now, however, a toggleable flag on the ``Web3`` instance via the
 ``w3.strict_bytes_type_checking`` property. As outlined above, this property is set to
 ``True`` by default but can be toggled on and off via the property's setter

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -302,7 +302,7 @@ WebSocketProvider
 
 .. py:class:: web3.providers.persistent.WebSocketProvider(endpoint_uri: str, websocket_kwargs: Dict[str, Any] = {}, use_text_frames: bool = False)
 
-    This provider handles interactions with an WS or WSS based JSON-RPC server.
+    This provider handles interactions with a WS or WSS based JSON-RPC server.
 
     * ``endpoint_uri`` should be the full URI to the RPC endpoint such as
       ``'ws://localhost:8546'``.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -39,7 +39,7 @@ Test Provider
 
 If you're just learning the ropes or doing some quick prototyping, you can use a test
 provider, `eth-tester <https://github.com/ethereum/eth-tester>`_. This provider includes
-some accounts prepopulated with test ether and instantly includes each transaction into a block.
+some accounts prepopulated with test ether and instantly includes each transaction in a block.
 web3.py makes this test provider available via ``EthereumTesterProvider``.
 
 .. note::


### PR DESCRIPTION

## Summary
- correct preposition in quickstart test-provider description
- remove redundant preposition in migration guide strict-bytes note
- fix article usage for WS/WSS providers documentation
