### PR TITLE
fix: preserve sync RPC empty params shape

### DIFF
--- a/newsfragments/3823.bugfix.rst
+++ b/newsfragments/3823.bugfix.rst
@@ -1,0 +1,1 @@
+Preserve empty named-params objects when sync providers encode JSON-RPC requests instead of rewriting them to empty positional params.

--- a/tests/core/caching-utils/test_request_caching.py
+++ b/tests/core/caching-utils/test_request_caching.py
@@ -967,6 +967,24 @@ async def test_ws_send_caching_dummy_request_preserves_method_and_params():
 @pytest.mark.parametrize(
     "input_params,expected",
     [
+        ({}, {}),
+        (None, []),
+    ],
+    ids=["empty-dict", "none"],
+)
+def test_sync_encode_rpc_request_preserves_params_shape(input_params, expected):
+    # Follow-up to gh-3823: keep sync JSON-RPC encoding aligned with async
+    # request formation so empty named-params payloads are not rewritten to [].
+    provider = HTTPProvider()
+    encoded = provider.encode_rpc_request(RPCEndpoint("eth_chainId"), input_params)
+    decoded = provider.decode_rpc_response(encoded)
+    assert decoded["params"] == expected
+    assert type(decoded["params"]) is type(expected)
+
+
+@pytest.mark.parametrize(
+    "input_params,expected",
+    [
         ((), ()),
         ({}, {}),
         (None, []),

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -142,7 +142,7 @@ class JSONBaseProvider(BaseProvider):
         rpc_dict = {
             "jsonrpc": "2.0",
             "method": method,
-            "params": params or [],
+            "params": [] if params is None else params,
             "id": next(self.request_counter),
         }
         encoded = FriendlyJsonSerde().json_encode(rpc_dict, Web3JsonEncoder)


### PR DESCRIPTION
### What was wrong?

Follow-up to #3823 / #3825.

#3825 fixed the async persistent-provider path by replacing `params or []` with `[] if params is None else params`, preserving empty tuple/dict params for cache-key consistency.

The sync `JSONBaseProvider.encode_rpc_request()` path still used `params or []`, so an empty named-params payload (`{}`) was serialized as positional params (`[]`). That changes JSON-RPC request shape before the request is sent.

### How was it fixed?

- Update sync JSON-RPC encoding to only default `None` to `[]`.
- Add a regression test for empty dict vs `None` on sync encoding.
- Add a bugfix newsfragment.

### Validation

- `git diff --check`
- `python -m pytest -q tests/core/caching-utils/test_request_caching.py -k 'sync_encode_rpc_request_preserves_params_shape or async_form_request_preserves_params_shape'` could not run in this local checkout because `cached_property` is not installed in the environment (`ModuleNotFoundError`).