### PR TITLE
docs: update README PyPI project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join the conversation on Discord](https://img.shields.io/discord/809793915578089484?color=blue&label=chat&logo=discord&logoColor=white)](https://discord.gg/GHryRvPB84)
 [![Build Status](https://circleci.com/gh/ethereum/web3.py.svg?style=shield)](https://circleci.com/gh/ethereum/web3.py)
 [![PyPI version](https://badge.fury.io/py/web3.svg)](https://badge.fury.io/py/web3)
-[![Python versions](https://img.shields.io/pypi/pyversions/web3.svg)](https://pypi.python.org/pypi/web3)
+[![Python versions](https://img.shields.io/pypi/pyversions/web3.svg)](https://pypi.org/project/web3/)
 [![Docs build](https://readthedocs.org/projects/web3py/badge/?version=latest)](https://web3py.readthedocs.io/en/latest/?badge=latest)
 
 ## A Python Library for Interacting with Ethereum


### PR DESCRIPTION
## Summary
- replace the deprecated `pypi.python.org` README link with the current `pypi.org` project URL
- keep the existing badge target behavior unchanged apart from the destination host

## Testing
- not run (README link change only)