### PR TITLE
Fix operator precedence on evicted-session close timeout

### DIFF
--- a/newsfragments/3832.bugfix.rst
+++ b/newsfragments/3832.bugfix.rst
@@ -1,0 +1,6 @@
+Fix an operator-precedence bug in ``HTTPSessionManager`` so the
+``+ 0.1`` slack on the evicted-session close timer is applied to the
+caller-supplied ``request_timeout`` rather than only to the
+``DEFAULT_HTTP_TIMEOUT`` fallback. Previously a non-default timeout
+caused the close timer to fire at exactly the request timeout, racing
+the in-flight request.

--- a/tests/core/utilities/test_http_session_manager.py
+++ b/tests/core/utilities/test_http_session_manager.py
@@ -26,6 +26,9 @@ from requests.adapters import (
 from web3._utils.caching import (
     generate_cache_key,
 )
+from web3._utils.http import (
+    DEFAULT_HTTP_TIMEOUT,
+)
 from web3._utils.http_session_manager import (
     HTTPSessionManager,
 )
@@ -245,9 +248,7 @@ def test_session_manager_evicted_close_timer_uses_request_timeout_plus_slack(
     # so any in-flight request has slack to finish before its session is closed.
     # An earlier version dropped the slack for non-default timeouts because of
     # operator precedence (``x or DEFAULT + 0.1`` parses as ``x or (DEFAULT + 0.1)``).
-    timer_mock = mocker.patch(
-        "web3._utils.http_session_manager.threading.Timer"
-    )
+    timer_mock = mocker.patch("web3._utils.http_session_manager.threading.Timer")
 
     http_session_manager.session_cache = SimpleCache(1)
     http_session_manager.cache_and_return_session(
@@ -266,9 +267,7 @@ def test_session_manager_evicted_close_timer_uses_request_timeout_plus_slack(
 def test_session_manager_evicted_close_timer_falls_back_to_default(
     mocker, http_session_manager
 ):
-    timer_mock = mocker.patch(
-        "web3._utils.http_session_manager.threading.Timer"
-    )
+    timer_mock = mocker.patch("web3._utils.http_session_manager.threading.Timer")
 
     http_session_manager.session_cache = SimpleCache(1)
     http_session_manager.cache_and_return_session(
@@ -281,8 +280,6 @@ def test_session_manager_evicted_close_timer_falls_back_to_default(
     assert timer_mock.called
     interval = timer_mock.call_args.args[0]
     # ``DEFAULT_HTTP_TIMEOUT`` is 30 in this codebase; verify we still add the slack.
-    from web3._utils.http import DEFAULT_HTTP_TIMEOUT
-
     assert interval == pytest.approx(DEFAULT_HTTP_TIMEOUT + 0.1)
 
 

--- a/tests/core/utilities/test_http_session_manager.py
+++ b/tests/core/utilities/test_http_session_manager.py
@@ -238,6 +238,54 @@ def test_session_manager_precached_session(mocker, http_session_manager):
     assert adapter._pool_maxsize == 100
 
 
+def test_session_manager_evicted_close_timer_uses_request_timeout_plus_slack(
+    mocker, http_session_manager
+):
+    # The evicted-session close timer should fire at ``request_timeout + 0.1``
+    # so any in-flight request has slack to finish before its session is closed.
+    # An earlier version dropped the slack for non-default timeouts because of
+    # operator precedence (``x or DEFAULT + 0.1`` parses as ``x or (DEFAULT + 0.1)``).
+    timer_mock = mocker.patch(
+        "web3._utils.http_session_manager.threading.Timer"
+    )
+
+    http_session_manager.session_cache = SimpleCache(1)
+    http_session_manager.cache_and_return_session(
+        URI("https://www.test1.com"), request_timeout=5.0
+    )
+    http_session_manager.cache_and_return_session(
+        URI("https://www.test2.com"), request_timeout=5.0
+    )
+
+    # eviction triggered the timer with the right interval
+    assert timer_mock.called
+    interval = timer_mock.call_args.args[0]
+    assert interval == pytest.approx(5.1)
+
+
+def test_session_manager_evicted_close_timer_falls_back_to_default(
+    mocker, http_session_manager
+):
+    timer_mock = mocker.patch(
+        "web3._utils.http_session_manager.threading.Timer"
+    )
+
+    http_session_manager.session_cache = SimpleCache(1)
+    http_session_manager.cache_and_return_session(
+        URI("https://www.test1.com"), request_timeout=None
+    )
+    http_session_manager.cache_and_return_session(
+        URI("https://www.test2.com"), request_timeout=None
+    )
+
+    assert timer_mock.called
+    interval = timer_mock.call_args.args[0]
+    # ``DEFAULT_HTTP_TIMEOUT`` is 30 in this codebase; verify we still add the slack.
+    from web3._utils.http import DEFAULT_HTTP_TIMEOUT
+
+    assert interval == pytest.approx(DEFAULT_HTTP_TIMEOUT + 0.1)
+
+
 def test_simple_cache_cache_session():
     cache = SimpleCache(2)
     _, evicted_items = cache.cache("1", "Hello1")
@@ -329,6 +377,45 @@ class AsyncMockedResponse:
     @staticmethod
     def raise_for_status() -> None:
         pass
+
+
+@pytest.mark.asyncio
+async def test_async_evicted_close_task_uses_request_timeout_plus_slack(
+    mocker, http_session_manager
+):
+    # Async equivalent of the sync precedence-bug regression test: the
+    # evicted-session close coroutine should be scheduled with
+    # ``request_timeout.total + 0.1``.
+    captured: dict[str, float] = {}
+
+    async def _capture(timeout, evicted_sessions):
+        captured["timeout"] = timeout
+
+    mocker.patch.object(
+        http_session_manager,
+        "_async_close_evicted_sessions",
+        side_effect=_capture,
+    )
+
+    http_session_manager.session_cache = SimpleCache(1)
+    timeout = ClientTimeout(total=5.0)
+
+    s1 = ClientSession()
+    s2 = ClientSession()
+    try:
+        await http_session_manager.async_cache_and_return_session(
+            URI("https://www.test1.com"), session=s1, request_timeout=timeout
+        )
+        await http_session_manager.async_cache_and_return_session(
+            URI("https://www.test2.com"), session=s2, request_timeout=timeout
+        )
+        # let the scheduled close-task run
+        await asyncio.sleep(0)
+    finally:
+        await s1.close()
+        await s2.close()
+
+    assert captured.get("timeout") == pytest.approx(5.1)
 
 
 @pytest.mark.asyncio

--- a/web3/_utils/http_session_manager.py
+++ b/web3/_utils/http_session_manager.py
@@ -95,8 +95,10 @@ class HTTPSessionManager:
                 )
             threading.Timer(
                 # If `request_timeout` is `None`, don't wait forever for the closing
-                # session to finish the request. Instead, wait over the default timeout.
-                request_timeout or DEFAULT_HTTP_TIMEOUT + 0.1,
+                # session to finish the request. Instead, wait over the default
+                # timeout. Parenthesize the `or` so the `+ 0.1` slack is applied to
+                # the chosen timeout rather than only to the fallback.
+                (request_timeout or DEFAULT_HTTP_TIMEOUT) + 0.1,
                 self._close_evicted_sessions,
                 args=[evicted_sessions],
             ).start()
@@ -267,8 +269,9 @@ class HTTPSessionManager:
                 self._async_close_evicted_sessions(
                     # if `ClientTimeout.total` is `None`, don't wait forever for the
                     # closing session to finish the request. Instead, use the default
-                    # timeout.
-                    request_timeout.total or DEFAULT_HTTP_TIMEOUT + 0.1,
+                    # timeout. Parenthesize the `or` so the `+ 0.1` slack is applied
+                    # to the chosen timeout rather than only to the fallback.
+                    (request_timeout.total or DEFAULT_HTTP_TIMEOUT) + 0.1,
                     evicted_sessions,
                 )
             )


### PR DESCRIPTION
## What was wrong?

`HTTPSessionManager.cache_and_return_session` (sync) and `async_cache_and_return_session` (async) schedule a close-evicted-sessions task to fire after the in-flight request would have timed out, plus a small `0.1`s slack so any request that started right before the eviction has time to finish before the underlying session is closed.

Both call sites used:

```python
# sync, web3/_utils/http_session_manager.py:99
request_timeout or DEFAULT_HTTP_TIMEOUT + 0.1
# async, web3/_utils/http_session_manager.py:271
request_timeout.total or DEFAULT_HTTP_TIMEOUT + 0.1
```

`+` binds tighter than `or` in Python, so the expression actually parses as `request_timeout or (DEFAULT_HTTP_TIMEOUT + 0.1)`. The intended `+ 0.1` slack only applied when the caller fell back to the default. Any caller that supplied a non-default timeout (e.g. `request_timeout=5`) had its close timer fire at exactly `5.0`s, racing the in-flight request:

```python
>>> request_timeout = 5
>>> DEFAULT_HTTP_TIMEOUT = 30
>>> request_timeout or DEFAULT_HTTP_TIMEOUT + 0.1
5
>>> (request_timeout or DEFAULT_HTTP_TIMEOUT) + 0.1
5.1
```

The comments above each call site already describe the intended behavior (`wait over the default timeout` / `bit more than the request_timeout`).

## How was it fixed?

Parenthesize the `or` so the slack is always applied to the chosen timeout:

```python
(request_timeout or DEFAULT_HTTP_TIMEOUT) + 0.1
```

Same change in both the sync and async paths.

## Cute Animal Picture

![cat](https://placecats.com/300/200)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

#### Test plan

Added focused regression tests in `tests/core/utilities/test_http_session_manager.py`:
- `test_session_manager_evicted_close_timer_uses_request_timeout_plus_slack` — patches `threading.Timer`, fills a 1-entry cache, and asserts the captured interval is `request_timeout + 0.1`.
- `test_session_manager_evicted_close_timer_falls_back_to_default` — same path with `request_timeout=None`, asserts the interval is `DEFAULT_HTTP_TIMEOUT + 0.1`.
- `test_async_evicted_close_task_uses_request_timeout_plus_slack` — async equivalent that patches `_async_close_evicted_sessions` and asserts it was scheduled with `ClientTimeout.total + 0.1`.

The pre-existing `test_async_session_manager_cache_does_not_close_session_before_call` already exercised the async eviction path and continues to pass with the change (it waited for `_timeout + 0.1` regardless and is not sensitive to the bug).