### PR TITLE
Add support for `eth_sendRawTransactionSync`

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -776,6 +776,39 @@ The following methods are available on the ``web3.eth`` namespace.
         HexBytes('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
 
 
+.. py:method:: Eth.send_raw_transaction_sync(raw_transaction, timeout_ms=None)
+
+    * Delegates to ``eth_sendRawTransactionSync`` RPC Method
+
+    Sends a signed and serialized transaction and waits synchronously for a transaction
+    receipt. Returns the receipt as a ``TxReceipt``.
+
+    ``timeout_ms`` is optional. If provided, it is passed to the RPC method as the
+    maximum wait time in milliseconds.
+
+    This RPC method is optional and may not be implemented by all providers. If the
+    connected node does not support it, the request will fail with a standard
+    ``method not found`` RPC error.
+
+    .. code-block:: python
+
+        >>> signed_txn = w3.eth.account.sign_transaction(
+        ...     {
+        ...         "nonce": w3.eth.get_transaction_count(public_address_of_senders_account, "pending"),
+        ...         "maxFeePerGas": 3000000000,
+        ...         "maxPriorityFeePerGas": 2000000000,
+        ...         "gas": 100000,
+        ...         "to": "0x582AC4D8929f58c217d4a52aDD361AE470a8a4cD",
+        ...         "value": 12345,
+        ...         "data": b"",
+        ...         "chainId": 1,
+        ...     },
+        ...     private_key_for_senders_account,
+        ... )
+        >>> w3.eth.send_raw_transaction_sync(signed_txn.raw_transaction, timeout_ms=5000)
+        AttributeDict({...})
+
+
 .. py:method:: Eth.replace_transaction(transaction_hash, new_transaction)
 
     * Delegates to ``eth_sendTransaction`` RPC Method

--- a/newsfragments/3823.feature.rst
+++ b/newsfragments/3823.feature.rst
@@ -1,0 +1,4 @@
+Added support for ``eth_sendRawTransactionSync`` through ``Eth.send_raw_transaction_sync()``
+and ``AsyncEth.send_raw_transaction_sync()``. The new API accepts an optional
+``timeout_ms`` argument and returns a transaction receipt on success, matching the
+response shape of ``eth_getTransactionReceipt``.

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -3,8 +3,12 @@ import pytest
 from eth_typing import (
     HexStr,
 )
+from hexbytes import (
+    HexBytes,
+)
 
 from web3._utils.method_formatters import (
+    PYTHONIC_RESULT_FORMATTERS,
     get_error_formatters,
     raise_contract_logic_error_on_revert,
     storage_key_to_hexstr,
@@ -59,6 +63,42 @@ OTHER_ERROR = RPCResponse(
             "message": "Method not found",
         },
         "id": 1,
+    }
+)
+
+EIP_7966_TIMEOUT_ERROR = RPCResponse(
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {
+            "code": 4,
+            "message": "timeout",
+            "data": "0x" + ("12" * 32),
+        },
+    }
+)
+
+EIP_7966_UNKNOWN_ERROR = RPCResponse(
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {
+            "code": 5,
+            "message": "queued",
+            "data": "0x" + ("34" * 32),
+        },
+    }
+)
+
+EIP_7966_NONCE_GAP_ERROR = RPCResponse(
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {
+            "code": 6,
+            "message": "nonce gap",
+            "data": "0x5",
+        },
     }
 )
 
@@ -198,6 +238,46 @@ def test_get_error_formatters() -> None:
     with pytest.raises(ContractLogicError):
         formatters(REVERT_WITHOUT_MSG)
     assert formatters(OTHER_ERROR) == OTHER_ERROR
+
+
+def test_eth_send_raw_transaction_sync_result_formatter_receipt() -> None:
+    receipt = {
+        "transactionHash": "0x" + ("11" * 32),
+        "transactionIndex": "0x0",
+        "blockHash": "0x" + ("22" * 32),
+        "blockNumber": "0x1",
+        "cumulativeGasUsed": "0x5208",
+        "gasUsed": "0x5208",
+        "contractAddress": None,
+        "logs": [],
+        "logsBloom": "0x" + ("00" * 256),
+        "status": "0x1",
+        "effectiveGasPrice": "0x1",
+        "type": "0x2",
+    }
+    formatter = PYTHONIC_RESULT_FORMATTERS[RPC.eth_sendRawTransactionSync]
+    formatted_receipt = formatter(receipt)
+
+    assert formatted_receipt["transactionHash"] == HexBytes("0x" + ("11" * 32))
+    assert formatted_receipt["blockHash"] == HexBytes("0x" + ("22" * 32))
+    assert formatted_receipt["blockNumber"] == 1
+    assert formatted_receipt["status"] == 1
+    assert formatted_receipt["gasUsed"] == 21000
+
+
+@pytest.mark.parametrize(
+    "error_response",
+    (
+        EIP_7966_TIMEOUT_ERROR,
+        EIP_7966_UNKNOWN_ERROR,
+        EIP_7966_NONCE_GAP_ERROR,
+    ),
+)
+def test_eth_send_raw_transaction_sync_error_payload_passthrough(
+    error_response: RPCResponse,
+) -> None:
+    formatter = get_error_formatters(RPC.eth_sendRawTransactionSync)
+    assert formatter(error_response) == error_response
 
 
 @pytest.mark.parametrize(

--- a/web3/_utils/batching.py
+++ b/web3/_utils/batching.py
@@ -59,6 +59,7 @@ RPC_METHODS_UNSUPPORTED_DURING_BATCH = {
     "eth_subscribe",
     "eth_unsubscribe",
     "eth_sendRawTransaction",
+    "eth_sendRawTransactionSync",
     "eth_sendTransaction",
     "eth_signTransaction",
     "eth_sign",

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -1028,6 +1028,10 @@ PYTHONIC_RESULT_FORMATTERS: dict[RPCEndpoint, Callable[..., Any]] = {
         apply_formatter_if(is_integer, str),
     ),
     RPC.eth_sendRawTransaction: to_hexbytes(32),
+    RPC.eth_sendRawTransactionSync: apply_formatter_if(
+        is_not_null,
+        receipt_formatter,
+    ),
     RPC.eth_sendTransaction: to_hexbytes(32),
     RPC.eth_sign: HexBytes,
     RPC.eth_signTransaction: apply_formatter_if(is_not_null, signed_tx_formatter),

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -696,6 +696,75 @@ class AsyncEthModuleTest:
         assert txn_hash == HexBytes(signed.hash)
 
     @pytest.mark.asyncio
+    async def test_async_eth_send_raw_transaction_sync(
+        self,
+        async_w3: "AsyncWeb3[Any]",
+        keyfile_account_pkey: HexStr,
+        request_mocker: type[RequestMocker],
+    ) -> None:
+        keyfile_account = async_w3.eth.account.from_key(keyfile_account_pkey)
+        txn = {
+            "chainId": 131277322940537,  # the chainId set for the fixture
+            "from": keyfile_account.address,
+            "to": keyfile_account.address,
+            "value": Wei(0),
+            "gas": 21000,
+            "nonce": await async_w3.eth.get_transaction_count(
+                keyfile_account.address, "pending"
+            ),
+            "gasPrice": 10**9,
+        }
+        signed = keyfile_account.sign_transaction(txn)
+        expected_raw_tx = HexBytes(signed.raw_transaction).to_0x_hex()
+        captured_params: list[Any] = []
+
+        mock_receipt = {
+            "transactionHash": HexBytes(signed.hash).to_0x_hex(),
+            "transactionIndex": "0x0",
+            "blockHash": "0x" + ("22" * 32),
+            "blockNumber": "0x1",
+            "from": keyfile_account.address,
+            "to": keyfile_account.address,
+            "cumulativeGasUsed": "0x5208",
+            "gasUsed": "0x5208",
+            "contractAddress": None,
+            "logs": [],
+            "logsBloom": "0x" + ("00" * 256),
+            "status": "0x1",
+            "effectiveGasPrice": "0x1",
+            "type": "0x2",
+        }
+
+        def _mock_send_raw_transaction_sync(method: RPCEndpoint, params: Any) -> Any:
+            captured_params.append(params)
+            return mock_receipt
+
+        async with request_mocker(
+            async_w3,
+            mock_results={
+                RPCEndpoint(
+                    "eth_sendRawTransactionSync"
+                ): _mock_send_raw_transaction_sync
+            },
+        ):
+            receipt = await async_w3.eth.send_raw_transaction_sync(
+                signed.raw_transaction
+            )
+            assert receipt["transactionHash"] == HexBytes(signed.hash)
+            assert receipt["blockNumber"] == 1
+
+            receipt_with_timeout = await async_w3.eth.send_raw_transaction_sync(
+                signed.raw_transaction,
+                timeout_ms=5000,
+            )
+            assert receipt_with_timeout["status"] == 1
+
+        assert captured_params == [
+            [expected_raw_tx],
+            [expected_raw_tx, "0x1388"],
+        ]
+
+    @pytest.mark.asyncio
     async def test_async_sign_and_send_raw_middleware(
         self, async_w3: "AsyncWeb3[Any]", keyfile_account_pkey: HexStr
     ) -> None:
@@ -3848,6 +3917,70 @@ class EthModuleTest:
         signed = keyfile_account.sign_transaction(txn)
         txn_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
         assert txn_hash == HexBytes(signed.hash)
+
+    def test_eth_send_raw_transaction_sync(
+        self,
+        w3: "Web3",
+        keyfile_account_pkey: HexStr,
+        request_mocker: type[RequestMocker],
+    ) -> None:
+        keyfile_account = w3.eth.account.from_key(keyfile_account_pkey)
+        txn = {
+            "chainId": 131277322940537,  # the chainId set for the fixture
+            "from": keyfile_account.address,
+            "to": keyfile_account.address,
+            "value": Wei(0),
+            "gas": 21000,
+            "nonce": w3.eth.get_transaction_count(keyfile_account.address, "pending"),
+            "gasPrice": 10**9,
+        }
+        signed = keyfile_account.sign_transaction(txn)
+        expected_raw_tx = HexBytes(signed.raw_transaction).to_0x_hex()
+        captured_params: list[Any] = []
+
+        mock_receipt = {
+            "transactionHash": HexBytes(signed.hash).to_0x_hex(),
+            "transactionIndex": "0x0",
+            "blockHash": "0x" + ("22" * 32),
+            "blockNumber": "0x1",
+            "from": keyfile_account.address,
+            "to": keyfile_account.address,
+            "cumulativeGasUsed": "0x5208",
+            "gasUsed": "0x5208",
+            "contractAddress": None,
+            "logs": [],
+            "logsBloom": "0x" + ("00" * 256),
+            "status": "0x1",
+            "effectiveGasPrice": "0x1",
+            "type": "0x2",
+        }
+
+        def _mock_send_raw_transaction_sync(method: RPCEndpoint, params: Any) -> Any:
+            captured_params.append(params)
+            return mock_receipt
+
+        with request_mocker(
+            w3,
+            mock_results={
+                RPCEndpoint(
+                    "eth_sendRawTransactionSync"
+                ): _mock_send_raw_transaction_sync
+            },
+        ):
+            receipt = w3.eth.send_raw_transaction_sync(signed.raw_transaction)
+            assert receipt["transactionHash"] == HexBytes(signed.hash)
+            assert receipt["blockNumber"] == 1
+
+            receipt_with_timeout = w3.eth.send_raw_transaction_sync(
+                signed.raw_transaction,
+                timeout_ms=5000,
+            )
+            assert receipt_with_timeout["status"] == 1
+
+        assert captured_params == [
+            [expected_raw_tx],
+            [expected_raw_tx, "0x1388"],
+        ]
 
     def test_sign_and_send_raw_middleware(
         self, w3: "Web3", keyfile_account_pkey: HexStr

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -515,6 +515,11 @@ class Web3ModuleTest:
                 batch.execute()
 
         with w3.batch_requests() as batch:
+            with pytest.raises(MethodNotSupported, match="eth_sendRawTransactionSync"):
+                batch.add(w3.eth.send_raw_transaction_sync(b""))
+                batch.execute()
+
+        with w3.batch_requests() as batch:
             with pytest.raises(MethodNotSupported, match="eth_sign"):
                 batch.add(w3.eth.sign(Address(b"\x00" * 20)))
                 batch.execute()
@@ -775,6 +780,11 @@ class AsyncWeb3ModuleTest(Web3ModuleTest):
         async with async_w3.batch_requests() as batch:
             with pytest.raises(MethodNotSupported, match="eth_sendRawTransaction"):
                 batch.add(async_w3.eth.send_raw_transaction(b""))
+                await batch.async_execute()
+
+        async with async_w3.batch_requests() as batch:
+            with pytest.raises(MethodNotSupported, match="eth_sendRawTransactionSync"):
+                batch.add(async_w3.eth.send_raw_transaction_sync(b""))
                 await batch.async_execute()
 
         async with async_w3.batch_requests() as batch:

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -97,6 +97,7 @@ class RPC:
     eth_newPendingTransactionFilter = RPCEndpoint("eth_newPendingTransactionFilter")
     eth_protocolVersion = RPCEndpoint("eth_protocolVersion")
     eth_sendRawTransaction = RPCEndpoint("eth_sendRawTransaction")
+    eth_sendRawTransactionSync = RPCEndpoint("eth_sendRawTransactionSync")
     eth_sendTransaction = RPCEndpoint("eth_sendTransaction")
     eth_sign = RPCEndpoint("eth_sign")
     eth_signTransaction = RPCEndpoint("eth_signTransaction")
@@ -192,6 +193,7 @@ RPC_ABIS: dict[str, Sequence[Any] | dict[str, str]] = {
     "eth_getUncleCountByBlockHash": ["bytes32"],
     "eth_newFilter": FILTER_PARAMS_ABIS,
     "eth_sendRawTransaction": ["bytes"],
+    "eth_sendRawTransactionSync": ["bytes", "uint"],
     "eth_sendTransaction": TRANSACTION_PARAMS_ABIS,
     "eth_signTransaction": TRANSACTION_PARAMS_ABIS,
     "eth_sign": ["address", "bytes"],

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -426,6 +426,29 @@ class AsyncEth(BaseEth):
     async def send_raw_transaction(self, transaction: HexStr | bytes) -> HexBytes:
         return await self._send_raw_transaction(transaction)
 
+    # eth_sendRawTransactionSync
+
+    def send_raw_transaction_sync_munger(
+        self,
+        transaction: HexStr | bytes,
+        timeout_ms: int | None = None,
+    ) -> tuple[HexStr | bytes] | tuple[HexStr | bytes, int]:
+        if timeout_ms is None:
+            return (transaction,)
+        return (transaction, timeout_ms)
+
+    _send_raw_transaction_sync: Method[
+        Callable[[HexStr | bytes, int | None], Awaitable[TxReceipt]]
+    ] = Method(
+        RPC.eth_sendRawTransactionSync,
+        mungers=[send_raw_transaction_sync_munger],
+    )
+
+    async def send_raw_transaction_sync(
+        self, transaction: HexStr | bytes, timeout_ms: int | None = None
+    ) -> TxReceipt:
+        return await self._send_raw_transaction_sync(transaction, timeout_ms)
+
     # eth_getBlockByHash
     # eth_getBlockByNumber
 

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -388,6 +388,29 @@ class Eth(BaseEth):
     def send_raw_transaction(self, transaction: HexStr | bytes) -> HexBytes:
         return self._send_raw_transaction(transaction)
 
+    # eth_sendRawTransactionSync
+
+    def send_raw_transaction_sync_munger(
+        self,
+        transaction: HexStr | bytes,
+        timeout_ms: int | None = None,
+    ) -> tuple[HexStr | bytes] | tuple[HexStr | bytes, int]:
+        if timeout_ms is None:
+            return (transaction,)
+        return (transaction, timeout_ms)
+
+    _send_raw_transaction_sync: Method[
+        Callable[[HexStr | bytes, int | None], TxReceipt]
+    ] = Method(
+        RPC.eth_sendRawTransactionSync,
+        mungers=[send_raw_transaction_sync_munger],
+    )
+
+    def send_raw_transaction_sync(
+        self, transaction: HexStr | bytes, timeout_ms: int | None = None
+    ) -> TxReceipt:
+        return self._send_raw_transaction_sync(transaction, timeout_ms)
+
     # eth_getBlockByHash
     # eth_getBlockByNumber
 

--- a/web3/providers/rpc/utils.py
+++ b/web3/providers/rpc/utils.py
@@ -54,6 +54,7 @@ REQUEST_RETRY_ALLOWLIST = [
     "eth_sign",
     "eth_signTypedData",
     "eth_sendRawTransaction",
+    "eth_sendRawTransactionSync",
 ]
 
 


### PR DESCRIPTION
### What was added?

New JSON-RPC method - `eth_sendRawTransactionSync`

Ref: https://eips.ethereum.org/EIPS/eip-7966

Related to Issue #3816
Closes #3816

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture
<img width="623" height="505" alt="image" src="https://github.com/user-attachments/assets/8d80d54c-f9ff-4280-86cd-737d51d57c24" />
