### PR TITLE
Fix Windows wheel smoke test venv usage

### DIFF
--- a/newsfragments/3852.internal.rst
+++ b/newsfragments/3852.internal.rst
@@ -1,0 +1,1 @@
+Tighten the Windows wheel release smoke test so the temporary virtualenv activation, wheel install, and import check run in the same shell session.

--- a/web3/scripts/release/test_windows_wheel_install.sh
+++ b/web3/scripts/release/test_windows_wheel_install.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 
+set -euo pipefail
+
 python --version
-bash.exe -c "set -e"
-bash.exe -c "rm -rf build dist"
+rm -rf build dist
 python -m build
-bash.exe -c "export temp_dir=$(mktemp -d)"
-cd $temp_dir
+
+temp_dir=$(mktemp -d)
+cd "$temp_dir"
 python -m venv venv-test
-bash.exe -c "source venv-test/Scripts/activate"
-bash.exe -c 'python -m pip install --upgrade "$(ls /c/Users/circleci/project/web3.py/dist/web3-*-py3-none-any.whl)" --progress-bar off'
-python -c "from web3 import Web3"
+source venv-test/Scripts/activate
+python -m pip install --upgrade "$(ls /c/Users/circleci/project/web3.py/dist/web3-*-py3-none-any.whl)" --progress-bar off
+python - <<'PY'
+import sys
+from pathlib import Path
+
+from web3 import Web3
+import web3
+
+python_path = str(Path(sys.executable)).replace('\\', '/')
+web3_path = str(Path(web3.__file__)).replace('\\', '/')
+assert 'venv-test' in python_path, python_path
+assert 'venv-test' in web3_path, web3_path
+assert Web3 is not None
+PY


### PR DESCRIPTION
## Summary

The Windows wheel smoke script currently activates the test virtualenv inside a separate `bash.exe -c` process. That activation does not persist for the following install/import steps, so the smoke test can run against the wrong interpreter environment.

This keeps the temporary directory, virtualenv activation, wheel install, and import check in the same shell session. It also asserts that both the Python executable and imported `web3` package come from the `venv-test` environment.

## Tests

- `bash -n web3/scripts/release/test_windows_wheel_install.sh`
- `git diff --check origin/main...HEAD`
- conflict-marker scan for `web3/scripts/release/test_windows_wheel_install.sh`

The Windows-specific script was not executed locally because this environment is not the CircleCI Windows executor.
