### PR TITLE
feat(ens): add `address_bytes()` for raw ENSIP-9 multichain resolution

### DIFF
--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -170,6 +170,13 @@ the ``coin_type`` keyword argument.
     eth_address = ns.address('ens.eth', coin_type=60)  # ETH is coin_type 60
     assert eth_address == '0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7'
 
+For non-Ethereum coin types, use :meth:`~ens.ENS.address_bytes` to obtain the
+raw ENSIP-9 binary record from the resolver, then encode it with a chain-specific
+library (for example, `ensdomains/address-encoder
+<https://github.com/ensdomains/address-encoder>`_). :meth:`~ens.ENS.address`
+applies EIP-55 checksumming and is only appropriate for 20-byte Ethereum
+records.
+
 
 Get the ENS Name for an Address
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -58,6 +58,7 @@ from ens.utils import (
     normal_name_to_hash,
     normalize_name,
     raw_name_to_hash,
+    resolved_address_to_bytes,
 )
 
 if TYPE_CHECKING:
@@ -147,6 +148,69 @@ class AsyncENS(BaseENS):
 
         return ns
 
+    async def address_bytes(
+        self,
+        name: str,
+        coin_type: int | None = None,
+    ) -> bytes | None:
+        """
+        Look up the raw address bytes that `name` points to.
+
+        Returns the ENSIP-9 native binary encoding from the resolver without
+        converting to a checksummed hex string. For Ethereum (``coin_type=60``
+        or the default ``addr(node)`` record), this is typically 20 bytes. For
+        other chains (for example Bitcoin or Solana), byte length and format
+        follow `ENSIP-9 <https://docs.ens.domains/ensip/9/#address-encoding>`_.
+
+        Use :meth:`address` when you need an EIP-55 checksummed Ethereum address.
+        For other coin types, encode the returned bytes with a chain-specific
+        library such as `ensdomains/address-encoder
+        <https://github.com/ensdomains/address-encoder>`_.
+
+        :param str name: an ENS name to look up
+        :param int coin_type: if provided, look up the address for this coin type
+        :raises InvalidName: if `name` has invalid syntax
+        """
+        from web3.exceptions import (
+            ContractLogicError,
+        )
+
+        if coin_type is None:
+            normal_name = normalize_name(name)
+            node = self.namehash(normal_name)
+            dns_name = dns_encode_name(normal_name)
+            calldata = self._resolver_contract.encode_abi("addr", args=[node])
+            try:
+                result, resolver_addr = await self._universal_resolver.caller.resolve(
+                    dns_name, calldata
+                )
+            except ContractLogicError:
+                return None
+            if not result or result == b"":
+                return None
+            decoded_result = self._decode_ensip10_resolve_data(
+                result, self._resolver_contract, "addr"
+            )
+            return resolved_address_to_bytes(decoded_result)
+
+        node = raw_name_to_hash(name)
+        normal_name = normalize_name(name)
+        dns_name = dns_encode_name(normal_name)
+        calldata = self._resolver_contract.encode_abi("addr", args=[node, coin_type])
+        try:
+            result, resolver_addr = await self._universal_resolver.caller.resolve(
+                dns_name, calldata
+            )
+        except ContractLogicError:
+            return None
+        if not result:
+            return None
+        decoded = self.w3.codec.decode(["bytes"], result)
+        address_as_bytes = decoded[0]
+        if is_none_or_zero_address(address_as_bytes):
+            return None
+        return address_as_bytes
+
     async def address(
         self,
         name: str,
@@ -159,32 +223,13 @@ class AsyncENS(BaseENS):
         :param int coin_type: if provided, look up the address for this coin type
         :raises InvalidName: if `name` has invalid syntax
         """
-        from web3.exceptions import (
-            ContractLogicError,
-        )
-
         if coin_type is None:
             return cast(ChecksumAddress, await self._resolve(name, "addr"))
-        else:
-            node = raw_name_to_hash(name)
-            normal_name = normalize_name(name)
-            dns_name = dns_encode_name(normal_name)
-            calldata = self._resolver_contract.encode_abi(
-                "addr", args=[node, coin_type]
-            )
-            try:
-                result, resolver_addr = await self._universal_resolver.caller.resolve(
-                    dns_name, calldata
-                )
-            except ContractLogicError:
-                return None
-            if not result:
-                return None
-            decoded = self.w3.codec.decode(["bytes"], result)
-            address_as_bytes = decoded[0]
-            if is_none_or_zero_address(address_as_bytes):
-                return None
-            return to_checksum_address(address_as_bytes)
+
+        address_as_bytes = await self.address_bytes(name, coin_type=coin_type)
+        if address_as_bytes is None:
+            return None
+        return to_checksum_address(address_as_bytes)
 
     async def setup_address(
         self,

--- a/ens/ens.py
+++ b/ens/ens.py
@@ -57,6 +57,7 @@ from .utils import (
     normal_name_to_hash,
     normalize_name,
     raw_name_to_hash,
+    resolved_address_to_bytes,
 )
 
 if TYPE_CHECKING:
@@ -138,6 +139,63 @@ class ENS(BaseENS):
 
         return ns
 
+    def address_bytes(
+        self,
+        name: str,
+        coin_type: int | None = None,
+    ) -> bytes | None:
+        """
+        Look up the raw address bytes that `name` points to.
+
+        Returns the ENSIP-9 native binary encoding from the resolver without
+        converting to a checksummed hex string. For Ethereum (``coin_type=60``
+        or the default ``addr(node)`` record), this is typically 20 bytes. For
+        other chains (for example Bitcoin or Solana), byte length and format
+        follow `ENSIP-9 <https://docs.ens.domains/ensip/9/#address-encoding>`_.
+
+        Use :meth:`address` when you need an EIP-55 checksummed Ethereum address.
+        For other coin types, encode the returned bytes with a chain-specific
+        library such as `ensdomains/address-encoder
+        <https://github.com/ensdomains/address-encoder>`_.
+
+        :param str name: an ENS name to look up
+        :param int coin_type: if provided, look up the address for this coin type
+        :raises InvalidName: if `name` has invalid syntax
+        """
+        from web3.exceptions import (
+            ContractLogicError,
+        )
+
+        if coin_type is None:
+            dns_name, calldata = self._prepare_resolve_call(name, "addr")
+            try:
+                result, resolver_addr = self._universal_resolver.caller.resolve(
+                    dns_name, calldata
+                )
+            except ContractLogicError:
+                return None
+            if not result or result == b"":
+                return None
+            decoded_result = self._decode_ensip10_resolve_data(
+                result, self._resolver_contract, "addr"
+            )
+            return resolved_address_to_bytes(decoded_result)
+
+        dns_name, calldata = self._prepare_resolve_call(name, "addr", [coin_type])
+        try:
+            result, resolver_addr = self._universal_resolver.caller.resolve(
+                dns_name, calldata
+            )
+        except ContractLogicError:
+            return None
+        if not result:
+            return None
+        decoded = self.w3.codec.decode(["bytes"], result)
+        address_as_bytes = decoded[0]
+        if is_none_or_zero_address(address_as_bytes):
+            return None
+        return address_as_bytes
+
     def address(
         self,
         name: str,
@@ -151,27 +209,13 @@ class ENS(BaseENS):
         :raises InvalidName: if `name` has invalid syntax
         :raises ResolverNotFound: if no resolver found for `name`
         """
-        from web3.exceptions import (
-            ContractLogicError,
-        )
-
         if coin_type is None:
             return cast(ChecksumAddress, self._resolve(name, "addr"))
-        else:
-            dns_name, calldata = self._prepare_resolve_call(name, "addr", [coin_type])
-            try:
-                result, resolver_addr = self._universal_resolver.caller.resolve(
-                    dns_name, calldata
-                )
-            except ContractLogicError:
-                return None
-            if not result:
-                return None
-            decoded = self.w3.codec.decode(["bytes"], result)
-            address_as_bytes = decoded[0]
-            if is_none_or_zero_address(address_as_bytes):
-                return None
-            return to_checksum_address(address_as_bytes)
+
+        address_as_bytes = self.address_bytes(name, coin_type=coin_type)
+        if address_as_bytes is None:
+            return None
+        return to_checksum_address(address_as_bytes)
 
     def setup_address(
         self,

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -278,6 +278,25 @@ def is_none_or_zero_address(addr: Address | ChecksumAddress | HexAddress) -> boo
     return not addr or addr == EMPTY_ADDR_HEX or addr == b"\x00" * 20
 
 
+def resolved_address_to_bytes(
+    value: Address | ChecksumAddress | HexAddress | bytes | str | None,
+) -> bytes | None:
+    """
+    Convert a resolver ``addr`` return value to raw bytes (ENSIP-9 on-chain form).
+    """
+    if value is None or is_none_or_zero_address(value):
+        return None
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        if value.startswith(("0x", "0X")):
+            return bytes.fromhex(value[2:])
+        return bytes.fromhex(value)
+    raise ENSValueError(
+        f"Cannot convert resolved address of type {type(value)!r} to bytes"
+    )
+
+
 def is_empty_name(name: str) -> bool:
     return name is None or name.strip() in {"", "."}
 

--- a/newsfragments/3854.feature.rst
+++ b/newsfragments/3854.feature.rst
@@ -1,0 +1,1 @@
+Add ``address_bytes()`` to ``ENS`` and ``AsyncENS`` for raw multichain ``addr`` resolution per ENSIP-9, without EIP-55 encoding.

--- a/tests/ens/test_ens.py
+++ b/tests/ens/test_ens.py
@@ -202,6 +202,56 @@ def test_ens_address_lookup_with_coin_type(ens):
     assert returned_address == address
 
 
+# ENSIP-9 Bitcoin P2PKH on-chain encoding (25 bytes)
+BITCOIN_ADDR_BYTES = bytes.fromhex(
+    "76a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1888ac"
+)
+
+
+def test_ens_address_bytes_with_coin_type(ens):
+    name = "tester.eth"
+    coin_type = 0
+    expected_node = raw_name_to_hash(name)
+
+    encoded_result = ens.w3.codec.encode(["bytes"], [BITCOIN_ADDR_BYTES])
+    mock_ur_caller = MagicMock()
+    mock_ur_caller.resolve.return_value = (encoded_result, ens.w3.eth.accounts[0])
+
+    with patch.object(ens._universal_resolver, "caller", mock_ur_caller):
+        returned_bytes = ens.address_bytes(name, coin_type=coin_type)
+
+    assert returned_bytes == BITCOIN_ADDR_BYTES
+    mock_ur_caller.resolve.assert_called_once()
+    _, calldata = mock_ur_caller.resolve.call_args.args
+    decoded_node, decoded_coin_type = ens.w3.codec.decode(
+        ["bytes32", "uint256"], bytes.fromhex(calldata[2:])[4:]
+    )
+    assert decoded_node == expected_node
+    assert decoded_coin_type == coin_type
+
+
+def test_ens_address_bytes_bitcoin_does_not_require_checksum(ens):
+    encoded_result = ens.w3.codec.encode(["bytes"], [BITCOIN_ADDR_BYTES])
+    mock_ur_caller = MagicMock()
+    mock_ur_caller.resolve.return_value = (encoded_result, ens.w3.eth.accounts[0])
+
+    with patch.object(ens._universal_resolver, "caller", mock_ur_caller):
+        # ``address()`` still applies EIP-55 encoding and fails for non-EVM bytes
+        with pytest.raises(ValueError):
+            ens.address("tester.eth", coin_type=0)
+        assert ens.address_bytes("tester.eth", coin_type=0) == BITCOIN_ADDR_BYTES
+
+
+def test_ens_address_delegates_to_address_bytes_for_coin_type(ens):
+    name = "tester.eth"
+    coin_type = 60
+    raw_bytes = bytes.fromhex(ens.w3.eth.accounts[0][2:])
+
+    with patch.object(ens, "address_bytes", return_value=raw_bytes) as mock_bytes:
+        assert ens.address(name, coin_type=coin_type) == ens.w3.eth.accounts[0]
+    mock_bytes.assert_called_once_with(name, coin_type=coin_type)
+
+
 @pytest.mark.parametrize(
     "ur_resolve_outcome",
     (
@@ -402,6 +452,24 @@ async def test_async_ens_address_lookup_with_coin_type(async_ens):
     assert decoded_node == expected_node
     assert decoded_coin_type == coin_type
     assert returned_address == address
+
+
+@pytest.mark.asyncio
+async def test_async_ens_address_bytes_with_coin_type(async_ens):
+    name = "tester.eth"
+    coin_type = 0
+    accounts = await async_ens.w3.eth.accounts
+    expected_node = raw_name_to_hash(name)
+
+    encoded_result = async_ens.w3.codec.encode(["bytes"], [BITCOIN_ADDR_BYTES])
+    mock_ur_caller = AsyncMock()
+    mock_ur_caller.resolve.return_value = (encoded_result, accounts[0])
+
+    with patch.object(async_ens._universal_resolver, "caller", mock_ur_caller):
+        returned_bytes = await async_ens.address_bytes(name, coin_type=coin_type)
+
+    assert returned_bytes == BITCOIN_ADDR_BYTES
+    mock_ur_caller.resolve.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

## Summary

Adds `ENS.address_bytes()` and `AsyncENS.address_bytes()` to return resolver `addr` records as raw bytes (per [ENSIP-9](https://docs.ens.domains/ensip/9/#address-encoding)), without applying EIP-55 checksumming. Refactors `address(coin_type=…)` to resolve via `address_bytes()` and then encode with `to_checksum_address()` for Ethereum-shaped records.

This lets integrators resolve Bitcoin, Solana, and other coin types without copying Universal Resolver logic or hitting `ValueError` from `to_checksum_address()` on non–20-byte payloads.

## Motivation

When `coin_type` is set, `address()` decodes resolver `bytes` and unconditionally calls `to_checksum_address()`. That works for Ethereum (`coin_type=60`, 20 bytes) but fails for typical ENSIP-9 encodings (e.g. Bitcoin 25-byte scriptPubKey) with `ValueError: Unknown format …`.

Integrators currently have to override `AsyncENS.address` to encode non-EVM addresses themselves. The requested API shape is:

1. **`address_bytes()`** — resolution only, returns raw bytes.
2. **`address()`** — calls `address_bytes()` when `coin_type` is set, then EIP-55 encoding (unchanged behavior for ETH; still raises for non-EVM bytes).

For display encoding of non-EVM bytes, [ensdomains/address-encoder](https://github.com/ensdomains/address-encoder) remains the recommended approach (same split as viem: resolve bytes → encode per coin type).

### ENSIP-9 and ENSIP-11

[ENSIP-9](https://docs.ens.domains/ensip/9/#address-encoding) defines `addr(node, coinType) → bytes` using each chain’s **native binary** encoding (Bitcoin scriptPubKey, Ethereum 20 bytes, Bech32 payloads, etc.).

[ENSIP-11](https://docs.ens.domains/ensip/11/) amends ENSIP-9 for **EVM-compatible chains**: coin types with the high bit set encode an EVM `chainId`:

- `coinType = 0x80000000 | chainId` (e.g. mainnet ETH remains SLIP-44 `60`; Arbitrum `42161` → `2147483657`)
- Reverse: `chainId = 0x7fffffff & coinType`
- On-chain form is still **20-byte ChecksummedHex** per ENSIP-9 — so `address(coin_type=0x80000000 | chainId)` can work when the record is standard EVM bytes

**Non-EVM** SLIP-44 types (e.g. Bitcoin `0`, Solana) use variable-length encodings; `address()` is not appropriate there — use `address_bytes()` plus [address-encoder](https://github.com/ensdomains/address-encoder) (which implements ENSIP-9/11 conversion helpers such as `convertEVMChainIdToCoinType`).

## Changes

- **`ens/ens.py`**, **`ens/async_ens.py`**: new `address_bytes(name, coin_type=None)`; `address()` delegates to it when `coin_type` is provided.
- **`ens/utils.py`**: `resolved_address_to_bytes()` helper for legacy `addr(node)` → `address` ABI decoding.
- **`docs/ens_overview.rst`**: document `address_bytes()` for multichain resolution.
- **`tests/ens/test_ens.py`**: coverage for Bitcoin ENSIP-9 bytes, delegation from `address()`, and async parity.
- **`newsfragments/3854.feature.rst`**: release note fragment.

## Behavior notes

| Method | `coin_type=None` / `60` (ETH) | `coin_type=0x80000000 \| chainId` ([ENSIP-11](https://docs.ens.domains/ensip/11/) EVM) | `coin_type=0` (BTC, etc., [ENSIP-9](https://docs.ens.domains/ensip/9/)) |
|--------|--------------------------------|-------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
| `address_bytes()` | 20-byte payload | 20-byte payload | Variable-length script / chain bytes |
| `address()` | Checksum ETH via `_resolve` or `address_bytes` + EIP-55 | Checksum ETH (if 20 bytes) | **`ValueError`** — not valid for EIP-55 |

- **EVM L2 / sidechain records** (ENSIP-11 coin types): `address()` remains valid when the resolver stores 20-byte EVM addresses.
- **Non-EVM records** (Bitcoin, Solana, …): use `address_bytes()` + `address-encoder` (or a custom encoder), not `address()`.

## Test plan

- [x] `pytest tests/ens/test_ens.py` — 32 passed
- [x] `pytest tests/ens/` — full ENS suite passed locally
- [x] Bitcoin ENSIP-9 fixture (`76a914…88ac`) returns bytes via `address_bytes()` without error
- [x] `address(coin_type=0)` still raises `ValueError` on Bitcoin bytes (documents current ETH-only encoding)
- [x] Existing `coin_type=60` and multichain setup tests unchanged
