### PR TITLE
fix: accept hex-encoded block number as contract call block_identifier

### DIFF
--- a/newsfragments/3646.bugfix.rst
+++ b/newsfragments/3646.bugfix.rst
@@ -1,1 +1,1 @@
-Accept a hex-encoded block number (e.g. ``"0x1510FA4"``) as a contract call ``block_identifier``, matching the documented behavior, instead of raising ``BlockNumberOutOfRange``.
+Accept a ``0x``-prefixed hex-encoded block number (e.g. ``"0x1510FA4"``) as a contract call ``block_identifier``, consistent with ``HexStr`` being part of the ``BlockIdentifier`` union, instead of raising ``BlockNumberOutOfRange``.

--- a/newsfragments/3646.bugfix.rst
+++ b/newsfragments/3646.bugfix.rst
@@ -1,0 +1,1 @@
+Accept a hex-encoded block number (e.g. ``"0x1510FA4"``) as a contract call ``block_identifier``, matching the documented behavior, instead of raising ``BlockNumberOutOfRange``.

--- a/tests/core/contracts/test_contract_util_functions.py
+++ b/tests/core/contracts/test_contract_util_functions.py
@@ -63,6 +63,16 @@ def test_parse_block_identifier_hex_block_number(w3, block_identifier, expected_
         1.5,
         "cats",
         -70,
+        # hex-like values that are not canonical ``0x``-prefixed hex must still
+        # be rejected rather than silently reinterpreted as base 16. see #3646
+        "abc",
+        "20",
+        "1000000",
+        " 0x1a ",
+        "0x1_a",
+        "+0x1a",
+        "0b11",
+        "0x",
     ),
 )
 def test_parse_block_identifier_error(w3, block_identifier):
@@ -147,6 +157,16 @@ async def test_async_parse_block_identifier_hex_block_number(
         1.5,
         "cats",
         -70,
+        # hex-like values that are not canonical ``0x``-prefixed hex must still
+        # be rejected rather than silently reinterpreted as base 16. see #3646
+        "abc",
+        "20",
+        "1000000",
+        " 0x1a ",
+        "0x1_a",
+        "+0x1a",
+        "0b11",
+        "0x",
     ),
 )
 async def test_async_parse_block_identifier_error(async_w3, block_identifier):

--- a/tests/core/contracts/test_contract_util_functions.py
+++ b/tests/core/contracts/test_contract_util_functions.py
@@ -41,6 +41,22 @@ def test_parse_block_identifier_bytes_and_hex(w3):
     assert block_id_by_hex == 0
 
 
+# a hex-encoded block number (documented as a valid ``block_identifier``) must
+# resolve to its integer block number without an extra ``eth_getBlockByHash``
+# round-trip, instead of raising ``BlockNumberOutOfRange``. see issue #3646
+@pytest.mark.parametrize(
+    "block_identifier,expected_output",
+    (
+        ("0x0", 0),
+        ("0x1a", 26),
+        ("0XABC", 2748),
+        ("0x1510FA4", 22089636),  # odd-length, mixed-case hex from the issue
+    ),
+)
+def test_parse_block_identifier_hex_block_number(w3, block_identifier, expected_output):
+    assert parse_block_identifier(w3, block_identifier) == expected_output
+
+
 @pytest.mark.parametrize(
     "block_identifier",
     (
@@ -105,6 +121,23 @@ async def test_async_parse_block_identifier_bytes_and_hex(async_w3):
     block_0_hexstring = async_w3.to_hex(block_0_hash)
     block_id_by_hex = await async_parse_block_identifier(async_w3, block_0_hexstring)
     assert block_id_by_hex == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "block_identifier,expected_output",
+    (
+        ("0x0", 0),
+        ("0x1a", 26),
+        ("0XABC", 2748),
+        ("0x1510FA4", 22089636),  # odd-length, mixed-case hex from the issue
+    ),
+)
+async def test_async_parse_block_identifier_hex_block_number(
+    async_w3, block_identifier, expected_output
+):
+    block_id = await async_parse_block_identifier(async_w3, block_identifier)
+    assert block_id == expected_output
 
 
 @pytest.mark.asyncio

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -51,6 +51,7 @@ from web3._utils.abi import (
 )
 from web3._utils.blocks import (
     is_hex_encoded_block_hash,
+    is_hex_encoded_block_number,
 )
 from web3._utils.encoding import (
     to_hex,
@@ -343,6 +344,8 @@ def parse_block_identifier(
         block_identifier
     ):
         return w3.eth.get_block(block_identifier)["number"]
+    elif is_hex_encoded_block_number(block_identifier):
+        return BlockNumber(int(block_identifier, 16))
     else:
         raise BlockNumberOutOfRange
 
@@ -372,6 +375,8 @@ async def async_parse_block_identifier(
     ):
         requested_block = await async_w3.eth.get_block(block_identifier)
         return requested_block["number"]
+    elif is_hex_encoded_block_number(block_identifier):
+        return BlockNumber(int(block_identifier, 16))
     else:
         raise BlockNumberOutOfRange
 

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -34,6 +34,9 @@ from eth_utils import (
     filter_abi_by_name,
     filter_abi_by_type,
     get_abi_input_types,
+    is_0x_prefixed,
+    is_hex,
+    is_text,
 )
 from eth_utils.toolz import (
     pipe,
@@ -331,6 +334,20 @@ def validate_payable(transaction: TxParams, abi_callable: ABICallable) -> None:
         )
 
 
+def _is_hex_block_number(block_identifier: Any) -> bool:
+    # Deliberately stricter than ``is_hex_encoded_block_number``, which is a
+    # routing predicate for requests that forward the raw string to the node and
+    # let the node reject it. Here the value is converted to an ``int`` locally,
+    # so anything looser would silently change its meaning -- e.g. the decimal
+    # string "20" would resolve to block 0x20 (32) instead of erroring.
+    # The ``is_hex_encoded_block_number`` term is also what keeps the subsequent
+    # ``int(..., 16)`` infallible: it rejects a bare "0x", which ``is_hex``
+    # accepts but ``int`` cannot parse.
+    if not is_text(block_identifier) or not is_0x_prefixed(block_identifier):
+        return False
+    return is_hex(block_identifier) and is_hex_encoded_block_number(block_identifier)
+
+
 def parse_block_identifier(
     w3: "Web3", block_identifier: BlockIdentifier | None
 ) -> BlockIdentifier:
@@ -344,7 +361,7 @@ def parse_block_identifier(
         block_identifier
     ):
         return w3.eth.get_block(block_identifier)["number"]
-    elif is_hex_encoded_block_number(block_identifier):
+    elif _is_hex_block_number(block_identifier):
         return BlockNumber(int(block_identifier, 16))
     else:
         raise BlockNumberOutOfRange
@@ -375,7 +392,7 @@ async def async_parse_block_identifier(
     ):
         requested_block = await async_w3.eth.get_block(block_identifier)
         return requested_block["number"]
-    elif is_hex_encoded_block_number(block_identifier):
+    elif _is_hex_block_number(block_identifier):
         return BlockNumber(int(block_identifier, 16))
     else:
         raise BlockNumberOutOfRange


### PR DESCRIPTION
### What was wrong?

Related to Issue #3646
Closes #3646

Passing a hex-encoded block number string (e.g. `"0x1510FA4"`) as a contract call `block_identifier` raised `BlockNumberOutOfRange`:

```python
deposit_contract.get_deposit_root("0x1510FA4")
# ...
#   File ".../web3/_utils/contracts.py", line 337, in parse_block_identifier
#     raise BlockNumberOutOfRange
# web3.exceptions.BlockNumberOutOfRange
```

`parse_block_identifier` (and its async twin) handled `int`, the named blocks, and block hashes, but had no case for a hex-encoded block number, so those values fell through to `else: raise BlockNumberOutOfRange` — even though `HexStr` is part of the `BlockIdentifier` union and `select_method_for_block_identifier` already accepts this form.

### How was it fixed?

Added a branch to both `parse_block_identifier` and `async_parse_block_identifier` that resolves a `0x`-prefixed hex block number to its integer `BlockNumber` — the same output type the plain-`int` branch produces, so it flows through `eth_call` unchanged with no extra RPC round-trip.

The branch is gated on a private `_is_hex_block_number` helper rather than the existing `is_hex_encoded_block_number`. That distinction is deliberate and is the important review point:

- `is_hex_encoded_block_number` is a **routing** predicate. `select_method_for_block_identifier` uses it to pick an endpoint and then forwards the raw string to the node, which performs final validation — so it does not require a `0x` prefix (it just attempts `int(value, 16)`).
- This branch instead **converts locally**, which removes the node's chance to reject bad input. Reusing the lax predicate would silently reinterpret values: the decimal string `"20"` would resolve to block `0x20` (32), `"abc"` to 2748, and `" 0x1a "` / `"0x1_a"` / `"+0x1a"` would all be accepted.

So `_is_hex_block_number` additionally requires text, a `0x`/`0X` prefix, and canonical hex. I kept it local rather than tightening `is_hex_encoded_block_number`, because that shared predicate feeds 12 `Method` declarations across `web3/eth/eth.py` and `web3/eth/async_eth.py` (`eth_getBlockBy*`, `eth_getUncle*`, etc.); tightening it would be a behavior change to those public methods and belongs in its own PR. Happy to go that route instead if you'd prefer.

Ordering is preserved: the new branch sits after the block-hash check, so a 64-character hex string is still treated as a block hash.

Tests: parametrized sync + async cases for `"0x0"`, mixed-case `"0XABC"`, and the odd-length `"0x1510FA4"` from the issue; plus negative cases (`"abc"`, `"20"`, `"1000000"`, `" 0x1a "`, `"0x1_a"`, `"+0x1a"`, `"0b11"`, `"0x"`) asserting those still raise.

Not changed: a block **hash** still resolves via `eth_getBlockByHash`. Per your note on the issue, passing a hash straight through to `eth_call` is a breaking change better suited to the next major version, so it's out of scope here.

Possible follow-up (not included, to keep this focused): `raise BlockNumberOutOfRange` is raised bare, so the error names neither the rejected value nor the accepted formats. Happy to add a message in a separate PR.

### Todo:

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Cat_November_2010-1a.jpg/640px-Cat_November_2010-1a.jpg)