### PR TITLE
fix: resolve TypeError when process_log is called as classmethod

### DIFF
--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -270,8 +270,9 @@ class BaseContractEvent:
             yield rich_log
 
     @combomethod
-    def process_log(self, log: LogReceipt) -> EventData:
-        return get_event_data(self.w3.codec, self.abi, log)
+    def process_log(cls, log: LogReceipt) -> EventData:
+        abi = getattr(cls, "abi", None) or cls._get_event_abi()
+        return get_event_data(cls.w3.codec, abi, log)
 
     @combomethod
     def _get_event_filter_params(


### PR DESCRIPTION
Closes #1648

When `ContractEvent.process_log()` is called as a classmethod, it throws a `TypeError` because `cls.abi` is not populated at the class level (it evaluates to `None`), causing `get_event_data` to fail. This fix checks for `cls.abi` and falls back to `cls._get_event_abi()` if missing, allowing the `combomethod` to work correctly in both instance and class contexts.