### PR TITLE
test: cover geth fixture cleanup on errors

### DIFF
--- a/newsfragments/3851.internal.rst
+++ b/newsfragments/3851.internal.rst
@@ -1,0 +1,1 @@
+Added regression coverage for geth integration fixture cleanup when tests fail after the fixture yields.

--- a/tests/integration/go_ethereum/test_conftest_cleanup.py
+++ b/tests/integration/go_ethereum/test_conftest_cleanup.py
@@ -1,0 +1,63 @@
+import pytest
+
+from tests.integration.go_ethereum import conftest as geth_conftest
+
+
+class FakeGethProcess:
+    stdin = None
+    stdout = None
+    stderr = None
+
+    def __init__(self, events):
+        self.events = events
+
+    def communicate(self, timeout):
+        self.events.append(("communicate", timeout))
+        return "", ""
+
+
+def test_start_geth_process_cleans_up_after_consumer_exception(monkeypatch):
+    events = []
+    proc = FakeGethProcess(events)
+
+    def fake_check_output(*args, **kwargs):
+        events.append(("check_output", args, kwargs))
+        return b""
+
+    def fake_popen(*args, **kwargs):
+        events.append(("popen", args, kwargs))
+        return proc
+
+    def fake_wait_for_port(received_proc):
+        assert received_proc is proc
+        events.append("wait_for_port")
+        return 30303
+
+    def fake_kill_proc_gracefully(received_proc):
+        assert received_proc is proc
+        events.append("kill_proc_gracefully")
+
+    monkeypatch.setattr(geth_conftest.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(geth_conftest.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(geth_conftest, "wait_for_port", fake_wait_for_port)
+    monkeypatch.setattr(
+        geth_conftest,
+        "kill_proc_gracefully",
+        fake_kill_proc_gracefully,
+    )
+
+    fixture_generator = geth_conftest.start_geth_process_and_yield_port.__wrapped__(
+        "geth",
+        "/tmp/datadir",
+        "/tmp/genesis.json",
+        ("geth", "--dev"),
+    )
+
+    assert next(fixture_generator) == 30303
+    with pytest.raises(RuntimeError, match="consumer failed"):
+        fixture_generator.throw(RuntimeError("consumer failed"))
+
+    assert "wait_for_port" in events
+    assert "kill_proc_gracefully" in events
+    assert ("communicate", 5) in events
+    assert events.index("kill_proc_gracefully") < events.index(("communicate", 5))


### PR DESCRIPTION
### What was wrong?

`start_geth_process_and_yield_port` now uses a `finally` block to stop the geth process when a test fails after the fixture yields, but that cleanup path was not covered by a focused regression test.

Related to the go-ethereum integration test fixture cleanup path.

### How was it fixed?

Added a small test that drives the fixture generator directly with monkeypatched geth process helpers. The test throws a consumer exception into the generator and asserts that:

- `kill_proc_gracefully()` is called
- `proc.communicate(timeout=5)` is called
- the process is killed before `communicate()` is invoked

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes: not needed, test-only regression coverage
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md): added `newsfragments/3851.internal.rst`

### Tests

- `git diff --check`
- `.venv/bin/python -m pytest tests/integration/go_ethereum/test_conftest_cleanup.py -q`

Note: `uv pip install -e '.[test]'` hit a local `safe-pysha3` build issue in this macOS CommandLineTools environment, so I installed the package plus the focused dependencies needed for this test and ran the targeted pytest above.

#### Cute Animal Picture

![red panda](https://upload.wikimedia.org/wikipedia/commons/thumb/5/50/RedPandaFullBody.JPG/640px-RedPandaFullBody.JPG)
