### PR TITLE
Merge request_kwargs headers with defaults (closes #3551)

### DIFF
--- a/newsfragments/3551.bugfix.rst
+++ b/newsfragments/3551.bugfix.rst
@@ -1,0 +1,4 @@
+Merge user-provided ``request_kwargs["headers"]`` with the default headers
+returned by ``(Async)HTTPProvider.get_request_headers``, so callers can extend
+the headers (for example to add an ``Authorization`` header) without losing
+required defaults like ``Content-Type``. User-supplied keys win on conflict.

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -114,6 +114,49 @@ def test_get_request_headers(provider):
     )
 
 
+def test_async_request_kwargs_headers_extend_defaults():
+    provider = AsyncHTTPProvider(
+        endpoint_uri=URI,
+        request_kwargs={"headers": {"Authorization": "Bearer token"}},
+    )
+    request_kwargs = provider.get_request_kwargs()
+
+    assert "headers" in request_kwargs
+    headers = request_kwargs["headers"]
+    assert headers["Content-Type"] == "application/json"
+    assert headers["User-Agent"] == (
+        f"web3.py/{web3py_version}/"
+        f"{AsyncHTTPProvider.__module__}.{AsyncHTTPProvider.__qualname__}"
+    )
+    assert headers["Authorization"] == "Bearer token"
+
+
+def test_async_request_kwargs_headers_override_default_keys():
+    provider = AsyncHTTPProvider(
+        endpoint_uri=URI,
+        request_kwargs={"headers": {"User-Agent": "custom-agent/1.0"}},
+    )
+    headers = provider.get_request_kwargs()["headers"]
+
+    assert headers["Content-Type"] == "application/json"
+    assert headers["User-Agent"] == "custom-agent/1.0"
+
+
+def test_async_request_kwargs_preserves_other_kwargs():
+    provider = AsyncHTTPProvider(
+        endpoint_uri=URI,
+        request_kwargs={
+            "timeout": 42,
+            "headers": {"X-Custom": "yes"},
+        },
+    )
+    request_kwargs = provider.get_request_kwargs()
+
+    assert request_kwargs["timeout"] == 42
+    assert request_kwargs["headers"]["X-Custom"] == "yes"
+    assert request_kwargs["headers"]["Content-Type"] == "application/json"
+
+
 @patch(
     "web3._utils.http_session_manager.HTTPSessionManager.async_make_post_request",
     new_callable=AsyncMock,

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -119,6 +119,54 @@ def test_get_request_headers(provider):
     )
 
 
+def test_request_kwargs_headers_extend_defaults():
+    # User-supplied headers should be merged on top of the defaults so that
+    # callers can add headers (e.g. ``Authorization``) without dropping the
+    # required ``Content-Type`` / ``User-Agent`` defaults.
+    provider = HTTPProvider(
+        endpoint_uri=URI,
+        request_kwargs={"headers": {"Authorization": "Bearer token"}},
+    )
+    request_kwargs = provider.get_request_kwargs()
+
+    assert "headers" in request_kwargs
+    headers = request_kwargs["headers"]
+    assert headers["Content-Type"] == "application/json"
+    assert headers["User-Agent"] == (
+        f"web3.py/{web3py_version}/"
+        f"{HTTPProvider.__module__}.{HTTPProvider.__qualname__}"
+    )
+    assert headers["Authorization"] == "Bearer token"
+
+
+def test_request_kwargs_headers_override_default_keys():
+    # When a user-supplied header collides with a default header, the user
+    # value wins.
+    provider = HTTPProvider(
+        endpoint_uri=URI,
+        request_kwargs={"headers": {"User-Agent": "custom-agent/1.0"}},
+    )
+    headers = provider.get_request_kwargs()["headers"]
+
+    assert headers["Content-Type"] == "application/json"
+    assert headers["User-Agent"] == "custom-agent/1.0"
+
+
+def test_request_kwargs_preserves_other_kwargs():
+    provider = HTTPProvider(
+        endpoint_uri=URI,
+        request_kwargs={
+            "timeout": 42,
+            "headers": {"X-Custom": "yes"},
+        },
+    )
+    request_kwargs = provider.get_request_kwargs()
+
+    assert request_kwargs["timeout"] == 42
+    assert request_kwargs["headers"]["X-Custom"] == "yes"
+    assert request_kwargs["headers"]["Content-Type"] == "application/json"
+
+
 @patch(
     "web3._utils.http_session_manager.HTTPSessionManager.make_post_request",
     new_callable=Mock,

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -99,9 +99,16 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
 
     @to_dict
     def get_request_kwargs(self) -> Iterable[tuple[str, Any]]:
-        if "headers" not in self._request_kwargs:
-            yield "headers", self.get_request_headers()
-        yield from self._request_kwargs.items()
+        # Merge default headers with any user-provided ``request_kwargs["headers"]``
+        # so callers can extend (e.g. add an ``Authorization`` header) without
+        # losing required defaults like ``Content-Type``. User-supplied keys win
+        # on conflict.
+        user_headers = self._request_kwargs.get("headers") or {}
+        yield "headers", {**self.get_request_headers(), **user_headers}
+        for key, value in self._request_kwargs.items():
+            if key == "headers":
+                continue
+            yield key, value
 
     @combomethod
     def get_request_headers(cls) -> dict[str, str]:

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -103,9 +103,16 @@ class HTTPProvider(JSONBaseProvider):
 
     @to_dict
     def get_request_kwargs(self) -> Iterable[tuple[str, Any]]:
-        if "headers" not in self._request_kwargs:
-            yield "headers", self.get_request_headers()
-        yield from self._request_kwargs.items()
+        # Merge default headers with any user-provided ``request_kwargs["headers"]``
+        # so callers can extend (e.g. add an ``Authorization`` header) without
+        # losing required defaults like ``Content-Type``. User-supplied keys win
+        # on conflict.
+        user_headers = self._request_kwargs.get("headers") or {}
+        yield "headers", {**self.get_request_headers(), **user_headers}
+        for key, value in self._request_kwargs.items():
+            if key == "headers":
+                continue
+            yield key, value
 
     @combomethod
     def get_request_headers(cls) -> dict[str, str]:


### PR DESCRIPTION
## What was wrong?

Closes #3551.

`(Async)HTTPProvider.get_request_kwargs` only yields the default headers from `get_request_headers()` when `headers` is *absent* from `request_kwargs`:

```python
@to_dict
def get_request_kwargs(self) -> Iterable[tuple[str, Any]]:
    if "headers" not in self._request_kwargs:
        yield "headers", self.get_request_headers()
    yield from self._request_kwargs.items()
```

So passing any custom headers silently drops the required defaults:

```python
HTTPProvider(
    endpoint_uri=URI,
    request_kwargs={"headers": {"Authorization": "Bearer ..."}},
)
# request_kwargs["headers"] -> {"Authorization": "Bearer ..."}
# Content-Type and User-Agent are gone
```

This matches what @souliane reported in #3551: passing `request_kwargs["headers"]` should *extend* the defaults from `HTTPProvider.get_request_headers`, not replace them.

## How was it fixed?

`get_request_kwargs` now merges the defaults with the user-supplied headers (user keys win on conflict), and yields the remaining `request_kwargs` items unchanged.

```python
@to_dict
def get_request_kwargs(self) -> Iterable[tuple[str, Any]]:
    user_headers = self._request_kwargs.get("headers") or {}
    yield "headers", {**self.get_request_headers(), **user_headers}
    for key, value in self._request_kwargs.items():
        if key == "headers":
            continue
        yield key, value
```

Same change applied to `AsyncHTTPProvider`.

## Cute Animal Picture

![cat](https://placecats.com/300/200)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

#### Test plan

- [x] New unit tests in `tests/core/providers/test_http_provider.py` and `tests/core/providers/test_async_http_provider.py` covering:
  - user headers extend the defaults (`Content-Type` / `User-Agent` preserved alongside `Authorization`)
  - user header keys override default keys on conflict (custom `User-Agent`)
  - other `request_kwargs` (e.g. `timeout`) are preserved alongside merged headers
- [x] Existing `test_get_request_headers` parametrized test continues to pass (defaults unchanged when no override).
- [x] Newsfragment added at `newsfragments/3551.bugfix.rst`.

#### Notes

The behavior change is opt-in to anyone who was already passing `request_kwargs["headers"]`; previously they were dropping the defaults. After this change those callers will additionally receive the defaults, which is what the public docstring on `get_request_headers` already implies.