### PR TITLE
docs: fix subscription response field path

### DIFF
--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -33,7 +33,8 @@ When you subscribe to an event – new block headers, for example – you'll rec
                 print(response)
 
                 # unsubscribe:
-                if response["number"] > 42012345:
+                new_head = response["result"]
+                if new_head["number"] > 42012345:
                     await w3.eth.unsubscribe(subscription_id)
                     break
 

--- a/newsfragments/3850.docs.rst
+++ b/newsfragments/3850.docs.rst
@@ -1,0 +1,1 @@
+Fix the introductory subscription example to read the block number from the formatted subscription response result.


### PR DESCRIPTION
## What was changed
- Update the introductory subscription example to read the new-head block number from `response["result"]`.
- Keep the example aligned with the formatted subscription response shape returned by `process_subscriptions()`.

## Why
`process_subscriptions()` yields formatted subscription responses with a top-level `subscription` and nested `result`. The example currently checks `response["number"]`, which is not the shape users receive when they copy this snippet.

## Validation
- `git diff --check origin/main...HEAD`
- changed-file conflict marker scan clean

Note: this PR is opened first so the follow-up commit can add the required newsfragment using the PR number, per `newsfragments/README.md`.
