### PR TITLE
Optimize response formatter application hot path

### DIFF
--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -3,7 +3,6 @@ from typing import (
     Any,
     Callable,
     Coroutine,
-    Literal,
     Union,
     cast,
 )
@@ -55,46 +54,37 @@ def _apply_response_formatters(
     error_formatters: Formatters,
     response: RPCResponse,
 ) -> RPCResponse:
-    def _format_response(
-        response_type: Literal["result", "error", "params"],
-        method_response_formatter: Callable[..., Any],
-    ) -> RPCResponse:
-        appropriate_response = response[response_type]
-
-        if response_type == "params":
-            appropriate_response = cast(EthSubscriptionParams, response[response_type])
-            return assoc(
-                response,
-                response_type,
-                assoc(
-                    response["params"],
-                    "result",
-                    method_response_formatter(appropriate_response["result"]),
-                ),
-            )
-        else:
-            return assoc(
-                response, response_type, method_response_formatter(appropriate_response)
-            )
-
     if not isinstance(response, dict):
         raise BadResponseFormat(
             "Malformed response: expected a valid JSON-RPC response object, got: "
             "`{}`".format(response)
         )
-    elif response.get("result") is not None and method in result_formatters:
-        return _format_response("result", result_formatters[method])
-    elif (
-        # eth_subscription responses
-        response.get("params") is not None
-        and response["params"].get("result") is not None
-        and method in result_formatters
-    ):
-        return _format_response("params", result_formatters[method])
-    elif "error" in response and method in error_formatters:
-        return _format_response("error", error_formatters[method])
-    else:
-        return response
+
+    result_formatter = result_formatters.get(method)
+    if result_formatter is not None:
+        result = response.get("result")
+        if result is not None:
+            return assoc(response, "result", result_formatter(result))
+
+        params = response.get("params")
+        if params is not None and params.get("result") is not None:
+            # eth_subscription responses
+            subscription_params = cast(EthSubscriptionParams, params)
+            return assoc(
+                response,
+                "params",
+                assoc(
+                    params,
+                    "result",
+                    result_formatter(subscription_params["result"]),
+                ),
+            )
+
+    error_formatter = error_formatters.get(method)
+    if error_formatter is not None and "error" in response:
+        return assoc(response, "error", error_formatter(response["error"]))
+
+    return response
 
 
 SYNC_FORMATTERS_BUILDER = Callable[["Web3", RPCEndpoint], FormattersDict]


### PR DESCRIPTION
Avoid allocating a nested helper function on every _apply_response_formatters call and replace repeated formatter membership checks plus indexed lookups with single dict.get() lookups.

This reduces overhead on the common no-formatter path while preserving the existing non-mutating response behavior, result formatting, subscription result formatting, and error formatting.

codex wrote this benchmark https://gist.github.com/yabirgb/e29c583a71f52069522f6fb2d326dd03

that gives

```
~/Documents/web3.py clean-deps !1 ?3 > uv run python benchs/benchmark_apply_response_formatters.py --number 10000 --repeat 2
warning: No `requires-python` value found in the workspace. Defaulting to `>=3.13`.
number=10000 repeat=2
case           legacy_best_s  current_best_s  speedup  legacy_mean_s  current_mean_s
----------------------------------------------------------------------------------
no_formatter          0.0030          0.0022     1.38x         0.0032          0.0024
result                0.0054          0.0041     1.32x         0.0057          0.0041
subscription          0.0073          0.0067     1.09x         0.0074          0.0074
error                 0.0082          0.0056     1.46x         0.0083          0.0059
```