### PR TITLE
fix: expose AsyncIPCProvider on AsyncWeb3

### DIFF
--- a/tests/core/providers/test_provider_init.py
+++ b/tests/core/providers/test_provider_init.py
@@ -55,3 +55,7 @@ def test_init_web3_with_async_provider(provider_class):
 def test_init_async_web3_with_sync_provider(provider_class):
     with pytest.raises(Web3ValidationError):
         AsyncWeb3(provider_class())
+
+
+def test_async_web3_exposes_async_ipc_provider():
+    assert AsyncWeb3.AsyncIPCProvider is AsyncIPCProvider

--- a/web3/main.py
+++ b/web3/main.py
@@ -137,6 +137,7 @@ from web3.providers import (
     WebSocketProvider,
 )
 from web3.providers.persistent import (
+    AsyncIPCProvider,
     PersistentConnection,
 )
 from web3.testing import (
@@ -461,6 +462,7 @@ class AsyncWeb3(BaseWeb3, Generic[AsyncProviderT]):
 
     # Providers
     AsyncHTTPProvider = AsyncHTTPProvider
+    AsyncIPCProvider = AsyncIPCProvider
     WebSocketProvider = WebSocketProvider
     AsyncEthereumTesterProvider = AsyncEthereumTesterProvider
 


### PR DESCRIPTION
## Summary

- expose `AsyncIPCProvider` on `AsyncWeb3`, matching the other async provider convenience attributes
- add a small regression test for the class-level provider export

## Rationale

`AsyncIPCProvider` is already exported from the package root, and the docs include examples that use `AsyncWeb3.AsyncIPCProvider(...)`. Unlike `AsyncHTTPProvider`, `WebSocketProvider`, and `AsyncEthereumTesterProvider`, the `AsyncWeb3` class did not expose this provider attribute, so those examples would fail at the symbol lookup step.

## Testing

- `.venv/bin/python -m pytest tests/core/providers/test_provider_init.py -q -k 'async_web3_exposes_async_ipc_provider'`
- `python3 -m py_compile web3/main.py tests/core/providers/test_provider_init.py`
- `git diff --check`

Note: running the full `tests/core/providers/test_provider_init.py` file in this local lightweight venv failed only for the existing EthereumTester provider parametrizations because `eth_tester` was not installed. The new focused regression test passed.
