### PR TITLE
decode custom revert errors from contract abi

### DIFF
--- a/tests/core/utilities/test_decode_custom_error.py
+++ b/tests/core/utilities/test_decode_custom_error.py
@@ -1,5 +1,3 @@
-import pytest
-
 from eth_abi import (
     abi,
 )
@@ -11,7 +9,6 @@ from eth_utils import (
 from web3._utils.error_formatters_utils import (
     decode_custom_error,
 )
-
 
 # --- test ABIs --- #
 

--- a/tests/core/utilities/test_decode_custom_error.py
+++ b/tests/core/utilities/test_decode_custom_error.py
@@ -1,0 +1,148 @@
+import pytest
+
+from eth_abi import (
+    abi,
+)
+from eth_utils import (
+    abi_to_signature,
+    function_signature_to_4byte_selector,
+)
+
+from web3._utils.error_formatters_utils import (
+    decode_custom_error,
+)
+
+
+# --- test ABIs --- #
+
+NO_ARGS_ERROR_ABI = [
+    {
+        "type": "error",
+        "name": "InitialEpochIsYetToArrive",
+        "inputs": [],
+    },
+]
+
+WITH_ARGS_ERROR_ABI = [
+    {
+        "type": "error",
+        "name": "InsufficientBalance",
+        "inputs": [
+            {"name": "available", "type": "uint256"},
+            {"name": "required", "type": "uint256"},
+        ],
+    },
+]
+
+MULTIPLE_ERRORS_ABI = [
+    {
+        "type": "error",
+        "name": "Unauthorized",
+        "inputs": [],
+    },
+    {
+        "type": "error",
+        "name": "InsufficientBalance",
+        "inputs": [
+            {"name": "available", "type": "uint256"},
+            {"name": "required", "type": "uint256"},
+        ],
+    },
+    {
+        "type": "function",
+        "name": "transfer",
+        "inputs": [
+            {"name": "to", "type": "address"},
+            {"name": "amount", "type": "uint256"},
+        ],
+        "outputs": [{"name": "", "type": "bool"}],
+    },
+]
+
+MIXED_ABI_NO_ERRORS = [
+    {
+        "type": "function",
+        "name": "transfer",
+        "inputs": [
+            {"name": "to", "type": "address"},
+            {"name": "amount", "type": "uint256"},
+        ],
+        "outputs": [{"name": "", "type": "bool"}],
+    },
+]
+
+
+def _build_error_data(error_abi_entry):
+    """Build hex-encoded revert data for a given error ABI entry with no args."""
+    sig = abi_to_signature(error_abi_entry)
+    selector = function_signature_to_4byte_selector(sig)
+    return "0x" + selector.hex()
+
+
+def _build_error_data_with_args(error_abi_entry, types, values):
+    """Build hex-encoded revert data for a given error ABI entry with args."""
+    sig = abi_to_signature(error_abi_entry)
+    selector = function_signature_to_4byte_selector(sig)
+    encoded_args = abi.encode(types, values)
+    return "0x" + selector.hex() + encoded_args.hex()
+
+
+class TestDecodeCustomError:
+    def test_decode_no_args_error(self):
+        data = _build_error_data(NO_ARGS_ERROR_ABI[0])
+        result = decode_custom_error(NO_ARGS_ERROR_ABI, data)
+        assert result == "InitialEpochIsYetToArrive()"
+
+    def test_decode_error_with_args(self):
+        data = _build_error_data_with_args(
+            WITH_ARGS_ERROR_ABI[0],
+            ["uint256", "uint256"],
+            [100, 200],
+        )
+        result = decode_custom_error(WITH_ARGS_ERROR_ABI, data)
+        assert result == "InsufficientBalance(available=100, required=200)"
+
+    def test_decode_error_from_multiple_errors_abi(self):
+        # match the second error in a mixed ABI
+        data = _build_error_data_with_args(
+            MULTIPLE_ERRORS_ABI[1],
+            ["uint256", "uint256"],
+            [50, 999],
+        )
+        result = decode_custom_error(MULTIPLE_ERRORS_ABI, data)
+        assert result == "InsufficientBalance(available=50, required=999)"
+
+    def test_decode_no_args_error_from_multiple(self):
+        data = _build_error_data(MULTIPLE_ERRORS_ABI[0])
+        result = decode_custom_error(MULTIPLE_ERRORS_ABI, data)
+        assert result == "Unauthorized()"
+
+    def test_returns_none_when_no_match(self):
+        # use a selector that doesn't match any error in the ABI
+        data = "0xdeadbeef"
+        result = decode_custom_error(NO_ARGS_ERROR_ABI, data)
+        assert result is None
+
+    def test_returns_none_when_no_errors_in_abi(self):
+        data = _build_error_data(NO_ARGS_ERROR_ABI[0])
+        result = decode_custom_error(MIXED_ABI_NO_ERRORS, data)
+        assert result is None
+
+    def test_returns_none_for_short_data(self):
+        result = decode_custom_error(NO_ARGS_ERROR_ABI, "0xab")
+        assert result is None
+
+    def test_returns_none_for_empty_data(self):
+        result = decode_custom_error(NO_ARGS_ERROR_ABI, "0x")
+        assert result is None
+
+    def test_works_without_0x_prefix(self):
+        sig = abi_to_signature(NO_ARGS_ERROR_ABI[0])
+        selector = function_signature_to_4byte_selector(sig)
+        data = selector.hex()  # no 0x prefix
+        result = decode_custom_error(NO_ARGS_ERROR_ABI, data)
+        assert result == "InitialEpochIsYetToArrive()"
+
+    def test_returns_none_for_empty_abi(self):
+        result = decode_custom_error([], "0xdeadbeef")
+        assert result is None

--- a/web3/_utils/error_formatters_utils.py
+++ b/web3/_utils/error_formatters_utils.py
@@ -1,7 +1,7 @@
-import warnings
 from typing import (
     Any,
 )
+import warnings
 
 from eth_abi import (
     abi,

--- a/web3/_utils/error_formatters_utils.py
+++ b/web3/_utils/error_formatters_utils.py
@@ -1,9 +1,18 @@
 import warnings
+from typing import (
+    Any,
+)
 
 from eth_abi import (
     abi,
 )
+from eth_typing import (
+    ABI,
+)
 from eth_utils import (
+    abi_to_signature,
+    filter_abi_by_type,
+    function_signature_to_4byte_selector,
     to_bytes,
 )
 
@@ -53,6 +62,58 @@ PANIC_ERROR_CODES = {
 }
 
 MISSING_DATA = "no data"
+
+
+def decode_custom_error(
+    contract_abi: ABI,
+    data: str,
+) -> str | None:
+    """
+    Try to decode a custom error revert from its hex data using the contract ABI.
+
+    Matches the first 4 bytes (function selector) of the revert data against
+    error entries in the ABI. If a match is found, decodes the parameters and
+    returns a human-readable string like ``ErrorName(arg1, arg2, ...)``.
+
+    Returns ``None`` if no matching error is found in the ABI.
+    """
+    # normalize: strip "0x" prefix if present
+    hex_data = data[2:] if data.startswith("0x") else data
+    if len(hex_data) < 8:
+        return None
+
+    error_selector = hex_data[:8]
+    error_abis = filter_abi_by_type("error", contract_abi)
+
+    for error_abi in error_abis:
+        sig = abi_to_signature(error_abi)
+        selector = function_signature_to_4byte_selector(sig).hex()
+        if selector == error_selector:
+            # matched - decode the parameters
+            input_types = [inp["type"] for inp in error_abi.get("inputs", [])]
+            input_names = [inp["name"] for inp in error_abi.get("inputs", [])]
+            if input_types:
+                try:
+                    encoded_params = bytes.fromhex(hex_data[8:])
+                    decoded_params: tuple[Any, ...] = abi.decode(
+                        input_types, encoded_params
+                    )
+                    # format params with names if available
+                    param_strs = []
+                    for i, val in enumerate(decoded_params):
+                        name = input_names[i] if i < len(input_names) else ""
+                        if name:
+                            param_strs.append(f"{name}={val!r}")
+                        else:
+                            param_strs.append(repr(val))
+                    return f"{error_abi['name']}({', '.join(param_strs)})"
+                except Exception:
+                    # if decoding fails, return just the error name
+                    return f"{error_abi['name']}()"
+            else:
+                return f"{error_abi['name']}()"
+
+    return None
 
 
 def _parse_error_with_reverted_prefix(data: str) -> str:

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -51,8 +51,12 @@ from web3._utils.normalizers import (
 from web3._utils.transactions import (
     fill_transaction_defaults,
 )
+from web3._utils.error_formatters_utils import (
+    decode_custom_error,
+)
 from web3.exceptions import (
     BadFunctionCallOutput,
+    ContractCustomError,
     Web3ValueError,
 )
 from web3.types import (
@@ -146,12 +150,19 @@ def call_contract_function(
         fn_kwargs=kwargs,
     )
 
-    return_data = w3.eth.call(
-        call_transaction,
-        block_identifier=block_id,
-        state_override=state_override,
-        ccip_read_enabled=ccip_read_enabled,
-    )
+    try:
+        return_data = w3.eth.call(
+            call_transaction,
+            block_identifier=block_id,
+            state_override=state_override,
+            ccip_read_enabled=ccip_read_enabled,
+        )
+    except ContractCustomError as e:
+        if contract_abi is not None and e.data is not None:
+            decoded = decode_custom_error(contract_abi, str(e.data))
+            if decoded is not None:
+                raise ContractCustomError(decoded, data=e.data) from e
+        raise
 
     if abi_callable is None:
         abi_callable = cast(
@@ -443,12 +454,19 @@ async def async_call_contract_function(
         fn_kwargs=kwargs,
     )
 
-    return_data = await async_w3.eth.call(
-        call_transaction,
-        block_identifier=block_id,
-        state_override=state_override,
-        ccip_read_enabled=ccip_read_enabled,
-    )
+    try:
+        return_data = await async_w3.eth.call(
+            call_transaction,
+            block_identifier=block_id,
+            state_override=state_override,
+            ccip_read_enabled=ccip_read_enabled,
+        )
+    except ContractCustomError as e:
+        if contract_abi is not None and e.data is not None:
+            decoded = decode_custom_error(contract_abi, str(e.data))
+            if decoded is not None:
+                raise ContractCustomError(decoded, data=e.data) from e
+        raise
 
     if fn_abi is None:
         fn_abi = cast(

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -45,14 +45,14 @@ from web3._utils.batching import (
 from web3._utils.contracts import (
     prepare_transaction,
 )
+from web3._utils.error_formatters_utils import (
+    decode_custom_error,
+)
 from web3._utils.normalizers import (
     BASE_RETURN_NORMALIZERS,
 )
 from web3._utils.transactions import (
     fill_transaction_defaults,
-)
-from web3._utils.error_formatters_utils import (
-    decode_custom_error,
 )
 from web3.exceptions import (
     BadFunctionCallOutput,

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -159,9 +159,9 @@ def call_contract_function(
         )
     except ContractCustomError as e:
         if contract_abi is not None and e.data is not None:
-            decoded = decode_custom_error(contract_abi, str(e.data))
-            if decoded is not None:
-                raise ContractCustomError(decoded, data=e.data) from e
+            decoded_error = decode_custom_error(contract_abi, str(e.data))
+            if decoded_error is not None:
+                raise ContractCustomError(decoded_error, data=e.data) from e
         raise
 
     if abi_callable is None:
@@ -463,9 +463,9 @@ async def async_call_contract_function(
         )
     except ContractCustomError as e:
         if contract_abi is not None and e.data is not None:
-            decoded = decode_custom_error(contract_abi, str(e.data))
-            if decoded is not None:
-                raise ContractCustomError(decoded, data=e.data) from e
+            decoded_error = decode_custom_error(contract_abi, str(e.data))
+            if decoded_error is not None:
+                raise ContractCustomError(decoded_error, data=e.data) from e
         raise
 
     if fn_abi is None:


### PR DESCRIPTION
## Summary

- when a contract reverts with a custom error, web3.py currently shows raw hex like `ContractCustomError('0xcd0883ea', ...)` which isn't very helpful
- this adds decoding of custom errors by matching the 4-byte selector against error entries in the contract ABI
- after this change, errors show up as human-readable like `InsufficientBalance(available=100, required=200)`

## What changed

- added `decode_custom_error()` in `web3/_utils/error_formatters_utils.py` — computes keccak256 selectors for ABI error entries, matches against revert data, decodes params
- wrapped `eth_call` in `call_contract_function` and `async_call_contract_function` to catch `ContractCustomError` and re-raise with the decoded message
- added 10 unit tests covering: no-arg errors, errors with params, multiple errors, no match, short data, empty abi

## Test plan

- [x] 10 new unit tests all pass
- [x] existing tests unaffected

fixes #3523