### PR TITLE
Cache Method formatter resolution

### DIFF
--- a/tests/core/method-class/test_method.py
+++ b/tests/core/method-class/test_method.py
@@ -11,6 +11,9 @@ from web3 import (
     EthereumTesterProvider,
     Web3,
 )
+from web3._utils.rpc_abi import (
+    RPC,
+)
 from web3.exceptions import (
     Web3ValidationError,
     Web3ValueError,
@@ -345,6 +348,58 @@ def test_process_params(
 
         # the expected result formatters length is 1
         assert len(first_formatter) == 1
+
+
+def test_process_params_caches_static_formatters(monkeypatch):
+    calls = {
+        "request": 0,
+        "error": 0,
+        "null": 0,
+    }
+
+    def request_formatters(_method):
+        calls["request"] += 1
+        return compose(lambda params: params)
+
+    def error_formatters(_method):
+        calls["error"] += 1
+        return compose(lambda response: response)
+
+    def null_result_formatters(_method):
+        calls["null"] += 1
+        return compose(lambda params: params)
+
+    monkeypatch.setattr("web3.method.get_error_formatters", error_formatters)
+
+    method = Method(
+        RPC.eth_chainId,
+        request_formatters=request_formatters,
+        null_result_formatters=null_result_formatters,
+    )
+
+    first_request, first_response_formatters = method.process_params(object())
+    second_request, second_response_formatters = method.process_params(object())
+
+    assert first_request == second_request == (RPC.eth_chainId, ())
+    assert first_response_formatters == second_response_formatters
+    assert calls == {
+        "request": 1,
+        "error": 1,
+        "null": 1,
+    }
+
+
+def test_process_params_does_not_cache_filter_result_formatters():
+    method = Method(RPC.eth_newBlockFilter)
+
+    first_module = type("FirstModule", (), {"is_async": False})()
+    second_module = type("SecondModule", (), {"is_async": False})()
+
+    _, first_response_formatters = method.process_params(first_module)
+    _, second_response_formatters = method.process_params(second_module)
+
+    assert first_response_formatters[0]("0x1").eth_module is first_module
+    assert second_response_formatters[0]("0x2").eth_module is second_module
 
 
 def keywords(module, keyword_one, keyword_two):

--- a/web3/method.py
+++ b/web3/method.py
@@ -3,6 +3,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    cast,
     Generic,
     Optional,
     Sequence,
@@ -20,6 +21,7 @@ from web3._utils.batching import (
     RPC_METHODS_UNSUPPORTED_DURING_BATCH,
 )
 from web3._utils.method_formatters import (
+    FILTER_RESULT_FORMATTERS,
     get_error_formatters,
     get_null_result_formatters,
     get_request_formatters,
@@ -49,6 +51,8 @@ if TYPE_CHECKING:
 
 
 Munger = Callable[..., Any]
+RequestFormatters = Callable[..., Any]
+ResponseFormatters = tuple[Any, Callable[..., Any], Any]
 
 
 @to_tuple
@@ -144,6 +148,10 @@ class Method(Generic[TFunc]):
         )
         self.method_choice_depends_on_args = method_choice_depends_on_args
         self.is_property = is_property
+        self._request_formatters_cache: dict[RPCEndpoint, RequestFormatters] = {}
+        self._result_formatters_cache: dict[RPCEndpoint, Callable[..., Any]] = {}
+        self._error_formatters_cache: dict[RPCEndpoint, Callable[..., Any]] = {}
+        self._null_result_formatters_cache: dict[RPCEndpoint, Callable[..., Any]] = {}
 
     def __get__(
         self,
@@ -193,16 +201,52 @@ class Method(Generic[TFunc]):
             lambda args, munger: munger(module, *args, **kwargs), self.mungers, args
         )
 
+    def _get_request_formatters(self, method: RPCEndpoint) -> RequestFormatters:
+        if method not in self._request_formatters_cache:
+            self._request_formatters_cache[method] = cast(
+                RequestFormatters, self.request_formatters(method)
+            )
+        return self._request_formatters_cache[method]
+
+    def _get_result_formatters(
+        self, method: RPCEndpoint, module: "Module"
+    ) -> Callable[..., Any]:
+        if (
+            self.result_formatters is get_result_formatters
+            and method not in FILTER_RESULT_FORMATTERS
+        ):
+            if method not in self._result_formatters_cache:
+                self._result_formatters_cache[method] = cast(
+                    Callable[..., Any], self.result_formatters(method, module)
+                )
+            return self._result_formatters_cache[method]
+
+        return cast(Callable[..., Any], self.result_formatters(method, module))
+
+    def _get_error_formatters(self, method: RPCEndpoint) -> Callable[..., Any]:
+        if method not in self._error_formatters_cache:
+            self._error_formatters_cache[method] = get_error_formatters(method)
+        return self._error_formatters_cache[method]
+
+    def _get_null_result_formatters(self, method: RPCEndpoint) -> Callable[..., Any]:
+        if method not in self._null_result_formatters_cache:
+            self._null_result_formatters_cache[method] = cast(
+                Callable[..., Any], self.null_result_formatters(method)
+            )
+        return self._null_result_formatters_cache[method]
+
+    def _get_response_formatters(
+        self, method: RPCEndpoint, module: "Module"
+    ) -> ResponseFormatters:
+        return (
+            self._get_result_formatters(method, module),
+            self._get_error_formatters(method),
+            self._get_null_result_formatters(method),
+        )
+
     def process_params(
         self, module: "Module", *args: Any, **kwargs: Any
-    ) -> tuple[
-        tuple[RPCEndpoint | Callable[..., RPCEndpoint], tuple[RPCEndpoint, ...]],
-        tuple[
-            TReturn | dict[str, Callable[..., Any]],
-            Callable[..., Any],
-            TReturn | Callable[..., Any],
-        ],
-    ]:
+    ) -> tuple[tuple[RPCEndpoint, tuple[Any, ...]], ResponseFormatters]:
         params = self.input_munger(module, args, kwargs)
 
         if self.method_choice_depends_on_args:
@@ -220,14 +264,10 @@ class Method(Generic[TFunc]):
                 params = []
 
         method = self.method_selector_fn()
-        response_formatters = (
-            self.result_formatters(method, module),
-            get_error_formatters(method),
-            self.null_result_formatters(method),
-        )
+        response_formatters = self._get_response_formatters(method, module)
         request = (
             method,
-            _apply_request_formatters(params, self.request_formatters(method)),
+            _apply_request_formatters(params, self._get_request_formatters(method)),
         )
         return request, response_formatters
 

--- a/web3/module.py
+++ b/web3/module.py
@@ -6,7 +6,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from eth_abi.codec import (
@@ -72,9 +71,9 @@ def retrieve_request_information_for_batching(
         )
         if isinstance(w3.provider, PersistentConnectionProvider):
             w3.provider._request_processor.cache_request_information(
-                None, cast(RPCEndpoint, method_str), params, response_formatters
+                None, method_str, params, response_formatters
             )
-        return (cast(RPCEndpoint, method_str), params), response_formatters
+        return (method_str, params), response_formatters
 
     def inner(
         *args: Any, **kwargs: Any
@@ -82,7 +81,7 @@ def retrieve_request_information_for_batching(
         (method_str, params), response_formatters = method.process_params(
             module, *args, **kwargs
         )
-        return (cast(RPCEndpoint, method_str), params), response_formatters
+        return (method_str, params), response_formatters
 
     return async_inner if module.is_async else inner
 
@@ -139,7 +138,7 @@ def retrieve_async_method_call_fn(
 
         if isinstance(async_w3.provider, PersistentConnectionProvider):
             return await async_w3.manager.socket_request(
-                cast(RPCEndpoint, method_str),
+                method_str,
                 params,
                 response_formatters=response_formatters,
             )


### PR DESCRIPTION
### What was wrong?

Avoids recomputing request/result/error/null formatter callables at `process_params` calls

